### PR TITLE
Better reporting of cluster state

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -115,6 +115,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	if len(allNodes) == 0 {
 		glog.Warningf("No nodes in the cluster")
 		scaleDown.CleanUpUnneededNodes()
+		UpdateEmptyClusterStateMetrics()
+		if autoscalingContext.WriteStatusConfigMap {
+			status := "Cluster has no nodes."
+			utils.WriteStatusConfigMap(autoscalingContext.ClientSet, autoscalingContext.ConfigNamespace, status, a.AutoscalingContext.LogRecorder)
+		}
 		return nil
 	}
 
@@ -132,6 +137,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	if len(readyNodes) == 0 {
 		glog.Warningf("No ready nodes in the cluster")
 		scaleDown.CleanUpUnneededNodes()
+		UpdateEmptyClusterStateMetrics()
+		if autoscalingContext.WriteStatusConfigMap {
+			status := "No ready nodes in the cluster."
+			utils.WriteStatusConfigMap(autoscalingContext.ClientSet, autoscalingContext.ConfigNamespace, status, a.AutoscalingContext.LogRecorder)
+		}
 		return nil
 	}
 

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -501,3 +501,10 @@ func getOldestCreateTime(pods []*apiv1.Pod) time.Time {
 	}
 	return oldest
 }
+
+// UpdateEmptyClusterStateMetrics updates metrics related to empty cluster's state.
+// TODO(aleksandra-malinowska): use long unregistered value from ClusterStateRegistry.
+func UpdateEmptyClusterStateMetrics() {
+	metrics.UpdateClusterSafeToAutoscale(false)
+	metrics.UpdateNodesCount(0, 0, 0, 0)
+}

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -489,7 +489,7 @@ func UpdateClusterStateMetrics(csr *clusterstate.ClusterStateRegistry) {
 	}
 	metrics.UpdateClusterSafeToAutoscale(csr.IsClusterHealthy())
 	readiness := csr.GetClusterReadiness()
-	metrics.UpdateNodesCount(readiness.Ready, readiness.Unready+readiness.LongNotStarted, readiness.NotStarted)
+	metrics.UpdateNodesCount(readiness.Ready, readiness.Unready+readiness.LongNotStarted, readiness.NotStarted, readiness.LongUnregistered)
 }
 
 func getOldestCreateTime(pods []*apiv1.Pod) time.Time {

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -489,7 +489,7 @@ func UpdateClusterStateMetrics(csr *clusterstate.ClusterStateRegistry) {
 	}
 	metrics.UpdateClusterSafeToAutoscale(csr.IsClusterHealthy())
 	readiness := csr.GetClusterReadiness()
-	metrics.UpdateNodesCount(readiness.Ready, readiness.Unready+readiness.LongNotStarted, readiness.NotStarted, readiness.LongUnregistered)
+	metrics.UpdateNodesCount(readiness.Ready, readiness.Unready+readiness.LongNotStarted, readiness.NotStarted, readiness.LongUnregistered, readiness.Unregistered)
 }
 
 func getOldestCreateTime(pods []*apiv1.Pod) time.Time {
@@ -506,5 +506,5 @@ func getOldestCreateTime(pods []*apiv1.Pod) time.Time {
 // TODO(aleksandra-malinowska): use long unregistered value from ClusterStateRegistry.
 func UpdateEmptyClusterStateMetrics() {
 	metrics.UpdateClusterSafeToAutoscale(false)
-	metrics.UpdateNodesCount(0, 0, 0, 0)
+	metrics.UpdateNodesCount(0, 0, 0, 0, 0)
 }

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -39,10 +39,11 @@ type FunctionLabel string
 type NodeGroupType string
 
 const (
-	caNamespace   = "cluster_autoscaler"
-	readyLabel    = "ready"
-	unreadyLabel  = "unready"
-	startingLabel = "notStarted"
+	caNamespace           = "cluster_autoscaler"
+	readyLabel            = "ready"
+	unreadyLabel          = "unready"
+	startingLabel         = "notStarted"
+	longUnregisteredLabel = "longUnregistered"
 
 	// Underutilized node was removed because of low utilization
 	Underutilized NodeScaleDownReason = "underutilized"
@@ -263,10 +264,11 @@ func UpdateClusterSafeToAutoscale(safe bool) {
 }
 
 // UpdateNodesCount records the number of nodes in cluster
-func UpdateNodesCount(ready, unready, starting int) {
+func UpdateNodesCount(ready, unready, starting, longUnregistered int) {
 	nodesCount.WithLabelValues(readyLabel).Set(float64(ready))
 	nodesCount.WithLabelValues(unreadyLabel).Set(float64(unready))
 	nodesCount.WithLabelValues(startingLabel).Set(float64(starting))
+	nodesCount.WithLabelValues(longUnregisteredLabel).Set(float64(longUnregistered))
 }
 
 // UpdateNodeGroupsCount records the number of node groups managed by CA

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -43,6 +43,7 @@ const (
 	readyLabel            = "ready"
 	unreadyLabel          = "unready"
 	startingLabel         = "notStarted"
+	unregisteredLabel     = "unregistered"
 	longUnregisteredLabel = "longUnregistered"
 
 	// Underutilized node was removed because of low utilization
@@ -264,11 +265,12 @@ func UpdateClusterSafeToAutoscale(safe bool) {
 }
 
 // UpdateNodesCount records the number of nodes in cluster
-func UpdateNodesCount(ready, unready, starting, longUnregistered int) {
+func UpdateNodesCount(ready, unready, starting, longUnregistered, unregistered int) {
 	nodesCount.WithLabelValues(readyLabel).Set(float64(ready))
 	nodesCount.WithLabelValues(unreadyLabel).Set(float64(unready))
 	nodesCount.WithLabelValues(startingLabel).Set(float64(starting))
 	nodesCount.WithLabelValues(longUnregisteredLabel).Set(float64(longUnregistered))
+	nodesCount.WithLabelValues(unregisteredLabel).Set(float64(unregistered))
 }
 
 // UpdateNodeGroupsCount records the number of node groups managed by CA


### PR DESCRIPTION
This PR somehow improves monitoring (metrics, events and configmap status) in the following cases:
- nodes unregistered for a long time,
- cluster is empty,
- cluster not healthy enough to autoscale.

This is intended as a temporary solution. We should probably process empty cluster in ClusterStateRegistry to cover following cases:
- accurately report unregistered nodes when there are no ready nodes,
- attempt to remove unregistered nodes while cluster is unhealthy,
- (feature) scale from 0 nodes in the cluster.