### PR TITLE
Fix reference to the docker image in the example

### DIFF
--- a/addon-resizer/README.md
+++ b/addon-resizer/README.md
@@ -57,7 +57,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: k8s.gcr.io/addon-resizer:1.8
+        - image: k8s.gcr.io/addon-resizer:1.8.1
           imagePullPolicy: Always
           name: pod-nanny
           resources:


### PR DESCRIPTION
It seems 1.8 doesn't exist, but 1.8.0 does -- and there is a 1.8.1 already.

----
Note that on the _1.8_ branch pointed to by the README the example actually talks about _1.7_, so I'm somewhat assuming that master is more "up-to-date" than that branch.