### PR TITLE
replace deprecated maintainer instruction with label

### DIFF
--- a/addon-resizer/Dockerfile
+++ b/addon-resizer/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER Quintin Lee "qlee@google.com"
 
 COPY pod_nanny /
 


### PR DESCRIPTION
As Dockerfile `MAINTAINER` instruction has been deprecated, we should use `LABEL maintainer=xxx` to replace original `MAINTAINER`. 

/cc @bskiba @mwielgus 