### PR TITLE
Consider GPU nodes unready until allocatable GPU is > 0

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
@@ -156,7 +157,7 @@ func getAdditionalPrice(resources apiv1.ResourceList, startTime time.Time, endTi
 	}
 	hours := getHours(startTime, endTime)
 	price := 0.0
-	gpu := resources[apiv1.ResourceNvidiaGPU]
+	gpu := resources[gpu.ResourceNvidiaGPU]
 	price += float64(gpu.MilliValue()) / 1000.0 * gpuPricePerHour * hours
 	return price
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	"github.com/stretchr/testify/assert"
@@ -69,14 +69,14 @@ func TestGetNodePrice(t *testing.T) {
 
 	// regular with gpu
 	node4 := BuildTestNode("sillyname4", 8000, 30*1024*1024*1024)
-	node4.Status.Capacity[apiv1.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	node4.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
 	node4.Labels = labels1
 	price4, err := model.NodePrice(node4, now, now.Add(time.Hour))
 
 	// preemptable with gpu
 	node5 := BuildTestNode("sillyname5", 8000, 30*1024*1024*1024)
 	node5.Labels = labels2
-	node5.Status.Capacity[apiv1.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	node5.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
 	price5, err := model.NodePrice(node5, now, now.Add(time.Hour))
 
 	// Nodes with GPU are way more expensive than regular.

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 
 	"github.com/golang/glog"
@@ -38,7 +39,6 @@ import (
 const (
 	mbPerGB           = 1000
 	millicoresPerCore = 1000
-	resourceNvidiaGPU = "nvidia.com/gpu"
 )
 
 // builds templates for gce cloud provider
@@ -98,7 +98,7 @@ func (t *templateBuilder) buildCapacity(machineType string, accelerators []*gce.
 	capacity[apiv1.ResourceMemory] = *resource.NewQuantity(mem, resource.DecimalSI)
 
 	if accelerators != nil && len(accelerators) > 0 {
-		capacity[resourceNvidiaGPU] = *resource.NewQuantity(t.getAcceleratorCount(accelerators), resource.DecimalSI)
+		capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(t.getAcceleratorCount(accelerators), resource.DecimalSI)
 	}
 
 	return capacity, nil

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -20,13 +20,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	gpuUtils "k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+
 	gce "google.golang.org/api/compute/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/quota"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
@@ -486,7 +489,7 @@ func makeResourceList(cpu string, memory string, gpu int64) (apiv1.ResourceList,
 		if err != nil {
 			return nil, err
 		}
-		result[resourceNvidiaGPU] = resultGpu
+		result[gpuUtils.ResourceNvidiaGPU] = resultGpu
 	}
 	return result, nil
 }

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	// MaxNodeStartupTime is the maximum time from the moment the node is registered to the time the node is ready.
-	MaxNodeStartupTime = 5 * time.Minute
+	MaxNodeStartupTime = 15 * time.Minute
 
 	// MaxStatusSettingDelayAfterCreation is the maximum time for node to set its initial status after the
 	// node is registered.

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpu
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/api"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
+	ResourceNvidiaGPU = "nvidia.com/gpu"
+)
+
+// SetGPUAllocatableToCapacity allows us to tolerate the fact that nodes with
+// GPUs can have allocatable set to 0 for multiple minutes after becoming ready
+// Without this workaround, Cluster Autoscaler will trigger an unnecessary
+// additional scale up before the node is fully operational.
+// TODO: Remove this once we handle dynamically privisioned resources well.
+func SetGPUAllocatableToCapacity(nodes []*apiv1.Node) []*apiv1.Node {
+	result := []*apiv1.Node{}
+	for _, node := range nodes {
+		newNode := node
+		if gpuCapacity, ok := node.Status.Capacity[ResourceNvidiaGPU]; ok {
+			if gpuAllocatable, ok := node.Status.Allocatable[ResourceNvidiaGPU]; !ok || gpuAllocatable.IsZero() {
+				nodeCopy, err := api.Scheme.DeepCopy(node)
+				if err != nil {
+					glog.Errorf("Failed to make a copy of node %v", node.ObjectMeta.Name)
+				} else {
+					newNode = nodeCopy.(*apiv1.Node)
+					newNode.Status.Allocatable[ResourceNvidiaGPU] = gpuCapacity.DeepCopy()
+				}
+			}
+		}
+		result = append(result, newNode)
+	}
+	return result
+}

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -26,29 +26,69 @@ import (
 const (
 	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
 	ResourceNvidiaGPU = "nvidia.com/gpu"
+	// GPULabel is the label added to nodes with GPU resource on GKE.
+	GPULabel = "cloud.google.com/gke-accelerator"
 )
 
-// SetGPUAllocatableToCapacity allows us to tolerate the fact that nodes with
-// GPUs can have allocatable set to 0 for multiple minutes after becoming ready
-// Without this workaround, Cluster Autoscaler will trigger an unnecessary
-// additional scale up before the node is fully operational.
-// TODO: Remove this once we handle dynamically privisioned resources well.
-func SetGPUAllocatableToCapacity(nodes []*apiv1.Node) []*apiv1.Node {
-	result := []*apiv1.Node{}
-	for _, node := range nodes {
-		newNode := node
-		if gpuCapacity, ok := node.Status.Capacity[ResourceNvidiaGPU]; ok {
-			if gpuAllocatable, ok := node.Status.Allocatable[ResourceNvidiaGPU]; !ok || gpuAllocatable.IsZero() {
-				nodeCopy, err := api.Scheme.DeepCopy(node)
-				if err != nil {
-					glog.Errorf("Failed to make a copy of node %v", node.ObjectMeta.Name)
-				} else {
-					newNode = nodeCopy.(*apiv1.Node)
-					newNode.Status.Allocatable[ResourceNvidiaGPU] = gpuCapacity.DeepCopy()
-				}
+// FilterOutNodesWithUnreadyGpus removes nodes that should have GPU, but don't have it in allocatable
+// from ready nodes list and updates their status to unready on all nodes list.
+// This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
+// in GPU missing from their allocatable and capacity.
+func FilterOutNodesWithUnreadyGpus(allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	newAllNodes := make([]*apiv1.Node, 0)
+	newReadyNodes := make([]*apiv1.Node, 0)
+	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
+	for _, node := range readyNodes {
+		isUnready := false
+		_, hasGpuLabel := node.Labels[GPULabel]
+		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[ResourceNvidiaGPU]
+		// We expect node to have GPU based on label, but it doesn't show up
+		// on node object. Assume the node is still not fully started (installing
+		// GPU drivers).
+		if hasGpuLabel && (!hasGpuAllocatable || gpuAllocatable.IsZero()) {
+			newNode, err := getUnreadyNodeCopy(node)
+			if err != nil {
+				glog.Errorf("Failed to override status of node %v with unready GPU: %v",
+					node.Name, err)
+			} else {
+				glog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
+					node.Name)
+				nodesWithUnreadyGpu[newNode.Name] = newNode
+				isUnready = true
 			}
 		}
-		result = append(result, newNode)
+		if !isUnready {
+			newReadyNodes = append(newReadyNodes, node)
+		}
 	}
-	return result
+	// Override any node with unready GPU with its "unready" copy
+	for _, node := range allNodes {
+		if newNode, found := nodesWithUnreadyGpu[node.Name]; found {
+			newAllNodes = append(newAllNodes, newNode)
+		} else {
+			newAllNodes = append(newAllNodes, node)
+		}
+	}
+	return newAllNodes, newReadyNodes
+}
+
+func getUnreadyNodeCopy(node *apiv1.Node) (*apiv1.Node, error) {
+	nodeCopy, err := api.Scheme.DeepCopy(node)
+	if err != nil {
+		return nil, err
+	}
+	newNode := nodeCopy.(*apiv1.Node)
+	newReadyCondition := apiv1.NodeCondition{
+		Type:               apiv1.NodeReady,
+		Status:             apiv1.ConditionFalse,
+		LastTransitionTime: node.CreationTimestamp,
+	}
+	newNodeConditions := []apiv1.NodeCondition{newReadyCondition}
+	for _, condition := range newNode.Status.Conditions {
+		if condition.Type != apiv1.NodeReady {
+			newNodeConditions = append(newNodeConditions, condition)
+		}
+	}
+	newNode.Status.Conditions = newNodeConditions
+	return newNode, nil
 }

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpu
+
+import (
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetGPUAllocatableToCapacity(t *testing.T) {
+	nodeGPU := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nodeGpu"}, Status: apiv1.NodeStatus{Capacity: apiv1.ResourceList{}, Allocatable: apiv1.ResourceList{}}}
+	nodeGPU.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeGPU.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeGPUUnready := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nodeGpuUnready"}, Status: apiv1.NodeStatus{Capacity: apiv1.ResourceList{}, Allocatable: apiv1.ResourceList{}}}
+	nodeGPUUnready.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
+	nodeGPUUnready.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(2, resource.DecimalSI)
+	nodeGPUNoAllocatable := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nodeGpuNoAllocatable"}, Status: apiv1.NodeStatus{Capacity: apiv1.ResourceList{}, Allocatable: apiv1.ResourceList{}}}
+	nodeGPUNoAllocatable.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeNoGPU := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nodeGpuUnready"}, Status: apiv1.NodeStatus{Capacity: apiv1.ResourceList{}, Allocatable: apiv1.ResourceList{}}}
+	nodeNoGPU.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeNoGPU.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(2, resource.DecimalSI)
+	result := SetGPUAllocatableToCapacity([]*apiv1.Node{nodeGPU, nodeGPUUnready, nodeGPUNoAllocatable, nodeNoGPU})
+	assertAllocatableAndCapacity(t, ResourceNvidiaGPU, 1, 1, result[0])
+	assertAllocatableAndCapacity(t, ResourceNvidiaGPU, 2, 2, result[1])
+	assertAllocatableAndCapacity(t, ResourceNvidiaGPU, 1, 1, result[2])
+	assertAllocatableAndCapacity(t, apiv1.ResourceCPU, 1, 2, result[3])
+}
+
+func assertAllocatableAndCapacity(t *testing.T, resourceName apiv1.ResourceName, allocatable, capacity int64, node *apiv1.Node) {
+	allocatableResource := *resource.NewQuantity(allocatable, resource.DecimalSI)
+	capacityResource := *resource.NewQuantity(capacity, resource.DecimalSI)
+	assert.Equal(t, node.Status.Allocatable[resourceName], allocatableResource,
+		"Node %v, expected allocatable %v: %v got: %v", node.ObjectMeta.Name, resourceName, node.Status.Allocatable[resourceName], allocatableResource)
+	assert.Equal(t, node.Status.Capacity[resourceName], capacityResource,
+		"Node %v, expected capacity %v: %v got: %v", node.ObjectMeta.Name, resourceName, node.Status.Capacity[resourceName], capacityResource)
+}


### PR DESCRIPTION
Fix for https://github.com/kubernetes/kubernetes/issues/54959.

The idea is to internally override status of nodes which should have GPUs to unready until they actually have allocatable GPU. That way our normal logic for handling long starting up nodes kicks in and counts those nodes in simulations.

The downside is we have to use the same timeout for GPU node start-up + driver installation as for normal nodes (defaults to 15 minutes, which may not be enough - we may need to temporarily increase this for 1.8).

Also fixes the issue where GCP pricing model was using old GPU resource name and not taking GPU into account when calculating node cost (leading to very sad scale-up decisions in my test...).