### PR TITLE
Cleanup model atoms

### DIFF
--- a/vertical-pod-autoscaler/recommender/cluster/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/recommender/cluster/metrics_client_test_util.go
@@ -38,7 +38,7 @@ type metricsClientTestCase struct {
 	snapshotTimestamp    time.Time
 	snapshotWindow       time.Duration
 	namespace            *v1.Namespace
-	pod1Snaps, pod2Snaps []*model.ContainerMetricsSnapshot
+	pod1Snaps, pod2Snaps []*ContainerMetricsSnapshot
 }
 
 func newMetricsClientTestCase() *metricsClientTestCase {
@@ -67,12 +67,12 @@ func newEmptyMetricsClientTestCase() *metricsClientTestCase {
 	return &metricsClientTestCase{}
 }
 
-func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerID, cpuUsage int64, memUsage int64) *model.ContainerMetricsSnapshot {
-	return &model.ContainerMetricsSnapshot{
+func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerID, cpuUsage int64, memUsage int64) *ContainerMetricsSnapshot {
+	return &ContainerMetricsSnapshot{
 		ID:             id,
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
-		Usage: map[model.MetricName]model.ResourceAmount{
+		Usage: model.Resources{
 			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
 			model.ResourceMemory: model.ResourceAmount(memUsage),
 		},
@@ -96,7 +96,7 @@ func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsL
 	return metrics
 }
 
-func makePodMetrics(snaps []*model.ContainerMetricsSnapshot) metricsapi.PodMetrics {
+func makePodMetrics(snaps []*ContainerMetricsSnapshot) metricsapi.PodMetrics {
 	firstSnap := snaps[0]
 	podMetrics := metricsapi.PodMetrics{
 		ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +118,7 @@ func makePodMetrics(snaps []*model.ContainerMetricsSnapshot) metricsapi.PodMetri
 	return podMetrics
 }
 
-func calculateResourceList(usage map[model.MetricName]model.ResourceAmount) k8sapiv1.ResourceList {
+func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	cpuCores := big.NewRat(int64(usage[model.ResourceCPU]), 1000)
 	cpuQuantityString := cpuCores.FloatString(3)
 
@@ -132,6 +132,6 @@ func calculateResourceList(usage map[model.MetricName]model.ResourceAmount) k8sa
 	return k8sapiv1.ResourceList(resourceMap)
 }
 
-func (tc *metricsClientTestCase) getAllSnaps() []*model.ContainerMetricsSnapshot {
+func (tc *metricsClientTestCase) getAllSnaps() []*ContainerMetricsSnapshot {
 	return append(tc.pod1Snaps, tc.pod2Snaps...)
 }

--- a/vertical-pod-autoscaler/recommender/cluster/spec_client_test_util.go
+++ b/vertical-pod-autoscaler/recommender/cluster/spec_client_test_util.go
@@ -91,7 +91,7 @@ func (m *podListerMock) Pods(namespace string) v1lister.PodNamespaceLister {
 }
 
 type specClientTestCase struct {
-	podSpecs []*model.BasicPodSpec
+	podSpecs []*BasicPodSpec
 	podYamls []string
 }
 
@@ -112,28 +112,28 @@ func newSpecClientTestCase() *specClientTestCase {
 	podSpec2 := newTestPodSpec(podID2, containerSpec21, containerSpec22)
 
 	return &specClientTestCase{
-		podSpecs: []*model.BasicPodSpec{podSpec1, podSpec2},
+		podSpecs: []*BasicPodSpec{podSpec1, podSpec2},
 		podYamls: []string{pod1Yaml, pod2Yaml},
 	}
 }
-func newTestContainerSpec(podID model.PodID, containerName string, milicores int, memory int) model.BasicContainerSpec {
+func newTestContainerSpec(podID model.PodID, containerName string, milicores int, memory int) BasicContainerSpec {
 	containerID := model.ContainerID{
 		PodID:         podID,
 		ContainerName: containerName,
 	}
-	requestedResources := map[model.MetricName]model.ResourceAmount{
+	requestedResources := model.Resources{
 		model.ResourceCPU:    model.ResourceAmount(milicores),
 		model.ResourceMemory: model.ResourceAmount(memory),
 	}
-	return model.BasicContainerSpec{
+	return BasicContainerSpec{
 		ID:      containerID,
 		Image:   containerName + "Image",
 		Request: requestedResources,
 	}
 }
 
-func newTestPodSpec(podId model.PodID, containerSpecs ...model.BasicContainerSpec) *model.BasicPodSpec {
-	return &model.BasicPodSpec{
+func newTestPodSpec(podId model.PodID, containerSpecs ...BasicContainerSpec) *BasicPodSpec {
+	return &BasicPodSpec{
 		ID:         podId,
 		PodLabels:  map[string]string{podId.PodName + "LabelKey": podId.PodName + "LabelValue"},
 		Containers: containerSpecs,

--- a/vertical-pod-autoscaler/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/recommender/logic/recommender_test.go
@@ -41,13 +41,13 @@ func addTestSample(cluster *model.ClusterState, container model.ContainerID, cpu
 	var sample model.ContainerUsageSampleWithKey
 	sample.Container = container
 	sample.MeasureStart = testTimestamp
-	sample.Usage = cpu
+	sample.Usage = model.CPUAmountFromCores(cpu)
 	sample.Resource = model.ResourceCPU
 	err := cluster.AddSample(&sample)
 	if err != nil {
 		return err
 	}
-	sample.Usage = memory
+	sample.Usage = model.MemoryAmountFromBytes(memory)
 	sample.Resource = model.ResourceMemory
 	return cluster.AddSample(&sample)
 }

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -28,8 +28,8 @@ var (
 	TimeLayout = "2006-01-02 15:04:05"
 )
 
-func newUsageSample(timestamp time.Time, usage float64, resource MetricName) *ContainerUsageSample {
-	return &ContainerUsageSample{timestamp, usage, resource}
+func newUsageSample(timestamp time.Time, usage int64, resource ResourceName) *ContainerUsageSample {
+	return &ContainerUsageSample{timestamp, ResourceAmount(usage), resource}
 }
 
 // Add 6 usage samples (3 valid, 3 invalid) to a container. Verifies that for
@@ -56,28 +56,28 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 
 	// Add three usage samples.
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp, 3.14, ResourceCPU)))
+		testTimestamp, 3140, ResourceCPU)))
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp, 5.0, ResourceMemory)))
+		testTimestamp, 5, ResourceMemory)))
 
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp.Add(MemoryAggregationInterval/2), 6.28, ResourceCPU)))
+		testTimestamp.Add(MemoryAggregationInterval/2), 6280, ResourceCPU)))
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp.Add(MemoryAggregationInterval/2), 10.0, ResourceMemory)))
+		testTimestamp.Add(MemoryAggregationInterval/2), 10, ResourceMemory)))
 
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp.Add(MemoryAggregationInterval), 1.57, ResourceCPU)))
+		testTimestamp.Add(MemoryAggregationInterval), 1570, ResourceCPU)))
 	assert.True(t, c.AddSample(newUsageSample(
-		testTimestamp.Add(MemoryAggregationInterval), 2.5, ResourceMemory)))
+		testTimestamp.Add(MemoryAggregationInterval), 2, ResourceMemory)))
 
 	// Discard invalid samples.
 	assert.False(t, c.AddSample(newUsageSample( // Out of order sample.
-		testTimestamp.Add(MemoryAggregationInterval), 1.0, ResourceCPU)))
+		testTimestamp.Add(MemoryAggregationInterval), 1000, ResourceCPU)))
 	assert.False(t, c.AddSample(newUsageSample( // Negative CPU usage.
-		testTimestamp.Add(MemoryAggregationInterval*2), -1.0, ResourceCPU)))
+		testTimestamp.Add(MemoryAggregationInterval*2), -1000, ResourceCPU)))
 	assert.False(t, c.AddSample(newUsageSample( // Negative memory usage.
-		testTimestamp.Add(MemoryAggregationInterval*2), -1.0, ResourceMemory)))
+		testTimestamp.Add(MemoryAggregationInterval*2), -1000, ResourceMemory)))
 
 	// Verify that memory peak samples were aggregated properly.
