### PR TITLE
Move calculateUnneededOnly check just before scale down

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -90,7 +90,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	scaleDown := a.scaleDown
 	autoscalingContext := a.AutoscalingContext
 	runStart := time.Now()
-	
+
 	glog.V(4).Infof("Starting main loop at %s", runStart.String())
 
 	readyNodes, err := readyNodeLister.List()

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -91,7 +91,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	autoscalingContext := a.AutoscalingContext
 	runStart := time.Now()
 
-	glog.V(4).Infof("Starting main loop at %s", runStart.String())
+	glog.V(4).Info("Starting main loop")
 
 	readyNodes, err := readyNodeLister.List()
 	if err != nil {


### PR DESCRIPTION
This fix moves the calculateUnneededOnly check after expensive unneeded calculations, to avoid a scenario where the scale down goroutine is still running when the next main loop starts.  This could cause a scale down to be skipped because scale down was still in progress at the beginning of the main loop, but is no longer after calculating unneeded.