### PR TITLE
Move calculateUnneededOnly check after unneeded calculations

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -91,6 +91,8 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	autoscalingContext := a.AutoscalingContext
 	runStart := time.Now()
 
+	glog.V(4).Info("Starting main loop")
+
 	readyNodes, err := readyNodeLister.List()
 	if err != nil {
 		glog.Errorf("Failed to list ready nodes: %v", err)
@@ -255,15 +257,6 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		}
 
 		unneededStart := time.Now()
-		// In dry run only utilization is updated
-		calculateUnneededOnly := a.lastScaleUpTime.Add(a.ScaleDownDelay).After(currentTime) ||
-			a.lastScaleDownFailedTrial.Add(a.ScaleDownTrialInterval).After(currentTime) ||
-			schedulablePodsPresent ||
-			scaleDown.nodeDeleteStatus.IsDeleteInProgress()
-
-		glog.V(4).Infof("Scale down status: unneededOnly=%v lastScaleUpTime=%s "+
-			"lastScaleDownFailedTrail=%s schedulablePodsPresent=%v", calculateUnneededOnly,
-			a.lastScaleUpTime, a.lastScaleDownFailedTrial, schedulablePodsPresent)
 
 		glog.V(4).Infof("Calculating unneeded nodes")
 
@@ -283,6 +276,16 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 				glog.V(4).Infof("%s is unneeded since %s duration %s", key, val.String(), time.Now().Sub(val).String())
 			}
 		}
+
+		// In dry run only utilization is updated
+		calculateUnneededOnly := a.lastScaleUpTime.Add(a.ScaleDownDelay).After(currentTime) ||
+			a.lastScaleDownFailedTrial.Add(a.ScaleDownTrialInterval).After(currentTime) ||
+			schedulablePodsPresent ||
+			scaleDown.nodeDeleteStatus.IsDeleteInProgress()
+
+		glog.V(4).Infof("Scale down status: unneededOnly=%v lastScaleUpTime=%s "+
+			"lastScaleDownFailedTrail=%s schedulablePodsPresent=%v", calculateUnneededOnly,
+			a.lastScaleUpTime, a.lastScaleDownFailedTrial, schedulablePodsPresent)
 
 		if !calculateUnneededOnly {
 			glog.V(4).Infof("Starting scale down")


### PR DESCRIPTION
This fix moves the calculateUnneededOnly check after expensive unneeded calculations, to avoid a scenario where the scale down goroutine is still running when the next main loop starts. This could cause a scale down to be skipped because scale down was still in progress at the beginning of the main loop, but is no longer after calculating unneeded.

The new log message is also intentional; to make it clear when the next main loop iteration starts, even when another goroutine may still be writing log messages.