### PR TITLE
Added aws c5 instance types.

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -111,6 +111,48 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     7680,
 		GPU:          0,
 	},
+	"c5": {
+		InstanceType: "c5",
+		VCPU:         72,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"c5.2xlarge": {
+		InstanceType: "c5.2xlarge",
+		VCPU:         8,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"c5.4xlarge": {
+		InstanceType: "c5.4xlarge",
+		VCPU:         16,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"c5.9xlarge": {
+		InstanceType: "c5.9xlarge",
+		VCPU:         36,
+		MemoryMb:     73728,
+		GPU:          0,
+	},
+	"c5.18xlarge": {
+		InstanceType: "c5.18xlarge",
+		VCPU:         72,
+		MemoryMb:     147456,
+		GPU:          0,
+	},
+	"c5.large": {
+		InstanceType: "c5.large",
+		VCPU:         2,
+		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"c5.xlarge": {
+		InstanceType: "c5.xlarge",
+		VCPU:         4,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
 	"cc1.4xlarge": {
 		InstanceType: "cc1.4xlarge",
 		VCPU:         16,

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -117,6 +117,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     0,
 		GPU:          0,
 	},
+	"c5.18xlarge": {
+		InstanceType: "c5.18xlarge",
+		VCPU:         72,
+		MemoryMb:     147456,
+		GPU:          0,
+	},
 	"c5.2xlarge": {
 		InstanceType: "c5.2xlarge",
 		VCPU:         8,
@@ -133,12 +139,6 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "c5.9xlarge",
 		VCPU:         36,
 		MemoryMb:     73728,
-		GPU:          0,
-	},
-	"c5.18xlarge": {
-		InstanceType: "c5.18xlarge",
-		VCPU:         72,
-		MemoryMb:     147456,
 		GPU:          0,
 	},
 	"c5.large": {
@@ -266,12 +266,6 @@ var InstanceTypes = map[string]*instanceType{
 		VCPU:         32,
 		MemoryMb:     249856,
 		GPU:          2,
-	},
-	"hi1.4xlarge": {
-		InstanceType: "hi1.4xlarge",
-		VCPU:         16,
-		MemoryMb:     61952,
-		GPU:          0,
 	},
 	"hs1.8xlarge": {
 		InstanceType: "hs1.8xlarge",
@@ -663,10 +657,40 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     0,
 		GPU:          0,
 	},
+	"x1e.16xlarge": {
+		InstanceType: "x1e.16xlarge",
+		VCPU:         64,
+		MemoryMb:     1998848,
+		GPU:          0,
+	},
+	"x1e.2xlarge": {
+		InstanceType: "x1e.2xlarge",
+		VCPU:         8,
+		MemoryMb:     249856,
+		GPU:          0,
+	},
 	"x1e.32xlarge": {
 		InstanceType: "x1e.32xlarge",
 		VCPU:         128,
 		MemoryMb:     3997696,
+		GPU:          0,
+	},
+	"x1e.4xlarge": {
+		InstanceType: "x1e.4xlarge",
+		VCPU:         16,
+		MemoryMb:     499712,
+		GPU:          0,
+	},
+	"x1e.8xlarge": {
+		InstanceType: "x1e.8xlarge",
+		VCPU:         32,
+		MemoryMb:     999424,
+		GPU:          0,
+	},
+	"x1e.xlarge": {
+		InstanceType: "x1e.xlarge",
+		VCPU:         4,
+		MemoryMb:     124928,
 		GPU:          0,
 	},
 }


### PR DESCRIPTION
C5 instances: https://www.ec2instances.info/?filter=c5

Added new instances types to aws provider, otherwise we have exception everytime:

```
I1122 07:03:30.997937       1 scale_up.go:54] Pod bi/presto.worker-59788c9f65-565tx is unschedulable
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x145189d]
goroutine 76 [running]:
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.(*AwsManager).buildNodeFromTemplate(0xc420b1c040, 0xc421bcc000, 0xc421e0c900, 0xc421e0c900, 0x0, 0x0)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_manager.go:252 +0x48d
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws.(*Asg).TemplateNodeInfo(0xc421bcc000, 0xc421dd3b00, 0xc421a2f380, 0x20)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go:355 +0x78
k8s.io/autoscaler/cluster-autoscaler/core.GetNodeInfosForGroups(0xc421201080, 0x27, 0x2a, 0x50ba120, 0xc421bc1f80, 0x50c44e0, 0xc420ab5c70, 0xc42116ba80, 0x2, 0x2, ...)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/core/utils.go:211 +0x65a
k8s.io/autoscaler/cluster-autoscaler/core.ScaleUp(0xc420b9b520, 0xc42116e360, 0x4, 0x4, 0xc421201080, 0x27, 0x2a, 0xc42116ba80, 0x2, 0x2, ...)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/core/scale_up.go:57 +0x28e
k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce(0xc4218d4230, 0xed1a7183c, 0xe37618c72, 0x518d0a0, 0x0, 0x0)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:246 +0x1378
k8s.io/autoscaler/cluster-autoscaler/core.(*PollingAutoscaler).RunOnce(0xc421bc4a40, 0xed1a7183c, 0xe37618c72, 0x518d0a0, 0x518d0a0, 0x4e200)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/core/polling_autoscaler.go:72 +0x146
main.run(0xc4207158b0)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/main.go:262 +0x46f
main.main.func2(0xc420bcf2c0)
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/main.go:344 +0x2a
created by k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
	/gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:145 +0x97
```