### PR TITLE
Support multiple node groups on Azure

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+// Asg is a wrapper over NodeGroup interface.
+type Asg interface {
+	cloudprovider.NodeGroup
+
+	getAzureRef() azureRef
+	getInstanceIDs() (map[azureRef]string, error)
+}
+
+type asgCache struct {
+	registeredAsgs     []Asg
+	instanceToAsg      map[azureRef]Asg
+	instanceToID       map[azureRef]string
+	notInRegisteredAsg map[azureRef]bool
+	mutex              sync.Mutex
+	interrupt          chan struct{}
+}
+
+func newAsgCache() (*asgCache, error) {
+	cache := &asgCache{
+		registeredAsgs:     make([]Asg, 0),
+		instanceToAsg:      make(map[azureRef]Asg),
+		instanceToID:       make(map[azureRef]string),
+		notInRegisteredAsg: make(map[azureRef]bool),
+		interrupt:          make(chan struct{}),
+	}
+
+	go wait.Until(func() {
+		cache.mutex.Lock()
+		defer cache.mutex.Unlock()
+		if err := cache.regenerate(); err != nil {
+			glog.Errorf("Error while regenerating Asg cache: %v", err)
+		}
+	}, time.Hour, cache.interrupt)
+
+	return cache, nil
+}
+
+// Register registers a node group if it hasn't been registered.
+func (m *asgCache) Register(asg Asg) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for i := range m.registeredAsgs {
+		if existing := m.registeredAsgs[i]; existing.Id() == asg.Id() {
+			if reflect.DeepEqual(existing, asg) {
+				return false
+			}
+
+			m.registeredAsgs[i] = asg
+			glog.V(4).Infof("ASG %q updated", asg.Id())
+			m.invalidateUnownedInstanceCache()
+			return true
+		}
+	}
+
+	glog.V(4).Infof("Registering ASG %q", asg.Id())
+	m.registeredAsgs = append(m.registeredAsgs, asg)
+	m.invalidateUnownedInstanceCache()
+	return true
+}
+
+func (m *asgCache) invalidateUnownedInstanceCache() {
+	glog.V(4).Info("Invalidating unowned instance cache")
+	m.notInRegisteredAsg = make(map[azureRef]bool)
+}
+
+// Unregister ASG. Returns true if the ASG was unregistered.
+func (m *asgCache) Unregister(asg Asg) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	updated := make([]Asg, 0, len(m.registeredAsgs))
+	changed := false
+	for _, existing := range m.registeredAsgs {
+		if existing.Id() == asg.Id() {
+			glog.V(1).Infof("Unregistered ASG %s", asg.Id())
+			changed = true
+			continue
+		}
+		updated = append(updated, existing)
+	}
+	m.registeredAsgs = updated
+	return changed
+}
+
+func (m *asgCache) get() []Asg {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.registeredAsgs
+}
+
+func (m *asgCache) getInstanceIDs(instances []*azureRef) []string {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	instanceIds := make([]string, len(instances))
+	for i, instance := range instances {
+		instanceIds[i] = m.instanceToID[*instance]
+	}
+
+	return instanceIds
+}
+
+// FindForInstance returns Asg of the given Instance
+func (m *asgCache) FindForInstance(instance *azureRef) (Asg, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.notInRegisteredAsg[*instance] {
+		// We already know we don't own this instance. Return early and avoid
+		// additional calls.
+		return nil, nil
+	}
+
+	if asg, found := m.instanceToAsg[*instance]; found {
+		return asg, nil
+	}
+
+	if err := m.regenerate(); err != nil {
+		return nil, fmt.Errorf("Error while looking for ASG for instance %+v, error: %v", *instance, err)
+	}
+	if config, found := m.instanceToAsg[*instance]; found {
+		return config, nil
+	}
+
+	m.notInRegisteredAsg[*instance] = true
+	return nil, nil
+}
+
+// Cleanup closes the channel to signal the go routine to stop that is handling the cache
+func (m *asgCache) Cleanup() {
+	close(m.interrupt)
+}
+
+func (m *asgCache) regenerate() error {
+	newCache := make(map[azureRef]Asg)
+
+	for _, nsg := range m.registeredAsgs {
+		instances, err := nsg.Nodes()
+		if err != nil {
+			return err
+		}
+
+		for _, instance := range instances {
+			ref := azureRef{Name: instance}
+			newCache[ref] = nsg
+		}
+	}
+
+	m.instanceToAsg = newCache
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/Azure/azure-sdk-for-go/arm/disk"
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/azure-sdk-for-go/arm/storage"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/glog"
+)
+
+// VirtualMachineScaleSetsClient defines needed functions for azure compute.VirtualMachineScaleSetsClient.
+type VirtualMachineScaleSetsClient interface {
+	Get(resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
+	CreateOrUpdate(resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet, cancel <-chan struct{}) (<-chan compute.VirtualMachineScaleSet, <-chan error)
+	DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error)
+	List(resourceGroupName string) (result compute.VirtualMachineScaleSetListResult, err error)
+	ListNextResults(lastResults compute.VirtualMachineScaleSetListResult) (result compute.VirtualMachineScaleSetListResult, err error)
+}
+
+// VirtualMachineScaleSetVMsClient defines needed functions for azure compute.VirtualMachineScaleSetVMsClient.
+type VirtualMachineScaleSetVMsClient interface {
+	List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result compute.VirtualMachineScaleSetVMListResult, err error)
+	ListNextResults(lastResults compute.VirtualMachineScaleSetVMListResult) (result compute.VirtualMachineScaleSetVMListResult, err error)
+}
+
+// VirtualMachinesClient defines needed functions for azure compute.VirtualMachinesClient.
+type VirtualMachinesClient interface {
+	Get(resourceGroupName string, VMName string, expand compute.InstanceViewTypes) (result compute.VirtualMachine, err error)
+	Delete(resourceGroupName string, VMName string, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error)
+	List(resourceGroupName string) (result compute.VirtualMachineListResult, err error)
+	ListNextResults(lastResults compute.VirtualMachineListResult) (result compute.VirtualMachineListResult, err error)
+}
+
+// InterfacesClient defines needed functions for azure network.InterfacesClient.
+type InterfacesClient interface {
+	Delete(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (<-chan autorest.Response, <-chan error)
+}
+
+// DeploymentsClient defines needed functions for azure network.DeploymentsClient.
+type DeploymentsClient interface {
+	Get(resourceGroupName string, deploymentName string) (result resources.DeploymentExtended, err error)
+	ExportTemplate(resourceGroupName string, deploymentName string) (result resources.DeploymentExportResult, err error)
+	CreateOrUpdate(resourceGroupName string, deploymentName string, parameters resources.Deployment, cancel <-chan struct{}) (<-chan resources.DeploymentExtended, <-chan error)
+}
+
+// DisksClient defines needed functions for azure disk.DisksClient.
+type DisksClient interface {
+	Delete(resourceGroupName string, diskName string, cancel <-chan struct{}) (<-chan disk.OperationStatusResponse, <-chan error)
+}
+
+// AccountsClient defines needed functions for azure storage.AccountsClient.
+type AccountsClient interface {
+	ListKeys(resourceGroupName string, accountName string) (result storage.AccountListKeysResult, err error)
+}
+
+type azClient struct {
+	virtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
+	virtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
+	virtualMachinesClient           VirtualMachinesClient
+	deploymentsClient               DeploymentsClient
+	interfacesClient                InterfacesClient
+	disksClient                     DisksClient
+	storageAccountsClient           AccountsClient
+}
+
+// newServicePrincipalTokenFromCredentials creates a new ServicePrincipalToken using values of the
+// passed credentials map.
+func newServicePrincipalTokenFromCredentials(config *Config, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, config.TenantID)
+	if err != nil {
+		return nil, fmt.Errorf("creating the OAuth config: %v", err)
+	}
+
+	if config.UseManagedIdentityExtension {
+		glog.V(2).Infoln("azure: using managed identity extension to retrieve access token")
+		msiEndpoint, err := adal.GetMSIVMEndpoint()
+		if err != nil {
+			return nil, fmt.Errorf("Getting the managed service identity endpoint: %v", err)
+		}
+		return adal.NewServicePrincipalTokenFromMSI(
+			msiEndpoint,
+			env.ServiceManagementEndpoint)
+	}
+
+	if len(config.AADClientSecret) > 0 {
+		glog.V(2).Infoln("azure: using client_id+client_secret to retrieve access token")
+		return adal.NewServicePrincipalToken(
+			*oauthConfig,
+			config.AADClientID,
+			config.AADClientSecret,
+			env.ServiceManagementEndpoint)
+	}
+
+	if len(config.AADClientCertPath) > 0 && len(config.AADClientCertPassword) > 0 {
+		glog.V(2).Infoln("azure: using jwt client_assertion (client_cert+client_private_key) to retrieve access token")
+		certData, err := ioutil.ReadFile(config.AADClientCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading the client certificate from file %s: %v", config.AADClientCertPath, err)
+		}
+		certificate, privateKey, err := decodePkcs12(certData, config.AADClientCertPassword)
+		if err != nil {
+			return nil, fmt.Errorf("decoding the client certificate: %v", err)
+		}
+		return adal.NewServicePrincipalTokenFromCertificate(
+			*oauthConfig,
+			config.AADClientID,
+			certificate,
+			privateKey,
+			env.ServiceManagementEndpoint)
+	}
+
+	return nil, fmt.Errorf("No credentials provided for AAD application %s", config.AADClientID)
+}
+
+func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
+	spt, err := newServicePrincipalTokenFromCredentials(cfg, env)
+	if err != nil {
+		return nil, err
+	}
+
+	scaleSetsClient := compute.NewVirtualMachineScaleSetsClient(cfg.SubscriptionID)
+	scaleSetsClient.BaseURI = env.ResourceManagerEndpoint
+	scaleSetsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	scaleSetsClient.PollingDelay = 5 * time.Second
+	configureUserAgent(&scaleSetsClient.Client)
+	glog.V(5).Infof("Created scale set client with authorizer: %v", scaleSetsClient)
+
+	scaleSetVMsClient := compute.NewVirtualMachineScaleSetVMsClient(cfg.SubscriptionID)
+	scaleSetVMsClient.BaseURI = env.ResourceManagerEndpoint
+	scaleSetVMsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	scaleSetVMsClient.PollingDelay = 5 * time.Second
+	configureUserAgent(&scaleSetVMsClient.Client)
+	glog.V(5).Infof("Created scale set vm client with authorizer: %v", scaleSetVMsClient)
+
+	virtualMachinesClient := compute.NewVirtualMachinesClient(cfg.SubscriptionID)
+	virtualMachinesClient.BaseURI = env.ResourceManagerEndpoint
+	virtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	virtualMachinesClient.PollingDelay = 5 * time.Second
+	configureUserAgent(&virtualMachinesClient.Client)
+	glog.V(5).Infof("Created vm client with authorizer: %v", virtualMachinesClient)
+
+	deploymentsClient := resources.NewDeploymentsClient(cfg.SubscriptionID)
+	deploymentsClient.BaseURI = env.ResourceManagerEndpoint
+	deploymentsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	deploymentsClient.PollingDelay = 5 * time.Second
+	configureUserAgent(&deploymentsClient.Client)
+	glog.V(5).Infof("Created deployments client with authorizer: %v", deploymentsClient)
+
+	interfacesClient := network.NewInterfacesClient(cfg.SubscriptionID)
+	interfacesClient.BaseURI = env.ResourceManagerEndpoint
+	interfacesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	interfacesClient.PollingDelay = 5 * time.Second
+	glog.V(5).Infof("Created interfaces client with authorizer: %v", interfacesClient)
+
+	storageAccountsClient := storage.NewAccountsClient(cfg.SubscriptionID)
+	storageAccountsClient.BaseURI = env.ResourceManagerEndpoint
+	storageAccountsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	storageAccountsClient.PollingDelay = 5 * time.Second
+	glog.V(5).Infof("Created storage accounts client with authorizer: %v", storageAccountsClient)
+
+	disksClient := disk.NewDisksClient(cfg.SubscriptionID)
+	disksClient.BaseURI = env.ResourceManagerEndpoint
+	disksClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	disksClient.PollingDelay = 5 * time.Second
+	glog.V(5).Infof("Created disks client with authorizer: %v", disksClient)
+
+	return &azClient{
+		disksClient:                     disksClient,
+		interfacesClient:                interfacesClient,
+		virtualMachineScaleSetsClient:   scaleSetsClient,
+		virtualMachineScaleSetVMsClient: scaleSetVMsClient,
+		deploymentsClient:               deploymentsClient,
+		virtualMachinesClient:           virtualMachinesClient,
+		storageAccountsClient:           storageAccountsClient,
+	}, nil
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -19,97 +19,37 @@ package azure
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/arm/compute"
-	"github.com/Azure/azure-sdk-for-go/arm/disk"
-	"github.com/Azure/azure-sdk-for-go/arm/network"
-	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
-	"github.com/Azure/azure-sdk-for-go/arm/storage"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/glog"
 
 	"gopkg.in/gcfg.v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 )
 
 const (
 	vmTypeVMSS     = "vmss"
 	vmTypeStandard = "standard"
+
+	scaleToZeroSupported = false
+	refreshInterval      = 1 * time.Minute
 )
