### PR TITLE
Add a class to aggregate container usage samples.

### DIFF
--- a/vertical-pod-autoscaler/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregations_config.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/vertical-pod-autoscaler/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregations_config.go
@@ -16,7 +16,7 @@ package model
 import (
 	"time"
 
-	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
 
 var (

--- a/vertical-pod-autoscaler/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregations_config.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+)
+
+var (
+	// MemoryAggregationWindowLength is the length of the memory usage history
+	// aggregated by VPA, which is 8 days.
+	MemoryAggregationWindowLength = time.Hour * 8 * 24
+	// MemoryAggregationInterval is the length of a single interval, for
+	// which the peak memory usage is computed.
+	// Memory usage peaks are aggregated in daily intervals. In other words
+	// there is one memory usage sample per day (the maximum usage over that
+	// day).
+	// Note: AggregationWindowLength must be integrally divisible by this value.
+	MemoryAggregationInterval = time.Hour * 24
+)
+
+func cpuHistogramOptions() util.HistogramOptions {
+	// CPU histograms use exponential bucketing scheme with the smallest bucket
+	// size of 0.1 core, max of 1000.0 cores and the relative error of 5%.
+	options, err := util.NewExponentialHistogramOptions(1000.0, 0.1, 1.05, 0.1)
+	if err != nil {
+		panic("Invalid CPU histogram options") // Should not happen.
+	}
+	return options
+}
+
+func memoryHistogramOptions() util.HistogramOptions {
+	// Memory histograms use exponential bucketing scheme with the smallest
+	// bucket size of 10MB, max of 1TB and the relative error of 5%.
+	options, err := util.NewExponentialHistogramOptions(1e12, 1e7, 1.05, 0.1)
+	if err != nil {
+		panic("Invalid memory histogram options") // Should not happen.
+	}
+	return options
+}

--- a/vertical-pod-autoscaler/recommender/model/container.go
+++ b/vertical-pod-autoscaler/recommender/model/container.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/vertical-pod-autoscaler/recommender/model/container.go
+++ b/vertical-pod-autoscaler/recommender/model/container.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"math"
+	"time"
+
+	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+)
+
+// ContainerUsageSample is a measure of resource usage of a container over some
+// interval.
+type ContainerUsageSample struct {
+	// Start of the measurement interval.
+	measureStart time.Time
+	// Average CPU usage in cores.
+	cpuUsage float64
+	// Randomly sampled instant memory usage in bytes.
+	memoryUsage float64
+}
+
+// ContainerStats stores information about a single container instance.
+// It holds the recent history of CPU and memory utilization.
+// * CPU is stored in form of a distribution (histogram).
+//   Currently we're using fixed weight samples in the CPU histogram (i.e. old
+//   and fresh samples are equally important). Old samples are never deleted.
+//   TODO: Add exponential decaying of weights over time to address this.
+// * Memory is stored for the period of length MemoryAggregationWindowLength in
+//   the form of usage peaks, one value per MemoryAggregationInterval.
+//   For example if window legth is one week and aggregation interval is one day
+//   it will store 7 peaks, one per day, for the last week.
+//   Note: samples are added to intervals based on their start timestamps.
+type ContainerStats struct {
+	// Distribution of CPU usage. The measurement unit is 1 CPU core.
+	cpuUsage util.Histogram
+	// Memory peaks stored in the intervals belonging to the aggregation window
+	// (one value per interval). The measurement unit is a byte.
+	memoryUsagePeaks util.FloatSlidingWindow
+	// End time of the most recent interval covered by the aggregation window.
+	windowEnd time.Time
+	// Start of the latest usage sample that was aggregated.
+	lastSampleStart time.Time
+}
+
+// NewContainerStats returns a new, empty Con
+func NewContainerStats() *ContainerStats {
+	return &ContainerStats{
+		util.NewHistogram(cpuHistogramOptions()), // cpuUsage
+		util.NewFloatSlidingWindow( // memoryUsagePeaks
+			int(MemoryAggregationWindowLength / MemoryAggregationInterval)),
+		time.Unix(0, 0),
+		time.Unix(0, 0)}
+}
+
+func (sample *ContainerUsageSample) isValid() bool {
+	return sample.cpuUsage >= 0.0 && sample.memoryUsage >= 0.0
+}
+
+// AddSample adds a usage sample to the given ContainerStats. Requires samples
+// to be passed in chronological order (i.e. in order of growing measureStart).
+// Invalid samples (out of order or measure out of legal range) are discarded.
+// Returns true if the sample was aggregated, false if it was discarded.
+// Note: usage samples don't hold their end timestamp / duration. They are
+// implicitly assumed to be disjoint when aggregating.
+func (container *ContainerStats) AddSample(sample *ContainerUsageSample) bool {
+	ts := sample.measureStart
+	if !sample.isValid() || !ts.After(container.lastSampleStart) {
+		return false // Discard invalid or out-of-order samples.
+	}
+	if !ts.Before(container.windowEnd.Add(MemoryAggregationWindowLength)) {
+		// The gap between this sample and the previous interval is so
+		// large that the whole sliding window gets reset.
+		// This also happens on the first memory usage sample.
+		container.memoryUsagePeaks.Clear()
+		container.windowEnd = ts.Add(MemoryAggregationInterval)
+	} else {
+		for !ts.Before(container.windowEnd) {
+			// Shift the memory aggregation window to the next interval.
+			container.memoryUsagePeaks.Push(0.0)
+			container.windowEnd =
+				container.windowEnd.Add(MemoryAggregationInterval)
+		}
+	}
+	// Update the memory peak for the current interval.
+	if container.memoryUsagePeaks.Head() == nil {
+		// Window is empty.
+		container.memoryUsagePeaks.Push(0.0)
+	}
+	*container.memoryUsagePeaks.Head() = math.Max(
+		*container.memoryUsagePeaks.Head(), sample.memoryUsage)
+	// Update the CPU usage distribution.
+	container.cpuUsage.AddSample(sample.cpuUsage, 1.0)
+	container.lastSampleStart = ts
+	return true
+}

