### PR TITLE
AWS DescribeAutoScalingGroups requests too aggressive - API limits reached

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -19,10 +19,8 @@ package aws
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type autoScalingGroups struct {
@@ -40,15 +38,6 @@ func newAutoScalingGroups(service autoScalingWrapper) *autoScalingGroups {
 		instanceToAsg:            make(map[AwsRef]*Asg),
 		instancesNotInManagedAsg: make(map[AwsRef]struct{}),
 	}
-
-	go wait.Forever(func() {
-		registry.cacheMutex.Lock()
-		defer registry.cacheMutex.Unlock()
-		if err := registry.regenerateCache(); err != nil {
-			glog.Errorf("Error while regenerating Asg cache: %v", err)
-		}
-	}, time.Hour)
-
 	return registry
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -104,7 +104,7 @@ func buildStaticallyDiscoveringProvider(awsManager *AwsManager, specs []string, 
 }
 
 // Cleanup stops the go routine that is handling the current view of the ASGs in the form of a cache
-func (aws *awsCloudProvider) Close() error {
+func (aws *awsCloudProvider) Cleanup() error {
 	aws.awsManager.Cleanup()
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -103,6 +103,12 @@ func buildStaticallyDiscoveringProvider(awsManager *AwsManager, specs []string, 
 	return aws, nil
 }
 
+// Cleanup stops the go routine that is handling the current view of the ASGs in the form of a cache
+func (aws *awsCloudProvider) Close() error {
+	aws.awsManager.Cleanup()
+	return nil
+}
+
 // addNodeGroup adds node group defined in string spec. Format:
 // minNodes:maxNodes:asgName
 func (aws *awsCloudProvider) addNodeGroup(spec string) error {

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -73,7 +73,8 @@ var testAwsManager = &AwsManager{
 		instanceToAsg:            make(map[AwsRef]*Asg),
 		instancesNotInManagedAsg: make(map[AwsRef]struct{}),
 	},
-	service: testService,
+	service:   testService,
+	interrupt: make(chan struct{}),
 }
 
 func newTestAwsManagerWithService(service autoScaling) *AwsManager {
@@ -86,6 +87,7 @@ func newTestAwsManagerWithService(service autoScaling) *AwsManager {
 			instancesNotInManagedAsg: make(map[AwsRef]struct{}),
 			service:                  wrapper,
 		},
+		interrupt: make(chan struct{}),
 	}
 }
 
@@ -370,4 +372,10 @@ func TestBuildAsg(t *testing.T) {
 	assert.Equal(t, 111, asg.MinSize())
 	assert.Equal(t, 222, asg.MaxSize())
 	assert.Equal(t, "test-name", asg.Name)
+}
+
+func TestClose(t *testing.T) {
+	provider := testProvider(t, testAwsManager)
+	err := provider.Close()
+	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -374,8 +374,8 @@ func TestBuildAsg(t *testing.T) {
 	assert.Equal(t, "test-name", asg.Name)
 }
 
-func TestClose(t *testing.T) {
+func TestCleanup(t *testing.T) {
 	provider := testProvider(t, testAwsManager)
-	err := provider.Close()
+	err := provider.Cleanup()
 	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -25,6 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	"runtime"
 )
 
 func TestBuildGenericLabels(t *testing.T) {
@@ -92,4 +93,12 @@ func makeTaintSet(taints []apiv1.Taint) map[apiv1.Taint]bool {
 		set[taint] = true
 	}
 	return set
+}
+
+func testCreateAWSManager(t *testing.T) {
+	manager, awsError := createAWSManagerInternal(nil, &testService)
+	assert.Nil(t, awsError, "Expected nil from the error when creating AWS Manager")
+	currentNumberRoutines := runtime.NumGoroutine()
+	manager.Cleanup()
+	assert.True(t, currentNumberRoutines-1 == runtime.NumGoroutine(), "current number of go routines should be one less since we called close")
 }

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -58,6 +58,9 @@ type CloudProvider interface {
 	// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 	GetResourceLimiter() (*ResourceLimiter, error)
 
+	// Close cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
+	Close() error
+
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 	Refresh() error

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -58,8 +58,8 @@ type CloudProvider interface {
 	// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 	GetResourceLimiter() (*ResourceLimiter, error)
 
-	// Close cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-	Close() error
+	// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
+	Cleanup() error
 
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -83,6 +83,12 @@ func BuildGceCloudProvider(gceManager GceManager, specs []string, resourceLimite
 	return gce, nil
 }
 
+// Close cleans up all resources before the cloud provider is removed
+func (gce *GceCloudProvider) Close() error {
+	gce.gceManager.Cleanup()
+	return nil
+}
+
 // addNodeGroup adds node group defined in string spec. Format:
 // minNodes:maxNodes:migUrl
 func (gce *GceCloudProvider) addNodeGroup(spec string) error {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -83,8 +83,8 @@ func BuildGceCloudProvider(gceManager GceManager, specs []string, resourceLimite
 	return gce, nil
 }
 
-// Close cleans up all resources before the cloud provider is removed
-func (gce *GceCloudProvider) Close() error {
+// Cleanup cleans up all resources before the cloud provider is removed
+func (gce *GceCloudProvider) Cleanup() error {
 	gce.gceManager.Cleanup()
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -77,6 +77,11 @@ func (m *gceManagerMock) Refresh() error {
 	return args.Error(0)
 }
 
+func (m *gceManagerMock) Cleanup() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *gceManagerMock) getMigs() []*migInformation {
 	args := m.Called()
 	return args.Get(0).([]*migInformation)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -105,6 +105,7 @@ type GceManager interface {
 	Refresh() error
 	// GetResourceLimiter returns resource limiter.
 	GetResourceLimiter() (*cloudprovider.ResourceLimiter, error)
+	// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
 	Cleanup() error
 	getMigs() []*migInformation
 	createNodePool(mig *Mig) error
@@ -128,17 +129,15 @@ type gceManagerImpl struct {
 	cacheMutex sync.Mutex
 	migsMutex  sync.Mutex
 
-	location    string
-	projectId   string
-	clusterName string
-	mode        GcpCloudProviderMode
-	templates   *templateBuilder
-	isRegional  bool
-
+	location        string
+	projectId       string
+	clusterName     string
+	mode            GcpCloudProviderMode
+	templates       *templateBuilder
+	interrupt       chan struct{}
+	isRegional      bool
 	resourceLimiter *cloudprovider.ResourceLimiter
-
-	interrupt   chan struct{}
-	lastRefresh time.Time
+	lastRefresh     time.Time
 }
 
 // CreateGceManager constructs gceManager object.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -128,6 +128,11 @@ func (kubemark *KubemarkCloudProvider) Refresh() error {
 	return nil
 }
 
+// Close cleans up all resources before the cloud provider is removed
+func (kubemark *KubemarkCloudProvider) Close() error {
+	return nil
+}
+
 // NodeGroup implements NodeGroup interfrace.
 type NodeGroup struct {
 	Name               string

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -128,8 +128,8 @@ func (kubemark *KubemarkCloudProvider) Refresh() error {
 	return nil
 }
 
-// Close cleans up all resources before the cloud provider is removed
-func (kubemark *KubemarkCloudProvider) Close() error {
+// Cleanup cleans up all resources before the cloud provider is removed
+func (kubemark *KubemarkCloudProvider) Cleanup() error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -70,3 +70,8 @@ func (kubemark *KubemarkCloudProvider) GetResourceLimiter() (*cloudprovider.Reso
 func (kubemark *KubemarkCloudProvider) Refresh() error {
 	return cloudprovider.ErrNotImplemented
 }
+
+// Close cleans up all resources before the cloud provider is removed
+func (kubemark *KubemarkCloudProvider) Close() error {
+	return cloudprovider.ErrNotImplemented
+}

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -71,7 +71,7 @@ func (kubemark *KubemarkCloudProvider) Refresh() error {
 	return cloudprovider.ErrNotImplemented
 }
 
-// Close cleans up all resources before the cloud provider is removed
-func (kubemark *KubemarkCloudProvider) Close() error {
+// Cleanup cleans up all resources before the cloud provider is removed
+func (kubemark *KubemarkCloudProvider) Cleanup() error {
 	return cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -192,8 +192,8 @@ func (tcp *TestCloudProvider) SetResourceLimiter(resourceLimiter *cloudprovider.
 	tcp.resourceLimiter = resourceLimiter
 }
 
-//Close this is a function to close resources associated with the cloud provider
-func (tcp *TestCloudProvider) Close() error {
+// Cleanup this is a function to close resources associated with the cloud provider
+func (tcp *TestCloudProvider) Cleanup() error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -192,6 +192,11 @@ func (tcp *TestCloudProvider) SetResourceLimiter(resourceLimiter *cloudprovider.
 	tcp.resourceLimiter = resourceLimiter
 }
 
+//Close this is a function to close resources associated with the cloud provider
+func (tcp *TestCloudProvider) Close() error {
+	return nil
+}
+
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 func (tcp *TestCloudProvider) Refresh() error {

--- a/cluster-autoscaler/core/polling_autoscaler.go
+++ b/cluster-autoscaler/core/polling_autoscaler.go
@@ -99,14 +99,14 @@ func (a *PollingAutoscaler) Poll() error {
 		glog.V(4).Infof("Detected change(s) in node group definitions. Recreating autoscaler...")
 
 		// See https://github.com/kubernetes/autoscaler/issues/252, we need to close any stray resources
-		a.autoscaler.CloudProvider().Close()
+		a.autoscaler.CloudProvider().Cleanup()
 
 		// For safety, any config change should stop and recreate all the stuff running in CA hence recreating all the Autoscaler instance here
 		// See https://github.com/kubernetes/contrib/pull/2226#discussion_r94126064
 		a.autoscaler = currentAutoscaler
 	} else {
 		// See https://github.com/kubernetes/autoscaler/issues/252, we need to close any stray resources
-		currentAutoscaler.CloudProvider().Close()
+		currentAutoscaler.CloudProvider().Cleanup()
 	}
 	glog.V(4).Infof("Poll finished")
 	return nil

--- a/cluster-autoscaler/core/polling_autoscaler.go
+++ b/cluster-autoscaler/core/polling_autoscaler.go
@@ -98,9 +98,15 @@ func (a *PollingAutoscaler) Poll() error {
 	if !reflect.DeepEqual(prevNodeGroupIds, currentNodeGroupIds) {
 		glog.V(4).Infof("Detected change(s) in node group definitions. Recreating autoscaler...")
 
+		// See https://github.com/kubernetes/autoscaler/issues/252, we need to close any stray resources
+		a.autoscaler.CloudProvider().Close()
+
 		// For safety, any config change should stop and recreate all the stuff running in CA hence recreating all the Autoscaler instance here
 		// See https://github.com/kubernetes/contrib/pull/2226#discussion_r94126064
 		a.autoscaler = currentAutoscaler
+	} else {
+		// See https://github.com/kubernetes/autoscaler/issues/252, we need to close any stray resources
+		currentAutoscaler.CloudProvider().Close()
 	}
 	glog.V(4).Infof("Poll finished")
 	return nil

--- a/cluster-autoscaler/core/polling_autoscaler_test.go
+++ b/cluster-autoscaler/core/polling_autoscaler_test.go
@@ -42,7 +42,7 @@ func TestRunOnce(t *testing.T) {
 	newCloudProvider.AddNode("ng2", n2)
 
 	initialAutoscaler := &AutoscalerMock{}
-	initialAutoscaler.On("CloudProvider").Return(initialCloudProvider).Once()
+	initialAutoscaler.On("CloudProvider").Return(initialCloudProvider).Twice()
 
 	newAutoscaler := &AutoscalerMock{}
 	newAutoscaler.On("RunOnce", currentTime).Once()


### PR DESCRIPTION
Fix for issue 252 where excessive API calls to AWS are the result of leaking go routines from the Polling auto scaler.