### PR TITLE
Use glog to replace fmt in azure cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -77,7 +77,7 @@ func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
-	glog.Infof("Searching for node group for the node: %s, %s\n", node.Spec.ExternalID, node.Spec.ProviderID)
+	glog.V(6).Infof("Searching for node group for the node: %s, %s\n", node.Spec.ExternalID, node.Spec.ProviderID)
 	ref := &AzureRef{
 		Name: node.Spec.ProviderID,
 	}
@@ -181,7 +181,7 @@ func (scaleSet *ScaleSet) DecreaseTargetSize(delta int) error {
 
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
-	glog.Infof("Check if node belongs to this scale set: scaleset:%v, node:%v\n", scaleSet, node)
+	glog.V(6).Infof("Check if node belongs to this scale set: scaleset:%v, node:%v\n", scaleSet, node)
 
 	ref := &AzureRef{
 		Name: node.Spec.ProviderID,
@@ -202,7 +202,7 @@ func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
 
 // DeleteNodes deletes the nodes from the group.
 func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
-	glog.Infof("Delete nodes requested: %v\n", nodes)
+	glog.V(8).Infof("Delete nodes requested: %v\n", nodes)
 	size, err := scaleSet.azureManager.GetScaleSetSize(scaleSet)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -75,7 +77,7 @@ func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
-	fmt.Printf("Searching for node group for the node: %s, %s\n", node.Spec.ExternalID, node.Spec.ProviderID)
+	glog.Infof("Searching for node group for the node: %s, %s\n", node.Spec.ExternalID, node.Spec.ProviderID)
 	ref := &AzureRef{
 		Name: node.Spec.ProviderID,
 	}
@@ -179,7 +181,7 @@ func (scaleSet *ScaleSet) DecreaseTargetSize(delta int) error {
 
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
-	fmt.Printf("Check if node belongs to this scale set: scaleset:%v, node:%v\n", scaleSet, node)
+	glog.Infof("Check if node belongs to this scale set: scaleset:%v, node:%v\n", scaleSet, node)
 
 	ref := &AzureRef{
 		Name: node.Spec.ProviderID,
@@ -200,7 +202,7 @@ func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
 
 // DeleteNodes deletes the nodes from the group.
 func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
-	fmt.Printf("Delete nodes requested: %v\n", nodes)
+	glog.Infof("Delete nodes requested: %v\n", nodes)
 	size, err := scaleSet.azureManager.GetScaleSetSize(scaleSet)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -225,12 +225,12 @@ func (m *AzureManager) RegisterScaleSet(scaleSet *ScaleSet) {
 
 // GetScaleSetSize gets Scale Set size.
 func (m *AzureManager) GetScaleSetSize(asConfig *ScaleSet) (int64, error) {
-	fmt.Printf("Get scale set size: %v\n", asConfig)
+	glog.Infof("Get scale set size: %v\n", asConfig)
 	set, err := m.scaleSetClient.Get(m.resourceGroupName, asConfig.Name)
 	if err != nil {
 		return -1, err
 	}
-	fmt.Printf("Returning scale set capacity: %d\n", *set.Sku.Capacity)
+	glog.Infof("Returning scale set capacity: %d\n", *set.Sku.Capacity)
 	return *set.Sku.Capacity, nil
 }
 
@@ -253,12 +253,12 @@ func (m *AzureManager) SetScaleSetSize(asConfig *ScaleSet, size int64) error {
 
 // GetScaleSetForInstance returns ScaleSetConfig of the given Instance
 func (m *AzureManager) GetScaleSetForInstance(instance *AzureRef) (*ScaleSet, error) {
-	fmt.Printf("Looking for scale set for instance: %v\n", instance)
+	glog.Infof("Looking for scale set for instance: %v\n", instance)
 	//if m.resourceGroupName == "" {
 	//	m.resourceGroupName = instance.ResourceGroup
 	//}
 
-	fmt.Printf("Cache BEFORE: %v\n", m.scaleSetCache)
+	glog.Infof("Cache BEFORE: %v\n", m.scaleSetCache)
 
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
@@ -269,7 +269,7 @@ func (m *AzureManager) GetScaleSetForInstance(instance *AzureRef) (*ScaleSet, er
 		return nil, fmt.Errorf("Error while looking for ScaleSet for instance %+v, error: %v", *instance, err)
 	}
 
-	fmt.Printf("Cache AFTER: %v\n", m.scaleSetCache)
+	glog.Infof("Cache AFTER: %v\n", m.scaleSetCache)
 
 	if config, found := m.scaleSetCache[*instance]; found {
 		return config, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -225,12 +225,12 @@ func (m *AzureManager) RegisterScaleSet(scaleSet *ScaleSet) {
 
 // GetScaleSetSize gets Scale Set size.
 func (m *AzureManager) GetScaleSetSize(asConfig *ScaleSet) (int64, error) {
-	glog.Infof("Get scale set size: %v\n", asConfig)
+	glog.V(5).Infof("Get scale set size: %v\n", asConfig)
 	set, err := m.scaleSetClient.Get(m.resourceGroupName, asConfig.Name)
 	if err != nil {
 		return -1, err
 	}
-	glog.Infof("Returning scale set capacity: %d\n", *set.Sku.Capacity)
+	glog.V(5).Infof("Returning scale set capacity: %d\n", *set.Sku.Capacity)
 	return *set.Sku.Capacity, nil
 }
 
@@ -253,12 +253,12 @@ func (m *AzureManager) SetScaleSetSize(asConfig *ScaleSet, size int64) error {
 
 // GetScaleSetForInstance returns ScaleSetConfig of the given Instance
 func (m *AzureManager) GetScaleSetForInstance(instance *AzureRef) (*ScaleSet, error) {
-	glog.Infof("Looking for scale set for instance: %v\n", instance)
+	glog.V(5).Infof("Looking for scale set for instance: %v\n", instance)
 	//if m.resourceGroupName == "" {
 	//	m.resourceGroupName = instance.ResourceGroup
 	//}
 
-	glog.Infof("Cache BEFORE: %v\n", m.scaleSetCache)
+	glog.V(8).Infof("Cache BEFORE: %v\n", m.scaleSetCache)
 
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
@@ -269,7 +269,7 @@ func (m *AzureManager) GetScaleSetForInstance(instance *AzureRef) (*ScaleSet, er
 		return nil, fmt.Errorf("Error while looking for ScaleSet for instance %+v, error: %v", *instance, err)
 	}
 
-	glog.Infof("Cache AFTER: %v\n", m.scaleSetCache)
+	glog.V(8).Infof("Cache AFTER: %v\n", m.scaleSetCache)
 
 	if config, found := m.scaleSetCache[*instance]; found {
 		return config, nil


### PR DESCRIPTION
In azure cloudprovider some log lines use fmt and others use glog.
I think this should be consistent.