### PR TITLE
Fix getEmptyNodes function in CA

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -366,7 +366,7 @@ func getEmptyNodes(candidates []*apiv1.Node, pods []*apiv1.Pod, maxEmptyBulkDele
 		}
 		var available int
 		var found bool
-		if _, found = availabilityMap[nodeGroup.Id()]; !found {
+		if available, found = availabilityMap[nodeGroup.Id()]; !found {
 			size, err := nodeGroup.TargetSize()
 			if err != nil {
 				glog.Errorf("Failed to get size for %s: %v ", nodeGroup.Id(), err)


### PR DESCRIPTION
Previously only one node could be deleted at a time.