### PR TITLE
Do not include ToBeDeleted taint when constructing a template

### DIFF
--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -295,9 +296,12 @@ func sanitizeTemplateNode(node *apiv1.Node, nodeGroup string) (*apiv1.Node, erro
 		// Rescheduler can put this taint on a node while evicting non-critical pods.
 		// New nodes will not have this taint and so we should strip it when creating
 		// template node.
-		if taint.Key == ReschedulerTaintKey {
+		switch taint.Key {
+		case ReschedulerTaintKey:
 			glog.V(4).Infof("Removing rescheduler taint when creating template from node %s", node.Name)
-		} else {
+		case deletetaint.ToBeDeletedTaint:
+			glog.V(4).Infof("Removing autoscaler taint when creating template from node %s", node.Name)
+		default:
 			newTaints = append(newTaints, taint)
 		}
 	}

--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"fmt"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"testing"
 	"time"
 
@@ -322,6 +323,11 @@ func TestSanitizeTaints(t *testing.T) {
 	taints = append(taints, apiv1.Taint{
 		Key:    "test-taint",
 		Value:  "test2",
+		Effect: apiv1.TaintEffectNoSchedule,
+	})
+	taints = append(taints, apiv1.Taint{
+		Key:    deletetaint.ToBeDeletedTaint,
+		Value:  "1",
 		Effect: apiv1.TaintEffectNoSchedule,
 	})
 	oldNode.Spec.Taints = taints


### PR DESCRIPTION
This results in the simulator being unable to place candidate pods because the taint blocks all scheduling.  The taint could be on the node because it's transitioning to unready and no other nodes are available to extract a template from.