### PR TITLE
Docker builder for cluster autoscaler

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -15,7 +15,10 @@ build: clean deps
 test-unit: clean deps build
 	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)
 
-release: build
+dev-release: build execute-release
+	echo "Release ${TAG} completed"
+
+execute-release:
 ifndef REGISTRY
 	ERR = $(error REGISTRY is undefined)
 	$(ERR)
@@ -30,4 +33,14 @@ format:
 	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -d {} + | tee /dev/stderr)" || \
     test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -w {} + | tee /dev/stderr)"
 
-.PHONY: all deps build test-unit clean format release
+docker-builder:
+	docker build -t ca-builder ./builder
+
+build-in-docker: clean docker-builder
+	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/  ca-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && make'
+
+release: build-in-docker execute-release
+	echo "Full in-docker release ${TAG} completed"
+
+.PHONY: all deps build test-unit clean format execute-release dev-release docker-builder build-in-docker release
+

--- a/cluster-autoscaler/builder/Dockerfile
+++ b/cluster-autoscaler/builder/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google-containers/ubuntu-slim:0.8
+MAINTAINER Marcin Wielgus "mwielgus@google.com"
+
+RUN apt-get update && apt-get install --yes git wget make\
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN wget https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz \
+   && tar -xvf go1.7.5.linux-amd64.tar.gz \
+   && rm go1.7.5.linux-amd64.tar.gz
+
+ENV GOROOT /go
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+RUN go version
+RUN go get github.com/tools/godep
+RUN godep version
+CMD ["/bin/bash"]


### PR DESCRIPTION
Our current build process is prone for gopath pollution and embeds homedir paths in binaries. With this PR the build will be done in a dedicated Docker container with empty gopath and correct golang binary.  

cc: @MaciekPytel @mumoshu @andrewsykim @fgrzadkowski 