### PR TITLE
storageclasses permission is required

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["watch","list","get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["watch","list","get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["watch","list","get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["watch","list","get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Getting this permission error on deployment

```
Listing and watching *v1.StorageClass from k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/informers/factory.go:86
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/informers/factory.go:86: Failed to list *v1.StorageClass: storageclasses.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list storageclasses.storage.k8s.io at the cluster scope
```