### PR TITLE
Added UT for cluster_autoscaler/simulator/cluster/FindNodesToRemove

### DIFF
--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -46,20 +46,14 @@ func TestFindUnneededNodes(t *testing.T) {
 
 	p2 := BuildTestPod("p2", 300, 0)
 	p2.Spec.NodeName = "n2"
-	p2.Annotations = map[string]string{
-		"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-	}
+	p2.Annotations = GetReplicaSetAnnotation()
 
 	p3 := BuildTestPod("p3", 400, 0)
-	p3.Annotations = map[string]string{
-		"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-	}
+	p3.Annotations = GetReplicaSetAnnotation()
 	p3.Spec.NodeName = "n3"
 
 	p4 := BuildTestPod("p4", 2000, 0)
-	p4.Annotations = map[string]string{
-		"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-	}
+	p4.Annotations = GetReplicaSetAnnotation()
 	p4.Spec.NodeName = "n4"
 
 	n1 := BuildTestNode("n1", 1000, 10)

--- a/cluster-autoscaler/simulator/drain_test.go
+++ b/cluster-autoscaler/simulator/drain_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	policyv1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -44,11 +45,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Replicated pod
 	pod2 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod2",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod2",
+			Namespace:   "ns",
+			Annotations: GetReplicaSetAnnotation(),
 		},
 	}
 	r2, err := FastGetPodsToMove(schedulercache.NewNodeInfo(pod2), true, true, nil)
@@ -88,11 +87,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Kube-system
 	pod5 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod5",
-			Namespace: "kube-system",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod5",
+			Namespace:   "kube-system",
+			Annotations: GetReplicaSetAnnotation(),
 		},
 	}
 	_, err = FastGetPodsToMove(schedulercache.NewNodeInfo(pod5), true, true, nil)
@@ -101,11 +98,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Local storage
 	pod6 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod6",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod6",
+			Namespace:   "ns",
+			Annotations: GetReplicaSetAnnotation(),
 		},
 		Spec: apiv1.PodSpec{
 			Volumes: []apiv1.Volume{
@@ -123,11 +118,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Non-local storage
 	pod7 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod7",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod7",
+			Namespace:   "ns",
+			Annotations: GetReplicaSetAnnotation(),
 		},
 		Spec: apiv1.PodSpec{
 			Volumes: []apiv1.Volume{
@@ -148,11 +141,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Pdb blocking
 	pod8 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod8",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod8",
+			Namespace:   "ns",
+			Annotations: GetReplicaSetAnnotation(),
 			Labels: map[string]string{
 				"critical": "true",
 			},
@@ -183,11 +174,9 @@ func TestFastGetPodsToMove(t *testing.T) {
 	// Pdb allowing
 	pod9 := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod9",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
-			},
+			Name:        "pod9",
+			Namespace:   "ns",
+			Annotations: GetReplicaSetAnnotation(),
 			Labels: map[string]string{
 				"critical": "true",
 			},

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -120,3 +120,10 @@ func RefJSON(o runtime.Object) string {
 	json := runtime.EncodeOrDie(codec, &apiv1.SerializedReference{Reference: *ref})
 	return string(json)
 }
+
+// GetReplicaSetAnnotation returns a map containing annotation simulating pod being created by ReplicaSet
+func GetReplicaSetAnnotation() map[string]string {
+	return map[string]string{
+		"kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\"}}",
+	}
+}


### PR DESCRIPTION
This was one major function in simulator, that wasn't covered. A few remaining uncovered methods have little custom logic and are just functions for fetching stuff from API server - testing them would require a lot of mocking for little real value.

This brings simulator coverage to 79.4%, which I'm willing to call close enough to target of 80% stated in https://github.com/kubernetes/autoscaler/issues/6.