### PR TITLE
Deprecate created-by annotation for pod drain, in favor of ControllerRef

### DIFF
--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -50,18 +50,18 @@ func TestDrain(t *testing.T) {
 
 	rcPod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "default",
+			Name:      "bar",
+			Namespace: "default",
 			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "core/v1",
- 					Kind:               "ReplicationController",
- 					Name:               "rc",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "core/v1",
+					Kind:               "ReplicationController",
+					Name:               "rc",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -70,21 +70,21 @@ func TestDrain(t *testing.T) {
 
 	kubeSystemRcPod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "kube-system",
+			Name:      "bar",
+			Namespace: "kube-system",
 			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
 			Labels: map[string]string{
 				"k8s-app": "bar",
 			},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "core/v1",
- 					Kind:               "ReplicationController",
- 					Name:               "rc",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "core/v1",
+					Kind:               "ReplicationController",
+					Name:               "rc",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -101,18 +101,18 @@ func TestDrain(t *testing.T) {
 
 	dsPod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "default",
+			Name:      "bar",
+			Namespace: "default",
 			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&ds)},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "DaemonSet",
- 					Name:               "ds",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "DaemonSet",
+					Name:               "ds",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -125,60 +125,60 @@ func TestDrain(t *testing.T) {
 			Namespace: "default",
 			SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/jobs/job",
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "Job",
- 					Name:               "job",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "Job",
+					Name:               "job",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 	}
 
 	jobPod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "default",
+			Name:      "bar",
+			Namespace: "default",
 			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&job)},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "Job",
- 					Name:               "job",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "Job",
+					Name:               "job",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 	}
 
 	/*	Disable stateful set test for a moment due to fake client problems with handling v1beta1 SS
 
-		statefulset := appsv1beta1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ss",
-				Namespace: "default",
-				SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/statefulsets/ss",
-			},
-		}
+			statefulset := appsv1beta1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ss",
+					Namespace: "default",
+					SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/statefulsets/ss",
+				},
+			}
 
-		ssPod := &apiv1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "bar",
-				Namespace:   "default",
-				Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&statefulset)},
-				OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "StatefulSet",
- 					Name:               "ss",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
-			},
-		}
+			ssPod := &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "bar",
+					Namespace:   "default",
+					Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&statefulset)},
+					OwnerReferences: []metav1.OwnerReference{
+	 				{
+	 					APIVersion:         "extensions/v1beta1",
+	 					Kind:               "StatefulSet",
+	 					Name:               "ss",
+	 					BlockOwnerDeletion: boolptr(true),
+	 					Controller:         boolptr(true),
+	 				},
+	 			},
+				},
+			}
 	*/
 	rs := extensions.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -193,18 +193,18 @@ func TestDrain(t *testing.T) {
 
 	rsPod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "default",
+			Name:      "bar",
+			Namespace: "default",
 			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "ReplicaSet",
- 					Name:               "rs",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "ReplicaSet",
+					Name:               "rs",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -213,19 +213,19 @@ func TestDrain(t *testing.T) {
 
 	rsPodDeleted := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "bar",
-			Namespace:         "default",
+			Name:      "bar",
+			Namespace: "default",
 			//Annotations:       map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
 			DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)},
 			OwnerReferences: []metav1.OwnerReference{
- 				{
- 					APIVersion:         "extensions/v1beta1",
- 					Kind:               "ReplicaSet",
- 					Name:               "rs",
- 					BlockOwnerDeletion: boolptr(true),
- 					Controller:         boolptr(true),
- 				},
- 			},
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "ReplicaSet",
+					Name:               "rs",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -155,30 +155,30 @@ func TestDrain(t *testing.T) {
 
 	/*	Disable stateful set test for a moment due to fake client problems with handling v1beta1 SS
 
-			statefulset := appsv1beta1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ss",
-					Namespace: "default",
-					SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/statefulsets/ss",
-				},
-			}
+				statefulset := appsv1beta1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ss",
+						Namespace: "default",
+						SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/statefulsets/ss",
+					},
+				}
 
-			ssPod := &apiv1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "bar",
-					Namespace:   "default",
-					Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&statefulset)},
-					OwnerReferences: []metav1.OwnerReference{
-	 				{
-	 					APIVersion:         "extensions/v1beta1",
-	 					Kind:               "StatefulSet",
-	 					Name:               "ss",
-	 					BlockOwnerDeletion: boolptr(true),
-	 					Controller:         boolptr(true),
-	 				},
-	 			},
-				},
-			}
+				ssPod := &apiv1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "bar",
+						Namespace:   "default",
+						Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&statefulset)},
+						OwnerReferences: []metav1.OwnerReference{
+		 				{
+		 					APIVersion:         "extensions/v1beta1",
+		 					Kind:               "StatefulSet",
+		 					Name:               "ss",
+		 					BlockOwnerDeletion: boolptr(true),
+		 					Controller:         boolptr(true),
+		 				},
+		 			},
+					},
+				}
 	*/
 	rs := extensions.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -52,7 +52,16 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "bar",
 			Namespace:   "default",
-			Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
+			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "core/v1",
+ 					Kind:               "ReplicationController",
+ 					Name:               "rc",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -63,10 +72,19 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "bar",
 			Namespace:   "kube-system",
-			Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
+			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rc)},
 			Labels: map[string]string{
 				"k8s-app": "bar",
 			},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "core/v1",
