### PR TITLE
Check ASG name list not empty

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -75,6 +75,11 @@ func (m autoScalingWrapper) getAutoscalingGroupByName(name string) (*autoscaling
 func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*autoscaling.Group, error) {
 	glog.V(6).Infof("Starting getAutoscalingGroupsByNames with names=%v", names)
 
+	if len(names) < 1 {
+		glog.V(4).Info("Failed to describe ASGs: Must specify at least one ASG name.")
+		return nil, fmt.Errorf("List of ASG names was empty. Must specify at least one ASG name")
+	}
+
 	nameRefs := []*string{}
 	for _, n := range names {
 		nameRefs = append(nameRefs, aws.String(n))


### PR DESCRIPTION
Fixes #278 

I have built and tested this on one of our clusters. 

If no autoscaling group matches both tags, the autoscaler exits and is restarted by kubernetes.

As soon as one ASG matches both tags, CA will stay up and run as designed. If this group is then removed (by changing the tags as described in the issue), then CA will also exit and get into a restart loop as above.

I considered returning an empty list of ASGs, but I believe this isn't the correct approach. If you return an empty list of ASGs then CA will continue through it's working process and only when it gets to the point where it wants to scale up or scale down will it fail. I feel users would prefer to know CA can't do anything earlier than this.

I also considered the fact that maybe CA should just emit a message and keep running and keep trying to build the cloudprovider on an interval so that it doesn't constantly restart the container (given it's run as a deployment, it will be in constant crash loops), but this requires discussion and is beyond the scope of this PR.