### PR TITLE
Fix aws ProviderID pattern to match with the kubernetes version.

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -225,7 +225,7 @@ func (m *AwsManager) GetAsgNodes(asg *Asg) ([]string, error) {
 	}
 	for _, instance := range group.Instances {
 		result = append(result,
-			fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
+			fmt.Sprintf("aws:////%s", *instance.InstanceId))
 	}
 	return result, nil
 }


### PR DESCRIPTION
Fix this issue : https://github.com/kubernetes/autoscaler/issues/16