### PR TITLE
add us-central zones to supported gce gpu zones.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gpu.go
+++ b/cluster-autoscaler/cloudprovider/gce/gpu.go
@@ -34,6 +34,7 @@ var (
 			"us-east1-c":     true,
 			"us-east1-d":     true,
 			"us-west1-b":     true,
+			"us-central-1c":  true,
 		},
 		"nvidia-tesla-p100": {
 			"europe-west1-b": true,
@@ -41,6 +42,8 @@ var (
 			"asia-east1-a":   true,
 			"us-east1-c":     true,
 			"us-west1-b":     true,
+			"us-central-1c":  true,
+			"us-central-1f":  true,
 		},
 	}
 


### PR DESCRIPTION
Title says most of it. These zones were added about a month ago, and are reflected in the official docs. The intent here was to address something similar to: https://github.com/kubernetes/autoscaler/issues/321

This doesn't appear to have address my issue by itself. Closing for now while I dig some more.
