### PR TITLE
Gke fixit

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -211,6 +211,9 @@ func (mig *Mig) MinSize() int {
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
 func (mig *Mig) TargetSize() (int, error) {
+	if !mig.exist {
+		return 0, nil
+	}
 	size, err := mig.gceManager.GetMigSize(mig)
 	return int(size), err
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -328,6 +328,7 @@ func TestMig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
 	mig1 := reflect.ValueOf(nodeGroup).Interface().(*Mig)
+	mig1.exist = true
 	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/nodeautoprovisioning-n1-standard-1"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	assert.Equal(t, 0, mig1.MinSize())
@@ -450,6 +451,7 @@ func TestMig(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test Create.
+	mig1.exist = false
 	gceManagerMock.On("createNodePool", mock.AnythingOfType("*gce.Mig")).Return(nil).Once()
 	err = mig1.Create()
 	assert.NoError(t, err)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -140,9 +140,20 @@ func CreateGceManager(configReader io.Reader, mode GcpCloudProviderMode, cluster
 		glog.V(1).Infof("Using default TokenSource %#v", tokenSource)
 	}
 	if len(projectId) == 0 || len(zone) == 0 {
-		projectId, zone, err = getProjectAndZone()
+		// XXX: On GKE discoveredProjectId is hosted master project and
+		// not the project we want to use, however, zone seems to not
+		// be specified in config. For now we can just assume that hosted
+		// master project is in the same zone as cluster and only use
+		// discoveredZone.
+		discoveredProjectId, discoveredZone, err := getProjectAndZone()
 		if err != nil {
 			return nil, err
+		}
+		if len(projectId) == 0 {
+			projectId = discoveredProjectId
+		}
+		if len(zone) == 0 {
+			zone = discoveredZone
 		}
 	}
 	glog.V(1).Infof("GCE projectId=%s zone=%s", projectId, zone)

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -66,7 +66,7 @@ func (flag *MultiStringFlag) Set(value string) error {
 
 var (
 	nodeGroupsFlag         MultiStringFlag
-	clusterName            = flag.String("clusterName", "", "Autoscaled cluster name, if available")
+	clusterName            = flag.String("cluster-name", "", "Autoscaled cluster name, if available")
 	address                = flag.String("address", ":8085", "The address to expose prometheus metrics.")
 	kubernetes             = flag.String("kubernetes", "", "Kubernetes master location. Leave blank for default")
 	kubeConfigFile         = flag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")


### PR DESCRIPTION
First batch of bugfixes for GKE cloudprovider:
 * Mig.TargetSize tried to query non-existing mig if autoprovisioning
      was enabled.
 * GKE client was created using hosted master project instead of users
   project.
 * Renamed clusterName flag to cluster-name for consistency.


