### PR TITLE
Add support for configuring etcd private keys

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -35,9 +35,21 @@ Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-vmss.y
 - ResourceGroup: `<base64-encoded-resource-group>`
 - SubscriptionID: `<base64-encode-subscription-id>`
 - TenantID: `<base64-encoded-tenant-id>`
-- NodeGroup: `<base64-encoded-scale-set-name>`
 
 Note that all data should be encoded with base64.
+
+And fill the node groups in container command by `--nodes`, e.g.
+
+```yaml
+        - --nodes=1:10:vmss1
+```
+
+or multipe node groups:
+
+```yaml
+        - --nodes=1:10:vmss1
+        - --nodes=1:10:vmss2
+```
 
 Then deploy cluster-autoscaler by running
 
@@ -58,12 +70,13 @@ Pre-requirements:
 - Get credentials from above `permissions` step.
 - Get the required paramters from acs-engine deployments (usually under directory `_output/<master-dns-prefix>` after running `acs-engine deploy` command)
   - Get `APIServerPrivateKey`, `CAPrivateKey`, `ClientPrivateKey` and `KubeConfigPrivateKey` from `azuredeploy.parameters.json`
+  - Get `EtcdClientPrivateKey` and `EtcdServerPrivateKey` if the cluster is deployed by acs-engine >= v0.12.0
   - If windows nodes are included, also get `WindowsAdminPassword` from acs-engine deployment manifests
   - Get the initial Azure deployment name from azure portal. If you have multiple deployments (e.g. have run `acs-engine scale` command), make sure to get the first one
   - Get a node pool name for nodes scaling from acs-engine deployment manifests
 - Encode each data with base64.
 
-Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-standard.yaml](cluster-autoscaler-standard.yaml), including
+Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-standard-master.yaml](cluster-autoscaler-standard-master.yaml), including
 
 - ClientID: `<base64-encoded-client-id>`
 - ClientSecret: `<base64-encoded-client-secret>`
@@ -76,19 +89,27 @@ Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-standa
 - CAPrivateKey: `<base64-encoded-ca-private-key>`
 - ClientPrivateKey: `<base64-encoded-client-private-key>`
 - KubeConfigPrivateKey: `<base64-encoded-kubeconfig-private-key>`
-- WindowsAdminPassword: `<base64-encoded-windows-admin-password>`
+- WindowsAdminPassword: `<base64-encoded-windows-admin-password>` (set `""` if no windows nodes in the cluster)
+- EtcdClientPrivateKey: `<base64-encoded-etcd-client-private-key>` (set `""` for acs-engine < v0.12.0)
+- EtcdServerPrivateKey: `<base64-encoded-etcd-server-private-key>` (set to `""` for acs-engine < v0.12.0)
 
 Note that all data should be encoded with base64.
+
+And fill the node groups in container command by `--nodes`, e.g.
+
+```yaml
+        - --nodes=1:10:agentpool1
+```
+
+or multipe node groups:
+
+```yaml
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
+```
 
 Then deploy cluster-autoscaler by running
 
 ```sh
-kubectl create -f cluster-autoscaler-standard.yaml
-```
-
-To run a CA pod in master node - CA deployment should tolerate the master `taint` and `nodeSelector` should be used to schedule the pods in master node.
-
-```sh
 kubectl create -f cluster-autoscaler-standard-master.yaml
 ```
-

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -115,6 +115,14 @@ func (as *AgentPool) preprocessParameters() {
 	if as.manager.config.WindowsAdminPassword != "" {
 		as.parameters["windowsAdminPassword"] = map[string]string{"value": as.manager.config.WindowsAdminPassword}
 	}
+
+	// etcd TLS parameters (for acs-engine >= v0.12.0).
+	if as.manager.config.EtcdClientPrivateKey != "" {
+		as.parameters["etcdClientPrivateKey"] = map[string]string{"value": as.manager.config.EtcdClientPrivateKey}
+	}
+	if as.manager.config.EtcdServerPrivateKey != "" {
+		as.parameters["etcdServerPrivateKey"] = map[string]string{"value": as.manager.config.EtcdServerPrivateKey}
+	}
 }
 
 // MinSize returns minimum size of the node group.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -73,6 +73,9 @@ type Config struct {
 	ClientPrivateKey     string `json:"clientPrivateKey" yaml:"clientPrivateKey"`
 	KubeConfigPrivateKey string `json:"kubeConfigPrivateKey" yaml:"kubeConfigPrivateKey"`
 	WindowsAdminPassword string `json:"windowsAdminPassword" yaml:"windowsAdminPassword"`
+	// etcd TLS parameters (for acs-engine >= v0.12.0).
+	EtcdClientPrivateKey string `json:"etcdClientPrivateKey" yaml:"etcdClientPrivateKey"`
+	EtcdServerPrivateKey string `json:"etcdServerPrivateKey" yaml:"etcdServerPrivateKey"`
 }
 
 // TrimSpace removes all leading and trailing white spaces.
@@ -92,6 +95,8 @@ func (c *Config) TrimSpace() {
 	c.ClientPrivateKey = strings.TrimSpace(c.ClientPrivateKey)
 	c.KubeConfigPrivateKey = strings.TrimSpace(c.KubeConfigPrivateKey)
 	c.WindowsAdminPassword = strings.TrimSpace(c.WindowsAdminPassword)
+	c.EtcdClientPrivateKey = strings.TrimSpace(c.EtcdClientPrivateKey)
+	c.EtcdServerPrivateKey = strings.TrimSpace(c.EtcdServerPrivateKey)
 }
 
 // CreateAzureManager creates Azure Manager object to work with Azure.
