### PR TITLE
Change function duration metric to histogram

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -78,8 +78,8 @@ var (
 		}, []string{"activity"},
 	)
 
-	functionDuration = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	functionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: caNamespace,
 			Name:      "function_duration_seconds",
 			Help:      "Time taken by various parts of CA main loop.",

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -38,7 +38,7 @@ of various parts of Cluster Autoscaler loop.
 | Metric name | Metric type | Labels | Description |
 | ----------- | ----------- | ------ | ----------- |
 | last_activity | Gauge | `activity`=&lt;autoscaler-activity&gt; | Last time certain part of CA logic executed |
-| function_duration_seconds | Summary | `function`=&lt;autoscaler-function&gt; | Time taken by various parts of CA main loop. |
+| function_duration_seconds | Histogram | `function`=&lt;autoscaler-function&gt; | Time taken by various parts of CA main loop. |
 
 * `last_activity` records last time certain part of cluster autoscaler logic
 executed. Represented with unix timestamp. autoscaler-activity values are:


### PR DESCRIPTION
Many functions take an order of magnitude more time
if they actually decide to take an action (like deleting
node in scale-down) and it's ok if executing action is
slow. That makes summary less useful, as we expect to
have large outliers on some percentile, depending on
churn in cluster. Instead having a histogram gives
us the fuller picture of how the distribution of
function runtimes look like.