### PR TITLE
Small optimize code and fix typos

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -146,8 +146,8 @@ func (aws *awsCloudProvider) Pricing() (cloudprovider.PricingModel, errors.Autos
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-// GetAvilableMachineTypes get all machine types that can be requested from the cloud provider.
-func (aws *awsCloudProvider) GetAvilableMachineTypes() ([]string, error) {
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
+func (aws *awsCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return []string{}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -43,9 +43,9 @@ type CloudProvider interface {
 	// Implementation optional.
 	Pricing() (PricingModel, errors.AutoscalerError)
 
-	// GetAvilableMachineTypes get all machine types that can be requested from the cloud provider.
+	// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 	// Implementation optional.
-	GetAvilableMachineTypes() ([]string, error)
+	GetAvailableMachineTypes() ([]string, error)
 
 	// NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 	// created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -121,8 +121,8 @@ func (gce *GceCloudProvider) Pricing() (cloudprovider.PricingModel, errors.Autos
 	return &GcePriceModel{}, nil
 }
 
-// GetAvilableMachineTypes get all machine types that can be requested from the cloud provider.
-func (gce *GceCloudProvider) GetAvilableMachineTypes() ([]string, error) {
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
+func (gce *GceCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return autoprovisionedMachineTypes, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -104,9 +104,9 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, nil
 }
 
-// GetAvilableMachineTypes get all machine types that can be requested from the cloud provider.
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (kubemark *KubemarkCloudProvider) GetAvilableMachineTypes() ([]string, error) {
+func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -52,7 +52,7 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-func (kubemark *KubemarkCloudProvider) GetAvilableMachineTypes() ([]string, error) {
+func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -93,8 +93,8 @@ func (tcp *TestCloudProvider) Pricing() (cloudprovider.PricingModel, errors.Auto
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-// GetAvilableMachineTypes get all machine types that can be requested from the cloud provider.
-func (tcp *TestCloudProvider) GetAvilableMachineTypes() ([]string, error) {
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
+func (tcp *TestCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return []string{}, nil
 }
 

--- a/cluster-autoscaler/config/dynamic/config_fetcher.go
+++ b/cluster-autoscaler/config/dynamic/config_fetcher.go
@@ -58,7 +58,7 @@ func NewConfigFetcher(options ConfigFetcherOptions, kubeClient kube_client.Inter
 // Returns the config if it has changed since the last sync. Returns nil if it has not changed.
 func (c *configFetcherImpl) FetchConfigIfUpdated() (*Config, error) {
 	opts := metav1.GetOptions{}
-	cm, err := c.kubeClient.Core().ConfigMaps(c.namespace).Get(c.configMapName, opts)
+	cm, err := c.kubeClient.CoreV1().ConfigMaps(c.namespace).Get(c.configMapName, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch config map named %s in namespace %s. please confirm if the configmap name and the namespace are correctly spelled and you've already created the configmap: %v", c.configMapName, c.namespace, err)
 	}

--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -57,10 +57,10 @@ type AutoscalingContext struct {
 type AutoscalingOptions struct {
 	// MaxEmptyBulkDelete is a number of empty nodes that can be removed at the same time.
 	MaxEmptyBulkDelete int
-	// ScaleDownUtilizationThreshold sets threshould for nodes to be considered for scale down.
+	// ScaleDownUtilizationThreshold sets threshold for nodes to be considered for scale down.
 	// Well-utilized nodes are not touched.
 	ScaleDownUtilizationThreshold float64
-	// ScaleDownUnneededTime sets the duriation CA exepects a node to be unneded/eligible for removal
+	// ScaleDownUnneededTime sets the duration CA expects a node to be unneeded/eligible for removal
 	// before scaling down the node.
 	ScaleDownUnneededTime time.Duration
 	// ScaleDownUnreadyTime represents how long an unready node should be unneeded before it is eligible for scale down
@@ -75,7 +75,7 @@ type AutoscalingOptions struct {
 	EstimatorName string
 	// ExpanderName sets the type of node group expander to be used in scale up
 	ExpanderName string
-	// MaxGracefulTerminationSec is maximum number of seconds scale down waits for pods to terminante before
+	// MaxGracefulTerminationSec is maximum number of seconds scale down waits for pods to terminate before
 	// removing the node from cloud provider.
 	MaxGracefulTerminationSec int
 	//  Maximum time CA waits for node to be provisioned
@@ -103,7 +103,7 @@ type AutoscalingOptions struct {
 	WriteStatusConfigMap bool
 	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
 	BalanceSimilarNodeGroups bool
-	// ConfigNamespace is the namesapce cluster-autoscaler is running in and all related configmaps live in
+	// ConfigNamespace is the namespace cluster-autoscaler is running in and all related configmaps live in
 	ConfigNamespace string
 	// ClusterName if available
 	ClusterName string

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -565,7 +565,7 @@ func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube
 				GracePeriodSeconds: &maxTermination,
 			},
 		}
-		lastError = client.Core().Pods(podToEvict.Namespace).Evict(eviction)
+		lastError = client.CoreV1().Pods(podToEvict.Namespace).Evict(eviction)
 		if lastError == nil {
 			return nil
 		}
@@ -630,7 +630,7 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 	for start := time.Now(); time.Now().Sub(start) < time.Duration(maxGracefulTerminationSec)*time.Second+PodEvictionHeadroom; time.Sleep(5 * time.Second) {
 		allGone = true
 		for _, pod := range pods {
-			podreturned, err := client.Core().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			podreturned, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 			if err == nil {
 				glog.Errorf("Not deleted yet %v", podreturned)
 				allGone = false

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -307,7 +307,7 @@ func addAutoprovisionedCandidates(context *AutoscalingContext, nodeGroups []clou
 		return
 	}
 
-	machines, err := context.CloudProvider.GetAvilableMachineTypes()
+	machines, err := context.CloudProvider.GetAvailableMachineTypes()
 	if err != nil {
 		glog.Warningf("Failed to get machine types: %v", err)
 	} else {

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -72,9 +72,7 @@ func (estimator *BinpackingNodeEstimator) Estimate(pods []*apiv1.Pod, nodeTempla
 	}
 
 	newNodes := make([]*schedulercache.NodeInfo, 0)
-	for _, node := range comingNodes {
-		newNodes = append(newNodes, node)
-	}
+	newNodes = append(newNodes, comingNodes...)
 
 	for _, podInfo := range podInfos {
 		found := false

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -121,27 +121,27 @@ func (basicEstimator *BasicNodeEstimator) Estimate(node *apiv1.Node, comingNodes
 		resources[apiv1.ResourcePods] = pods
 	}
 
-	if cpuCapcaity, ok := node.Status.Capacity[apiv1.ResourceCPU]; ok {
+	if cpuCapacity, ok := node.Status.Capacity[apiv1.ResourceCPU]; ok {
 		comingCpu := resources[apiv1.ResourceCPU]
 		prop := int(math.Ceil(float64(
 			basicEstimator.cpuSum.MilliValue()-comingCpu.MilliValue()) /
-			float64(cpuCapcaity.MilliValue())))
+			float64(cpuCapacity.MilliValue())))
 
 		buffer.WriteString(fmt.Sprintf("CPU: %d\n", prop))
 		result = maxInt(result, prop)
 	}
-	if memCapcaity, ok := node.Status.Capacity[apiv1.ResourceMemory]; ok {
+	if memCapacity, ok := node.Status.Capacity[apiv1.ResourceMemory]; ok {
 		comingMem := resources[apiv1.ResourceMemory]
 		prop := int(math.Ceil(float64(
 			basicEstimator.memorySum.Value()-comingMem.Value()) /
-			float64(memCapcaity.Value())))
+			float64(memCapacity.Value())))
 		buffer.WriteString(fmt.Sprintf("Mem: %d\n", prop))
 		result = maxInt(result, prop)
 	}
-	if podCapcaity, ok := node.Status.Capacity[apiv1.ResourcePods]; ok {
+	if podCapacity, ok := node.Status.Capacity[apiv1.ResourcePods]; ok {
 		comingPods := resources[apiv1.ResourcePods]
 		prop := int(math.Ceil(float64(basicEstimator.GetCount()-int(comingPods.Value())) /
-			float64(podCapcaity.Value())))
+			float64(podCapacity.Value())))
 		buffer.WriteString(fmt.Sprintf("Pods: %d\n", prop))
 		result = maxInt(result, prop)
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -276,7 +276,7 @@ func main() {
 		kubeClient := createKubeClient()
 
 		// Validate that the client is ok.
-		_, err = kubeClient.Core().Nodes().List(metav1.ListOptions{})
+		_, err = kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 		if err != nil {
 			glog.Fatalf("Failed to get nodes from apiserver: %v", err)
 		}
@@ -285,7 +285,7 @@ func main() {
 			leaderElection.ResourceLock,
 			*namespace,
 			"cluster-autoscaler",
-			kubeClient.Core(),
+			kubeClient.CoreV1(),
 			resourcelock.ResourceLockConfig{
 				Identity:      id,
 				EventRecorder: kube_util.CreateEventRecorder(kubeClient),

--- a/cluster-autoscaler/proposals/node_autoprovisioning.md
+++ b/cluster-autoscaler/proposals/node_autoprovisioning.md
@@ -80,7 +80,7 @@ Then it will add these labels to all machine types available in the cloud provid
 
 To allow this the following extensions will be made in CloudProvider interface:
 
- * `GetAvilableMachineTypes() ([]string, error)` returns all node types that could be requested from the cloud provider.
+ * `GetAvailableMachineTypes() ([]string, error)` returns all node types that could be requested from the cloud provider.
  * `NewNodeGroup(name string, machineType string, labels map[string]string, extraResources map[Resource]Quantity) (NodeGroup, error)` builds a theoretical node group based on the node definition provided. The node group is not automatically created on the cloud provider side. The argument list will probably be expanded with GPU specific stuff.
  * `NodeGroups` will only return created node groups. Theoretical/temporary node groups will not be included.
 

--- a/cluster-autoscaler/simulator/nodes.go
+++ b/cluster-autoscaler/simulator/nodes.go
@@ -35,7 +35,7 @@ import (
 func GetRequiredPodsForNode(nodename string, client kube_client.Interface) ([]*apiv1.Pod, errors.AutoscalerError) {
 
 	// TODO: we should change this to use informer
-	podListResult, err := client.Core().Pods(apiv1.NamespaceAll).List(
+	podListResult, err := client.CoreV1().Pods(apiv1.NamespaceAll).List(
 		metav1.ListOptions{FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodename}).String()})
 	if err != nil {
 		return []*apiv1.Pod{}, errors.ToAutoscalerError(errors.ApiCallError, err)

--- a/cluster-autoscaler/utils/deletetaint/delete.go
+++ b/cluster-autoscaler/utils/deletetaint/delete.go
@@ -36,7 +36,7 @@ const (
 // MarkToBeDeleted sets a taint that makes the node unschedulable.
 func MarkToBeDeleted(node *apiv1.Node, client kube_client.Interface) error {
 	// Get the newest version of the node.
-	freshNode, err := client.Core().Nodes().Get(node.Name, metav1.GetOptions{})
+	freshNode, err := client.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 	if err != nil || freshNode == nil {
 		return fmt.Errorf("failed to get node %v: %v", node.Name, err)
 	}
@@ -45,7 +45,7 @@ func MarkToBeDeleted(node *apiv1.Node, client kube_client.Interface) error {
 	if added == false {
 		return err
 	}
-	_, err = client.Core().Nodes().Update(freshNode)
+	_, err = client.CoreV1().Nodes().Update(freshNode)
 	if err != nil {
 		glog.Warningf("Error while adding taints on node %v: %v", node.Name, err)
 		return err
@@ -96,7 +96,7 @@ func GetToBeDeletedTime(node *apiv1.Node) (*time.Time, error) {
 
 // CleanToBeDeleted cleans ToBeDeleted taint.
 func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface) (bool, error) {
-	freshNode, err := client.Core().Nodes().Get(node.Name, metav1.GetOptions{})
+	freshNode, err := client.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 	if err != nil || freshNode == nil {
 		return false, fmt.Errorf("failed to get node %v: %v", node.Name, err)
 	}
@@ -111,7 +111,7 @@ func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface) (bool, err
 
 	if len(newTaints) != len(freshNode.Spec.Taints) {
 		freshNode.Spec.Taints = newTaints
-		_, err := client.Core().Nodes().Update(freshNode)
+		_, err := client.CoreV1().Nodes().Update(freshNode)
 		if err != nil {
 			glog.Warningf("Error while releasing taints on node %v: %v", node.Name, err)
 			return false, err

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -83,7 +83,7 @@ func GetPodsForDeletionOnNodeDrain(
 
 		if refKind == "ReplicationController" {
 			if checkReferences {
-				rc, err := client.Core().ReplicationControllers(controllerNamespace).Get(controllerRef.Name, metav1.GetOptions{})
+				rc, err := client.CoreV1().ReplicationControllers(controllerNamespace).Get(controllerRef.Name, metav1.GetOptions{})
 				// Assume a reason for an error is because the RC is either
 				// gone/missing or that the rc has too few replicas configured.
 				// TODO: replace the minReplica check with pod disruption budget.

--- a/cluster-autoscaler/utils/kubernetes/factory.go
+++ b/cluster-autoscaler/utils/kubernetes/factory.go
@@ -32,7 +32,7 @@ func CreateEventRecorder(kubeClient clientset.Interface) kube_record.EventRecord
 	eventBroadcaster := kube_record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.V(4).Infof)
 	if _, isfake := kubeClient.(*fake.Clientset); !isfake {
-		eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.Core().RESTClient()).Events("")})
+		eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	}
 	return eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: "cluster-autoscaler"})
 }

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -222,10 +222,7 @@ func (allNodeLister *AllNodeLister) List() ([]*apiv1.Node, error) {
 	if err != nil {
 		return []*apiv1.Node{}, err
 	}
-	allNodes := make([]*apiv1.Node, 0, len(nodes))
-	for _, node := range nodes {
-		allNodes = append(allNodes, node)
-	}
+	allNodes := append(make([]*apiv1.Node, 0, len(nodes)), nodes...)
 	return allNodes, nil
 }
 

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -138,7 +138,7 @@ func NewUnschedulablePodInNamespaceLister(kubeClient client.Interface, namespace
 	// watch unscheduled pods
 	selector := fields.ParseSelectorOrDie("spec.nodeName==" + "" + ",status.phase!=" +
 		string(apiv1.PodSucceeded) + ",status.phase!=" + string(apiv1.PodFailed))
-	podListWatch := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "pods", namespace, selector)
+	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespace, selector)
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := v1lister.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &apiv1.Pod{}, store, time.Hour)
@@ -163,7 +163,7 @@ func NewScheduledPodLister(kubeClient client.Interface, stopchannel <-chan struc
 	// watch unscheduled pods
 	selector := fields.ParseSelectorOrDie("spec.nodeName!=" + "" + ",status.phase!=" +
 		string(apiv1.PodSucceeded) + ",status.phase!=" + string(apiv1.PodFailed))
-	podListWatch := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "pods", apiv1.NamespaceAll, selector)
+	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, selector)
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := v1lister.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &apiv1.Pod{}, store, time.Hour)
@@ -201,7 +201,7 @@ func (readyNodeLister *ReadyNodeLister) List() ([]*apiv1.Node, error) {
 
 // NewReadyNodeLister builds a node lister.
 func NewReadyNodeLister(kubeClient client.Interface, stopChannel <-chan struct{}) *ReadyNodeLister {
-	listWatcher := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "nodes", apiv1.NamespaceAll, fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "nodes", apiv1.NamespaceAll, fields.Everything())
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	nodeLister := v1lister.NewNodeLister(store)
 	reflector := cache.NewReflector(listWatcher, &apiv1.Node{}, store, time.Hour)
@@ -231,7 +231,7 @@ func (allNodeLister *AllNodeLister) List() ([]*apiv1.Node, error) {
 
 // NewAllNodeLister builds a node lister that returns all nodes (ready and unready)
 func NewAllNodeLister(kubeClient client.Interface, stopchannel <-chan struct{}) *AllNodeLister {
-	listWatcher := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "nodes", apiv1.NamespaceAll, fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "nodes", apiv1.NamespaceAll, fields.Everything())
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	nodeLister := v1lister.NewNodeLister(store)
 	reflector := cache.NewReflector(listWatcher, &apiv1.Node{}, store, time.Hour)


### PR DESCRIPTION
1. Change from deprecated Core to CoreV1 for kube client
2. Fix typo GetAvilableMachineTypes() => GetAvailableMachineTypes() 
3. Fix small typos 
4. Small optimize code