-
-// VirtualMachineScaleSetsClient defines needed functions for azure compute.VirtualMachineScaleSetsClient.
-type VirtualMachineScaleSetsClient interface {
-	Get(resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
-	CreateOrUpdate(resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet, cancel <-chan struct{}) (<-chan compute.VirtualMachineScaleSet, <-chan error)
-	DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error)
-}
-
-// VirtualMachineScaleSetVMsClient defines needed functions for azure compute.VirtualMachineScaleSetVMsClient.
-type VirtualMachineScaleSetVMsClient interface {
-	List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result compute.VirtualMachineScaleSetVMListResult, err error)
-	ListNextResults(lastResults compute.VirtualMachineScaleSetVMListResult) (result compute.VirtualMachineScaleSetVMListResult, err error)
-}
-
-// VirtualMachinesClient defines needed functions for azure compute.VirtualMachinesClient.
-type VirtualMachinesClient interface {
-	Get(resourceGroupName string, VMName string, expand compute.InstanceViewTypes) (result compute.VirtualMachine, err error)
-	Delete(resourceGroupName string, VMName string, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error)
-	List(resourceGroupName string) (result compute.VirtualMachineListResult, err error)
-	ListNextResults(lastResults compute.VirtualMachineListResult) (result compute.VirtualMachineListResult, err error)
-}
-
-// InterfacesClient defines needed functions for azure network.InterfacesClient.
-type InterfacesClient interface {
-	Delete(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (<-chan autorest.Response, <-chan error)
-}
-
-// DeploymentsClient defines needed functions for azure network.DeploymentsClient.
-type DeploymentsClient interface {
-	Get(resourceGroupName string, deploymentName string) (result resources.DeploymentExtended, err error)
-	ExportTemplate(resourceGroupName string, deploymentName string) (result resources.DeploymentExportResult, err error)
-	CreateOrUpdate(resourceGroupName string, deploymentName string, parameters resources.Deployment, cancel <-chan struct{}) (<-chan resources.DeploymentExtended, <-chan error)
-}
-
-// DisksClient defines needed functions for azure disk.DisksClient.
-type DisksClient interface {
-	Delete(resourceGroupName string, diskName string, cancel <-chan struct{}) (<-chan disk.OperationStatusResponse, <-chan error)
-}
-
-// AccountsClient defines needed functions for azure storage.AccountsClient.
-type AccountsClient interface {
-	ListKeys(resourceGroupName string, accountName string) (result storage.AccountListKeysResult, err error)
-}
 
 // AzureManager handles Azure communication and data caching.
 type AzureManager struct {
-	config *Config
-	env    azure.Environment
+	config   *Config
+	azClient *azClient
+	env      azure.Environment
 
-	virtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
-	virtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
-	virtualMachinesClient           VirtualMachinesClient
-	deploymentsClient               DeploymentsClient
-	interfacesClient                InterfacesClient
-	disksClient                     DisksClient
-	storageAccountsClient           AccountsClient
-
-	nodeGroups []cloudprovider.NodeGroup
-	// cache of mapping from instance name to nodeGroup.
-	nodeGroupsCache map[AzureRef]cloudprovider.NodeGroup
-	// cache of mapping from instance name to instanceID.
-	instanceIDsCache map[string]string
-
-	cacheMutex sync.Mutex
-	interrupt  chan struct{}
+	asgCache              *asgCache
+	lastRefresh           time.Time
+	asgAutoDiscoverySpecs []cloudprovider.LabelAutoDiscoveryConfig
+	explicitlyConfigured  map[azureRef]bool
 }
 
 // Config holds the configuration parsed from the --cloud-config flag
@@ -155,7 +95,7 @@ func (c *Config) TrimSpace() {
 }
 
 // CreateAzureManager creates Azure Manager object to work with Azure.
-func CreateAzureManager(configReader io.Reader) (*AzureManager, error) {
+func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*AzureManager, error) {
 	var err error
 	var cfg Config
 
@@ -196,6 +136,7 @@ func CreateAzureManager(configReader io.Reader) (*AzureManager, error) {
 		cfg.VMType = vmTypeVMSS
 	}
 
+	// Defaulting env to Azure Public Cloud.
 	env := azure.PublicCloud
 	if cfg.Cloud != "" {
 		env, err = azure.EnvironmentFromName(cfg.Cloud)
@@ -204,355 +145,268 @@ func CreateAzureManager(configReader io.Reader) (*AzureManager, error) {
 		}
 	}
 
-	if cfg.ResourceGroup == "" {
-		return nil, fmt.Errorf("resource group not set")
-	}
-
-	if cfg.SubscriptionID == "" {
-		return nil, fmt.Errorf("subscription ID not set")
-	}
-
-	if cfg.TenantID == "" {
-		return nil, fmt.Errorf("tenant ID not set")
-	}
-
-	if cfg.AADClientID == "" {
-		return nil, fmt.Errorf("ARM Client ID not set")
-	}
-
-	if cfg.VMType == vmTypeStandard {
-		if cfg.Deployment == "" {
-			return nil, fmt.Errorf("deployment not set")
-		}
-
-		if cfg.APIServerPrivateKey == "" {
-			return nil, fmt.Errorf("apiServerPrivateKey not set")
-		}
-
-		if cfg.CAPrivateKey == "" {
-			return nil, fmt.Errorf("caPrivateKey not set")
-		}
-
-		if cfg.ClientPrivateKey == "" {
-			return nil, fmt.Errorf("clientPrivateKey not set")
-		}
-
-		if cfg.KubeConfigPrivateKey == "" {
-			return nil, fmt.Errorf("kubeConfigPrivateKey not set")
-		}
+	if err := validateConfig(&cfg); err != nil {
+		return nil, err
 	}
 
 	glog.Infof("Starting azure manager with subscription ID %q", cfg.SubscriptionID)
 
-	spt, err := NewServicePrincipalTokenFromCredentials(&cfg, &env)
+	azClient, err := newAzClient(&cfg, &env)
 	if err != nil {
 		return nil, err
 	}
 
-	scaleSetsClient := compute.NewVirtualMachineScaleSetsClient(cfg.SubscriptionID)
-	scaleSetsClient.BaseURI = env.ResourceManagerEndpoint
-	scaleSetsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	scaleSetsClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&scaleSetsClient.Client)
-	glog.V(5).Infof("Created scale set client with authorizer: %v", scaleSetsClient)
-
-	scaleSetVMsClient := compute.NewVirtualMachineScaleSetVMsClient(cfg.SubscriptionID)
-	scaleSetVMsClient.BaseURI = env.ResourceManagerEndpoint
-	scaleSetVMsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	scaleSetVMsClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&scaleSetVMsClient.Client)
-	glog.V(5).Infof("Created scale set vm client with authorizer: %v", scaleSetVMsClient)
-
-	virtualMachinesClient := compute.NewVirtualMachinesClient(cfg.SubscriptionID)
-	virtualMachinesClient.BaseURI = env.ResourceManagerEndpoint
-	virtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	virtualMachinesClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&virtualMachinesClient.Client)
-	glog.V(5).Infof("Created vm client with authorizer: %v", virtualMachinesClient)
-
-	deploymentsClient := resources.NewDeploymentsClient(cfg.SubscriptionID)
-	deploymentsClient.BaseURI = env.ResourceManagerEndpoint
-	deploymentsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	deploymentsClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&deploymentsClient.Client)
-	glog.V(5).Infof("Created deployments client with authorizer: %v", deploymentsClient)
-
-	interfacesClient := network.NewInterfacesClient(cfg.SubscriptionID)
-	interfacesClient.BaseURI = env.ResourceManagerEndpoint
-	interfacesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	interfacesClient.PollingDelay = 5 * time.Second
-	glog.V(5).Infof("Created interfaces client with authorizer: %v", interfacesClient)
-
-	storageAccountsClient := storage.NewAccountsClient(cfg.SubscriptionID)
-	storageAccountsClient.BaseURI = env.ResourceManagerEndpoint
-	storageAccountsClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	storageAccountsClient.PollingDelay = 5 * time.Second
-	glog.V(5).Infof("Created storage accounts client with authorizer: %v", storageAccountsClient)
-
-	disksClient := disk.NewDisksClient(cfg.SubscriptionID)
-	disksClient.BaseURI = env.ResourceManagerEndpoint
-	disksClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	disksClient.PollingDelay = 5 * time.Second
-	glog.V(5).Infof("Created disks client with authorizer: %v", disksClient)
-
 	// Create azure manager.
 	manager := &AzureManager{
-		config:                          &cfg,
-		env:                             env,
-		disksClient:                     disksClient,
-		interfacesClient:                interfacesClient,
-		virtualMachineScaleSetsClient:   scaleSetsClient,
-		virtualMachineScaleSetVMsClient: scaleSetVMsClient,
-		deploymentsClient:               deploymentsClient,
-		virtualMachinesClient:           virtualMachinesClient,
-		storageAccountsClient:           storageAccountsClient,
-
-		interrupt:        make(chan struct{}),
-		instanceIDsCache: make(map[string]string),
-		nodeGroups:       make([]cloudprovider.NodeGroup, 0),
-		nodeGroupsCache:  make(map[AzureRef]cloudprovider.NodeGroup),
+		config:               &cfg,
+		env:                  env,
+		azClient:             azClient,
+		explicitlyConfigured: make(map[azureRef]bool),
 	}
 
