### PR TITLE
Add support for GPU for NAP

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -162,7 +162,8 @@ func (aws *awsCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (aws *awsCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (aws *awsCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -108,7 +108,7 @@ func (azure *AzureCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (azure *AzureCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (azure *AzureCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -53,7 +53,7 @@ type CloudProvider interface {
 	// NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 	// created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 	// Implementation optional.
-	NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (NodeGroup, error)
+	NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, extraResources map[string]resource.Quantity) (NodeGroup, error)
 
 	// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 	GetResourceLimiter() (*ResourceLimiter, error)
@@ -71,6 +71,10 @@ var ErrNotImplemented errors.AutoscalerError = errors.NewAutoscalerError(errors.
 
 // ErrAlreadyExist is returned if a method is not implemented.
 var ErrAlreadyExist errors.AutoscalerError = errors.NewAutoscalerError(errors.InternalError, "Already exist")
+
+// ErrIllegalConfiguration is returned when trying to create NewNodeGroup with
+// configuration that is not supported by cloudprovider.
+var ErrIllegalConfiguration errors.AutoscalerError = errors.NewAutoscalerError(errors.InternalError, "Configuration not allowed by cloud provider")
 
 // NodeGroup contains configuration info and functions to control a set
 // of nodes that have the same capacity and set of labels.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -137,7 +137,8 @@ func (gce *GceCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	nodePoolName := fmt.Sprintf("%s-%s-%d", nodeAutoprovisioningPrefix, machineType, time.Now().Unix())
 	mig := &Mig{
 		autoprovisioned: true,

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -376,7 +376,7 @@ func TestMig(t *testing.T) {
 	gceManagerMock.On("getLocation").Return("us-central1-b").Once()
 	gceManagerMock.On("getTemplates").Return(templateBuilder).Once()
 	server.On("handle", "/project1/zones/us-central1-b/machineTypes/n1-standard-1").Return(getMachineTypeResponse).Once()
-	nodeGroup, err := gce.NewNodeGroup("n1-standard-1", nil, nil)
+	nodeGroup, err := gce.NewNodeGroup("n1-standard-1", nil, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
 	mig1 := reflect.ValueOf(nodeGroup).Interface().(*Mig)

--- a/cluster-autoscaler/cloudprovider/gce/gpu.go
+++ b/cluster-autoscaler/cloudprovider/gce/gpu.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"strconv"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+var (
+	// TODO(maciekpytel): get this from API
+	gpuZones = map[string]map[string]bool{
+		"nvidia-tesla-k80": {
+			"europe-west1-b": true,
+			"europe-west1-d": true,
+			"asia-east1-a":   true,
+			"asia-east1-b":   true,
+			"us-east1-c":     true,
+			"us-east1-d":     true,
+			"us-west1-b":     true,
+		},
+		"nvidia-tesla-p100": {
+			"europe-west1-b": true,
+			"europe-west1-d": true,
+			"asia-east1-a":   true,
+			"us-east1-c":     true,
+			"us-west1-b":     true,
+		},
+	}
+
+	maxGpuCount = map[string]int64{
+		"nvidia-tesla-k80":  8,
+		"nvidia-tesla-p100": 4,
+	}
+
+	maxCpuCount = map[string]map[int64]int{
+		"nvidia-tesla-k80": {
+			1: 8,
+			2: 16,
+			4: 32,
+			8: 64,
+		},
+		"nvidia-tesla-p100": {
+			1: 16,
+			2: 32,
+			4: 64,
+		},
+	}
+)
+
+func validateGpuConfig(gpuType string, gpuCount int64, zone, machineType string) error {
+	zoneInfo, found := gpuZones[gpuType]
+	if !found {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+	if allowed := zoneInfo[zone]; !allowed {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+
+	maxGpu, found := maxGpuCount[gpuType]
+	if !found || gpuCount > maxGpu {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+
+	parts := strings.Split(machineType, "-")
+	cpus, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+	maxCpuInfo, found := maxCpuCount[gpuType]
+	if !found {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+	maxCpus, found := maxCpuInfo[gpuCount]
+	if !found || cpus > maxCpus {
+		return cloudprovider.ErrIllegalConfiguration
+	}
+
+	return nil
+}
+
+func getNormalizedGpuCount(initialCount int64) (int64, error) {
+	for i := int64(1); i <= int64(8); i = 2 * i {
+		if i >= initialCount {
+			return i, nil
+		}
+	}
+	return 0, cloudprovider.ErrIllegalConfiguration
+}

--- a/cluster-autoscaler/cloudprovider/gce/gpu_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gpu_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNormalizedGpuCount(t *testing.T) {
+	gpus, err := getNormalizedGpuCount(int64(0))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(1))
+
+	gpus, err = getNormalizedGpuCount(int64(1))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(1))
+
+	gpus, err = getNormalizedGpuCount(int64(2))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(2))
+
+	gpus, err = getNormalizedGpuCount(int64(3))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(4))
+
+	gpus, err = getNormalizedGpuCount(int64(7))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(8))
+
+	gpus, err = getNormalizedGpuCount(int64(8))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, gpus, int64(8))
+
+	gpus, err = getNormalizedGpuCount(int64(9))
+	assert.Error(t, err)
+}
+
+func TestValidateGpuConfig(t *testing.T) {
+	// valid configs
+	err := validateGpuConfig("nvidia-tesla-k80", int64(1), "europe-west1-b", "n1-standard-1")
+	assert.Equal(t, err, nil)
+	err = validateGpuConfig("nvidia-tesla-p100", int64(1), "europe-west1-b", "n1-standard-1")
+	assert.Equal(t, err, nil)
+	err = validateGpuConfig("nvidia-tesla-k80", int64(4), "europe-west1-b", "n1-standard-32")
+	assert.Equal(t, err, nil)
+
+	// invalid gpu
+	err = validateGpuConfig("duke-igthorn", int64(1), "europe-west1-b", "n1-standard-1")
+	assert.Error(t, err)
+
+	// invalid zone
+	err = validateGpuConfig("nvidia-tesla-k80", int64(1), "castle-drekmore", "n1-standard-1")
+	assert.Error(t, err)
+
+	// invalid machine type
+	err = validateGpuConfig("nvidia-tesla-k80", int64(1), "europe-west1-b", "toadie-the-ogre")
+	assert.Error(t, err)
+
+	// 1 gpu with large machine
+	err = validateGpuConfig("nvidia-tesla-k80", int64(1), "europe-west1-b", "n1-standard-32")
+	assert.Error(t, err)
+}

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -230,11 +230,16 @@ func (t *templateBuilder) buildNodeFromAutoprovisioningSpec(mig *Mig) (*apiv1.No
 		SelfLink: fmt.Sprintf("/api/v1/nodes/%s", nodeName),
 		Labels:   map[string]string{},
 	}
-	// TODO: Handle GPU
+
 	capacity, err := t.buildCapacity(mig.spec.machineType, nil, mig.GceRef.Zone)
 	if err != nil {
 		return nil, err
 	}
+
+	if gpuRequest, found := mig.spec.extraResources[gpu.ResourceNvidiaGPU]; found {
+		capacity[gpu.ResourceNvidiaGPU] = gpuRequest.DeepCopy()
+	}
+
 	node.Status = apiv1.NodeStatus{
 		Capacity:    capacity,
 		Allocatable: t.buildAllocatableFromCapacity(capacity),

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -250,6 +250,9 @@ func (t *templateBuilder) buildNodeFromAutoprovisioningSpec(mig *Mig) (*apiv1.No
 		return nil, err
 	}
 	node.Labels = labels
+
+	node.Spec.Taints = mig.spec.taints
+
 	// Ready status
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
 	return &node, nil

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -113,7 +113,8 @@ func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, err
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided.
-func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -56,7 +56,8 @@ func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, err
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
-func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -136,7 +136,8 @@ func (tcp *TestCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (tcp *TestCloudProvider) NewNodeGroup(machineType string, labels map[string]string, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (tcp *TestCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return &TestNodeGroup{
 		cloudProvider:   tcp,
 		id:              "autoprovisioned-" + machineType,

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/nodegroupset"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
@@ -371,27 +373,59 @@ func addAutoprovisionedCandidates(context *AutoscalingContext, nodeGroups []clou
 		return nodeGroups, nodeInfos
 	}
 
+	newGroupsCount := 0
+
+	newNodeGroups := addAllMachineTypesForConfig(context, map[string]string{}, map[string]resource.Quantity{},
+		nodeInfos, unschedulablePods)
+	newGroupsCount += len(newNodeGroups)
+	nodeGroups = append(nodeGroups, newNodeGroups...)
+
+	gpuRequests := gpu.GetGpuRequests(unschedulablePods)
+	for _, gpuRequestInfo := range gpuRequests {
+		glog.V(4).Info("Adding node groups using GPU to NAP simulations")
+		extraResources := map[string]resource.Quantity{
+			gpu.ResourceNvidiaGPU: gpuRequestInfo.MaxRequest,
+		}
+		newNodeGroups := addAllMachineTypesForConfig(context, gpuRequestInfo.SystemLabels, extraResources,
+			nodeInfos, gpuRequestInfo.Pods)
+		newGroupsCount += len(newNodeGroups)
+		nodeGroups = append(nodeGroups, newNodeGroups...)
+	}
+	glog.V(4).Infof("Considering %v potential node groups in NAP simulations", newGroupsCount)
+
+	return nodeGroups, nodeInfos
+}
+
+func addAllMachineTypesForConfig(context *AutoscalingContext, systemLabels map[string]string, extraResources map[string]resource.Quantity,
+	nodeInfos map[string]*schedulercache.NodeInfo, unschedulablePods []*apiv1.Pod) []cloudprovider.NodeGroup {
+
+	nodeGroups := make([]cloudprovider.NodeGroup, 0)
 	machines, err := context.CloudProvider.GetAvailableMachineTypes()
 	if err != nil {
 		glog.Warningf("Failed to get machine types: %v", err)
-	} else {
-		bestLabels := labels.BestLabelSet(unschedulablePods)
-		for _, machineType := range machines {
-			nodeGroup, err := context.CloudProvider.NewNodeGroup(machineType, bestLabels, nil)
-			if err != nil {
-				glog.Warningf("Unable to build temporary node group for %s: %v", machineType, err)
-				continue
-			}
-			nodeInfo, err := nodeGroup.TemplateNodeInfo()
-			if err != nil {
-				glog.Warningf("Unable to build template for node group for %s: %v", nodeGroup.Id(), err)
-				continue
-			}
-			nodeInfos[nodeGroup.Id()] = nodeInfo
-			nodeGroups = append(nodeGroups, nodeGroup)
-		}
+		return nodeGroups
 	}
-	return nodeGroups, nodeInfos
+
+	bestLabels := labels.BestLabelSet(unschedulablePods)
+	for _, machineType := range machines {
+		nodeGroup, err := context.CloudProvider.NewNodeGroup(machineType, bestLabels, systemLabels, extraResources)
+		if err != nil {
+			// We don't check if a given node group setup is allowed.
+			// It's fine if it isn't, just don't consider it an option.
+			if err != cloudprovider.ErrIllegalConfiguration {
+				glog.Warningf("Unable to build temporary node group for %s: %v", machineType, err)
+			}
+			continue
+		}
+		nodeInfo, err := nodeGroup.TemplateNodeInfo()
+		if err != nil {
+			glog.Warningf("Unable to build template for node group for %s: %v", nodeGroup.Id(), err)
+			continue
+		}
+		nodeInfos[nodeGroup.Id()] = nodeInfo
+		nodeGroups = append(nodeGroups, nodeGroup)
+	}
+	return nodeGroups
 }
 
 func calculateClusterCoresMemoryTotal(nodeGroups []cloudprovider.NodeGroup, nodeInfos map[string]*schedulercache.NodeInfo) (int64, int64) {

--- a/cluster-autoscaler/expander/price/price_test.go
+++ b/cluster-autoscaler/expander/price/price_test.go
@@ -73,7 +73,7 @@ func TestPriceExpander(t *testing.T) {
 	provider.AddNode("ng2", n2)
 	ng1, _ := provider.NodeGroupForNode(n1)
 	ng2, _ := provider.NodeGroupForNode(n2)
-	ng3, _ := provider.NewNodeGroup("MT1", nil, nil)
+	ng3, _ := provider.NewNodeGroup("MT1", nil, nil, nil)
 
 	ni1 := schedulercache.NewNodeInfo()
 	ni1.SetNode(n1)

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -98,6 +98,9 @@ type GpuRequestInfo struct {
 	MaxRequest resource.Quantity
 	// Pods is a list of pods requesting GPU
 	Pods []*apiv1.Pod
+	// SystemLabels is a set of system labels corresponding to selected GPU
+	// that needs to be passed to cloudprovider
+	SystemLabels map[string]string
 }
 
 // GetGpuRequests returns a GpuRequestInfo for each type of GPU requested by
@@ -127,6 +130,9 @@ func GetGpuRequests(pods []*apiv1.Pod) map[string]GpuRequestInfo {
 			requestInfo = GpuRequestInfo{
 				MaxRequest: podGpu,
 				Pods:       make([]*apiv1.Pod, 0),
+				SystemLabels: map[string]string{
+					GPULabel: gpuType,
+				},
 			}
 		}
 		if podGpu.Cmp(requestInfo.MaxRequest) > 0 {

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -18,6 +18,7 @@ package gpu
 
 import (
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/golang/glog"
 )
@@ -27,6 +28,9 @@ const (
 	ResourceNvidiaGPU = "nvidia.com/gpu"
 	// GPULabel is the label added to nodes with GPU resource on GKE.
 	GPULabel = "cloud.google.com/gke-accelerator"
+	// DefaultGPUType is the type of GPU used in NAP if the user
+	// don't specify what type of GPU his pod wants.
+	DefaultGPUType = "nvidia-tesla-k80"
 )
 
 // FilterOutNodesWithUnreadyGpus removes nodes that should have GPU, but don't have it in allocatable
@@ -86,4 +90,50 @@ func getUnreadyNodeCopy(node *apiv1.Node) (*apiv1.Node, error) {
 	}
 	newNode.Status.Conditions = newNodeConditions
 	return newNode, nil
+}
+
+// GpuRequestInfo contains an information about a set of pods requesting a GPU.
+type GpuRequestInfo struct {
+	// MaxRequest is maximum GPU request among pods
+	MaxRequest resource.Quantity
+	// Pods is a list of pods requesting GPU
+	Pods []*apiv1.Pod
+}
+
+// GetGpuRequests returns a GpuRequestInfo for each type of GPU requested by
+// any pod in pods argument. If the pod requests GPU, but doesn't specify what
+// type of GPU it wants (via NodeSelector) it assumes it's DefaultGPUType.
+func GetGpuRequests(pods []*apiv1.Pod) map[string]GpuRequestInfo {
+	result := make(map[string]GpuRequestInfo)
+	for _, pod := range pods {
+		var podGpu resource.Quantity
+		for _, container := range pod.Spec.Containers {
+			if container.Resources.Requests != nil {
+				containerGpu := container.Resources.Requests[ResourceNvidiaGPU]
+				podGpu.Add(containerGpu)
+			}
+		}
+		if podGpu.Value() == 0 {
+			continue
+		}
+
+		gpuType := DefaultGPUType
+		if gpuTypeFromSelector, found := pod.Spec.NodeSelector[GPULabel]; found {
+			gpuType = gpuTypeFromSelector
+		}
+
+		requestInfo, found := result[gpuType]
+		if !found {
+			requestInfo = GpuRequestInfo{
+				MaxRequest: podGpu,
+				Pods:       make([]*apiv1.Pod, 0),
+			}
+		}
+		if podGpu.Cmp(requestInfo.MaxRequest) > 0 {
+			requestInfo.MaxRequest = podGpu
+		}
+		requestInfo.Pods = append(requestInfo.Pods, pod)
+		result[gpuType] = requestInfo
+	}
+	return result
 }


### PR DESCRIPTION
The user experience will be as follows:
 - If there is a pending pod with GPU request NAP will create a node pool with nvidia P80 for it
 - If the pod uses nodeSelector on `cloud.google.com/gke-accelerator` label NAP will use the value of node selector to determine GPU type (you can get nvidia P100 by setting nodeSelector `cloud.google.com/gke-accelerator: nvidia-tesla-p100`).
 - New node pools with gpu will come with taint `gke-accelerator: <gpu_type>` with no schedule effect (to mitigate the risk of pods not requiring GPU landing on expensive node with GPU, there is no way user can do it themselves in NAP)
 - We validate if a node pool with GPU can be created against criteria specified in https://cloud.google.com/compute/docs/gpus/ (zone with GPU enabled, maximum CPU/GPU ratio, number of GPUs on node)

@vishh Does that look reasonable to you?