### PR TITLE
Bump cluster autoscaler version to 0.6-alpha1

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "0.5.4"
+const ClusterAutoscalerVersion = "0.6.0-alpha1"


### PR DESCRIPTION
cc: @MaciekPytel @aleksandra-malinowska 