### PR TITLE
storageclass permission is required

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss-master.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
@@ -44,6 +44,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["watch","list","get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Without this, cluster-autoscaler would report errors:

```
Listing and watching *v1.StorageClass from k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/informers/factory.go:86
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/informers/factory.go:86: Failed to list *v1.StorageClass: storageclasses.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list storageclasses.storage.k8s.io at the cluster scope
```
