### PR TITLE
cluster-autoscaler: Fix an incorrect message when CA failed to find a place for a to-be-removed pod

### DIFF
--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -105,7 +105,7 @@ candidateloop:
 				break candidateloop
 			}
 		} else {
-			glog.V(2).Infof("%s: node %s is not suitable for removal %v", evaluationType, node.Name, err)
+			glog.V(2).Infof("%s: node %s is not suitable for removal: %v", evaluationType, node.Name, findProblems)
 		}
 	}
 	return result, newHints, nil


### PR DESCRIPTION
The message has been always `<evaluation type>: node <node name> is not suitable for removal nil`.
It should be `<evaluation type>: node <node name> is not suitable for removal: failed to find place for <pod key>`