### PR TITLE
Add an expander that always expands the group with the fewest nodes.

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -451,6 +451,8 @@ would match the cluster size. This expander is described in more details
 [HERE](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/pricing.md). Currently
 it works only for GCE and GKE.
 
+* `fewest-nodes` - selects the node group with the fewest nodes. Falls back to the random expander if all node groups are the same size.
+
 ************
 
 # Troubleshooting:

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// AvailableExpanders is a list of available expander options
-	AvailableExpanders = []string{RandomExpanderName, MostPodsExpanderName, LeastWasteExpanderName, PriceBasedExpanderName}
+	AvailableExpanders = []string{RandomExpanderName, MostPodsExpanderName, LeastWasteExpanderName, PriceBasedExpanderName, FewestNodesExpanderName}
 	// RandomExpanderName selects a node group at random
 	RandomExpanderName = "random"
 	// MostPodsExpanderName selects a node group that fits the most pods
@@ -34,6 +34,8 @@ var (
 	// PriceBasedExpanderName selects a node group that is the most cost-effective and consistent with
 	// the preferred node size for the cluster
 	PriceBasedExpanderName = "price"
+	// FewestNodesExpanderName selects the node group with the fewest nodes
+	FewestNodesExpanderName = "fewest-nodes"
 )
 
 // Option describes an option to expand the cluster.

--- a/cluster-autoscaler/expander/factory/expander_factory.go
+++ b/cluster-autoscaler/expander/factory/expander_factory.go
@@ -19,6 +19,7 @@ package factory
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
+	"k8s.io/autoscaler/cluster-autoscaler/expander/fewestnodes"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/mostpods"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/price"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -46,6 +47,9 @@ func ExpanderStrategyFromString(expanderFlag string, cloudProvider cloudprovider
 		return price.NewStrategy(pricing,
 			price.NewSimplePreferredNodeProvider(nodeLister),
 			price.SimpleNodeUnfitness), nil
+	case expander.FewestNodesExpanderName:
+		return fewestnodes.NewStrategy(), nil
 	}
+
 	return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s not supported", expanderFlag)
 }

--- a/cluster-autoscaler/expander/fewestnodes/fewestnodes.go
+++ b/cluster-autoscaler/expander/fewestnodes/fewestnodes.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fewestnodes
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type fewestNodes struct {
+	fallbackStrategy expander.Strategy
+}
+
+// NewStrategy returns an expansion strategy that picks the node group with the
+// fewest nodes.
+func NewStrategy() expander.Strategy {
+	return &fewestNodes{fallbackStrategy: random.NewStrategy()}
+}
+
+// BestOption selects the node group with the fewest nodes.
+func (f *fewestNodes) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	if len(expansionOptions) == 1 {
+		return &expansionOptions[0]
+	}
+
+	smallest := expansionOptions[0]
+	foundSmaller := false
+	for _, o := range expansionOptions[1:] {
+		foundSmaller = true
+		if o.NodeCount < smallest.NodeCount {
+			smallest = o
+		}
+	}
+
+	// All expansion options have the same node count.
+	if !foundSmaller {
+		return f.fallbackStrategy.BestOption(expansionOptions, nodeInfo)
+	}
+
+	return &smallest
+}

--- a/cluster-autoscaler/expander/fewestnodes/fewestnodes_test.go
+++ b/cluster-autoscaler/expander/fewestnodes/fewestnodes_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fewestnodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+)
+
+func TestFewestNodesExpander(t *testing.T) {
+	cases := []struct {
+		name    string
+		options []expander.Option
+		want    expander.Option
+	}{
+		{
+			name:    "SingleOption",
+			options: []expander.Option{{NodeCount: 42}},
+			want:    expander.Option{NodeCount: 42},
+		},
+		{
+			name: "OptionsWithEqualNodeCounts",
+			options: []expander.Option{
+				{NodeCount: 42},
+				{NodeCount: 42},
+				{NodeCount: 42},
+			},
+			// We hope this is a random choice of one of the above. :)
+			want: expander.Option{NodeCount: 42},
+		},
+		{
+			name: "OptionsWithDifferentNodeCounts",
+			options: []expander.Option{
+				{NodeCount: 1},
+				{NodeCount: 42},
+				{NodeCount: 8},
+			},
+			want: expander.Option{NodeCount: 1},
+		},
+	}
+
+	e := NewStrategy()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := e.BestOption(tc.options, nil)
+			assert.True(t, assert.ObjectsAreEqual(tc.want, *got), "\nwant: %#v\ngot: %#v", tc.want, *got)
+		})
+	}
+}


### PR DESCRIPTION
Consider this an RFC. I haven't really thought through the implications.

Typically my clusters are setup to scale a homogenous set of node groups. I need only one flavour of node, but I want my nodes to be spread across all zones in an AWS or GCE region. I create one node group per zone so the CA can make intelligent scaling decisions for pods that must be created in a particular zone (i.e. to access cloud provider backed physical volumes).

When using the random expander with 3-4 node groups I notice it often picks an already quite large node group to expand. I end up with some node groups that have orders of magnitude more nodes than others for no real reason. My hope is that defaulting to embiggening the smallest node group will help smooth this out a little.