### PR TITLE
Bug fix for auto-resizer 1.8.1 not reading command arguments

### DIFF
--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -163,6 +163,7 @@ func loadNannyConfiguration(configDir string, defaultConfig *nannyconfigalpha.Na
 	} else if configMapConfig, err = decodeNannyConfiguration(data, scheme, codecs); err != nil {
 		glog.V(0).Infof("Unable to decode Nanny Configuration from config map, using default parameters")
 	}
+	nannyconfigalpha.SetDefaults_NannyConfiguration(configMapConfig)
 	glog.Infof("%s", configMapConfig.BaseCPU)
 	// overwrite defaults with config map parameters
 	nannyconfigalpha.FillInDefaults_NannyConfiguration(configMapConfig, defaultConfig)

--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -161,6 +161,7 @@ func loadNannyConfiguration(configDir string, defaultConfig *nannyconfigalpha.Na
 	if err != nil {
 		glog.V(0).Infof("Failed to read data from config file %q: %v, using default parameters", path, err)
 	} else if configMapConfig, err = decodeNannyConfiguration(data, scheme, codecs); err != nil {
+		configMapConfig = &nannyconfigalpha.NannyConfiguration{}
 		glog.V(0).Infof("Unable to decode Nanny Configuration from config map, using default parameters")
 	}
 	nannyconfigalpha.SetDefaults_NannyConfiguration(configMapConfig)

--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -165,7 +165,6 @@ func loadNannyConfiguration(configDir string, defaultConfig *nannyconfigalpha.Na
 		glog.V(0).Infof("Unable to decode Nanny Configuration from config map, using default parameters")
 	}
 	nannyconfigalpha.SetDefaults_NannyConfiguration(configMapConfig)
-	glog.Infof("%s", configMapConfig.BaseCPU)
 	// overwrite defaults with config map parameters
 	nannyconfigalpha.FillInDefaults_NannyConfiguration(configMapConfig, defaultConfig)
 	return convertNannyConfiguration(configMapConfig, scheme)


### PR DESCRIPTION
Cpu and memory arguments from command line are not read at all, leaving them empty. ```nannyConfigurationFromFlags``` sets default values to argument values. In ```loadNannyConfiguration``` it attempts to read from config, but if config is not set it just creates an empty ```configMapConfig```. Since this is empty calling ```nannyconfigalpha.FillInDefaults_NannyConfiguration``` doesn't actually do anything as it compares the values against default values, so when all values are empty this does nothing. In the end function just returns empty values for everything and never uses command line arguments.

Starting container in acs-engine leads to these errors now:
```
ERROR: logging before flag.Parse: I0118 13:57:09.157760       1 pod_nanny.go:64] Invoked by [/pod_nanny --cpu=80m --extra-cpu=0.5m --memory=140Mi --extra-memory=4Mi --threshold=5 --deployment=heapster --container=heapster --poll-period=300000 --estimator=exponential]
ERROR: logging before flag.Parse: I0118 13:57:09.157850       1 pod_nanny.go:76] Watching namespace: kube-system, pod: heapster-548bd647cc-7fpgv, container: heapster.
ERROR: logging before flag.Parse: I0118 13:57:09.157856       1 pod_nanny.go:77] storage: MISSING, extra_storage: 0Gi
ERROR: logging before flag.Parse: I0118 13:57:09.159734       1 pod_nanny.go:162] Failed to read data from config file "MISSING/NannyConfiguration": open MISSING/NannyConfiguration: no such file or directory, using default parameters
ERROR: logging before flag.Parse: I0118 13:57:09.159804       1 pod_nanny.go:166]
ERROR: logging before flag.Parse: I0118 13:57:09.159917       1 pod_nanny.go:101] cpu: , extra_cpu: , memory: , extra_memory:
panic: cannot parse '': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```