+ 					Kind:               "ReplicationController",
+ 					Name:               "rc",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -85,7 +103,16 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "bar",
 			Namespace:   "default",
-			Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&ds)},
+			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&ds)},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "DaemonSet",
+ 					Name:               "ds",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -97,6 +124,15 @@ func TestDrain(t *testing.T) {
 			Name:      "job",
 			Namespace: "default",
 			SelfLink:  "/apiv1s/extensions/v1beta1/namespaces/default/jobs/job",
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "Job",
+ 					Name:               "job",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 	}
 
@@ -104,7 +140,16 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "bar",
 			Namespace:   "default",
-			Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&job)},
+			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&job)},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "Job",
+ 					Name:               "job",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 	}
 
@@ -123,6 +168,15 @@ func TestDrain(t *testing.T) {
 				Name:        "bar",
 				Namespace:   "default",
 				Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&statefulset)},
+				OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "StatefulSet",
+ 					Name:               "ss",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 			},
 		}
 	*/
@@ -141,7 +195,16 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "bar",
 			Namespace:   "default",
-			Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
+			//Annotations: map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "ReplicaSet",
+ 					Name:               "rs",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -152,8 +215,17 @@ func TestDrain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "bar",
 			Namespace:         "default",
-			Annotations:       map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
+			//Annotations:       map[string]string{apiv1.CreatedByAnnotation: RefJSON(&rs)},
 			DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+ 				{
+ 					APIVersion:         "extensions/v1beta1",
+ 					Kind:               "ReplicaSet",
+ 					Name:               "rs",
+ 					BlockOwnerDeletion: boolptr(true),
+ 					Controller:         boolptr(true),
+ 				},
+ 			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",

--- a/vertical-pod-autoscaler/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/updater/eviction/pods_eviction_restriction.go
@@ -38,9 +38,9 @@ type PodsEvictionRestriction interface {
 }
 
 type podsEvictionRestrictionImpl struct {
-	client         kube_client.Interface
-	podsControllers   map[string]podReplicaController
-	evictionBudget map[podReplicaController]int
+	client          kube_client.Interface
+	podsControllers map[string]podReplicaController
+	evictionBudget  map[podReplicaController]int
 }
 
 // PodsEvictionRestrictionFactory creates PodsEvictionRestriction

--- a/vertical-pod-autoscaler/updater/test/test_utils.go
+++ b/vertical-pod-autoscaler/updater/test/test_utils.go
@@ -45,9 +45,9 @@ func BuildTestPod(name, containerName, cpu, mem string, creator runtime.Object) 
 		},
 	}
 	/*
-	if creator != nil {
-		pod.ObjectMeta.Annotations = map[string]string{apiv1.CreatedByAnnotation: RefJSON(creator)}
-	}
+		if creator != nil {
+			pod.ObjectMeta.Annotations = map[string]string{apiv1.CreatedByAnnotation: RefJSON(creator)}
+		}
 	*/
 	if len(cpu) > 0 {
 		cpuVal, _ := resource.ParseQuantity(cpu)

--- a/vertical-pod-autoscaler/updater/test/test_utils.go
+++ b/vertical-pod-autoscaler/updater/test/test_utils.go
@@ -44,11 +44,11 @@ func BuildTestPod(name, containerName, cpu, mem string, creator runtime.Object) 
 			Containers: []apiv1.Container{BuildTestContainer(containerName, cpu, mem)},
 		},
 	}
-
+	/*
 	if creator != nil {
 		pod.ObjectMeta.Annotations = map[string]string{apiv1.CreatedByAnnotation: RefJSON(creator)}
 	}
-
+	*/
 	if len(cpu) > 0 {
 		cpuVal, _ := resource.ParseQuantity(cpu)
 		pod.Spec.Containers[0].Resources.Requests[apiv1.ResourceCPU] = cpuVal


### PR DESCRIPTION
Addressing https://github.com/kubernetes/autoscaler/issues/220