### PR TITLE
metrics and specs clients package refactoring

### DIFF
--- a/vertical-pod-autoscaler/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/recommender/input/history/history_provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/recommender/input/history/history_provider_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/recommender/input/history/prometheus_client.go
+++ b/vertical-pod-autoscaler/recommender/input/history/prometheus_client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/recommender/input/history/prometheus_client_test.go
+++ b/vertical-pod-autoscaler/recommender/input/history/prometheus_client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/recommender/input/history/prometheus_util.go
+++ b/vertical-pod-autoscaler/recommender/input/history/prometheus_util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"encoding/json"

--- a/vertical-pod-autoscaler/recommender/input/history/prometheus_util_test.go
+++ b/vertical-pod-autoscaler/recommender/input/history/prometheus_util_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"strings"

--- a/vertical-pod-autoscaler/recommender/input/history/types.go
+++ b/vertical-pod-autoscaler/recommender/input/history/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package signals
+package history
 
 import (
 	"time"

--- a/vertical-pod-autoscaler/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/recommender/input/metrics/metrics_client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package metrics
 
 import (
 	"time"

--- a/vertical-pod-autoscaler/recommender/input/metrics/metrics_client_test.go
+++ b/vertical-pod-autoscaler/recommender/input/metrics/metrics_client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package metrics
 
 import (
 	"testing"

--- a/vertical-pod-autoscaler/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/recommender/input/metrics/metrics_client_test_util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package metrics
 
 import (
 	"math/big"

--- a/vertical-pod-autoscaler/recommender/input/spec/spec_client.go
+++ b/vertical-pod-autoscaler/recommender/input/spec/spec_client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package spec
 
 import (
 	"k8s.io/api/core/v1"

--- a/vertical-pod-autoscaler/recommender/input/spec/spec_client_test.go
+++ b/vertical-pod-autoscaler/recommender/input/spec/spec_client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package spec
 
 import (
 	"testing"

--- a/vertical-pod-autoscaler/recommender/input/spec/spec_client_test_util.go
+++ b/vertical-pod-autoscaler/recommender/input/spec/spec_client_test_util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package spec
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/recommender/main.go
+++ b/vertical-pod-autoscaler/recommender/main.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	kube_flag "k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/signals"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/input/history"
 	"k8s.io/client-go/rest"
 	kube_restclient "k8s.io/client-go/rest"
 )
@@ -37,7 +37,7 @@ func main() {
 	glog.Infof("Running VPA Recommender")
 
 	config := createKubeConfig()
-	recommender := NewRecommender(config, *metricsFetcherInterval, signals.NewPrometheusHistoryProvider(*prometheusAddress))
+	recommender := NewRecommender(config, *metricsFetcherInterval, history.NewPrometheusHistoryProvider(*prometheusAddress))
 	recommender.Run()
 }
 


### PR DESCRIPTION
Proposal of a simple refactoring.
I'm not 100% sure about repeating package name in Interface name like: `spec.SpecClient`, however having two different `Client` interfaces imported in a single file also seemed a little confusing.

Let me know if it seems good to you or if you suggest a different approach.

CC: @kgrygiel @mwielgus 