### PR TITLE
Allow testing against GCE without running on GCE

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -76,7 +76,7 @@ func (b CloudProviderBuilder) Build(discoveryOpts cloudprovider.NodeGroupDiscove
 			gceManager, gceError = gce.CreateGceManager(nil, mode, b.clusterName)
 		}
 		if gceError != nil {
-			glog.Fatalf("Failed to create GCE Manager: %v", err)
+			glog.Fatalf("Failed to create GCE Manager: %v", gceError)
 		}
 		cloudProvider, err = gce.BuildGceCloudProvider(gceManager, nodeGroupsFlag)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -235,7 +235,7 @@ func (mig *Mig) IncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 func (mig *Mig) DecreaseTargetSize(delta int) error {
 	if delta >= 0 {
-		return fmt.Errorf("size decrease must be netative")
+		return fmt.Errorf("size decrease must be negative")
 	}
 	size, err := mig.gceManager.GetMigSize(mig)
 	if err != nil {


### PR DESCRIPTION
Fixes issues hit while trying to test the autoscaler outside of a GCE cluster.

On the node template check, we warn, but I'm wondering whether we should fail harder. If the template can't be loaded is that a permanent blocker to autoscaling, or does it just make estimation less efficient?