### PR TITLE
Add operator and value to pod tolerations in azure example yaml

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
@@ -31,6 +31,8 @@ spec:
     spec:
       tolerations:
       - effect: NoSchedule
+        operator: "Equal"
+        value: "true"
         key: node-role.kubernetes.io/master
       nodeSelector:
         kubernetes.io/role: master
@@ -78,7 +80,7 @@ spec:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-      - image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
+      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always
         name: cluster-autoscaler
         resources:


### PR DESCRIPTION
I created an acs-engine k8s cluster and tried to deploy 
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml

but got:
```
Warning  FailedScheduling  1s (x6 over 16s)  default-scheduler  No nodes are available that match all of the predicates: MatchNodeSelector (2), PodToleratesNodeTaints (1).
```

With this small fix pod got scheduled. 