### PR TITLE
add taints to GCE node template

### DIFF
--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -293,7 +293,7 @@ func sanitizeTemplateNode(node *apiv1.Node, nodeGroup string) (*apiv1.Node, erro
 	return newNode, nil
 }
 
-// Removes unregisterd nodes if needed. Returns true if anything was removed and error if such occurred.
+// Removes unregistered nodes if needed. Returns true if anything was removed and error if such occurred.
 func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNode, context *AutoscalingContext,
 	currentTime time.Time) (bool, error) {
 	removedAny := false


### PR DESCRIPTION
This addresses #168.

Tested manually in the following steps:
1. Deploy new image of CA
2. Create an empty node group with NODE_TAINTS set in kube-env
3. Taint any other nodes in the cluster
4. Create pod with tolerations matching taints of empty node group, but not those of other nodes
5. Verify CA increased this node group