### PR TITLE
Status configmap fixes

### DIFF
--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -33,6 +33,7 @@ import (
 type testInfo struct {
 	client       *fake.Clientset
 	configMap    *apiv1.ConfigMap
+	namespace    string
 	getError     error
 	getCalled    bool
 	updateCalled bool
@@ -41,15 +42,17 @@ type testInfo struct {
 }
 
 func setUpTest(t *testing.T) *testInfo {
+	namespace := "kube-system"
 	result := testInfo{
 		client: &fake.Clientset{},
 		configMap: &apiv1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: StatusConfigMapNamespace,
+				Namespace: namespace,
 				Name:      StatusConfigMapName,
 			},
 			Data: map[string]string{},
 		},
+		namespace:    namespace,
 		getCalled:    false,
 		updateCalled: false,
 		createCalled: false,
@@ -57,7 +60,7 @@ func setUpTest(t *testing.T) *testInfo {
 	}
 	result.client.Fake.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
 		get := action.(core.GetAction)
-		assert.Equal(result.t, StatusConfigMapNamespace, get.GetNamespace())
+		assert.Equal(result.t, namespace, get.GetNamespace())
 		assert.Equal(result.t, StatusConfigMapName, get.GetName())
 		result.getCalled = true
 		if result.getError != nil {
@@ -67,13 +70,13 @@ func setUpTest(t *testing.T) *testInfo {
 	})
 	result.client.Fake.AddReactor("update", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
 		update := action.(core.UpdateAction)
-		assert.Equal(result.t, StatusConfigMapNamespace, update.GetNamespace())
+		assert.Equal(result.t, namespace, update.GetNamespace())
 		result.updateCalled = true
 		return true, result.configMap, nil
 	})
 	result.client.Fake.AddReactor("create", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
 		create := action.(core.CreateAction)
-		assert.Equal(result.t, StatusConfigMapNamespace, create.GetNamespace())
+		assert.Equal(result.t, namespace, create.GetNamespace())
 		configMap := create.GetObject().(*apiv1.ConfigMap)
 		assert.Equal(result.t, StatusConfigMapName, configMap.ObjectMeta.Name)
 		result.createCalled = true
@@ -84,7 +87,7 @@ func setUpTest(t *testing.T) *testInfo {
 
 func TestWriteStatusConfigMapExisting(t *testing.T) {
 	ti := setUpTest(t)
-	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	result, err := WriteStatusConfigMap(ti.client, ti.namespace, "TEST_MSG", nil)
 	assert.Equal(t, ti.configMap, result)
 	assert.Contains(t, result.Data["status"], "TEST_MSG")
 	assert.Contains(t, result.ObjectMeta.Annotations, ConfigMapLastUpdatedKey)
@@ -97,7 +100,7 @@ func TestWriteStatusConfigMapExisting(t *testing.T) {
 func TestWriteStatusConfigMapCreate(t *testing.T) {
 	ti := setUpTest(t)
 	ti.getError = kube_errors.NewNotFound(apiv1.Resource("configmap"), "nope, not found")
-	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	result, err := WriteStatusConfigMap(ti.client, ti.namespace, "TEST_MSG", nil)
 	assert.Contains(t, result.Data["status"], "TEST_MSG")
 	assert.Contains(t, result.ObjectMeta.Annotations, ConfigMapLastUpdatedKey)
 	assert.Nil(t, err)
@@ -109,7 +112,7 @@ func TestWriteStatusConfigMapCreate(t *testing.T) {
 func TestWriteStatusConfigMapError(t *testing.T) {
 	ti := setUpTest(t)
 	ti.getError = errors.New("stuff bad")
-	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	result, err := WriteStatusConfigMap(ti.client, ti.namespace, "TEST_MSG", nil)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "stuff bad")
 	assert.Nil(t, result)

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -45,9 +45,8 @@ func setUpTest(t *testing.T) *testInfo {
 		client: &fake.Clientset{},
 		configMap: &apiv1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   StatusConfigMapNamespace,
-				Name:        StatusConfigMapName,
-				Annotations: map[string]string{},
+				Namespace: StatusConfigMapNamespace,
+				Name:      StatusConfigMapName,
 			},
 			Data: map[string]string{},
 		},
@@ -112,6 +111,7 @@ func TestWriteStatusConfigMapError(t *testing.T) {
 	ti.getError = errors.New("stuff bad")
 	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
 	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "stuff bad")
 	assert.Nil(t, result)
 	assert.True(t, ti.getCalled)
 	assert.False(t, ti.updateCalled)

--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -105,6 +105,8 @@ type AutoscalingOptions struct {
 	WriteStatusConfigMap bool
 	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
 	BalanceSimilarNodeGroups bool
+	// ConfigNamespace is the namesapce cluster-autoscaler is running in and all related configmaps live in
+	ConfigNamespace string
 }
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -68,7 +68,7 @@ func TestFindUnneededNodes(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 2)
@@ -273,7 +273,7 @@ func TestScaleDown(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
@@ -331,7 +331,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	provider.AddNode("ng1", n2)
 
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
@@ -435,7 +435,7 @@ func TestScaleDownNoMove(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -80,7 +80,7 @@ func TestScaleUpOK(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, kube_record.NewFakeRecorder(5), false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -157,7 +157,7 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -222,7 +222,7 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -280,7 +280,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -329,7 +329,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
 	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, kube_record.NewFakeRecorder(5), false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -407,7 +407,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes(nodes, time.Now())
 	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, kube_record.NewFakeRecorder(5), false)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName:            estimator.BinpackingEstimatorName,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -128,6 +128,7 @@ func createAutoscalerOptions() core.AutoscalerOptions {
 		VerifyUnschedulablePods:       *verifyUnschedulablePods,
 		WriteStatusConfigMap:          *writeStatusConfigMapFlag,
 		BalanceSimilarNodeGroups:      *balanceSimilarNodeGroupsFlag,
+		ConfigNamespace:               *namespace,
 	}
 
 	configFetcherOpts := dynamic.ConfigFetcherOptions{


### PR DESCRIPTION
Ref: #106 #108 

This fixes the following issues:
- No longer discards original error when failing to read/write status configmap
- No longer panics if a configmap already exists, but has no annotations on it
- Write status configmap in namespace specified by --namespace flag