### PR TITLE
Split kubemark cloud provider implementation to linux and non-linux

### DIFF
--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +build linux
+
+// Version to be compiled in the linux environment. May cause compilation issues on
+// other OS.
+
+package kubemark
+
+import (
+	// Placeholder
+	_ "k8s.io/kubernetes/pkg/kubemark"
+	// Placeholder
+	_ "k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -14,11 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubemark
+// +build !linux
 
-import (
-	// Placeholder
-	_ "k8s.io/kubernetes/pkg/kubemark"
-	// Placeholder
-	_ "k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
-)
+// Dummy implementation. Real one should be build on linux.
+
+package kubemark


### PR DESCRIPTION
Kubemark cloud provider dependencies require some constants that are only available on linux, forcing to compile CA using docker even for development. As docker compilation on macos is much much longer and cpu-intensive this PR splits kubemark implementation to 2 files - one with the real implementation that is used on linux and one with fake/mock that is used everywhere else. 