### PR TITLE
Do not return error from exist

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -204,8 +204,8 @@ func (asg *Asg) TargetSize() (int, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (asg *Asg) Exist() (bool, error) {
-	return true, nil
+func (asg *Asg) Exist() bool {
+	return true
 }
 
 // Create creates the node group on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -110,7 +110,7 @@ type NodeGroup interface {
 
 	// Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 	// theoretical node group from the real one. Implementation required.
-	Exist() (bool, error)
+	Exist() bool
 
 	// Create creates the node group on the cloud provider side. Implementation optional.
 	Create() error

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -316,8 +316,8 @@ func (mig *Mig) Nodes() ([]string, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (mig *Mig) Exist() (bool, error) {
-	return mig.exist, nil
+func (mig *Mig) Exist() bool {
+	return mig.exist
 }
 
 // Create creates the node group on the cloud provider side.
@@ -344,13 +344,8 @@ func (mig *Mig) Autoprovisioned() bool {
 
 // TemplateNodeInfo returns a node template for this node group.
 func (mig *Mig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
-
 	var node *apiv1.Node
-	exists, err := mig.Exist()
-	if err != nil {
-		return nil, err
-	}
-	if exists {
+	if mig.Exist() {
 		template, err := mig.gceManager.templates.getMigTemplate(mig)
 		if err != nil {
 			return nil, err

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -225,8 +225,8 @@ func (nodeGroup *NodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error)
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
-func (nodeGroup *NodeGroup) Exist() (bool, error) {
-	return true, nil
+func (nodeGroup *NodeGroup) Exist() bool {
+	return true
 }
 
 // Create creates the node group on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -175,8 +175,8 @@ func (tng *TestNodeGroup) IncreaseSize(delta int) error {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (tng *TestNodeGroup) Exist() (bool, error) {
-	return true, nil
+func (tng *TestNodeGroup) Exist() bool {
+	return true
 }
 
 // Create creates the node group on the cloud provider side.

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -182,7 +182,7 @@ func ScaleUp(context *AutoscalingContext, unschedulablePods []*apiv1.Pod, nodes 
 			}
 		}
 		if context.AutoscalingOptions.NodeAutoprovisioningEnabled {
-			if exist, err := bestOption.NodeGroup.Exist(); err == nil && !exist {
+			if !bestOption.NodeGroup.Exist() {
 				err := bestOption.NodeGroup.Create()
 				if err != nil {
 					return false, errors.ToAutoscalerError(errors.CloudProviderError, err)

--- a/cluster-autoscaler/expander/price/price.go
+++ b/cluster-autoscaler/expander/price/price.go
@@ -125,7 +125,7 @@ nextoption:
 
 		optionScore := supressedUnfitness * priceSubScore
 
-		if exist, err := option.NodeGroup.Exist(); err != nil && !exist {
+		if !option.NodeGroup.Exist() {
 			optionScore *= notExistCoeficient
 		}
 

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -46,7 +46,7 @@ func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{},
 func (f *FakeNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
-func (f *FakeNodeGroup) Exist() (bool, error)  { return true, nil }
+func (f *FakeNodeGroup) Exist() bool           { return true }
 func (f *FakeNodeGroup) Create() error         { return cloudprovider.ErrAlreadyExist }
 func (f *FakeNodeGroup) Delete() error         { return cloudprovider.ErrNotImplemented }
 func (f *FakeNodeGroup) Autoprovisioned() bool { return false }


### PR DESCRIPTION
We should not invoke any remote calls for exist. Node groups are not expected to go away. This function is to check whether the group has been created or not, not to do a health-check ping.
Following the pattern as we have in func autoprovisioned().