### PR TITLE
Get CPU, memory and labels history from Prometheus

### DIFF
--- a/vertical-pod-autoscaler/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/recommender/Dockerfile
@@ -17,4 +17,4 @@ MAINTAINER Karol Kraskiewicz "karol.kraskiewicz@gmail.com"
 
 ADD recommender recommender
 
-CMD ./recommender --v=4 --stderrthreshold=info
+CMD ./recommender --v=4 --stderrthreshold=info --prometheus-address=http://prometheus.monitoring.svc

--- a/vertical-pod-autoscaler/recommender/main.go
+++ b/vertical-pod-autoscaler/recommender/main.go
@@ -22,14 +22,16 @@ import (
 
 	"github.com/golang/glog"
 	kube_flag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/signals"
 	"k8s.io/client-go/rest"
 	kube_restclient "k8s.io/client-go/rest"
 )
 
 var (
-	namespace              = *flag.String("namespace", "default", `Namespace to manage`)
-	metricsFetcherInterval = *flag.Duration("recommender-interval", 1*time.Minute, `How often metrics should be fetched`)
-	prometheusAddress      = *flag.String("prometheus-address", "", `Where to reach for Prometheus metrics`)
+	// TODO: Remove the namespace flag. Recommender should control all namespaces.
+	namespace              = flag.String("namespace", "default", `Namespace to manage`)
+	metricsFetcherInterval = flag.Duration("recommender-interval", 1*time.Minute, `How often metrics should be fetched`)
+	prometheusAddress      = flag.String("prometheus-address", "", `Where to reach for Prometheus metrics`)
 )
 
 func main() {
@@ -37,7 +39,7 @@ func main() {
 	kube_flag.InitFlags()
 
 	config := createKubeConfig()
-	recommender := NewRecommender(namespace, config, metricsFetcherInterval, prometheusAddress)
+	recommender := NewRecommender(*namespace, config, *metricsFetcherInterval, signals.NewPrometheusHistoryProvider(*prometheusAddress))
 	recommender.Run()
 }
 

--- a/vertical-pod-autoscaler/recommender/signals/history_provider.go
+++ b/vertical-pod-autoscaler/recommender/signals/history_provider.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/model"
+)
+
+const (
+	historyLength  = "1d"
+	podLabelPrefix = "pod_label_"
+)
+
+// PodHistory represents history of usage and labels for a given pod.
+type PodHistory struct {
+	// Current samples if pod is still alive, last known samples otherwise.
+	LastLabels map[string]string
+	LastSeen   time.Time
+	// A map for container name to a list of its usage samples, in chronological
+	// order.
+	Samples map[string][]model.ContainerUsageSample
+}
+
+func newEmptyHistory() *PodHistory {
+	return &PodHistory{LastLabels: map[string]string{}, Samples: map[string][]model.ContainerUsageSample{}}
+}
+
+// HistoryProvider gives history of all pods in a cluster.
+type HistoryProvider interface {
+	GetClusterHistory() (map[model.PodID]*PodHistory, error)
+}
+
+type prometheusHistoryProvider struct {
+	prometheusClient PrometheusClient
+}
+
+// NewPrometheusHistoryProvider contructs a history provider that gets data from Prometheus.
+func NewPrometheusHistoryProvider(prometheusAddress string) HistoryProvider {
+	return &prometheusHistoryProvider{
+		prometheusClient: NewPrometheusClient(&http.Client{}, prometheusAddress),
+	}
+}
+
+func getContainerIDFromLabels(labels map[string]string) (*model.ContainerID, error) {
+	namespace, ok := labels["namespace"]
+	if !ok {
+		return nil, fmt.Errorf("no namespace label")
+	}
+	podName, ok := labels["pod_name"]
+	if !ok {
+		return nil, fmt.Errorf("no pod_name label")
+	}
+	containerName, ok := labels["name"]
+	if !ok {
+		return nil, fmt.Errorf("no name label on container data")
+	}
+	return &model.ContainerID{
+		PodID: model.PodID{
+			Namespace: namespace,
+			PodName:   podName},
+		ContainerName: containerName}, nil
+}
+
+func getPodIDFromLabels(labels map[string]string) (*model.PodID, error) {
+	namespace, ok := labels["kubernetes_namespace"]
+	if !ok {
+		return nil, fmt.Errorf("no kubernetes_namespace label")
+	}
+	podName, ok := labels["kubernetes_pod_name"]
+	if !ok {
+		return nil, fmt.Errorf("no kubernetes_pod_name label")
+	}
+	return &model.PodID{Namespace: namespace, PodName: podName}, nil
+}
+
+func getPodLabelsMap(metricLabels map[string]string) map[string]string {
+	podLabels := make(map[string]string)
+	for key, value := range metricLabels {
+		podLabelKey := strings.TrimPrefix(key, podLabelPrefix)
+		if podLabelKey != key {
+			podLabels[podLabelKey] = value
+		}
+	}
+	return podLabels
+}
+
+func getContainerUsageSamplesFromSamples(samples []Sample, resource model.MetricName) []model.ContainerUsageSample {
+	res := make([]model.ContainerUsageSample, 0)
+	for _, sample := range samples {
+		res = append(res, model.ContainerUsageSample{
+			MeasureStart: sample.Timestamp,
+			Usage:        sample.Value,
+			Resource:     resource})
+	}
+	return res
+}
+
+func (p *prometheusHistoryProvider) readResourceHistory(res map[model.PodID]*PodHistory, query string, resource model.MetricName) error {
+	tss, err := p.prometheusClient.GetTimeseries(query)
+	if err != nil {
+		return fmt.Errorf("cannot get timeseries for %v: %v", resource, err)
+	}
+	for _, ts := range tss {
+		containerID, err := getContainerIDFromLabels(ts.Labels)
+		if err != nil {
+			return fmt.Errorf("cannot get container ID from labels: %v", ts.Labels)
+		}
+		newSamples := getContainerUsageSamplesFromSamples(ts.Samples, resource)
+		podHistory, ok := res[containerID.PodID]
+		if !ok {
+			podHistory = newEmptyHistory()
+			res[containerID.PodID] = podHistory
+		}
+		podHistory.Samples[containerID.ContainerName] = append(
+			podHistory.Samples[containerID.ContainerName],
+			newSamples...)
+	}
+	return nil
+}
+
+func (p *prometheusHistoryProvider) readLastLabels(res map[model.PodID]*PodHistory, query string) error {
+	tss, err := p.prometheusClient.GetTimeseries(query)
+	if err != nil {
+		return fmt.Errorf("cannot get timeseries for labels: %v", err)
+	}
+	for _, ts := range tss {
+		podID, err := getPodIDFromLabels(ts.Labels)
+		if err != nil {
+			return fmt.Errorf("cannot get container ID from labels: %v", ts.Labels)
+		}
+		podHistory, ok := res[*podID]
+		if !ok {
+			podHistory = newEmptyHistory()
+			res[*podID] = podHistory
+		}
+		podLabels := getPodLabelsMap(ts.Labels)
+		for _, sample := range ts.Samples {
+			if sample.Timestamp.After(podHistory.LastSeen) {
+				podHistory.LastSeen = sample.Timestamp
+				podHistory.LastLabels = podLabels
+			}
+		}
+	}
+	return nil
+}
+
+func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
+	res := make(map[model.PodID]*PodHistory)
+	podSelector := "job=\"kubernetes-cadvisor\", pod_name=~\".+\""
+	err := p.readResourceHistory(res, fmt.Sprintf("container_cpu_usage_seconds_total{%s}[%s]", podSelector, historyLength), model.ResourceCPU)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get usage history: %v", err)
+	}
+	err = p.readResourceHistory(res, fmt.Sprintf("container_memory_usage_bytes{%s}[%s]", podSelector, historyLength), model.ResourceMemory)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get usage history: %v", err)
+	}
+	for _, podHistory := range res {
+		for _, samples := range podHistory.Samples {
+			sort.Slice(samples, func(i, j int) bool { return samples[i].MeasureStart.Before(samples[j].MeasureStart) })
+		}
+	}
+	p.readLastLabels(res, fmt.Sprintf("up{job=\"kubernetes-pods\"}[%s]", historyLength))
+	return res, nil
+}

