### PR TITLE
Update clusterstate after scale-up

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -288,6 +288,18 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime ti
 	return nil
 }
 
+// Recalculate cluster state after scale-ups or scale-downs were registered.
+func (csr *ClusterStateRegistry) Recalculate() {
+	targetSizes, err := getTargetSizes(csr.cloudProvider)
+	if err != nil {
+		glog.Warningf("Failed to get target sizes, when trying to recalculate cluster state: %v", err)
+	}
+
+	csr.Lock()
+	defer csr.Unlock()
+	csr.updateAcceptableRanges(targetSizes)
+}
+
 // getTargetSizes gets target sizes of node groups.
 func getTargetSizes(cp cloudprovider.CloudProvider) (map[string]int, error) {
 	result := make(map[string]int)

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -283,6 +283,7 @@ func ScaleUp(context *AutoscalingContext, unschedulablePods []*apiv1.Pod, nodes 
 				"pod triggered scale-up: %v", scaleUpInfos)
 		}
 
+		context.ClusterStateRegistry.Recalculate()
 		return true, nil
 	}
 	for pod, unschedulable := range podsRemainUnschedulable {


### PR DESCRIPTION
This stops CA from considering newly created node group as unhealthy and prevents error messages showing in log when NAP is enabled. Also previously status configmap would only inform about scale-up after next loop has completed (10+s delay), now it does it immediately.