### PR TITLE
Fixed typoes of name 'Kubernetes'

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -184,7 +184,7 @@ func (asg *Asg) MinSize() int {
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
-// number is different from the number of nodes registered in Kuberentes.
+// number is different from the number of nodes registered in Kubernetes.
 func (asg *Asg) TargetSize() (int, error) {
 	size, err := asg.awsManager.GetAsgSize(asg)
 	return int(size), err

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -132,7 +132,7 @@ func (scaleSet *ScaleSet) MaxSize() int {
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
-// number is different from the number of nodes registered in Kuberentes.
+// number is different from the number of nodes registered in Kubernetes.
 func (scaleSet *ScaleSet) TargetSize() (int, error) {
 	size, err := scaleSet.azureManager.GetScaleSetSize(scaleSet)
 	return int(size), err

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -132,7 +132,7 @@ func (mig *Mig) MinSize() int {
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
-// number is different from the number of nodes registered in Kuberentes.
+// number is different from the number of nodes registered in Kubernetes.
 func (mig *Mig) TargetSize() (int, error) {
 	size, err := mig.gceManager.GetMigSize(mig)
 	return int(size), err

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -721,7 +721,7 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() map[string]int {
 	return result
 }
 
-// Calculates which of the existing cloud provider nodes are not registered in Kuberenetes.
+// Calculates which of the existing cloud provider nodes are not registered in Kubernetes.
 func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProvider cloudprovider.CloudProvider, time time.Time) ([]UnregisteredNode, error) {
 	registered := sets.NewString()
 	for _, node := range allNodes {

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -145,7 +145,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	metrics.UpdateDuration("updateClusterState", runStart)
 	metrics.UpdateLastTime("autoscaling", time.Now())
 
-	// Check if there are any nodes that failed to register in kuberentes
+	// Check if there are any nodes that failed to register in Kubernetes
 	// master.
 	unregisteredNodes := a.ClusterStateRegistry.GetUnregisteredNodes()
 	if len(unregisteredNodes) > 0 {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -63,7 +63,7 @@ func (flag *MultiStringFlag) Set(value string) error {
 var (
 	nodeGroupsFlag          MultiStringFlag
 	address                 = flag.String("address", ":8085", "The address to expose prometheus metrics.")
-	kubernetes              = flag.String("kubernetes", "", "Kuberentes master location. Leave blank for default")
+	kubernetes              = flag.String("kubernetes", "", "Kubernetes master location. Leave blank for default")
 	cloudConfig             = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	configMapName           = flag.String("configmap", "", "The name of the ConfigMap containing settings used for dynamic reconfiguration. Empty string for no ConfigMap.")
 	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run. If a --configmap flag is also provided, ensure that the configmap exists in this namespace before CA runs.")
@@ -145,12 +145,12 @@ func createAutoscalerOptions() core.AutoscalerOptions {
 func createKubeClient() kube_client.Interface {
 	url, err := url.Parse(*kubernetes)
 	if err != nil {
-		glog.Fatalf("Failed to parse Kuberentes url: %v", err)
+		glog.Fatalf("Failed to parse Kubernetes url: %v", err)
 	}
 
 	kubeConfig, err := config.GetKubeClientConfig(url)
 	if err != nil {
-		glog.Fatalf("Failed to build Kuberentes client configuration: %v", err)
+		glog.Fatalf("Failed to build Kubernetes client configuration: %v", err)
 	}
 
 	return kube_client.NewForConfigOrDie(kubeConfig)

--- a/vertical-pod-autoscaler/updater/main.go
+++ b/vertical-pod-autoscaler/updater/main.go
@@ -60,7 +60,7 @@ func main() {
 func createKubeClient() kube_client.Interface {
 	config, err := kube_restclient.InClusterConfig()
 	if err != nil {
-		glog.Fatalf("Failed to build Kuberentes client : fail to create config: %v", err)
+		glog.Fatalf("Failed to build Kubernetes client : fail to create config: %v", err)
 	}
 	return kube_client.NewForConfigOrDie(config)
 }


### PR DESCRIPTION
Corrected 'kuberentes' -> 'Kubernetes' in some log messages and CLI help message.