### PR TITLE
Bump CA version to 0.5.4

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "0.5.3"
+const ClusterAutoscalerVersion = "0.5.4"


### PR DESCRIPTION
Fixes  drain timeouts when pods are ignoring SIGTERM.