### PR TITLE
cluster-autoscaler: Add ca-certificates to the docker image

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -15,6 +15,10 @@
 FROM gcr.io/google-containers/ubuntu-slim:0.8
 MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
+RUN apt-get update && apt-get install --yes ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 ADD cluster-autoscaler cluster-autoscaler
 ADD run.sh run.sh
 


### PR DESCRIPTION
This commit is manually tested by running `TAG=add-ca-certificates REGISTRY=mydockerrepo make release` and running it inside author's k8s cluster

The docker image is available at https://hub.docker.com/r/mumoshu/cluster-autoscaler
Looking into the various tags in the repo, you'll see that the image size is increased by 2MB, which is acceptable IMHO
![image](https://cloud.githubusercontent.com/assets/22009/25836283/674a9a3a-34c0-11e7-8386-c35d77e62b6e.png)

No errors seem to be occurring while accessing AWS API with the ca-certificates bundled in the image hence I assume it is working as expected:

```
I0509 05:07:58.029029       1 aws_manager.go:187] Regenerating ASG information for kube4-Asg1-5GX1OEW9YLPA-Workers-1WBDQUOBGXA6A
I0509 05:07:58.083395       1 aws_manager.go:187] Regenerating ASG information for kube4-Asg3-1QWZDGNI50QW-Workers-1OD7QVXAHMALV
I0509 05:07:58.125027       1 scale_down.go:218] Skipping ip-10-0-0-133.ap-northeast-1.compute.internal - no node group config
```

Resolves #38