### PR TITLE
running updater podLister in a separate go routine

### DIFF
--- a/vertical-pod-autoscaler/updater/updater.go
+++ b/vertical-pod-autoscaler/updater/updater.go
@@ -164,7 +164,7 @@ func newPodLister(kubeClient kube_client.Interface) v1lister.PodLister {
 	podLister := v1lister.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &apiv1.Pod{}, store, time.Hour)
 	stopCh := make(chan struct{})
-	podReflector.Run(stopCh)
+	go podReflector.Run(stopCh)
 
 	return podLister
 }


### PR DESCRIPTION
bugfix after recent godep update
- without it, updater would just hang on running reflector.