### PR TITLE
cluster-autoscaler: Fix scale-down when the node group auto-discovery feature is enabled

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -41,6 +42,8 @@ type Autoscaler interface {
 	RunOnce(currentTime time.Time) errors.AutoscalerError
 	// CleanUp represents a clean-up required before the first invocation of RunOnce
 	CleanUp()
+	// CloudProvider returns the cloud provider associated to this autoscaler
+	CloudProvider() cloudprovider.CloudProvider
 	// ExitCleanUp is a clean-up performed just before process termination.
 	ExitCleanUp()
 }

--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -39,8 +39,6 @@ type AutoscalingContext struct {
 	AutoscalingOptions
 	// CloudProvider used in CA.
 	CloudProvider cloudprovider.CloudProvider
-	// CloudProviderBuilder is used to new CloudProvider
-	CloudProviderBuilder builder.CloudProviderBuilder
 	// ClientSet interface.
 	ClientSet kube_client.Interface
 	// ClusterState for maintaining the state of custer nodes.
@@ -134,7 +132,6 @@ func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulat
 	autoscalingContext := AutoscalingContext{
 		AutoscalingOptions:   options,
 		CloudProvider:        cloudProvider,
-		CloudProviderBuilder: cloudProviderBuilder,
 		ClusterStateRegistry: clusterStateRegistry,
 		ClientSet:            kubeClient,
 		Recorder:             kubeEventRecorder,

--- a/cluster-autoscaler/core/dynamic_autoscaler.go
+++ b/cluster-autoscaler/core/dynamic_autoscaler.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -49,6 +50,11 @@ func NewDynamicAutoscaler(autoscalerBuilder AutoscalerBuilder, configFetcher dyn
 // CleanUp does the work required before all the iterations of a dynamic autoscaler run
 func (a *DynamicAutoscaler) CleanUp() {
 	a.autoscaler.CleanUp()
+}
+
+// CloudProvider returns the cloud provider associated to this autoscaler
+func (a *DynamicAutoscaler) CloudProvider() cloudprovider.CloudProvider {
+	return a.autoscaler.CloudProvider()
 }
 
 // ExitCleanUp cleans-up after autoscaler, so no mess remains after process termination.

--- a/cluster-autoscaler/core/dynamic_autoscaler_test.go
+++ b/cluster-autoscaler/core/dynamic_autoscaler_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"github.com/stretchr/testify/mock"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"testing"
@@ -35,6 +36,11 @@ func (m *AutoscalerMock) RunOnce(currentTime time.Time) errors.AutoscalerError {
 
 func (m *AutoscalerMock) CleanUp() {
 	m.Called()
+}
+
+func (m *AutoscalerMock) CloudProvider() cloudprovider.CloudProvider {
+	args := m.Called()
+	return args.Get(0).(cloudprovider.CloudProvider)
 }
 
 func (m *AutoscalerMock) ExitCleanUp() {

--- a/cluster-autoscaler/core/polling_autoscaler_test.go
+++ b/cluster-autoscaler/core/polling_autoscaler_test.go
@@ -21,15 +21,32 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
 func TestRunOnce(t *testing.T) {
 	currentTime := time.Now()
 
+	n1 := BuildTestNode("n1", 1000, 10)
+	n2 := BuildTestNode("n2", 1000, 10)
+
+	initialCloudProvider := testprovider.NewTestCloudProvider(nil, nil)
+	initialCloudProvider.AddNodeGroup("ng1", 1, 10, 2)
+	initialCloudProvider.AddNode("ng1", n1)
+
+	newCloudProvider := testprovider.NewTestCloudProvider(nil, nil)
+	newCloudProvider.AddNodeGroup("ng1", 1, 10, 2)
+	newCloudProvider.AddNode("ng1", n1)
+	newCloudProvider.AddNodeGroup("ng2", 1, 10, 2)
+	newCloudProvider.AddNode("ng2", n2)
+
 	initialAutoscaler := &AutoscalerMock{}
+	initialAutoscaler.On("CloudProvider").Return(initialCloudProvider).Once()
 
 	newAutoscaler := &AutoscalerMock{}
 	newAutoscaler.On("RunOnce", currentTime).Once()
+	newAutoscaler.On("CloudProvider").Return(newCloudProvider).Once()
 
 	builder := &AutoscalerBuilderMock{}
 	builder.On("Build").Return(initialAutoscaler).Once()

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -21,14 +21,14 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
-
 	kube_record "k8s.io/client-go/tools/record"
 	kube_client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 
 	"github.com/golang/glog"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
 // StaticAutoscaler is an autoscaler which has all the core functionality of a CA but without the reconfiguration feature
@@ -73,6 +73,11 @@ func (a *StaticAutoscaler) CleanUp() {
 	if readyNodes, err := a.ReadyNodeLister().List(); err != nil {
 		cleanToBeDeleted(readyNodes, a.AutoscalingContext.ClientSet, a.Recorder)
 	}
+}
+
+// CloudProvider returns the cloud provider associated to this autoscaler
+func (a *StaticAutoscaler) CloudProvider() cloudprovider.CloudProvider {
+	return a.AutoscalingContext.CloudProvider
 }
 
 // RunOnce iterates over node groups and scales them up/down if necessary


### PR DESCRIPTION
By fixing CA not to reset states of `StaticAutoscaler` and `ScaleDown` before each iteration.

Resolves #85 

This is how I'm going to test it:

- [x] Build and release a CA docker image `quay.io/kube-aws/cluster-autoscaler:8b7d410fc5b9dbc9b7c707994259770f15613676`
- [x] Deploy CA with [the example yaml](https://github.com/kubernetes/autoscaler/pull/11#issuecomment-297737376)
- [x] Create a k8s deployment as a scaling target: `kubectl run php-apache --image=gcr.io/google_containers/hpa-example --requests=cpu=1000m,memory=1000M --expose --port=8`
- [x] Do a few manual tests with scaling a deployment up and down (Accordingly to [FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-should-i-test-my-code-before-submitting-pr))
  - [x] Confirm that scale-up occurs
  - [x] Confirm that scale-down occurs (Added 8b7d410 in order to fix the issue found here)
    - `kubectl scale deployment php-apache --replicas 1` and wait for the default scale-down-delay - 10 minutes
- [x] ~~Run e2e test suite on AWS, confirm it passes and all metrics have reasonable values after it's done~~
  * It turned out that e2e for CA doesn't work on AWS, probably due to e2e's inability to determine original cluster size which is required in order to reset the cluster size after each test. [Revelant log can be seen in my gist](https://gist.github.com/mumoshu/f73d2bbf45f82d732cc577524e7ca2f7)

cc @MaciekPytel 