### PR TITLE
allow specifying arbitrary resource capacity via aws asg tags

### DIFF
--- a/cluster-autoscaler/cloudprovider/utils.go
+++ b/cluster-autoscaler/cloudprovider/utils.go
@@ -123,3 +123,14 @@ func JoinStringMaps(items ...map[string]string) map[string]string {
 	}
 	return result
 }
+
+// JoinStringMaps joins resource lists
+func JoinResourceLists(items ...apiv1.ResourceList) apiv1.ResourceList {
+	result := make(apiv1.ResourceList)
+	for _, m := range items {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/cluster-autoscaler/cloudprovider/utils.go
+++ b/cluster-autoscaler/cloudprovider/utils.go
@@ -124,7 +124,7 @@ func JoinStringMaps(items ...map[string]string) map[string]string {
 	return result
 }
 
-// JoinStringMaps joins resource lists
+// JoinResourceLists joins resource lists
 func JoinResourceLists(items ...apiv1.ResourceList) apiv1.ResourceList {
 	result := make(apiv1.ResourceList)
 	for _, m := range items {


### PR DESCRIPTION
We're starting to work with device plugins and want to be able to scale up node groups from 0 when an unschedulable pod requests custom resources provided by a device plugin

for example my pod requests
```
resources:
  requests:
    acme.inc/widget: 5
```

This changeset allows adding aws asgs tags to specify additional resources capacity, using a autoscaler prefix similar to how node labels are specified. example tags: 
```
Key: k8s.io/cluster-autoscaler/node-template/resource-capacity/acme.inc/widget
Value: 5
```
Is this an acceptable approach?

Making the PR against master. Please advise if master isn't the right branch.