### PR TITLE
Skip nodes in min-sized groups in scale-down simulation

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -119,7 +119,7 @@ func (sd *ScaleDown) CleanUpUnneededNodes() {
 // managed by CA.
 func (sd *ScaleDown) UpdateUnneededNodes(
 	nodes []*apiv1.Node,
-	managedNodes []*apiv1.Node,
+	nodesToCheck []*apiv1.Node,
 	pods []*apiv1.Pod,
 	timestamp time.Time,
 	pdbs []*policyv1.PodDisruptionBudget) errors.AutoscalerError {
@@ -129,24 +129,24 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	utilizationMap := make(map[string]float64)
 
 	// Filter out nodes that were recently checked
-	nodesToCheck := make([]*apiv1.Node, 0)
-	for _, node := range managedNodes {
+	filteredNodesToCheck := make([]*apiv1.Node, 0)
+	for _, node := range nodesToCheck {
 		if unremovableTimestamp, found := sd.unremovableNodes[node.Name]; found {
 			if unremovableTimestamp.After(timestamp) {
 				continue
 			}
 			delete(sd.unremovableNodes, node.Name)
 		}
-		nodesToCheck = append(nodesToCheck, node)
+		filteredNodesToCheck = append(filteredNodesToCheck, node)
 	}
-	skipped := len(managedNodes) - len(nodesToCheck)
+	skipped := len(nodesToCheck) - len(filteredNodesToCheck)
 	if skipped > 0 {
 		glog.V(1).Infof("Scale-down calculation: ignoring %v nodes, that were unremovable in the last %v", skipped, UnremovableNodeRecheckTimeout)
 	}
 
 	// Phase1 - look at the nodes utilization. Calculate the utilization
 	// only for the managed nodes.
-	for _, node := range nodesToCheck {
+	for _, node := range filteredNodesToCheck {
 
 		// Skip nodes marked to be deleted, if they were marked recently.
 		// Old-time marked nodes are again eligible for deletion - something went wrong with them

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -265,9 +265,9 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		glog.V(4).Infof("Calculating unneeded nodes")
 
 		scaleDown.CleanUp(time.Now())
-		managedNodes := getManagedNodes(autoscalingContext, allNodes)
+		potentiallyUnneeded := getPotentiallyUnneededNodes(autoscalingContext, allNodes)
 
-		typedErr := scaleDown.UpdateUnneededNodes(allNodes, managedNodes, allScheduled, time.Now(), pdbs)
+		typedErr := scaleDown.UpdateUnneededNodes(allNodes, potentiallyUnneeded, allScheduled, time.Now(), pdbs)
 		if typedErr != nil {
 			glog.Errorf("Failed to scale down: %v", typedErr)
 			return typedErr


### PR DESCRIPTION
Currently we track if those nodes can be removed and only
skip them at the execution step. Since checking if node is
unneeded is pretty expensive it's better to filter them out
early.