### PR TITLE
DO NOT MERGE - Example of unmanaged instance group autoscale

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -90,7 +90,7 @@ func CreateGceManager(configReader io.Reader, mode GcpCloudProviderMode, cluster
 	var err error
 	tokenSource := google.ComputeTokenSource("")
 	if len(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")) > 0 {
-		tokenSource, err = google.DefaultTokenSource(oauth2.NoContext, gce.ComputeScope)
+		tokenSource, err = google.DefaultTokenSource(oauth2.NoContext, defaultOAuthScopes...)
 		if err != nil {
 			return nil, err
 		}
@@ -343,6 +343,9 @@ func (m *GceManager) createNodePool(mig *Mig) error {
 
 // GetMigSize gets MIG size.
 func (m *GceManager) GetMigSize(mig *Mig) (int64, error) {
+	if mig.unmanaged {
+		return m.GetMigInstanceSize(mig)
+	}
 	igm, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
 	if err != nil {
 		return -1, err
@@ -353,6 +356,9 @@ func (m *GceManager) GetMigSize(mig *Mig) (int64, error) {
 // SetMigSize sets MIG size.
 func (m *GceManager) SetMigSize(mig *Mig, size int64) error {
 	glog.V(0).Infof("Setting mig size %s to %d", mig.Id(), size)
+	if mig.unmanaged {
+		return m.SetMigInstanceSize(mig, size)
+	}
 	op, err := m.gceService.InstanceGroupManagers.Resize(mig.Project, mig.Zone, mig.Name, size).Do()
 	if err != nil {
 		return err
@@ -462,10 +468,26 @@ func (m *GceManager) GetMigForInstance(instance *GceRef) (*Mig, error) {
 		return mig, nil
 	}
 
+	refreshedUnmanaged := false
 	for _, mig := range m.getMigs() {
-		if mig.config.Project == instance.Project &&
-			mig.config.Zone == instance.Zone &&
-			strings.HasPrefix(instance.Name, mig.basename) {
+		if mig.config.Project != instance.Project || mig.config.Zone != instance.Zone {
+			continue
+		}
+		// refresh the cache exactly once in case this instance is new, otherwise ignore
+		if mig.config.unmanaged {
+			if !refreshedUnmanaged {
+				refreshedUnmanaged = true
+				if err := m.regenerateCache(); err != nil {
+					return nil, fmt.Errorf("Error while looking for MIG for instance %+v, error: %v", *instance, err)
+				}
+				if mig, found := m.migCache[*instance]; found {
+					return mig, nil
+				}
+			}
+			// we cannot depend on basename
+			continue
+		}
+		if strings.HasPrefix(instance.Name, mig.basename) {
 			if err := m.regenerateCache(); err != nil {
 				return nil, fmt.Errorf("Error while looking for MIG for instance %+v, error: %v", *instance, err)
 			}
@@ -486,23 +508,38 @@ func (m *GceManager) regenerateCache() error {
 		mig := migInfo.config
 		glog.V(4).Infof("Regenerating MIG information for %s %s %s", mig.Project, mig.Zone, mig.Name)
 
-		instanceGroupManager, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
-		if err != nil {
-			return err
-		}
-		m.updateMigBasename(migInfo.config.GceRef, instanceGroupManager.BaseInstanceName)
-
-		instances, err := m.gceService.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
-		if err != nil {
-			glog.V(4).Infof("Failed MIG info request for %s %s %s: %v", mig.Project, mig.Zone, mig.Name, err)
-			return err
-		}
-		for _, instance := range instances.ManagedInstances {
-			project, zone, name, err := ParseInstanceUrl(instance.Instance)
+		if mig.unmanaged {
+			instances, running, _, err := m.ListInstances(mig)
 			if err != nil {
 				return err
 			}
-			newMigCache[GceRef{Project: project, Zone: zone, Name: name}] = mig
+			glog.V(4).Infof("Found %d/%d running instances for group %s", len(running), len(instances), mig.Name)
+			for _, instance := range instances {
+				project, zone, name, err := ParseInstanceUrl(instance)
+				if err != nil {
+					return err
+				}
+				newMigCache[GceRef{Project: project, Zone: zone, Name: name}] = mig
+			}
+		} else {
+			instanceGroupManager, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
+			if err != nil {
+				return err
+			}
+			m.updateMigBasename(migInfo.config.GceRef, instanceGroupManager.BaseInstanceName)
+
+			instances, err := m.gceService.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
+			if err != nil {
+				glog.V(4).Infof("Failed MIG info request for %s %s %s: %v", mig.Project, mig.Zone, mig.Name, err)
+				return err
+			}
+			for _, instance := range instances.ManagedInstances {
+				project, zone, name, err := ParseInstanceUrl(instance.Instance)
+				if err != nil {
+					return err
+				}
+				newMigCache[GceRef{Project: project, Zone: zone, Name: name}] = mig
+			}
 		}
 	}
 
@@ -512,6 +549,22 @@ func (m *GceManager) regenerateCache() error {
 
 // GetMigNodes returns mig nodes.
 func (m *GceManager) GetMigNodes(mig *Mig) ([]string, error) {
+	if mig.unmanaged {
+		_, running, _, err := m.ListInstances(mig)
+		if err != nil {
+			return nil, err
+		}
+		result := make([]string, 0)
+		for _, instance := range running {
+			project, zone, name, err := ParseInstanceUrl(instance)
+			if err != nil {
+				return []string{}, err
+			}
+			result = append(result, fmt.Sprintf("gce://%s/%s/%s", project, zone, name))
+		}
+		return result, nil
+	}
+
 	instances, err := m.gceService.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
 	if err != nil {
 		return []string{}, err

--- a/cluster-autoscaler/cloudprovider/gce/gce_unmanaged.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_unmanaged.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/golang/glog"
+	gce "google.golang.org/api/compute/v1"
+)
+
+const (
+	// maxPages prevents bugs from causing infinitely looping
+	maxPages = 25
+
+	startOperationTimeout  = 1 * time.Minute
+	startOperationInterval = 1 * time.Second
+	stopOperationTimeout   = 1 * time.Minute
+	stopOperationInterval  = 1 * time.Second
+)
+
+func (m *GceManager) ListInstances(mig *Mig) (all, running, stopping []string, err error) {
+	names := make(map[string]struct{})
+	pageToken := ""
+	page := 0
+	for ; page == 0 || (pageToken != "" && page < maxPages); page++ {
+		opts := &gce.InstanceGroupsListInstancesRequest{}
+		listCall := m.gceService.InstanceGroups.ListInstances(mig.Project, mig.Zone, mig.Name, opts)
+		if pageToken != "" {
+			listCall.PageToken(pageToken)
+		}
+		res, err := listCall.Do()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		pageToken = res.NextPageToken
+		for _, i := range res.Items {
+			name := i.Instance
+			if _, ok := names[name]; ok {
+				continue
+			}
+			all = append(all, name)
+			names[name] = struct{}{}
+
+			switch i.Status {
+			case "STOPPING":
+				stopping = append(stopping, name)
+			case "RUNNING":
+				running = append(running, name)
+			}
+		}
+		if page >= maxPages {
+			sort.Strings(all)
+			sort.Strings(stopping)
+			sort.Strings(running)
+			return all, running, stopping, fmt.Errorf("received too many pages of results for managed instance group %v", mig)
+		}
+	}
+	sort.Strings(all)
+	sort.Strings(stopping)
+	sort.Strings(running)
+	return all, running, stopping, nil
+}
+
+func (m *GceManager) GetMigInstanceSize(mig *Mig) (int64, error) {
+	_, running, stopping, err := m.ListInstances(mig)
+	if err != nil {
+		return -1, err
+	}
+	return int64(len(running) - len(stopping)), nil
+}
+
+type zonedOp struct {
+	op   *gce.Operation
+	zone string
+}
+
+func (m *GceManager) SetMigInstanceSize(mig *Mig, size int64) error {
+	all, running, _, err := m.ListInstances(mig)
+	if err != nil {
+		return err
+	}
+	needed := size - int64(len(running))
+	free := make(map[string]struct{})
+	for _, instance := range all {
+		free[instance] = struct{}{}
+	}
+	for _, instance := range running {
+		delete(free, instance)
+	}
+
+	var ops []zonedOp
+	var errs []error
+
+	for instance := range free {
+		if needed <= 0 {
+			break
+		}
+		needed--
+		project, zone, name, err := ParseInstanceUrl(instance)
+		if err != nil {
+			return err
+		}
+		glog.V(3).Infof("Starting unmanaged instance %s in project %s and zone %s to match scale goals", name, project, zone)
+		op, err := m.gceService.Instances.Start(project, zone, name).Do()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		ops = append(ops, zonedOp{op: op, zone: zone})
+	}
+
+	for _, op := range ops {
+		if err := m.waitForOpTimeout(op.op, mig.Project, op.zone, startOperationTimeout, startOperationInterval); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	if needed > 0 {
+		return fmt.Errorf("not enough instances available to reach %d, %d/%d are running", size, len(running), len(all))
+	}
+	return nil
+}
+
+// StopInstances stops the given instances. All instances must be controlled by the same instance group.
+func (m *GceManager) StopInstances(instances []*GceRef) error {
+	if len(instances) == 0 {
+		return nil
+	}
+	commonMig, err := m.GetMigForInstance(instances[0])
+	if err != nil {
+		return err
+	}
+	for _, instance := range instances {
+		mig, err := m.GetMigForInstance(instance)
+		if err != nil {
+			return err
+		}
+		if mig != commonMig {
+			return fmt.Errorf("Cannot stop instances which don't belong to the same MIG.")
+		}
+	}
+
+	var ops []*gce.Operation
+	var errs []error
+	for _, instance := range instances {
+		op, err := m.gceService.Instances.Stop(instance.Project, instance.Zone, instance.Name).Do()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		ops = append(ops, op)
+	}
+
+	for _, op := range ops {
+		if err := m.waitForOpTimeout(op, commonMig.Project, commonMig.Zone, stopOperationTimeout, stopOperationInterval); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	return nil
+}
+
+// GCE
+func (m *GceManager) waitForOpTimeout(operation *gce.Operation, project string, zone string, timeout, interval time.Duration) error {
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		glog.V(4).Infof("Waiting for operation %s %s %s", project, zone, operation.Name)
+		if op, err := m.gceService.ZoneOperations.Get(project, zone, operation.Name).Do(); err == nil {
+			glog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
+			if op.Status == "DONE" {
+				return nil
+			}
+		} else {
+			glog.Warningf("Error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
+		}
+	}
+	return fmt.Errorf("Timeout while waiting for operation %s on %s to complete.", operation.Name, operation.TargetLink)
+}

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -59,6 +59,8 @@ const (
 	ScaleDownNodeDeleteStarted ScaleDownResult = iota
 	// ScaleDownDisabledKey is the name of annotation marking node as not eligible for scale down.
 	ScaleDownDisabledKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+	// ScaleDownWhenUnreadyDisabledKey is the name of annotation marking node as not eligible for scale down when unready.
+	ScaleDownWhenUnreadyDisabledKey = "cluster-autoscaler.kubernetes.io/scale-down-when-unready-disabled"
 )
 
 const (
@@ -173,6 +175,11 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	// Phase1 - look at the nodes utilization. Calculate the utilization
 	// only for the managed nodes.
 	for _, node := range filteredNodesToCheck {
+		// Skip nodes that do not expect to be deleted, just stopped
+		if hasNoScaleDownWhenDeletedAnnotation(node) {
+			glog.V(4).Infof("Skipping %s from delete considerations - the node is marked as being down when deleted and unready", node.Name)
+			continue
+		}
 
 		// Skip nodes marked to be deleted, if they were marked recently.
 		// Old-time marked nodes are again eligible for deletion - something went wrong with them
@@ -720,6 +727,17 @@ func deleteNodeFromCloudProvider(node *apiv1.Node, cloudProvider cloudprovider.C
 
 func hasNoScaleDownAnnotation(node *apiv1.Node) bool {
 	return node.Annotations[ScaleDownDisabledKey] == "true"
+}
+
+func hasNoScaleDownWhenDeletedAnnotation(node *apiv1.Node) bool {
+	if !deletetaint.HasToBeDeletedTaint(node) {
+		return false
+	}
+	ready, _, _ := kube_util.GetReadinessState(node)
+	if ready {
+		return false
+	}
+	return node.Annotations[ScaleDownWhenUnreadyDisabledKey] == "true"
 }
 
 func cleanUpNodeAutoprovisionedGroups(cloudProvider cloudprovider.CloudProvider) error {

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -186,6 +186,7 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.Clou
 		return false, nil
 	}
 
+	var lastErr errors.AutoscalerError
 	for _, node := range nodes {
 		// Broken nodes might have some stuff missing. Skipping.
 		if !kube_util.IsNodeReadyAndSchedulable(node) {
@@ -193,9 +194,11 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.Clou
 		}
 		_, typedErr := processNode(node)
 		if typedErr != nil {
-			return map[string]*schedulercache.NodeInfo{}, typedErr
+			lastErr = typedErr
+			continue
 		}
 	}
+
 	for _, nodeGroup := range cloudProvider.NodeGroups() {
 		id := nodeGroup.Id()
 		if _, found := result[id]; found {
@@ -242,6 +245,10 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.Clou
 				glog.Warningf("Built template for %s based on unready/unschedulable node %s", nodeGroup.Id(), node.Name)
 			}
 		}
+	}
+
+	if len(result) == 0 && lastErr != nil {
+		return map[string]*schedulercache.NodeInfo{}, lastErr
 	}
 
 	return result, nil


### PR DESCRIPTION
As discussed on the SIG meeting, this fleshes out the concept of unmanaged instance group scaling vs managed instance group scaling. I did not fork the GCE cloud provider because the vast majority of the code is the same, but a few small refactors would make it easy to separate the cloud provider scale behavior from other logic.

Some things it doesn't do

* doesn't get a node template, has no concept of node name prefix (that's fairly easy)
* may perform worse because it gets the instance group list instead of simply reading the MIG scale

Worked pretty well in light testing.