### PR TITLE
Strip rescheduler taint from node templates

### DIFF
--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -119,6 +119,26 @@ func TestSanitizeLabels(t *testing.T) {
 	assert.Equal(t, node.Labels[kubeletapis.LabelHostname], node.Name)
 }
 
+func TestSanitizeTaints(t *testing.T) {
+	oldNode := BuildTestNode("ng1-1", 1000, 1000)
+	taints := make([]apiv1.Taint, 0)
+	taints = append(taints, apiv1.Taint{
+		Key:    ReschedulerTaintKey,
+		Value:  "test1",
+		Effect: apiv1.TaintEffectNoSchedule,
+	})
+	taints = append(taints, apiv1.Taint{
+		Key:    "test-taint",
+		Value:  "test2",
+		Effect: apiv1.TaintEffectNoSchedule,
+	})
+	oldNode.Spec.Taints = taints
+	node, err := sanitizeTemplateNode(oldNode, "bzium")
+	assert.NoError(t, err)
+	assert.Equal(t, len(node.Spec.Taints), 1)
+	assert.Equal(t, node.Spec.Taints[0].Key, "test-taint")
+}
+
 func TestRemoveFixNodeTargetSize(t *testing.T) {
 	sizeChanges := make(chan string, 10)
 	now := time.Now()


### PR DESCRIPTION
This is a temporary taint added by rescheduler, we shouldn't assume it will be present on all nodes in node group.