### PR TITLE
NAP bugfixes

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -329,7 +329,7 @@ func TestMig(t *testing.T) {
 	assert.NotNil(t, nodeGroup)
 	mig1 := reflect.ValueOf(nodeGroup).Interface().(*Mig)
 	mig1.exist = true
-	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/nodeautoprovisioning-n1-standard-1"))
+	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	assert.Equal(t, 0, mig1.MinSize())
 	assert.Equal(t, 1000, mig1.MaxSize())

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -124,7 +124,11 @@ const allNodePools2 = `{
         "serviceAccount": "default"
       },
       "initialNodeCount": 3,
-      "autoscaling": {},
+      "autoscaling": {
+         "Enabled": true,
+         "MinNodeCount": 0,
+         "MaxNodeCount": 1000
+      },
       "management": {},
       "selfLink": "https://container.googleapis.com/v1/projects/project1/zones/us-central1-b/clusters/cluster-1/nodePools/nodeautoprovisioning-323233232",
       "version": "1.6.9",
@@ -418,8 +422,7 @@ func TestFetchAllNodePools(t *testing.T) {
 	assert.NoError(t, err)
 	migs = g.getMigs()
 	assert.Equal(t, 2, len(migs))
-	validateMig(t, migs[0].config, "gke-cluster-1-default-pool", 1,
-		11)
+	validateMig(t, migs[0].config, "gke-cluster-1-default-pool", 1, 11)
 	validateMig(t, migs[1].config, "gke-cluster-1-nodeautoprovisioning-323233232", 0, 1000)
 	mock.AssertExpectationsForObjects(t, server)
 


### PR DESCRIPTION
Fixed some issues related to NAP on GKE: 
 * Make autoprovisioned node pools names shorter (previously it
    was exceeding max name length).
 * Set autoscaling fields when creating node pool.
 * Handle NodeGroup id changing when NG is created.

Fixes in this PR are enough for CA to create and delete autoprovisioned nodepool, though there are some smaller issues remaining (new node group is reported as unhealthy when it's created, errors in logs, missing events). I'll fix those issues in follow-up PR.
