### PR TITLE
cluster-autoscaler: Resource slack for faster pod startup

### DIFF
--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -73,6 +73,8 @@ type AutoscalingOptions struct {
 	EstimatorName string
 	// ExpanderName sets the type of node group expander to be used in scale up
 	ExpanderName string
+	// MinExtraCapacityRate is the rate of the amount of extra cpu/memory, compared to your cluster's total capacity, used to create resource slacks for faster pod startup
+	MinExtraCapacityRate float64
 	// MaxGratefulTerminationSec is maximum number of seconds scale down waits for pods to terminante before
 	// removing the node from cloud provider.
 	MaxGratefulTerminationSec int

--- a/cluster-autoscaler/core/placeholderpod/create.go
+++ b/cluster-autoscaler/core/placeholderpod/create.go
@@ -1,0 +1,68 @@
+package placeholderpod
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+)
+
+// CreateReplicaSets create one or more replica set(s) of placeholder pods
+func CreateReplicaSets(sets ...ReplicaSet) []*apiv1.Pod {
+	pods := []*apiv1.Pod{}
+	for _, set := range sets {
+		for i := int64(0); i < set.Count; i++ {
+			podSpec := set.PodSpec
+			nodeStickiness := podSpec.NodeStickiness
+			milliCPU := podSpec.MilliCPU
+			memory := podSpec.Memory
+			req := apiv1.ResourceList{}
+			req[apiv1.ResourceCPU] = *resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
+			req[apiv1.ResourceMemory] = *resource.NewQuantity(memory, resource.DecimalSI)
+			var name string
+			if set.Count > 1 {
+				name = fmt.Sprintf("%s-%d", set.Name, i)
+			} else {
+				name = set.Name
+			}
+			pod := &apiv1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              fmt.Sprintf("placeholder-%s-%dm-%dMB", name, milliCPU, memory/1024/1024),
+					CreationTimestamp: metav1.NewTime(time.Now()),
+					// Without a namespace, this causes an error like:
+					// > POST https://10.3.0.1:443/api/v1/namespaces/default/events 422 Unprocessable Entity in 1 milliseconds
+					// due to an invalid pod:
+					// > 'Event "placeholder-12-2800m-5626449100.14bd31ca98a9fa02" is invalid: involvedObject.namespace: Required value: required for kind Pod' (will not retry!)
+					Namespace: "default",
+				},
+				Spec: apiv1.PodSpec{
+					Affinity: &apiv1.Affinity{
+						NodeAffinity: &apiv1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: nodeStickiness.NodeAffinityRequiredTerms,
+						},
+						PodAntiAffinity: &apiv1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: nodeStickiness.PodAntiAffinityRequiredTerms,
+						},
+					},
+					NodeSelector: nodeStickiness.NodeSelector,
+					Containers: []apiv1.Container{
+						{
+							Resources: apiv1.ResourceRequirements{
+								Requests: req,
+							},
+						},
+					},
+				},
+				Status: apiv1.PodStatus{},
+			}
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}

--- a/cluster-autoscaler/core/placeholderpod/types.go
+++ b/cluster-autoscaler/core/placeholderpod/types.go
@@ -1,0 +1,47 @@
+package placeholderpod
+
+import (
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+)
+
+// Tolerations is a slice of k8s tolerations
+type Tolerations []apiv1.Toleration
+
+// Spec is a specification of a placeholder pod
+type Spec struct {
+	// MilliCPU is the amount of CPU cpu requested for the virtual primary container of a placeholder pod
+	MilliCPU int64
+	// Memory is the amount of memory requested for the virtual primary container of a placeholder pod
+	Memory int64
+	// NodeStickiness represents what kind of nodes this placeholder pod wants to be scheduled on
+	NodeStickiness NodeStickiness
+}
+
+// NodeStickiness represents what kind of nodes this placeholder pod wants to be scheduled on
+type NodeStickiness struct {
+	// NodeSelector is the contents of the `spec.nodeSelector` field of a placeholder pod
+	NodeSelector map[string]string
+	// PodAntiAffinityRequiredTerms is the contents of the `spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution` field of a placeholder pod
+	PodAntiAffinityRequiredTerms []apiv1.PodAffinityTerm
+	// NodeAffinityRequiredTerms is the contents of the `spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` field of a placeholder pod
+	NodeAffinityRequiredTerms *apiv1.NodeSelector
+}
+
+// ReplicaSet is a definition for a set of equivalent placeholder pods
+type ReplicaSet struct {
+	// Count is the number of replicas to be created
+	Count int64
+	// Name is the name of this set which will also be included in the names of placeholder pods
+	Name string
+	// PodSpec is the spec of placeholder pods created by this command
+	PodSpec Spec
+}
+
+// New creates a new placeholder specification
+func New(milliCPU int64, memory int64, nodeStickiness NodeStickiness) Spec {
+	return Spec{
+		MilliCPU:       milliCPU,
+		Memory:         memory,
+		NodeStickiness: nodeStickiness,
+	}
+}

