### PR TITLE
bump container image version to 0.6.0

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -72,7 +72,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-autoscaler:v0.5.4
+        - image: gcr.io/google_containers/cluster-autoscaler:v0.6.0
           name: cluster-autoscaler
           resources:
             limits:
@@ -123,7 +123,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-autoscaler:v0.5.4
+        - image: gcr.io/google_containers/cluster-autoscaler:v0.6.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/deploy/deploy.sh
+++ b/cluster-autoscaler/deploy/deploy.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Usage:
-#   REGISTRY=<my_reg> MIG_LINK=<my_mig> [MIN=1] [MAX=4] [VERSION=v1.1] deploy.sh 
+#   REGISTRY=<my_reg> MIG_LINK=<my_mig> [MIN=1] [MAX=4] [VERSION=v0.6.0] deploy.sh
 
 set -e
 


### PR DESCRIPTION
I don't see any docs as to a release process, but ideally this process should be added to such a thing if it exists.