### PR TITLE
Keep track of nodes that failed to register for a long time

### DIFF
--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -152,6 +152,7 @@ func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulat
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: options.MaxTotalUnreadyPercentage,
 		OkTotalUnreadyCount:       options.OkTotalUnreadyCount,
+		MaxNodeProvisionTime:      options.MaxNodeProvisionTime,
 	}
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(cloudProvider, clusterStateConfig, logEventRecorder)
 

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -328,6 +328,15 @@ func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNod
 				glog.Warningf("No node group for node %s, skipping", unregisteredNode.Node.Name)
 				continue
 			}
+			size, err := nodeGroup.TargetSize()
+			if err != nil {
+				glog.Warningf("Failed to get node group size, err: %v", err)
+				continue
+			}
+			if nodeGroup.MinSize() >= size {
+				glog.Warningf("Failed to remove node %s: node group min size reached, skipping unregistered node removal", unregisteredNode.Node.Name)
+				continue
+			}
 			logRecorder.Eventf(apiv1.EventTypeNormal, "DeleteUnregistered",
 				"Removing unregistered node %v", unregisteredNode.Node.Name)
 			err = nodeGroup.DeleteNodes([]*apiv1.Node{unregisteredNode.Node})

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -72,6 +72,9 @@ func BuildTestNode(name string, millicpu int64, mem int64) *apiv1.Node {
 			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", name),
 			Labels:   map[string]string{},
 		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: name,
+		},
 		Status: apiv1.NodeStatus{
 			Capacity: apiv1.ResourceList{
 				apiv1.ResourcePods: *resource.NewQuantity(100, resource.DecimalSI),


### PR DESCRIPTION
Fix: #369 

Previously a node that failed to register and couldn't be deleted basically broke CA. Now we will keep track of it in clusterstate and continue operating mostly normally.