--- a/cluster-autoscaler/core/resource_slack.go
+++ b/cluster-autoscaler/core/resource_slack.go
@@ -1,0 +1,227 @@
+package core
+
+import (
+	"fmt"
+	"math"
+
+	"k8s.io/autoscaler/cluster-autoscaler/core/placeholderpod"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+
+	"github.com/golang/glog"
+)
+
+// CreateAndSchedulePlaceholderPods creates placeholder pods and try to virtually assign pods to nodes so that CA keeps more nodes than actually necessary
+func CreateAndSchedulePlaceholderPods(readyNodes []*apiv1.Node, allScheduled []*apiv1.Pod, autoscalingContext *AutoscalingContext, predicateChecker *simulator.PredicateChecker) ([]*apiv1.Pod, []*apiv1.Pod, error) {
+	toGB := func(value float64) float64 {
+		return value / 1024 / 1024 / 1024
+	}
+
+	// TODO Could be simplified more
+	// Ty our best to make all the words match to the original design at https://github.com/kubernetes/contrib/issues/2251#issuecomment-272893268
+	clusterSize := int64(len(readyNodes))
+	clusterSizeInFloat := float64(clusterSize)
+	// Foundamental statistics used for creating placeholder pods matching the reality
+	// Use Quantity where possible not to introduce bugs due to numeric conversion among different formats
+	clusterCpuSum := &resource.Quantity{}
+	clusterMemorySum := &resource.Quantity{}
+	minNodeMilliCPU := int64(math.MaxInt64)
+	minNodeMemory := int64(math.MaxInt64)
+	for _, n := range readyNodes {
+		if cpu := n.Status.Capacity.Cpu(); cpu != nil {
+			clusterCpuSum.Add(*cpu)
+			v := cpu.MilliValue()
+			if v < minNodeMilliCPU {
+				minNodeMilliCPU = v
+			}
+		}
+		if mem := n.Status.Capacity.Memory(); mem != nil {
+			clusterMemorySum.Add(*mem)
+			v := mem.Value()
+			if v < minNodeMemory {
+				minNodeMemory = v
+			}
+		}
+	}
+	// Resource occupied by each node
+	avgNodeMilliCPU := clusterCpuSum.MilliValue() / clusterSize
+	avgNodeMemory := float64(clusterMemorySum.Value()) / clusterSizeInFloat
+	// Resource occupied by the cluster
+	clusterMilliCPU := avgNodeMilliCPU * clusterSize
+	clusterMemory := avgNodeMemory * clusterSizeInFloat
+	// Resource should be occupied by placeholder pods
+	minExtraCapacityRate := autoscalingContext.MinExtraCapacityRate
+	clusterExtraMilliCPU := int64(float64(clusterMilliCPU) * minExtraCapacityRate)
+	clusterExtraMemory := clusterMemory * minExtraCapacityRate
+	// Mix different types of placeholder pods to ensure both:
+	// (1) providing extra capacity even for the largest pod in the cluster and
+	// (2) not wasting cluster capacity by making all the placeholder pods too big
+	//
+	// * Note that (1) could be made configurable if necessary. How about capping the max size of a placeholder pod via
+	// flags --placeholder-pod-max-cpu and --placeholder-pod-max-memory so that CA won't waste money by keeping
+	// considerably large nodes for the latest pod.
+	//
+	// In a nutshell, we prefer choosing a node group with a largest machine type for scaling up so that
+	// every pod can have a chance to be scheduled faster. Choosing a too small machine type for scaling up result in
+	// large pods to not fit within extra capacity, which breaks the original purpose of the resource slack feature(--min-extra-capacity-rate)
+	//
+	// General rules
+	// * Every place holder pod should be small enough to fit within at least one of nodes
+	//   For example, a 30GB placeholder pod which doesn't fit to any small node which results in more nodes doesn't make sense.
+	// * Exactly one place holder pod should be sized the same as the largest(in terms of resource requests) pod
+	//   so that CA can make extra space even for the largest pod.
+	//   Beware that this results in CA to choose a node group for the larger machine type as a scaling target.
+	// * All the other placeholder pods should be small enough not to unnecessarily occupy capacity to add unnecessary nodes
+	//   For example, a 5GB placeholder pod doesn't fit to the smallest node doesn't make sense
+	maxPodRequestedMilliCPU := int64(0)
+	maxPodRequestedMemory := int64(0)
+	for _, p := range allScheduled {
+		maxContainerMilliCPU := int64(0)
+		maxContainerMemory := int64(0)
+		for _, c := range p.Spec.Containers {
+			cpuRes := c.Resources.Requests[apiv1.ResourceCPU]
+			cpu := (&cpuRes).MilliValue()
+			if cpu > maxContainerMilliCPU {
+				maxContainerMilliCPU = cpu
+			}
+			memRes := c.Resources.Requests[apiv1.ResourceMemory]
+			mem := (&memRes).Value()
+			if mem > maxContainerMemory {
+				maxContainerMemory = mem
+			}
+		}
+		if maxContainerMilliCPU > maxPodRequestedMilliCPU {
+			maxPodRequestedMilliCPU = maxContainerMilliCPU
+		}
+		if maxContainerMemory > maxPodRequestedMemory {
+			maxPodRequestedMemory = maxContainerMemory
+		}
+	}
+
+	// Resource required for all the remaining placeholder pods
+	remainingClusterExtraMilliCPU := clusterExtraMilliCPU - maxPodRequestedMilliCPU
+	remainingClusterExtraMemory := clusterExtraMemory - float64(maxPodRequestedMemory)
+	// Could be computed via e.g. ceil(minNodeMilliCPU / avgPodMilliCPU) but then it would result in less deterministic behavior of CA
+	// because avgPodMilliCPU would change greatly over time
+	granularity := int64(5)
+	// Resource required for each of other placeholder pods
+	// This is intended to be the amount of CPU requested by a typical pod running in the cluster.
+	// The higher this value is, the more cluster capacity is wasted.
+	// ppMilliCPU is the amount of CPU requested for a placeholder pod should be smaller than the CPU of the minimum node
+	// It should be less than or equal to maxPodRequestedMilliCPU not to instruct CA to add unnecessarily large nodes
+	ppMilliCPU := minNodeMilliCPU / granularity
+	if ppMilliCPU > maxPodRequestedMilliCPU {
+		ppMilliCPU = maxPodRequestedMilliCPU
+	}
+	// ppMemory is the amount of memory requested for a placeholder pod should be smaller than the memory of the minimum node
+	// It should be less than or equal to maxPodRequestedMemory not to instruct CA to add unnecessarily large nodes
+	ppMemory := minNodeMemory / granularity
+	if ppMemory > maxPodRequestedMemory {
+		ppMemory = maxPodRequestedMemory
+	}
+	// Don't round but ceil to ensure the rate specified via --min-extra-capacity-rate is met
+	extraPlaceholderPodsCount := int64(math.Ceil(float64(remainingClusterExtraMilliCPU) / float64(ppMilliCPU)))
+	if extraPlaceholderPodsCount < 0 {
+		extraPlaceholderPodsCount = 0
+	}
+
+	glog.V(4).Infof(
+		"Creating placeholder pods based on the following observations: "+
+			"cluster size = %v, cluster cpu sum = %s cores, cluster memory sum = %s, avg milli cpu per node = %v, avg memory per node = %.1fGB, "+
+			"cluster total milli cpu = %v, cluster total memory = %.1fGB, cluster extra milli cpu = %v, cluster extra memory = %.1fGB, "+
+			"max pod milli cpu = %d, max pod memory = %.1fGB, remaining cluster extra milli cpu = %d, remaining cluster extra memory = %.1fGB, "+
+			"min node milli cpu = %d, min node memory = %.1fGB, "+
+			"milli cpu per extra placeholder pod = %d, memory per extra placeholder pod = %.1fGB, extra placeholder pods count = %v",
+		clusterSize,
+		clusterCpuSum.String(),
+		clusterMemorySum.String(),
+		avgNodeMilliCPU,
+		toGB(avgNodeMemory),
+		clusterMilliCPU,
+		toGB(clusterMemory),
+		clusterExtraMilliCPU,
+		toGB(clusterExtraMemory),
+		maxPodRequestedMilliCPU,
+		toGB(float64(maxPodRequestedMemory)),
+		remainingClusterExtraMilliCPU,
+		toGB(remainingClusterExtraMemory),
+		minNodeMilliCPU,
+		toGB(float64(minNodeMemory)),
+		ppMilliCPU,
+		toGB(float64(ppMemory)),
+		extraPlaceholderPodsCount,
+	)
+
+	nodeStickiness := placeholderpod.NodeStickiness{
+		NodeSelector:                 map[string]string{},
+		PodAntiAffinityRequiredTerms: []apiv1.PodAffinityTerm{},
+		NodeAffinityRequiredTerms:    nil,
+	}
+
+	largestCPU := placeholderpod.New(
+		int64(maxPodRequestedMilliCPU),
+		int64(0),
+		nodeStickiness,
+	)
+
+	largestMemory := placeholderpod.New(
+		int64(0),
+		int64(maxPodRequestedMemory),
+		nodeStickiness,
+	)
+
+	standard := placeholderpod.New(
+		int64(ppMilliCPU),
+		int64(ppMemory),
+		nodeStickiness,
+	)
+
+	// TODO Create at least one placeholder pod for every occurrence of a set of nodeSelector + affinity + tolerations
+	// so that even pods demanding such specific requirements on nodes can have extra capacity
+	// TODO Pods dedicated to master nodes should be ignored as master nodes shouldn't be auto-scaled
+	placeholderPods := placeholderpod.CreateReplicaSets(
+		placeholderpod.ReplicaSet{Name: "largestcpu", Count: 1, PodSpec: largestCPU},
+		placeholderpod.ReplicaSet{Name: "largestmemory", Count: 1, PodSpec: largestMemory},
+		placeholderpod.ReplicaSet{Name: "standard", Count: extraPlaceholderPodsCount, PodSpec: standard},
+	)
+
+	glog.V(4).Infof("Created %d placeholder pods", len(placeholderPods))
+
+	return schedulePlaceholderPods(placeholderPods, readyNodes, allScheduled, predicateChecker)
+}
+
+// schedulePlaceholderPods try to fit placeholder pods to actual nodes and virtually assign pods
+// to the fitted nodes so that CA keeps more nodes than actually necessary
+func schedulePlaceholderPods(placeholderPods []*apiv1.Pod, nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, predicateChecker *simulator.PredicateChecker) ([]*apiv1.Pod, []*apiv1.Pod, error) {
+	scheduledPlaceholderPods := []*apiv1.Pod{}
+	unscheduledPlaceholderPods := []*apiv1.Pod{}
+	nodeNameToNodeInfo := createNodeNameToInfoMap(scheduledPods, nodes)
+
+	for _, pod := range placeholderPods {
+		if nodeName, err := predicateChecker.FitsAny(pod, nodeNameToNodeInfo); err == nil {
+			glog.Infof("Pod %s is virtually scheduled on %s", pod.Name, nodeName)
+
+			scheduledPlaceholderPod := *pod
+			scheduledPlaceholderPod.Spec.NodeName = nodeName
+
+			scheduledPlaceholderPods = append(scheduledPlaceholderPods, &scheduledPlaceholderPod)
+
+			oldNodeInfo := nodeNameToNodeInfo[nodeName]
+			newPods := oldNodeInfo.Pods()
+			newPods = append(newPods, &scheduledPlaceholderPod)
+			newNodeInfo := schedulercache.NewNodeInfo(newPods...)
+			if err := newNodeInfo.SetNode(oldNodeInfo.Node()); err != nil {
+				return []*apiv1.Pod{}, []*apiv1.Pod{}, fmt.Errorf("failed to schedule placeholder pods: %v", err)
+			}
+
+			nodeNameToNodeInfo[nodeName] = newNodeInfo
+		} else {
+			unscheduledPlaceholderPods = append(unscheduledPlaceholderPods, pod)
+		}
+	}
+
+	return scheduledPlaceholderPods, unscheduledPlaceholderPods, nil
+}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -88,6 +88,7 @@ var (
 	maxTotalUnreadyPercentage   = flag.Float64("max-total-unready-percentage", 33, "Maximum percentage of unready nodes after which CA halts operations")
 	okTotalUnreadyCount         = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	maxNodeProvisionTime        = flag.Duration("max-node-provision-time", 15*time.Minute, "Maximum time CA waits for node to be provisioned")
+	minExtraCapacityRateFlag    = flag.Float64("min-extra-capacity-rate", 0.0, "The rate of the amount of extra cpu/memory, compared to your cluster's total capacity, used to create resource slacks for faster pod startup. For example, 0.1 means 10% at minimum - CA tries to keep more nodes to make at least 10% of free capacity")
 	unregisteredNodeRemovalTime = flag.Duration("unregistered-node-removal-time", 15*time.Minute, "Time that CA waits before removing nodes that are not registered in Kubernetes")
 
 	estimatorFlag = flag.String("estimator", estimator.BinpackingEstimatorName,
@@ -111,6 +112,7 @@ func createAutoscalerOptions() core.AutoscalerOptions {
 		MaxGratefulTerminationSec:     *maxGratefulTerminationFlag,
 		MaxNodeProvisionTime:          *maxNodeProvisionTime,
 		MaxNodesTotal:                 *maxNodesTotal,
+		MinExtraCapacityRate:          *minExtraCapacityRateFlag,
 		NodeGroups:                    nodeGroupsFlag,
 		UnregisteredNodeRemovalTime:   *unregisteredNodeRemovalTime,
 		ScaleDownDelay:                *scaleDownDelay,


### PR DESCRIPTION
Ref https://github.com/kubernetes/contrib/issues/2251

* `--min-extra-capacity-rate=0.1` to make 10% resource slack

A working example of CA running inside my test cluster with `--min-extra-capacity-rate=2`(=200%) with 2 node groups:
```
I0511 07:32:48.984318       1 aws_manager.go:187] Regenerating ASG information for kube5-Asg1-1EAU86YWRJGT6-Workers-5FQ8MWC9B6QG
I0511 07:32:49.019873       1 aws_manager.go:187] Regenerating ASG information for kube5-Asg3-PTR2VK0YHXGP-Workers-W0KCGPQKD92H
I0511 07:32:49.057607       1 resource_slack.go:156] Creating placeholder pods based on the following observations: cluster size = 3, cluster cpu sum = 6 cores, cluster memory sum = 12148524Ki, avg milli cpu per node = 2000, avg memory per node = 3.9GB, cluster total milli cpu = 6000, cluster total memory = 11.6GB, cluster extra milli cpu = 12000, cluster extra memory = 23.2GB, max pod milli cpu = 200, max pod memory = 0.3GB, remaining cluster extra milli cpu = 11800, remaining cluster extra memory = 22.9GB, min node milli cpu = 2000, min node memory = 3.9GB, milli cpu per extra placeholder pod = 200, memory per extra placeholder pod = 0.3GB, extra placeholder pods count = 59
I0511 07:32:49.057786       1 resource_slack.go:191] Created 61 placeholder pods
I0511 07:32:49.057851       1 resource_slack.go:205] Pod placeholder-largestcpu-200m-0MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.057884       1 resource_slack.go:205] Pod placeholder-largestmemory-0m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.057921       1 resource_slack.go:205] Pod placeholder-standard-0-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.057941       1 resource_slack.go:205] Pod placeholder-standard-1-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.057966       1 resource_slack.go:205] Pod placeholder-standard-2-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.057995       1 resource_slack.go:205] Pod placeholder-standard-3-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.058015       1 resource_slack.go:205] Pod placeholder-standard-4-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.058035       1 resource_slack.go:205] Pod placeholder-standard-5-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.058060       1 resource_slack.go:205] Pod placeholder-standard-6-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.058083       1 resource_slack.go:205] Pod placeholder-standard-7-200m-300MB is virtually scheduled on ip-10-0-0-240.ap-northeast-1.compute.internal
I0511 07:32:49.058117       1 resource_slack.go:205] Pod placeholder-standard-8-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.058138       1 resource_slack.go:205] Pod placeholder-standard-9-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.058158       1 resource_slack.go:205] Pod placeholder-standard-10-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.058180       1 resource_slack.go:205] Pod placeholder-standard-11-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.058210       1 resource_slack.go:205] Pod placeholder-standard-12-200m-300MB is virtually scheduled on ip-10-0-0-176.ap-northeast-1.compute.internal
I0511 07:32:49.058851       1 static_autoscaler.go:211] Filtering out schedulables
I0511 07:32:49.059482       1 static_autoscaler.go:219] No schedulable pods
I0511 07:32:49.059492       1 scale_up.go:44] Pod default/placeholder-standard-13-200m-300MB is unschedulable
I0511 07:32:49.059496       1 scale_up.go:44] Pod default/placeholder-standard-14-200m-300MB is unschedulable
I0511 07:32:49.059498       1 scale_up.go:44] Pod default/placeholder-standard-15-200m-300MB is unschedulable
I0511 07:32:49.059501       1 scale_up.go:44] Pod default/placeholder-standard-16-200m-300MB is unschedulable
*snip*
I0511 07:32:49.059613       1 scale_up.go:44] Pod default/placeholder-standard-57-200m-300MB is unschedulable
I0511 07:32:49.059615       1 scale_up.go:44] Pod default/placeholder-standard-58-200m-300MB is unschedulable
I0511 07:32:49.059652       1 aws_manager.go:187] Regenerating ASG information for kube5-Asg1-1EAU86YWRJGT6-Workers-5FQ8MWC9B6QG
I0511 07:32:49.115802       1 aws_manager.go:187] Regenerating ASG information for kube5-Asg3-PTR2VK0YHXGP-Workers-W0KCGPQKD92H
I0511 07:32:49.164903       1 round_trippers.go:417] GET https://10.3.0.1:443/api/v1/pods?fieldSelector=spec.nodeName%3Dip-10-0-0-240.ap-northeast-1.compute.internal 200 OK in 3 milliseconds
I0511 07:32:49.169433       1 round_trippers.go:417] GET https://10.3.0.1:443/api/v1/pods?fieldSelector=spec.nodeName%3Dip-10-0-0-176.ap-northeast-1.compute.internal 200 OK in 2 milliseconds
I0511 07:32:49.170768       1 scale_up.go:62] Upcoming 0 nodes
I0511 07:32:49.250576       1 waste.go:57] Expanding Node Group kube5-Asg1-1EAU86YWRJGT6-Workers-5FQ8MWC9B6QG would waste 8.00% CPU, 30.21% Memory, 19.10% Blended
I0511 07:32:49.250606       1 waste.go:57] Expanding Node Group kube5-Asg3-PTR2VK0YHXGP-Workers-W0KCGPQKD92H would waste 8.00% CPU, 30.21% Memory, 19.10% Blended
I0511 07:32:49.250620       1 scale_up.go:145] Best option to resize: kube5-Asg3-PTR2VK0YHXGP-Workers-W0KCGPQKD92H
I0511 07:32:49.250628       1 scale_up.go:149] Estimated 5 nodes needed in kube5-Asg3-PTR2VK0YHXGP-Workers-W0KCGPQKD92H
```

Although this work is rough around the edges but I hope it is reviewable.
@Raffo Would you mind taking a look?
