### PR TITLE
Add checking for pod not found error on eviction

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -575,7 +575,7 @@ func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube
 			},
 		}
 		lastError = client.CoreV1().Pods(podToEvict.Namespace).Evict(eviction)
-		if lastError == nil {
+		if lastError == nil || kube_errors.IsNotFound(lastError) {
 			return nil
 		}
 	}


### PR DESCRIPTION
Addresses #313 by checking for error. 

This has been tested manually by deleting a pod after an eviction was scheduled, but before it was attempted (using modified version of CA which introduced sufficient delay.)