### PR TITLE
Introduce recommendation confidence.

### DIFF
--- a/vertical-pod-autoscaler/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/recommender/logic/estimator_test.go
@@ -99,9 +99,9 @@ func TestConfidenceMultiplierEstimatorNoHistory(t *testing.T) {
 	testedEstimator2 := &confidenceMultiplierEstimator{-1.0, baseEstimator}
 	s := newAggregateContainerState()
 	// Expect testedEstimator1 to return the maximum possible resource amount.
-	assert.Equal(t, 1e11, model.CoresFromCPUAmount(
-		testedEstimator1.GetResourceEstimation(s)[model.ResourceCPU]))
+	assert.Equal(t, model.ResourceAmount(1e14),
+		testedEstimator1.GetResourceEstimation(s)[model.ResourceCPU])
 	// Expect testedEstimator2 to return zero.
-	assert.Equal(t, 0.0, model.CoresFromCPUAmount(
-		testedEstimator2.GetResourceEstimation(s)[model.ResourceCPU]))
+	assert.Equal(t, model.ResourceAmount(0),
+		testedEstimator2.GetResourceEstimation(s)[model.ResourceCPU])
 }

--- a/vertical-pod-autoscaler/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/recommender/logic/recommender.go
@@ -17,6 +17,8 @@ limitations under the License.
 package logic
 
 import (
+	"time"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
@@ -61,7 +63,9 @@ func (r *podResourceRecommender) GetRecommendedPodResources(vpa *model.Vpa) Reco
 	aggregateContainerStateMap := buildAggregateContainerStateMap(&vpa.Pods)
 	var recommendation RecommendedPodResources = make(RecommendedPodResources)
 	for containerName, aggregatedContainerState := range aggregateContainerStateMap {
-		recommendation[containerName] = r.getRecommendedContainerResources(aggregatedContainerState)
+		if aggregatedContainerState.totalSamplesCount > 0 {
+			recommendation[containerName] = r.getRecommendedContainerResources(aggregatedContainerState)
+		}
 	}
 	return recommendation
 }
@@ -71,6 +75,9 @@ func (r *podResourceRecommender) GetRecommendedPodResources(vpa *model.Vpa) Reco
 type AggregateContainerState struct {
 	aggregateCPUUsage    util.Histogram
 	aggregateMemoryPeaks util.Histogram
+	firstSampleStart     time.Time
+	lastSampleStart      time.Time
+	totalSamplesCount    int
 }
 
 // Merges the state of an individual container into AggregateContainerState.
@@ -82,13 +89,21 @@ func (a *AggregateContainerState) mergeContainerState(container *model.Container
 		a.aggregateMemoryPeaks.AddSample(float64(memoryPeaks[i]), 1.0, peakTime)
 		peakTime = peakTime.Add(-model.MemoryAggregationInterval)
 	}
+	// Note: we look at CPU samples to calculate the total lifespan and sample count.
+	if a.firstSampleStart.IsZero() || (!container.FirstCPUSampleStart.IsZero() && container.FirstCPUSampleStart.Before(a.firstSampleStart)) {
+		a.firstSampleStart = container.FirstCPUSampleStart
+	}
+	if container.LastCPUSampleStart.After(a.lastSampleStart) {
+		a.lastSampleStart = container.LastCPUSampleStart
+	}
+	a.totalSamplesCount += container.CPUSamplesCount
 }
 
 // Returns a new, empty AggregateContainerState.
 func newAggregateContainerState() *AggregateContainerState {
 	return &AggregateContainerState{
-		util.NewDecayingHistogram(model.CPUHistogramOptions, model.CPUHistogramDecayHalfLife),
-		util.NewDecayingHistogram(model.MemoryHistogramOptions, model.MemoryHistogramDecayHalfLife),
+		aggregateCPUUsage:    util.NewDecayingHistogram(model.CPUHistogramOptions, model.CPUHistogramDecayHalfLife),
+		aggregateMemoryPeaks: util.NewDecayingHistogram(model.MemoryHistogramOptions, model.MemoryHistogramDecayHalfLife),
 	}
 }
 

--- a/vertical-pod-autoscaler/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/recommender/model/cluster_test.go
@@ -51,7 +51,7 @@ func TestClusterAddSample(t *testing.T) {
 
 	// Verify that the sample was aggregated into the container stats.
 	containerStats := cluster.Pods[testPodID].Containers["container-1"]
-	assert.Equal(t, testTimestamp, containerStats.lastCPUSampleStart)
+	assert.Equal(t, testTimestamp, containerStats.LastCPUSampleStart)
 }
 
 // Verifies that AddSample and AddOrUpdateContainer methods return a proper

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -43,11 +43,11 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
-		mockCPUHistogram,
-		time.Unix(0, 0),
-		memoryUsagePeaks,
-		time.Unix(0, 0),
-		time.Unix(0, 0)}
+		CPUUsage:              mockCPUHistogram,
+		LastCPUSampleStart:    time.Unix(0, 0),
+		MemoryUsagePeaks:      memoryUsagePeaks,
+		WindowEnd:             time.Unix(0, 0),
+		lastMemorySampleStart: time.Unix(0, 0)}
 
 	// Verify that CPU measures are added to the CPU histogram.
 	timeStep := MemoryAggregationInterval / 2

--- a/vertical-pod-autoscaler/recommender/model/types.go
+++ b/vertical-pod-autoscaler/recommender/model/types.go
@@ -102,7 +102,7 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 
 // RoundResourceAmount returns the given resource amount rounded down to the
 // whole multiple of another resource amount (unit).
-func RoundResourceAmount(amount ResourceAmount, unit ResourceAmount) ResourceAmount {
+func RoundResourceAmount(amount, unit ResourceAmount) ResourceAmount {
 	return ResourceAmount(int64(amount) - int64(amount)%int64(unit))
 }
 


### PR DESCRIPTION
The confidence grows with the amount of aggregated utilization history.
The recommender multiplies MaxRecommendation by the factor of (1+1/confidence) and divides MinRecommendation by the same factor. This means that the [Min..Max] range is very wide when there is small amount of available history (either the VPA recommender has just started and didn't have access to the historical data or all pods matched by the VPA are new). The [Min..Max] range gets more narrow as the history accumulates.
As the effect, the Updater will be less likely to evict a pod when the confidence of the recommendation is low.