### PR TITLE
Select all pods, so pods in state Unknown are not deleted from the Cluster State.

### DIFF
--- a/vertical-pod-autoscaler/recommender/recommender.go
+++ b/vertical-pod-autoscaler/recommender/recommender.go
@@ -196,8 +196,7 @@ func newMetricsClient(config *rest.Config) cluster.MetricsClient {
 
 // Creates PodLister, listing only not terminated pods.
 func newPodLister(kubeClient kube_client.Interface) v1lister.PodLister {
-	selector := fields.ParseSelectorOrDie("status.phase!=" + string(apiv1.PodPending) + ",status.phase!=" + string(apiv1.PodUnknown))
-	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, selector)
+	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, fields.Everything())
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := v1lister.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &apiv1.Pod{}, store, time.Hour)

--- a/vertical-pod-autoscaler/recommender/recommender.go
+++ b/vertical-pod-autoscaler/recommender/recommender.go
@@ -196,7 +196,8 @@ func newMetricsClient(config *rest.Config) cluster.MetricsClient {
 
 // Creates PodLister, listing only not terminated pods.
 func newPodLister(kubeClient kube_client.Interface) v1lister.PodLister {
-	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, fields.Everything())
+	selector := fields.ParseSelectorOrDie("status.phase!=" + string(apiv1.PodPending))
+	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, selector)
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := v1lister.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &apiv1.Pod{}, store, time.Hour)


### PR DESCRIPTION
State Unknown is may happen due to transient error (https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase), so it shouldn't be deleted from the Cluster State.