### PR TITLE
Improve azure node's providerID handling

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -166,7 +165,7 @@ func (as *AgentPool) GetVMIndexes() ([]int, map[int]string, error) {
 		}
 
 		indexes = append(indexes, index)
-		indexToVM[index] = "azure://" + strings.ToLower(*instance.ID)
+		indexToVM[index] = "azure://" + *instance.ID
 	}
 
 	sortedIndexes := sort.IntSlice(indexes)
@@ -322,7 +321,7 @@ func (as *AgentPool) Belongs(node *apiv1.Node) (bool, error) {
 	glog.V(6).Infof("Check if node belongs to this agent pool: AgentPool:%v, node:%v\n", as, node)
 
 	ref := &azureRef{
-		Name: strings.ToLower(node.Spec.ProviderID),
+		Name: node.Spec.ProviderID,
 	}
 
 	targetAsg, err := as.manager.GetAsgForInstance(ref)
@@ -401,7 +400,7 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 		}
 
 		ref := &azureRef{
-			Name: strings.ToLower(node.Spec.ProviderID),
+			Name: node.Spec.ProviderID,
 		}
 		refs = append(refs, ref)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -29,7 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
-var virtualMachineRE = regexp.MustCompile(`^azure://(?:.*)/providers/microsoft.compute/virtualmachines/(.+)$`)
+var virtualMachineRE = regexp.MustCompile(`^azure://(?:.*)/providers/Microsoft.Compute/virtualMachines/(.+)$`)
 
 type asgCache struct {
 	registeredAsgs     []cloudprovider.NodeGroup
@@ -172,8 +171,7 @@ func (m *asgCache) regenerate() error {
 		}
 
 		for _, instance := range instances {
-			// Convert to lower because instance.ID is in different in different API calls (e.g. GET and LIST).
-			ref := azureRef{Name: strings.ToLower(instance)}
+			ref := azureRef{Name: instance}
 			newCache[ref] = nsg
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -43,6 +43,7 @@ type VirtualMachineScaleSetsClient interface {
 
 // VirtualMachineScaleSetVMsClient defines needed functions for azure compute.VirtualMachineScaleSetVMsClient.
 type VirtualMachineScaleSetVMsClient interface {
+	Get(resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVM, err error)
 	List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result compute.VirtualMachineScaleSetVMListResult, err error)
 	ListNextResults(lastResults compute.VirtualMachineScaleSetVMListResult) (result compute.VirtualMachineScaleSetVMListResult, err error)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -17,8 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"strings"
-
 	"github.com/golang/glog"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -74,7 +72,7 @@ func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	glog.V(6).Infof("Searching for node group for the node: %s, %s\n", node.Spec.ExternalID, node.Spec.ProviderID)
 	ref := &azureRef{
-		Name: strings.ToLower(node.Spec.ProviderID),
+		Name: node.Spec.ProviderID,
 	}
 
 	return azure.azureManager.GetAsgForInstance(ref)

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -123,6 +123,20 @@ type VirtualMachineScaleSetVMsClientMock struct {
 	mock.Mock
 }
 
+// Get gets a VirtualMachineScaleSetVM by VMScaleSetName and instanceID.
+func (m *VirtualMachineScaleSetVMsClientMock) Get(resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVM, err error) {
+	ID := fakeVirtualMachineScaleSetVMID
+	vmID := "123E4567-E89B-12D3-A456-426655440000"
+	properties := compute.VirtualMachineScaleSetVMProperties{
+		VMID: &vmID,
+	}
+	return compute.VirtualMachineScaleSetVM{
+		ID:                                 &ID,
+		InstanceID:                         &instanceID,
+		VirtualMachineScaleSetVMProperties: &properties,
+	}, nil
+}
+
 // List gets a list of VirtualMachineScaleSetVMs.
 func (m *VirtualMachineScaleSetVMsClientMock) List(resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) (result compute.VirtualMachineScaleSetVMListResult, err error) {
 	value := make([]compute.VirtualMachineScaleSetVM, 1)


### PR DESCRIPTION
This PR improves azure node's providerID handling by:

- Avoid converting cases for azure node's providerID 
- Use GET API to fetch node's ID for vmss virtual machines. This is because the virtual machines ID format in LIST is not consistent with GET results. We use GET here because azure cloud provider also uses GET API.