### PR TITLE
updated IAM policy resource section with aws arn for autoscaling

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -20,7 +20,7 @@ A minimum IAM policy would look like:
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
-            "Resource": "*"
+            "Resource": "arn:aws:autoscaling:*"
         }
     ]
 }
@@ -41,13 +41,13 @@ If you'd like to auto-discover node groups by specifing the `--node-group-auto-d
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
-            "Resource": "*"
+            "Resource": "arn:aws:autoscaling:*"
         }
     ]
 }
 ```
 
-Unfortunately AWS does not support ARNs for autoscaling groups yet so you must use "*" as the resource. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).
+AWS IAM policy above limits permission only to autoscaling resources. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).
 
 ## Deployment Specification
 


### PR DESCRIPTION
Updated the IAM policy to have resources specified as AWS arn based syntax for auto scaling groups.