### PR TITLE
Move regexp.MustCompile in AWS provider to global variable

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -162,11 +162,12 @@ type AwsRef struct {
 	Name string
 }
 
+var validAwsRefIdRegex = regexp.MustCompile(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*$`)
+
 // AwsRefFromProviderId creates InstanceConfig object from provider id which
 // must be in format: aws:///zone/name
 func AwsRefFromProviderId(id string) (*AwsRef, error) {
-	validIdRegex := regexp.MustCompile(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*$`)
-	if validIdRegex.FindStringSubmatch(id) == nil {
+	if validAwsRefIdRegex.FindStringSubmatch(id) == nil {
 		return nil, fmt.Errorf("Wrong id: expected format aws:///<zone>/<name>, got %v", id)
 	}
 	splitted := strings.Split(id[7:], "/")


### PR DESCRIPTION
Function AwsRefFromProviderId call many times. If scale down enable this call default every 10 seconds per each node.
regexp.MustCompile it very heavy function and not need call each time