### PR TITLE
Add a method to NodeGroup for providing a template NodeInfo

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 // AwsCloudProvider implements CloudProvider interface.
@@ -225,6 +226,11 @@ func (asg *Asg) Debug() string {
 // Nodes returns a list of all nodes that belong to this node group.
 func (asg *Asg) Nodes() ([]string, error) {
 	return asg.awsManager.GetAsgNodes(asg)
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (asg *Asg) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }
 
 func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 // AzureCloudProvider provides implementation of CloudProvider interface for Azure.
@@ -226,6 +227,11 @@ func (scaleSet *ScaleSet) Id() string {
 // Debug returns a debug string for the Scale Set.
 func (scaleSet *ScaleSet) Debug() string {
 	return fmt.Sprintf("%s (%d:%d)", scaleSet.Id(), scaleSet.MinSize(), scaleSet.MaxSize())
+}
+
+// TemplateNodeInfo returns a node template for this scale set.
+func (scaleSet *ScaleSet) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Create ScaleSet from provided spec.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"fmt"
+
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 // CloudProvider contains configuration info and functions for interacting with
@@ -34,6 +37,9 @@ type CloudProvider interface {
 	// occurred.
 	NodeGroupForNode(*apiv1.Node) (NodeGroup, error)
 }
+
+// ErrNotImplemented is returned if a method is not implemented.
+var ErrNotImplemented error = fmt.Errorf("Not implemented")
 
 // NodeGroup contains configuration info and functions to control a set
 // of nodes that have the same capacity and set of labels.
@@ -75,4 +81,12 @@ type NodeGroup interface {
 
 	// Nodes returns a list of all nodes that belong to this node group.
 	Nodes() ([]string, error)
+
+	// TemplateNodeInfo returns a schedulercache.NodeInfo structure of an empty
+	// (as if just strarted) node. This will be used in scale-up simulations to
+	// predict what would a new node look like if a node group was expanded. The returned
+	// NodeInfo is expected to have a fully populated Node object, with all of the labels,
+	// capacity and allocatable information as well as all pods that are started on
+	// the node by default, using manifest (most likely only kube-proxy).
+	TemplateNodeInfo() (*schedulercache.NodeInfo, error)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 // GceCloudProvider implements CloudProvider interface.
@@ -228,6 +229,11 @@ func (mig *Mig) Debug() string {
 // Nodes returns a list of all nodes that belong to this node group.
 func (mig *Mig) Nodes() ([]string, error) {
 	return mig.gceManager.GetMigNodes(mig)
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (mig *Mig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }
 
 func buildMig(value string, gceManager *GceManager) (*Mig, error) {

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 // TestCloudProvider is a dummy cloud provider to be used in tests.
@@ -210,4 +211,9 @@ func (tng *TestNodeGroup) Nodes() ([]string, error) {
 		}
 	}
 	return result, nil
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (tng *TestNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,9 @@ func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
 func (f *FakeNodeGroup) Id() string                         { return f.id }
 func (f *FakeNodeGroup) Debug() string                      { return f.id }
 func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{}, nil }
+func (f *FakeNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
 
 func makeNodeInfo(cpu int64, memory int64, pods int64) *schedulercache.NodeInfo {
 	node := &apiv1.Node{


### PR DESCRIPTION
... that can be used in scale-ups in case of no live node example.

Part of #43.

cc: @MaciekPytel @fgrzadkowski 