### PR TITLE
Better GPU handling in price expander

### DIFF
--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	scheduler_util "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 
@@ -515,6 +516,20 @@ func getOldestCreateTime(pods []*apiv1.Pod) time.Time {
 		}
 	}
 	return oldest
+}
+
+func getOldestCreateTimeWithGpu(pods []*apiv1.Pod) (bool, time.Time) {
+	oldest := time.Now()
+	gpuFound := false
+	for _, pod := range pods {
+		if gpu.PodRequestsGpu(pod) {
+			gpuFound = true
+			if oldest.After(pod.CreationTimestamp.Time) {
+				oldest = pod.CreationTimestamp.Time
+			}
+		}
+	}
+	return gpuFound, oldest
 }
 
 // UpdateEmptyClusterStateMetrics updates metrics related to empty cluster's state.

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -101,6 +101,19 @@ func NodeHasGpu(node *apiv1.Node) bool {
 	return hasGpuLabel || (hasGpuAllocatable && !gpuAllocatable.IsZero())
 }
 
+// PodRequestsGpu returns true if a given pod has GPU request.
+func PodRequestsGpu(pod *apiv1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Resources.Requests != nil {
+			_, gpuFound := container.Resources.Requests[ResourceNvidiaGPU]
+			if gpuFound {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // GpuRequestInfo contains an information about a set of pods requesting a GPU.
 type GpuRequestInfo struct {
 	// MaxRequest is maximum GPU request among pods

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -92,6 +92,15 @@ func getUnreadyNodeCopy(node *apiv1.Node) (*apiv1.Node, error) {
 	return newNode, nil
 }
 
+// NodeHasGpu returns true if a given node has GPU hardware.
+// The result will be true if there is hardware capability. It doesn't matter
+// if the drivers are installed and GPU is ready to use.
+func NodeHasGpu(node *apiv1.Node) bool {
+	_, hasGpuLabel := node.Labels[GPULabel]
+	gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[ResourceNvidiaGPU]
+	return hasGpuLabel || (hasGpuAllocatable && !gpuAllocatable.IsZero())
+}
+
 // GpuRequestInfo contains an information about a set of pods requesting a GPU.
 type GpuRequestInfo struct {
 	// MaxRequest is maximum GPU request among pods

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -151,6 +151,49 @@ func TestFilterOutNodesWithUnreadyGpus(t *testing.T) {
 	}
 }
 
+func TestNodeHasGpu(t *testing.T) {
+	gpuLabels := map[string]string{
+		GPULabel: "nvidia-tesla-k80",
+	}
+	nodeGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodeGpuReady",
+			Labels: gpuLabels,
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+		},
+	}
+	nodeGpuReady.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeGpuReady.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	assert.True(t, NodeHasGpu(nodeGpuReady))
+
+	nodeGpuUnready := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodeGpuUnready",
+			Labels: gpuLabels,
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+		},
+	}
+	assert.True(t, NodeHasGpu(nodeGpuUnready))
+
+	nodeNoGpu := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodeNoGpu",
+			Labels: map[string]string{},
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+		},
+	}
+	assert.False(t, NodeHasGpu(nodeNoGpu))
+}
+
 func TestGetGpuRequests(t *testing.T) {
 	podNoGpu := test.BuildTestPod("podNoGpu", 0, 1000)
 	podNoGpu.Spec.NodeSelector = map[string]string{}

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -194,6 +194,15 @@ func TestNodeHasGpu(t *testing.T) {
 	assert.False(t, NodeHasGpu(nodeNoGpu))
 }
 
+func TestPodRequestsGpu(t *testing.T) {
+	podNoGpu := test.BuildTestPod("podNoGpu", 0, 1000)
+	podWithGpu := test.BuildTestPod("pod1AnyGpu", 0, 1000)
+	podWithGpu.Spec.Containers[0].Resources.Requests[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+
+	assert.False(t, PodRequestsGpu(podNoGpu))
+	assert.True(t, PodRequestsGpu(podWithGpu))
+}
+
 func TestGetGpuRequests(t *testing.T) {
 	podNoGpu := test.BuildTestPod("podNoGpu", 0, 1000)
 	podNoGpu.Spec.NodeSelector = map[string]string{}


### PR DESCRIPTION
Use constant, very high unfitness for nodes with GPU to make them very unattractive for any pod that doesn't require GPU and to avoid situation where CA values CPU usage efficiency over GPU price optimization.

Also additionally delay scale-up if there are very new pods requesting GPU. We lose a bit of latency for pods requesting GPU, but we can pack them more densely that way.