--- a/vertical-pod-autoscaler/recommender/model/container.go
+++ b/vertical-pod-autoscaler/recommender/model/container.go
@@ -17,7 +17,7 @@ import (
 	"math"
 	"time"
 
-	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
 
 // ContainerUsageSample is a measure of resource usage of a container over some

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+)
+
+var (
+	TimeLayout = "2006-01-02 15:04:05"
+)
+
+func newUsageSample(timestamp time.Time, cpuUsage float64, memoryUsage float64) *ContainerUsageSample {
+	return &ContainerUsageSample{timestamp, cpuUsage, memoryUsage}
+}
+
+// Add 6 usage samples (3 valid, 3 invalid) to a container. Verifies that for
+// valid samples the CPU measures are aggregated in the CPU histogram and
+// the memory measures are aggregated in the memory peaks sliding window.
+// Verifies that invalid samples (out-of-order or negative usage) are ignored.
+func TestAggregateContainerUsageSamples(t *testing.T) {
+	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
+	assert.Nil(t, err)
+	mockCPUHistogram := new(util.MockHistogram)
+	memoryUsagePeaks := util.NewFloatSlidingWindow(
+		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
+	c := &ContainerStats{
+		mockCPUHistogram,
+		memoryUsagePeaks,
+		time.Unix(0, 0),
+		time.Unix(0, 0)}
+
+	// Verify that a CPU measures are added to the CPU histogram.
+	mockCPUHistogram.On("AddSample", 3.14, 1.0)
+	mockCPUHistogram.On("AddSample", 6.28, 1.0)
+	mockCPUHistogram.On("AddSample", 1.57, 1.0)
+
+	// Add three usage samples.
+	assert.True(t, c.AddSample(newUsageSample(
+		testTimestamp, 3.14, 5.0)))
+	assert.True(t, c.AddSample(newUsageSample(
+		testTimestamp.Add(MemoryAggregationInterval/2), 6.28, 10.0)))
+	assert.True(t, c.AddSample(newUsageSample(
+		testTimestamp.Add(MemoryAggregationInterval), 1.57, 2.5)))
+
+	// Discard invalid samples.
+	assert.False(t, c.AddSample(newUsageSample( // Out of order sample.
+		testTimestamp.Add(MemoryAggregationInterval), 1.0, 1.0)))
+	assert.False(t, c.AddSample(newUsageSample( // Negative CPU usage.
+		testTimestamp.Add(MemoryAggregationInterval*2), -1.0, 1.0)))
+	assert.False(t, c.AddSample(newUsageSample( // Negative memory usage.
+		testTimestamp.Add(MemoryAggregationInterval*2), 1.0, -1.0)))
+
+	// Verify that memory peak samples were aggregated properly.
+	assert.Equal(t, []float64{10.0, 2.5}, memoryUsagePeaks.Contents())
+}

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/kubernetes/autoscaler/vertical-pod-autoscaler/recommender/util"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
 
 var (

--- a/vertical-pod-autoscaler/recommender/util/histogram_mock.go
+++ b/vertical-pod-autoscaler/recommender/util/histogram_mock.go
@@ -45,5 +45,4 @@ func (m *MockHistogram) SubtractSample(value float64, weight float64) {
 func (m *MockHistogram) IsEmpty() bool {
 	args := m.Called()
 	return args.Bool(0)
-
 }

--- a/vertical-pod-autoscaler/recommender/util/histogram_mock.go
+++ b/vertical-pod-autoscaler/recommender/util/histogram_mock.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockHistogram struct {
+	mock.Mock
+}
+
+func (m *MockHistogram) Percentile(percentile float64) float64 {
+	args := m.Called(percentile)
+	return args.Get(0).(float64)
+}
+
+func (m *MockHistogram) AddSample(value float64, weight float64) {
+	m.Called(value, weight)
+}
+
+func (m *MockHistogram) SubtractSample(value float64, weight float64) {
+	m.Called(value, weight)
+}
+
+func (m *MockHistogram) IsEmpty() bool {
+	args := m.Called()
+	return args.Bool(0)
+
+}
+

--- a/vertical-pod-autoscaler/recommender/util/histogram_mock.go
+++ b/vertical-pod-autoscaler/recommender/util/histogram_mock.go
@@ -20,26 +20,30 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockHistogram is a mock implementation of Histogram interface.
 type MockHistogram struct {
 	mock.Mock
 }
 
+// Percentile is a mock implementation of Histogram.Percentile.
 func (m *MockHistogram) Percentile(percentile float64) float64 {
 	args := m.Called(percentile)
 	return args.Get(0).(float64)
 }
 
+// AddSample is a mock implementation of Histogram.AddSample.
 func (m *MockHistogram) AddSample(value float64, weight float64) {
 	m.Called(value, weight)
 }
 
+// SubtractSample is a mock implementation of Histogram.SubtractSample.
 func (m *MockHistogram) SubtractSample(value float64, weight float64) {
 	m.Called(value, weight)
 }
 
+// IsEmpty is a mock implementation of Histogram.IsEmpty.
 func (m *MockHistogram) IsEmpty() bool {
 	args := m.Called()
 	return args.Bool(0)
 
 }
-

--- a/vertical-pod-autoscaler/recommender/util/slidingwindow.go
+++ b/vertical-pod-autoscaler/recommender/util/slidingwindow.go
@@ -33,6 +33,9 @@ type FloatSlidingWindow interface {
 	// be used to modify the last element. It is only valid until the next
 	// call to Push(). Return nil if called on an empty buffer.
 	Head() *float64
+
+	// Reset the contents of the window.
+	Clear()
 }
 
 // NewFloatSlidingWindow returns a new instance of FloatSlidingWindowImpl with a
@@ -89,3 +92,11 @@ func (b *floatSlidingWindow) Push(value float64) (bool, float64) {
 	b.buffer[b.head] = value
 	return true, prevValue
 }
+
+// Clear resets the contents of the window.
+func (b *floatSlidingWindow) Clear() {
+	b.buffer = make([]float64, 0)
+	b.head = -1
+	b.isFull = false
+}
+

--- a/vertical-pod-autoscaler/recommender/util/slidingwindow.go
+++ b/vertical-pod-autoscaler/recommender/util/slidingwindow.go
@@ -99,4 +99,3 @@ func (b *floatSlidingWindow) Clear() {
 	b.head = -1
 	b.isFull = false
 }
-


### PR DESCRIPTION
Introducing ContainerStats, a type which stores the aggregated usage history for a single container (CPU histogram + a sliding window with daily memory peaks from the last week). The history stored in this object will be populated from usage samples fetched from the real time usage data source with the AddSample() method.

The ContainerStats objects will be the main input for the Recommender to produce a recommendation for a container.