--- a/vertical-pod-autoscaler/recommender/signals/history_provider_test.go
+++ b/vertical-pod-autoscaler/recommender/signals/history_provider_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/model"
+)
+
+const (
+	cpuQuery    = "container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\"}[1d]"
+	memoryQuery = "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\"}[1d]"
+	labelsQuery = "up{job=\"kubernetes-pods\"}[1d]"
+)
+
+type mockPrometheusClient struct {
+	mock.Mock
+}
+
+func (m *mockPrometheusClient) GetTimeseries(query string) ([]Timeseries, error) {
+	args := m.Called(query)
+	var returnArg []Timeseries
+	if args.Get(0) != nil {
+		returnArg = args.Get(0).([]Timeseries)
+	}
+	return returnArg, args.Error(1)
+}
+
+func TestGetEmptyClusterHistory(t *testing.T) {
+	mockClient := mockPrometheusClient{}
+	historyProvider := prometheusHistoryProvider{
+		prometheusClient: &mockClient}
+	mockClient.On("GetTimeseries", mock.AnythingOfType("string")).Times(3).Return(
+		[]Timeseries{}, nil)
+	tss, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.NotNil(t, tss)
+	assert.Empty(t, tss)
+}
+
+func TestPrometheusError(t *testing.T) {
+	mockClient := mockPrometheusClient{}
+	historyProvider := prometheusHistoryProvider{
+		prometheusClient: &mockClient}
+	mockClient.On("GetTimeseries", mock.AnythingOfType("string")).Times(3).Return(
+		nil, fmt.Errorf("bla"))
+	_, err := historyProvider.GetClusterHistory()
+	assert.NotNil(t, err)
+}
+
+func TestGetCPUSamples(t *testing.T) {
+	mockClient := mockPrometheusClient{}
+	historyProvider := prometheusHistoryProvider{
+		prometheusClient: &mockClient}
+	mockClient.On("GetTimeseries", cpuQuery).Return(
+		[]Timeseries{{
+			Labels: map[string]string{
+				"namespace": "default",
+				"pod_name":  "pod",
+				"name":      "container"},
+			Samples: []Sample{{
+				Value: 5.5, Timestamp: time.Unix(1, 0)}}}}, nil)
+	mockClient.On("GetTimeseries", memoryQuery).Return([]Timeseries{}, nil)
+	mockClient.On("GetTimeseries", labelsQuery).Return([]Timeseries{}, nil)
+	podID := model.PodID{Namespace: "default", PodName: "pod"}
+	podHistory := &PodHistory{
+		LastLabels: map[string]string{},
+		Samples: map[string][]model.ContainerUsageSample{"container": {{
+			MeasureStart: time.Unix(1, 0),
+			Usage:        5.5,
+			Resource:     model.ResourceCPU}}}}
+	histories, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
+}
+
+func TestGetMemorySamples(t *testing.T) {
+	mockClient := mockPrometheusClient{}
+	historyProvider := prometheusHistoryProvider{
+		prometheusClient: &mockClient}
+	mockClient.On("GetTimeseries", cpuQuery).Return([]Timeseries{}, nil)
+	mockClient.On("GetTimeseries", memoryQuery).Return(
+		[]Timeseries{{
+			Labels: map[string]string{
+				"namespace": "default",
+				"pod_name":  "pod",
+				"name":      "container"},
+			Samples: []Sample{{
+				Value: 12345, Timestamp: time.Unix(1, 0)}}}}, nil)
+	mockClient.On("GetTimeseries", labelsQuery).Return([]Timeseries{}, nil)
+	podID := model.PodID{Namespace: "default", PodName: "pod"}
+	podHistory := &PodHistory{
+		LastLabels: map[string]string{},
+		Samples: map[string][]model.ContainerUsageSample{"container": {{
+			MeasureStart: time.Unix(1, 0),
+			Usage:        12345,
+			Resource:     model.ResourceMemory}}}}
+	histories, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
+}
+
+func TestGetLabels(t *testing.T) {
+	mockClient := mockPrometheusClient{}
+	historyProvider := prometheusHistoryProvider{
+		prometheusClient: &mockClient}
+	mockClient.On("GetTimeseries", cpuQuery).Return([]Timeseries{}, nil)
+	mockClient.On("GetTimeseries", memoryQuery).Return([]Timeseries{}, nil)
+	mockClient.On("GetTimeseries", labelsQuery).Return([]Timeseries{
+		{
+			Labels: map[string]string{
+				"kubernetes_namespace": "default",
+				"kubernetes_pod_name":  "pod",
+				"pod_label_x":          "y"},
+			Samples: []Sample{{
+				Value: 1, Timestamp: time.Unix(10, 0)}}},
+		{
+			Labels: map[string]string{
+				"kubernetes_namespace": "default",
+				"kubernetes_pod_name":  "pod",
+				"pod_label_x":          "z"},
+			Samples: []Sample{{
+				Value: 1, Timestamp: time.Unix(20, 0)}}}}, nil)
+	podID := model.PodID{Namespace: "default", PodName: "pod"}
+	podHistory := &PodHistory{
+		LastLabels: map[string]string{"x": "z"},
+		LastSeen:   time.Unix(20, 0),
+		Samples:    map[string][]model.ContainerUsageSample{}}
+	histories, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
+}


### PR DESCRIPTION
This also refactors out history provider from recommender.go (as you originally requested) and fixes issues with the recommender flags, client queries etc. I now tested it e2e in my cluster and it pushes some samples and labels to clusterState.