### PR TITLE
Add h1 and m5 AWS instance types

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -153,12 +153,6 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     8192,
 		GPU:          0,
 	},
-	"cc1.4xlarge": {
-		InstanceType: "cc1.4xlarge",
-		VCPU:         16,
-		MemoryMb:     23552,
-		GPU:          0,
-	},
 	"cc2.8xlarge": {
 		InstanceType: "cc2.8xlarge",
 		VCPU:         32,
@@ -266,6 +260,36 @@ var InstanceTypes = map[string]*instanceType{
 		VCPU:         32,
 		MemoryMb:     249856,
 		GPU:          2,
+	},
+	"h1": {
+		InstanceType: "h1",
+		VCPU:         64,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"h1.16xlarge": {
+		InstanceType: "h1.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"h1.2xlarge": {
+		InstanceType: "h1.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"h1.4xlarge": {
+		InstanceType: "h1.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"h1.8xlarge": {
+		InstanceType: "h1.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          0,
 	},
 	"hs1.8xlarge": {
 		InstanceType: "hs1.8xlarge",
@@ -455,6 +479,48 @@ var InstanceTypes = map[string]*instanceType{
 	},
 	"m4.xlarge": {
 		InstanceType: "m4.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"m5": {
+		InstanceType: "m5",
+		VCPU:         96,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"m5.12xlarge": {
+		InstanceType: "m5.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          0,
+	},
+	"m5.24xlarge": {
+		InstanceType: "m5.24xlarge",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"m5.2xlarge": {
+		InstanceType: "m5.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"m5.4xlarge": {
+		InstanceType: "m5.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"m5.large": {
+		InstanceType: "m5.large",
+		VCPU:         2,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
+	"m5.xlarge": {
+		InstanceType: "m5.xlarge",
 		VCPU:         4,
 		MemoryMb:     16384,
 		GPU:          0,


### PR DESCRIPTION
Regenerated `ec2_instance_types.go` by running `make generate`. This adds support for the new AWS h1 and m5 instance types as in https://github.com/kubernetes/autoscaler/pull/483.