### PR TITLE
Add allowing eviction of kube-system pods with PDB

### DIFF
--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
-	api "k8s.io/kubernetes/pkg/api"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	policyv1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
@@ -39,7 +38,7 @@ func FastGetPodsToMove(nodeInfo *schedulercache.NodeInfo, skipNodesWithSystemPod
 	pdbs []*policyv1.PodDisruptionBudget) ([]*apiv1.Pod, error) {
 	pods, err := drain.GetPodsForDeletionOnNodeDrain(
 		nodeInfo.Pods(),
-		api.Codecs.UniversalDecoder(),
+		pdbs,
 		false,
 		skipNodesWithSystemPods,
 		skipNodesWithLocalStorage,
@@ -67,7 +66,7 @@ func DetailedGetPodsForMove(nodeInfo *schedulercache.NodeInfo, skipNodesWithSyst
 	pdbs []*policyv1.PodDisruptionBudget) ([]*apiv1.Pod, error) {
 	pods, err := drain.GetPodsForDeletionOnNodeDrain(
 		nodeInfo.Pods(),
-		api.Codecs.UniversalDecoder(),
+		pdbs,
 		false,
 		skipNodesWithSystemPods,
 		skipNodesWithLocalStorage,

--- a/cluster-autoscaler/simulator/nodes.go
+++ b/cluster-autoscaler/simulator/nodes.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	api "k8s.io/kubernetes/pkg/api"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	policyv1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 	kube_client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
@@ -47,7 +47,7 @@ func GetRequiredPodsForNode(nodename string, client kube_client.Interface) ([]*a
 
 	podsToRemoveList, err := drain.GetPodsForDeletionOnNodeDrain(
 		allPods,
-		api.Codecs.UniversalDecoder(),
+		[]*policyv1.PodDisruptionBudget{}, // PDBs are irrelevant when considering new node.
 		true, // Force all removals.
 		false,
 		false,


### PR DESCRIPTION
This addresses #64 on CA side by allowing it to drain nodes with kube-system pods running if these pods match a PodDistrubutionBudget with allowed-disruptions > 0.