@@ -120,6 +125,8 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		cfg.ClientPrivateKey = os.Getenv("ARM_CLIENT_PRIVATE_KEY")
 		cfg.KubeConfigPrivateKey = os.Getenv("ARM_KUBECONFIG_PRIVATE_KEY")
 		cfg.WindowsAdminPassword = os.Getenv("ARM_WINDOWS_ADMIN_PASSWORD")
+		cfg.EtcdClientPrivateKey = os.Getenv("ARM_ETCD_CLIENT_RPIVATE_KEY")
+		cfg.EtcdServerPrivateKey = os.Getenv("ARM_ETCD_SERVER_PRIVATE_KEY")
 
 		useManagedIdentityExtensionFromEnv := os.Getenv("ARM_USE_MANAGED_IDENTITY_EXTENSION")
 		if len(useManagedIdentityExtensionFromEnv) > 0 {

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
@@ -5,13 +5,14 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  NodeGroup: <base64-encoded-node-pool-name>
   Deployment: <base64-encoded-azure-initial-deploy-name>
   APIServerPrivateKey: <base64-encoded-apiserver-private-key>
   CAPrivateKey: <base64-encoded-ca-private-key>
   ClientPrivateKey: <base64-encoded-client-private-key>
   KubeConfigPrivateKey: <base64-encoded-kubeconfig-private-key>
   WindowsAdminPassword: <base64-encoded-windows-admin-password>
+  EtcdClientPrivateKey: <base64-encoded-etcd-client-private-key>
+  EtcdServerPrivateKey: <base64-encoded-etcd-server-private-key>
   VMType: c3RhbmRhcmQ=
 kind: Secret
 metadata:
@@ -49,7 +50,8 @@ spec:
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:$(ARM_NODE_GROUP)
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -75,11 +77,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ClientSecret
-              name: cluster-autoscaler-azure
-        - name: ARM_NODE_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: NodeGroup
               name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:
@@ -115,6 +112,16 @@ spec:
           valueFrom:
             secretKeyRef:
               key: WindowsAdminPassword
+              name: cluster-autoscaler-azure
+        - name: ARM_ETCD_CLIENT_RPIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EtcdClientPrivateKey
+              name: cluster-autoscaler-azure
+        - name: ARM_ETCD_SERVER_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EtcdServerPrivateKey
               name: cluster-autoscaler-azure
         image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
@@ -5,13 +5,14 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  NodeGroup: <base64-encoded-node-pool-name>
   Deployment: <base64-encoded-azure-initial-deploy-name>
   APIServerPrivateKey: <base64-encoded-apiserver-private-key>
   CAPrivateKey: <base64-encoded-ca-private-key>
   ClientPrivateKey: <base64-encoded-client-private-key>
   KubeConfigPrivateKey: <base64-encoded-kubeconfig-private-key>
   WindowsAdminPassword: <base64-encoded-windows-admin-password>
+  EtcdClientPrivateKey: <base64-encoded-etcd-client-private-key>
+  EtcdServerPrivateKey: <base64-encoded-etcd-server-private-key>
   VMType: c3RhbmRhcmQ=
 kind: Secret
 metadata:
@@ -42,7 +43,8 @@ spec:
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:$(ARM_NODE_GROUP)
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -68,11 +70,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ClientSecret
-              name: cluster-autoscaler-azure
-        - name: ARM_NODE_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: NodeGroup
               name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:
@@ -108,6 +105,16 @@ spec:
           valueFrom:
             secretKeyRef:
               key: WindowsAdminPassword
+              name: cluster-autoscaler-azure
+        - name: ARM_ETCD_CLIENT_RPIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EtcdClientPrivateKey
+              name: cluster-autoscaler-azure
+        - name: ARM_ETCD_SERVER_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: EtcdServerPrivateKey
               name: cluster-autoscaler-azure
         image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
@@ -5,7 +5,6 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  NodeGroup: <base64-encoded-scale-set-name>
   VMType: dm1zcw==
 kind: Secret
 metadata:
@@ -43,7 +42,8 @@ spec:
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:$(ARM_NODE_GROUP)
+        - --nodes=1:10:vmss1
+        - --nodes=1:10:vmss2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -69,11 +69,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ClientSecret
-              name: cluster-autoscaler-azure
-        - name: ARM_NODE_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: NodeGroup
               name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
@@ -5,7 +5,6 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  NodeGroup: <base64-encoded-scale-set-name>
   VMType: dm1zcw==
 kind: Secret
 metadata:
@@ -36,7 +35,8 @@ spec:
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:$(ARM_NODE_GROUP)
+        - --nodes=1:10:vmss1
+        - --nodes=1:10:vmss2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -62,11 +62,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ClientSecret
-              name: cluster-autoscaler-azure
-        - name: ARM_NODE_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: NodeGroup
               name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:


### PR DESCRIPTION
acs-engine [v0.12.0](https://github.com/Azure/acs-engine/releases/tag/v0.12.0) adds a breaking change of etcd TLS. It introduces two extra etcd private keys: EtcdClientPrivateKey and EtcdServerPrivateKey.

This PR adds the configuration for them and updates the deploy documentation.