### PR TITLE
Add autoscaling:DescribeLaunchConfigurations

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -17,6 +17,7 @@ A minimum IAM policy would look like:
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
@@ -37,6 +38,7 @@ If you'd like to auto-discover node groups by specifing the `--node-group-auto-d
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"


### PR DESCRIPTION
I needed to add the `autoscaling:DescribeLaunchConfigurations` action for scaling from/to 0 nodes for AWS to work.  

This is the error I was getting prior to adding this action:

```
Failed to scale up: failed to build node infos for node groups: AccessDenied: User: arn:aws:sts::[REDACTED]:assumed-role/[REDACTED]/i-09097b6eabc4f689d is not authorized to perform: autoscaling:DescribeLaunchConfigurations
```