### PR TITLE
Respect minimum cores/memory limit during scale down

### DIFF
--- a/cluster-autoscaler/config/const.go
+++ b/cluster-autoscaler/config/const.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	// DefaultMaxClusterCores is the default maximum number of cores in the cluster.
+	DefaultMaxClusterCores = 5000 * 64
+	// DefaultMaxClusterMemory is the default maximum number of gigabytes of memory in cluster.
+	DefaultMaxClusterMemory = 5000 * 64 * 20
+)

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -103,8 +103,8 @@ var (
 			"max(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count).")
 	scanInterval                = flag.Duration("scan-interval", 10*time.Second, "How often cluster is reevaluated for scale up or down")
 	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
-	coresTotal                  = flag.String("cores-total", "0:320000", "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	memoryTotal                 = flag.String("memory-total", "0:6400000", "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	memoryTotal                 = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
 	cloudProviderFlag           = flag.String("cloud-provider", "gce", "Cloud provider type. Allowed values: gce, aws, kubemark")
 	maxEmptyBulkDeleteFlag      = flag.Int("max-empty-bulk-delete", 10, "Maximum number of empty nodes that can be deleted at the same time.")
 	maxGracefulTerminationFlag  = flag.Int("max-graceful-termination-sec", 10*60, "Maximum number of seconds CA waits for pod termination when trying to scale down a node.")
@@ -418,4 +418,8 @@ func validateMinMaxFlag(min, max int64) error {
 		return fmt.Errorf("max size must be greater or equal to min size")
 	}
 	return nil
+}
+
+func minMaxFlagString(min, max int64) string {
+	return fmt.Sprintf("%v:%v", min, max)
 }


### PR DESCRIPTION
Follow up to #295, adding support for lower limits of total cluster cores/memory.