-	go wait.Until(func() {
-		manager.cacheMutex.Lock()
-		defer manager.cacheMutex.Unlock()
-		if err := manager.regenerateCache(); err != nil {
-			glog.Errorf("Error while regenerating AS cache: %v", err)
-		}
-	}, 5*time.Minute, manager.interrupt)
+	cache, err := newAsgCache()
+	if err != nil {
+		return nil, err
+	}
+	manager.asgCache = cache
+
+	specs, err := discoveryOpts.ParseLabelAutoDiscoverySpecs()
+	if err != nil {
+		return nil, err
+	}
+	manager.asgAutoDiscoverySpecs = specs
+
+	if err := manager.fetchExplicitAsgs(discoveryOpts.NodeGroupSpecs); err != nil {
+		return nil, err
+	}
+
+	if err := manager.forceRefresh(); err != nil {
+		return nil, err
+	}
 
 	return manager, nil
 }
 
-// NewServicePrincipalTokenFromCredentials creates a new ServicePrincipalToken using values of the
-// passed credentials map.
-func NewServicePrincipalTokenFromCredentials(config *Config, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, config.TenantID)
+func (m *AzureManager) fetchExplicitAsgs(specs []string) error {
+	changed := false
+	for _, spec := range specs {
+		asg, err := m.buildAsgFromSpec(spec)
+		if err != nil {
+			return fmt.Errorf("failed to parse node group spec: %v", err)
+		}
+		if m.RegisterAsg(asg) {
+			changed = true
+		}
+		m.explicitlyConfigured[asg.getAzureRef()] = true
+	}
+
+	if changed {
+		if err := m.regenerateCache(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *AzureManager) buildAsgFromSpec(spec string) (Asg, error) {
+	s, err := dynamic.SpecFromString(spec, scaleToZeroSupported)
 	if err != nil {
-		return nil, fmt.Errorf("creating the OAuth config: %v", err)
+		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
 	}
-
-	if config.UseManagedIdentityExtension {
-		glog.V(2).Infoln("azure: using managed identity extension to retrieve access token")
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		if err != nil {
-			return nil, fmt.Errorf("Getting the managed service identity endpoint: %v", err)
-		}
-		return adal.NewServicePrincipalTokenFromMSI(
-			msiEndpoint,
-			env.ServiceManagementEndpoint)
-	}
-
-	if len(config.AADClientSecret) > 0 {
-		glog.V(2).Infoln("azure: using client_id+client_secret to retrieve access token")
-		return adal.NewServicePrincipalToken(
-			*oauthConfig,
-			config.AADClientID,
-			config.AADClientSecret,
-			env.ServiceManagementEndpoint)
-	}
-
-	if len(config.AADClientCertPath) > 0 && len(config.AADClientCertPassword) > 0 {
-		glog.V(2).Infoln("azure: using jwt client_assertion (client_cert+client_private_key) to retrieve access token")
-		certData, err := ioutil.ReadFile(config.AADClientCertPath)
-		if err != nil {
-			return nil, fmt.Errorf("reading the client certificate from file %s: %v", config.AADClientCertPath, err)
-		}
-		certificate, privateKey, err := decodePkcs12(certData, config.AADClientCertPassword)
-		if err != nil {
-			return nil, fmt.Errorf("decoding the client certificate: %v", err)
-		}
-		return adal.NewServicePrincipalTokenFromCertificate(
-			*oauthConfig,
-			config.AADClientID,
-			certificate,
-			privateKey,
-			env.ServiceManagementEndpoint)
-	}
-
-	return nil, fmt.Errorf("No credentials provided for AAD application %s", config.AADClientID)
-}
-
-// RegisterNodeGroup registers node group in Azure Manager.
-func (m *AzureManager) RegisterNodeGroup(nodeGroup cloudprovider.NodeGroup) {
-	m.cacheMutex.Lock()
-	defer m.cacheMutex.Unlock()
-
-	m.nodeGroups = append(m.nodeGroups, nodeGroup)
-}
-
-func (m *AzureManager) nodeGroupRegisted(nodeGroup string) bool {
-	for _, ng := range m.nodeGroups {
-		if nodeGroup == ng.Id() {
-			return true
-		}
-	}
-
-	return false
-}
-
-// GetNodeGroupForInstance returns nodeGroup of the given Instance
-func (m *AzureManager) GetNodeGroupForInstance(instance *AzureRef) (cloudprovider.NodeGroup, error) {
-	glog.V(5).Infof("Looking for node group for instance: %q", instance)
-
-	glog.V(8).Infof("Cache BEFORE: %v\n", m.nodeGroupsCache)
-
-	m.cacheMutex.Lock()
-	defer m.cacheMutex.Unlock()
-	if nodeGroup, found := m.nodeGroupsCache[*instance]; found {
-		return nodeGroup, nil
-	}
-
-	if err := m.regenerateCache(); err != nil {
-		return nil, fmt.Errorf("Error while looking for nodeGroup for instance %+v, error: %v", *instance, err)
-	}
-
-	glog.V(8).Infof("Cache AFTER: %v\n", m.nodeGroupsCache)
-
-	if nodeGroup, found := m.nodeGroupsCache[*instance]; found {
-		return nodeGroup, nil
-	}
-
-	// instance does not belong to any configured nodeGroup.
-	return nil, nil
-}
-
-// GetInstanceIDs gets instanceIDs for specified instances.
-func (m *AzureManager) GetInstanceIDs(instances []*AzureRef) []string {
-	m.cacheMutex.Lock()
-	defer m.cacheMutex.Unlock()
-
-	instanceIds := make([]string, len(instances))
-	for i, instance := range instances {
-		instanceIds[i] = m.instanceIDsCache[instance.Name]
-	}
-
-	return instanceIds
-}
-
-func (m *AzureManager) regenerateCache() (err error) {
-	var newCache map[AzureRef]cloudprovider.NodeGroup
-	var newInstanceIDsCache map[string]string
 
 	switch m.config.VMType {
-	case vmTypeVMSS:
-		newCache, newInstanceIDsCache, err = m.listScaleSets()
 	case vmTypeStandard:
-		newCache, newInstanceIDsCache, err = m.listAgentPools()
+		return NewAgentPool(s, m)
+	case vmTypeVMSS:
+		return NewScaleSet(s, m)
+	default:
+		return nil, fmt.Errorf("vmtype %s not supported", m.config.VMType)
+	}
+}
+
+// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
+// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
+func (m *AzureManager) Refresh() error {
+	if m.lastRefresh.Add(refreshInterval).After(time.Now()) {
+		return nil
+	}
+	return m.forceRefresh()
+}
+
+func (m *AzureManager) forceRefresh() error {
+	if err := m.fetchAutoAsgs(); err != nil {
+		glog.Errorf("Failed to fetch ASGs: %v", err)
+		return err
+	}
+	m.lastRefresh = time.Now()
+	glog.V(2).Infof("Refreshed ASG list, next refresh after %v", m.lastRefresh.Add(refreshInterval))
+	return nil
+}
+
+// Fetch automatically discovered ASGs. These ASGs should be unregistered if
+// they no longer exist in Azure.
+func (m *AzureManager) fetchAutoAsgs() error {
+	groups, err := m.getFilteredAutoscalingGroups(m.asgAutoDiscoverySpecs)
+	if err != nil {
+		return fmt.Errorf("cannot autodiscover ASGs: %s", err)
+	}
+
+	changed := false
+	exists := make(map[azureRef]bool)
+	for _, asg := range groups {
+		azRef := asg.getAzureRef()
+		exists[azRef] = true
+		if m.explicitlyConfigured[azRef] {
+			// This ASG was explicitly configured, but would also be
+			// autodiscovered. We want the explicitly configured min and max
+			// nodes to take precedence.
+			glog.V(3).Infof("Ignoring explicitly configured ASG %s for autodiscovery.", asg.Id())
+			continue
+		}
+		if m.RegisterAsg(asg) {
+			glog.V(3).Infof("Autodiscovered ASG %s using tags %v", asg.Id(), m.asgAutoDiscoverySpecs)
+			changed = true
+		}
+	}
+
+	for _, asg := range m.getAsgs() {
+		azRef := asg.getAzureRef()
+		if !exists[azRef] && !m.explicitlyConfigured[azRef] {
+			m.UnregisterAsg(asg)
+			changed = true
+		}
+	}
+
+	if changed {
+		if err := m.regenerateCache(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *AzureManager) getAsgs() []Asg {
+	return m.asgCache.get()
+}
+
+func (m *AzureManager) getInstanceIDs(instances []*azureRef) []string {
+	return m.asgCache.getInstanceIDs(instances)
+}
+
+// RegisterAsg registers an ASG.
+func (m *AzureManager) RegisterAsg(asg Asg) bool {
+	return m.asgCache.Register(asg)
+}
+
+// UnregisterAsg unregisters an ASG.
+func (m *AzureManager) UnregisterAsg(asg Asg) bool {
+	return m.asgCache.Unregister(asg)
+}
+
+// GetAsgForInstance returns AsgConfig of the given Instance
+func (m *AzureManager) GetAsgForInstance(instance *azureRef) (Asg, error) {
+	return m.asgCache.FindForInstance(instance)
+}
+
+func (m *AzureManager) regenerateCache() error {
+	m.asgCache.mutex.Lock()
+	defer m.asgCache.mutex.Unlock()
+	return m.asgCache.regenerate()
+}
+
+// Cleanup the ASG cache.
+func (m *AzureManager) Cleanup() {
+	m.asgCache.Cleanup()
+}
+
+func (m *AzureManager) getFilteredAutoscalingGroups(filter []cloudprovider.LabelAutoDiscoveryConfig) (asgs []Asg, err error) {
+	switch m.config.VMType {
+	case vmTypeVMSS:
+		asgs, err = m.listScaleSets(filter)
+	case vmTypeStandard:
+		asgs, err = m.listAgentPools(filter)
 	default:
 		err = fmt.Errorf("vmType %q not supported", m.config.VMType)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	m.nodeGroupsCache = newCache
-	m.instanceIDsCache = newInstanceIDsCache
-	return nil
-}
-
-func (m *AzureManager) getNodeGroupByID(id string) cloudprovider.NodeGroup {
-	for _, ng := range m.nodeGroups {
-		if id == ng.Id() {
-			return ng
-		}
-	}
-
-	return nil
-}
-
-func (m *AzureManager) listAgentPools() (map[AzureRef]cloudprovider.NodeGroup, map[string]string, error) {
-	as := make(map[AzureRef]cloudprovider.NodeGroup)
-	instanceIDs := make(map[string]string)
-
-	for _, nodeGroup := range m.nodeGroups {
-		agentPool, ok := nodeGroup.(*AgentPool)
-		if !ok {
-			return nil, nil, fmt.Errorf("node group %q is not AgentPool", nodeGroup)
-		}
-
-		_, vmIndex, err := agentPool.GetVMIndexes()
-		if err != nil {
-			glog.Errorf("GetVMIndexes for node group %q failed: %v", nodeGroup.Id(), err)
-			return nil, nil, err
-		}
-
-		for idx := range vmIndex {
-			id := vmIndex[idx].ID
-			vmID := vmIndex[idx].VMID
-
-			idRef := AzureRef{
-				Name: id,
-			}
-			vmIDRef := AzureRef{
-				Name: vmID,
-			}
-			as[idRef] = nodeGroup
-			as[vmIDRef] = nodeGroup
-			instanceIDs[id] = fmt.Sprintf("%d", idx)
-			instanceIDs[vmID] = fmt.Sprintf("%d", idx)
-		}
-	}
-
-	return as, instanceIDs, nil
+	return asgs, nil
 }
 
 // listScaleSets gets a list of scale sets and instanceIDs.
-func (m *AzureManager) listScaleSets() (map[AzureRef]cloudprovider.NodeGroup, map[string]string, error) {
-	var err error
-	scaleSets := make(map[AzureRef]cloudprovider.NodeGroup)
-	instanceIDs := make(map[string]string)
-
-	for _, sset := range m.nodeGroups {
-		glog.V(4).Infof("Listing Scale Set information for %s", sset.Id())
-
-		resourceGroup := m.config.ResourceGroup
-		ssInfo, err := m.virtualMachineScaleSetsClient.Get(resourceGroup, sset.Id())
-		if err != nil {
-			glog.Errorf("Failed to get scaleSet with name %s: %v", sset.Id(), err)
-			return nil, nil, err
-		}
-
-		result, err := m.virtualMachineScaleSetVMsClient.List(resourceGroup, *ssInfo.Name, "", "", "")
-		if err != nil {
-			glog.Errorf("Failed to list vm for scaleSet %s: %v", *ssInfo.Name, err)
-			return nil, nil, err
-		}
-
-		moreResult := (result.Value != nil && len(*result.Value) > 0)
-		for moreResult {
-			for _, instance := range *result.Value {
-				// Convert to lower because instance.ID is in different in different API calls (e.g. GET and LIST).
-				name := "azure://" + strings.ToLower(*instance.ID)
-				vmID := "azure://" + strings.ToLower(*instance.VMID)
-				ref := AzureRef{
-					Name: name,
-				}
-				vmIDRef := AzureRef{
-					Name: vmID,
-				}
-				scaleSets[ref] = sset
-				scaleSets[vmIDRef] = sset
-				instanceIDs[name] = *instance.InstanceID
-			}
-
-			moreResult = false
-			if result.NextLink != nil {
-				result, err = m.virtualMachineScaleSetVMsClient.ListNextResults(result)
-				if err != nil {
-					glog.Errorf("virtualMachineScaleSetVMsClient.ListNextResults failed: %v", err)
-					return nil, nil, err
-				}
-
-				moreResult = (result.Value != nil && len(*result.Value) > 0)
-			}
-		}
+func (m *AzureManager) listScaleSets(filter []cloudprovider.LabelAutoDiscoveryConfig) (asgs []Asg, err error) {
+	result, err := m.azClient.virtualMachineScaleSetsClient.List(m.config.ResourceGroup)
+	if err != nil {
+		glog.Errorf("VirtualMachineScaleSetsClient.List for %v failed: %v", m.config.ResourceGroup, err)
+		return nil, err
 	}
 
-	return scaleSets, instanceIDs, err
+	moreResults := (result.Value != nil && len(*result.Value) > 0)
+	for moreResults {
+		for _, scaleSet := range *result.Value {
+			if len(filter) > 0 {
+				if scaleSet.Tags == nil || len(*scaleSet.Tags) == 0 {
+					continue
+				}
+
+				if !matchDiscoveryConfig(*scaleSet.Tags, filter) {
+					continue
+				}
+			}
+
+			spec := &dynamic.NodeGroupSpec{
+				Name:               *scaleSet.Name,
+				MinSize:            1,
+				MaxSize:            -1,
+				SupportScaleToZero: scaleToZeroSupported,
+			}
+			asg, _ := NewScaleSet(spec, m)
+			asgs = append(asgs, asg)
+		}
+		moreResults = false
+
+		if result.NextLink != nil {
+			result, err = m.azClient.virtualMachineScaleSetsClient.ListNextResults(result)
+			if err != nil {
+				glog.Errorf("VirtualMachineScaleSetsClient.ListNextResults for %v failed: %v", m.config.ResourceGroup, err)
+				return nil, err
+			}
+
+			moreResults = (result.Value != nil && len(*result.Value) > 0)
+		}
+
+	}
+
+	return asgs, nil
 }
 
-// Cleanup closes the channel to signal the go routine to stop that is handling the cache
-func (m *AzureManager) Cleanup() {
-	close(m.interrupt)
+// listAgentPools gets a list of agent pools and instanceIDs.
+// Note: filter won't take effect for agent pools.
+func (m *AzureManager) listAgentPools(filter []cloudprovider.LabelAutoDiscoveryConfig) (asgs []Asg, err error) {
+	deploy, err := m.azClient.deploymentsClient.Get(m.config.ResourceGroup, m.config.Deployment)
+	if err != nil {
+		glog.Errorf("deploymentsClient.Get(%s, %s) failed: %v", m.config.ResourceGroup, m.config.Deployment, err)
+		return nil, err
+	}
+
+	for k := range *deploy.Properties.Parameters {
+		if k == "masterVMSize" || !strings.HasSuffix(k, "VMSize") {
+			continue
+		}
+
+		poolName := strings.TrimRight(k, "VMSize")
+		spec := &dynamic.NodeGroupSpec{
+			Name:               poolName,
+			MinSize:            1,
+			MaxSize:            -1,
+			SupportScaleToZero: scaleToZeroSupported,
+		}
+		asg, _ := NewAgentPool(spec, m)
+		asgs = append(asgs, asg)
+	}
+
+	return asgs, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/glog"
 	"golang.org/x/crypto/pkcs12"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/client-go/pkg/version"
 )
 
@@ -346,4 +347,65 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 	}
 
 	return agentIndex, nil
+}
+
+func matchDiscoveryConfig(labels map[string]*string, configs []cloudprovider.LabelAutoDiscoveryConfig) bool {
+	for _, c := range configs {
+		for k, v := range c.Selector {
+			value, ok := labels[k]
+			if !ok {
+				return false
+			}
+
+			if len(v) > 0 {
+				if value == nil || *value != v {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func validateConfig(cfg *Config) error {
+	if cfg.ResourceGroup == "" {
+		return fmt.Errorf("resource group not set")
+	}
+
+	if cfg.SubscriptionID == "" {
+		return fmt.Errorf("subscription ID not set")
+	}
+
+	if cfg.TenantID == "" {
+		return fmt.Errorf("tenant ID not set")
+	}
+
+	if cfg.AADClientID == "" {
+		return fmt.Errorf("ARM Client ID not set")
+	}
+
+	if cfg.VMType == vmTypeStandard {
+		if cfg.Deployment == "" {
+			return fmt.Errorf("deployment not set")
+		}
+
+		if cfg.APIServerPrivateKey == "" {
+			return fmt.Errorf("apiServerPrivateKey not set")
+		}
+
+		if cfg.CAPrivateKey == "" {
+			return fmt.Errorf("caPrivateKey not set")
+		}
+
+		if cfg.ClientPrivateKey == "" {
+			return fmt.Errorf("clientPrivateKey not set")
+		}
+
+		if cfg.KubeConfigPrivateKey == "" {
+			return fmt.Errorf("kubeConfigPrivateKey not set")
+		}
+	}
+
+	return nil
 }

--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -155,11 +155,11 @@ func (b CloudProviderBuilder) buildAzure(do cloudprovider.NodeGroupDiscoveryOpti
 	} else {
 		glog.Info("Creating Azure Manager with default configuration.")
 	}
-	manager, err := azure.CreateAzureManager(config)
+	manager, err := azure.CreateAzureManager(config, do)
 	if err != nil {
 		glog.Fatalf("Failed to create Azure Manager: %v", err)
 	}
-	provider, err := azure.BuildAzureCloudProvider(manager, do.NodeGroupSpecs, rl)
+	provider, err := azure.BuildAzureCloudProvider(manager, rl)
 	if err != nil {
 		glog.Fatalf("Failed to create Azure cloud provider: %v", err)
 	}


### PR DESCRIPTION
Continue of #449. This PR adds support of multiple node groups on Azure.

It also improve code organization by wrapping clients, config validation.