### PR TITLE
fix: add . to end of entry in FAQ.md

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -316,12 +316,12 @@ Expanders can be selected by passing the name to the `--expander` flag. i.e.
 Currently Cluster Autoscaler has 4 expanders:
 
 * `random` - this is the default expander, and should be used when you don't have a particular
-need for the node groups to scale differently
+need for the node groups to scale differently.
 
 * `most-pods` - selects the node group that would be able to schedule the most pods when scaling
 up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. 
 Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can grow multiple
-smaller nodes at once
+smaller nodes at once.
 
 * `least-waste` - selects the node group that will have the least idle CPU (and if tied, unused Memory) node group
 when scaling up. This is useful when you have different classes of nodes, for example, high CPU or high Memory nodes,


### PR DESCRIPTION
I see some entry end up with ".", but some others don't. So I fix it.