### PR TITLE
Re-introduce flags that are used to configure Addon Resizer resources if not specified by config map

### DIFF
--- a/addon-resizer/README.md
+++ b/addon-resizer/README.md
@@ -15,9 +15,13 @@ The cluster size is periodically checked, and used to calculate the expected res
 Usage of pod_nanny:
       --config-dir="": The name of directory used to specify resources for scaled container.
       --container="pod-nanny": The name of the container to watch. This defaults to the nanny itself.
+      --cpu="MISSING": The base CPU resource requirement.
       --deployment="": The name of the deployment being monitored. This is required.
+      --extra-cpu="0": The amount of CPU to add per node.
+      --extra-memory="0Mi": The amount of memory to add per node.
       --extra-storage="0Gi": The amount of storage to add per node.
       --log-flush-frequency=5s: Maximum number of seconds between log flushes
+      --memory="MISSING": The base memory resource requirement.
       --namespace=$MY_POD_NAMESPACE: The namespace of the ward. This defaults to the nanny's own pod.
       --pod=$MY_POD_NAME: The name of the pod to watch. This defaults to the nanny's own pod.
       --poll-period=10000: The time, in milliseconds, to poll the dependent container.
@@ -39,10 +43,6 @@ data:
   NannyConfiguration: |-
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
-    baseCPU: "80m"
-    cpuPerNode: "0.5"
-    baseMemory: "140Mi"
-    memoryPerNode: "4"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -91,6 +91,10 @@ spec:
           command:
             - /pod_nanny
             - --config-dir=/etc/config
+            - --cpu=300m
+            - --extra-cpu=20m
+            - --memory=200Mi
+            - --extra-memory=10Mi
             - --threshold=5
             - --deployment=nanny-v1
         volumes:

--- a/addon-resizer/nanny/apis/nannyconfig/v1alpha1/defaults.go
+++ b/addon-resizer/nanny/apis/nannyconfig/v1alpha1/defaults.go
@@ -39,3 +39,18 @@ func SetDefaults_NannyConfiguration(obj *NannyConfiguration) {
 		obj.MemoryPerNode = "0"
 	}
 }
+
+func FillInDefaults_NannyConfiguration(obj *NannyConfiguration, defaults *NannyConfiguration) {
+	if obj.BaseCPU == nannyconfig.NoValue {
+		obj.BaseCPU = defaults.BaseCPU
+	}
+	if obj.CPUPerNode == "0" {
+		obj.CPUPerNode = defaults.CPUPerNode
+	}
+	if obj.BaseMemory == nannyconfig.NoValue {
+		obj.BaseMemory = defaults.BaseMemory
+	}
+	if obj.MemoryPerNode == "0" {
+		obj.MemoryPerNode = defaults.MemoryPerNode
+	}
+}


### PR DESCRIPTION
This introduces following logic:
- By default, the hardcoded values will be used.
- If flags are specified, they will overwrite defaults in code.
- If config map is specified, any parameters present there will overwrite both flags and defaults from the code.

This covers following scenario:
- Customer wants to overwrite resources requirements for some addon with config map.
- In next kubernetes version, addon resources are adjusted.
- The customer upgrades his cluster. If he has overwritten resource requirements, the values he specified still apply. If he hasn't, addon resource requirements are updated correctly.