### PR TITLE
Dont block scale downs if no nodes can be removed

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -294,7 +294,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 				glog.Errorf("Failed to scale down: %v", err)
 				return typedErr
 			}
-			if result == ScaleDownError || result == ScaleDownNoNodeDeleted {
+			if result == ScaleDownError {
 				a.lastScaleDownFailedTrial = time.Now()
 			}
 		}


### PR DESCRIPTION
#261 puts "on hold" unremovable nodes.