-	assert.Equal(t, []float64{10.0, 2.5}, memoryUsagePeaks.Contents())
+	assert.Equal(t, []float64{10, 2}, memoryUsagePeaks.Contents())
 }

--- a/vertical-pod-autoscaler/recommender/model/types.go
+++ b/vertical-pod-autoscaler/recommender/model/types.go
@@ -17,27 +17,27 @@ limitations under the License.
 package model
 
 import (
-	"time"
-
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// MetricName represents the name of the resource monitored by recommender.
-type MetricName string
+// ResourceName represents the name of the resource monitored by recommender.
+type ResourceName string
 
 // ResourceAmount represents quantity of a certain resource within a container.
+// Note this keeps CPU in millicores (which is not a standard unit in APIs)
+// and memory in bytes.
 type ResourceAmount int64
 
 // Resources is a map from resource name to the corresponding ResourceAmount.
-type Resources map[MetricName]ResourceAmount
+type Resources map[ResourceName]ResourceAmount
 
 const (
 	// ResourceCPU represents CPU in millicores (1core = 1000millicores).
-	ResourceCPU MetricName = "cpu"
+	ResourceCPU ResourceName = "cpu"
 	// ResourceMemory represents memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024).
-	ResourceMemory MetricName = "memory"
+	ResourceMemory ResourceName = "memory"
 )
 
 // CPUAmountFromCores converts CPU cores to a ResourceAmount.
@@ -98,36 +98,4 @@ type ContainerID struct {
 type VpaID struct {
 	Namespace string
 	VpaName   string
-}
-
-// ContainerMetricsSnapshot contains information about usage of certain container within defined time window.
-type ContainerMetricsSnapshot struct {
-	// ID identifies a specific container those metrics are coming from.
-	ID ContainerID
-	// End time of the measurement interval.
-	SnapshotTime time.Time
-	// Duration of the measurement interval, which is [SnapshotTime - SnapshotWindow, SnapshotTime].
-	SnapshotWindow time.Duration
-	// Actual usage of the resources over the measurement interval.
-	Usage Resources
-}
-
-// BasicPodSpec contains basic information defining a pod and its containers.
-type BasicPodSpec struct {
-	// ID identifies a pod within a cluster.
-	ID PodID
-	// Labels of the pod. It is used to match pods with certain VPA opjects.
-	PodLabels map[string]string
-	// List of containers within this pod.
-	Containers []BasicContainerSpec
-}
-
-// BasicContainerSpec contains basic information defining a container.
-type BasicContainerSpec struct {
-	// ID identifies the container within a cluster.
-	ID ContainerID
-	// Name of the image running within the container.
-	Image string
-	// Currently requested resources for this container.
-	Request Resources
 }

--- a/vertical-pod-autoscaler/recommender/signals/history_provider_test.go
+++ b/vertical-pod-autoscaler/recommender/signals/history_provider_test.go
@@ -86,7 +86,7 @@ func TestGetCPUSamples(t *testing.T) {
 		LastLabels: map[string]string{},
 		Samples: map[string][]model.ContainerUsageSample{"container": {{
 			MeasureStart: time.Unix(1, 0),
-			Usage:        5.5,
+			Usage:        model.CPUAmountFromCores(5.5),
 			Resource:     model.ResourceCPU}}}}
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
@@ -112,7 +112,7 @@ func TestGetMemorySamples(t *testing.T) {
 		LastLabels: map[string]string{},
 		Samples: map[string][]model.ContainerUsageSample{"container": {{
 			MeasureStart: time.Unix(1, 0),
-			Usage:        12345,
+			Usage:        model.MemoryAmountFromBytes(12345),
 			Resource:     model.ResourceMemory}}}}
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)


### PR DESCRIPTION
* Change float64 to ResourceAmount in cotainer samples
* Rename MetricName to ResourceName to better reflect what it is and improve consistence with core API
* Move struct that are not used for storage from model package to where they are used (cluster package)