### PR TITLE
Extend the Updater policy with new rules

### DIFF
--- a/vertical-pod-autoscaler/admission-controller/logic/recommendation_provider.go
+++ b/vertical-pod-autoscaler/admission-controller/logic/recommendation_provider.go
@@ -50,7 +50,7 @@ func getRecomendedResources(pod *v1.Pod, podRecommendation vpa_types.Recommended
 			glog.V(2).Infof("%v", err)
 			continue
 		}
-		res[i] = recommendation
+		res[i] = recommendation.Target
 	}
 	return res
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -19,6 +19,7 @@ package test
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
@@ -30,9 +31,14 @@ import (
 	v1 "k8s.io/client-go/listers/core/v1"
 )
 
+var (
+	TimeLayout       = "2006-01-02 15:04:05"
+	testTimestamp, _ = time.Parse(TimeLayout, "2017-04-18 17:35:05")
+)
+
 // BuildTestPod creates a pod with specified resources.
 func BuildTestPod(name, containerName, cpu, mem string, creatorObjectMeta *metav1.ObjectMeta, creatorTypeMeta *metav1.TypeMeta) *apiv1.Pod {
-	startTime := metav1.Now()
+	startTime := metav1.Time{testTimestamp}
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	TimeLayout       = "2006-01-02 15:04:05"
-	testTimestamp, _ = time.Parse(TimeLayout, "2017-04-18 17:35:05")
+	timeLayout       = "2006-01-02 15:04:05"
+	testTimestamp, _ = time.Parse(timeLayout, "2017-04-18 17:35:05")
 )
 
 // BuildTestPod creates a pod with specified resources.
@@ -100,20 +100,20 @@ func BuildTestContainer(containerName, cpu, mem string) apiv1.Container {
 }
 
 // BuildTestPolicy creates ResourcesPolicy with specified constraints
-func BuildTestPolicy(containerName, minCpu, maxCpu, minMemory, maxMemory string) *vpa_types.PodResourcePolicy {
-	minCpuVal, _ := resource.ParseQuantity(minCpu)
-	maxCpuVal, _ := resource.ParseQuantity(maxCpu)
+func BuildTestPolicy(containerName, minCPU, maxCPU, minMemory, maxMemory string) *vpa_types.PodResourcePolicy {
+	minCPUVal, _ := resource.ParseQuantity(minCPU)
+	maxCPUVal, _ := resource.ParseQuantity(maxCPU)
 	minMemVal, _ := resource.ParseQuantity(minMemory)
 	maxMemVal, _ := resource.ParseQuantity(maxMemory)
 	return &vpa_types.PodResourcePolicy{ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
 		Name: containerName,
 		MinAllowed: apiv1.ResourceList{
 			apiv1.ResourceMemory: minMemVal,
-			apiv1.ResourceCPU:    minCpuVal,
+			apiv1.ResourceCPU:    minCPUVal,
 		},
 		MaxAllowed: apiv1.ResourceList{
 			apiv1.ResourceMemory: maxMemVal,
-			apiv1.ResourceCPU:    maxCpuVal,
+			apiv1.ResourceCPU:    maxCPUVal,
 		},
 	},
 	}}
@@ -121,14 +121,14 @@ func BuildTestPolicy(containerName, minCpu, maxCpu, minMemory, maxMemory string)
 
 // BuildTestVerticalPodAutoscaler creates VerticalPodAutoscaler with specified policy constraints.
 // TODO: Allow passing arbitrary MinRecommended and MaxRecommended values.
-func BuildTestVerticalPodAutoscaler(containerName, targetCpu, minCpu, maxCpu, targetMemory, minMemory, maxMemory string, selector string) *vpa_types.VerticalPodAutoscaler {
-	resourcesPolicy := BuildTestPolicy(containerName, minCpu, maxCpu, minMemory, maxMemory)
+func BuildTestVerticalPodAutoscaler(containerName, targetCPU, minCPU, maxCPU, targetMemory, minMemory, maxMemory string, selector string) *vpa_types.VerticalPodAutoscaler {
+	resourcesPolicy := BuildTestPolicy(containerName, minCPU, maxCPU, minMemory, maxMemory)
 
 	labelSelector, err := metav1.ParseToLabelSelector(selector)
 	if err != nil {
 		log.Fatal(err)
 	}
-	recommendedResources := Resources(targetCpu, targetMemory)
+	recommendedResources := Resources(targetCPU, targetMemory)
 
 	return &vpa_types.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -69,10 +69,10 @@ func TestRecommendationChosenForProperContainer(t *testing.T) {
 
 	res, err := GetCappedRecommendationForContainer(container, &podRecommendation, &policy)
 	assert.Nil(t, err)
-	assert.Equal(t, res, apiv1.ResourceList{
+	assert.Equal(t, apiv1.ResourceList{
 		apiv1.ResourceCPU:    *resource.NewScaledQuantity(10, 1),
 		apiv1.ResourceMemory: *resource.NewScaledQuantity(5000, 1),
-	})
+	}, res.Target)
 }
 
 func TestRecommendationCappedToLimit(t *testing.T) {
@@ -93,6 +93,10 @@ func TestRecommendationCappedToLimit(t *testing.T) {
 					apiv1.ResourceCPU:    *resource.NewScaledQuantity(10, 1),
 					apiv1.ResourceMemory: *resource.NewScaledQuantity(5000, 1),
 				},
+				MaxRecommended: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(2, 1),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(9000, 1),
+				},
 			},
 		},
 	}
@@ -100,10 +104,14 @@ func TestRecommendationCappedToLimit(t *testing.T) {
 
 	res, err := GetCappedRecommendationForContainer(container, &podRecommendation, &policy)
 	assert.Nil(t, err)
-	assert.Equal(t, res, apiv1.ResourceList{
+	assert.Equal(t, apiv1.ResourceList{
 		apiv1.ResourceCPU:    *resource.NewScaledQuantity(3, 1),
 		apiv1.ResourceMemory: *resource.NewScaledQuantity(5000, 1),
-	})
+	}, res.Target)
+	assert.Equal(t, apiv1.ResourceList{
+		apiv1.ResourceCPU:    *resource.NewScaledQuantity(2, 1),
+		apiv1.ResourceMemory: *resource.NewScaledQuantity(7000, 1),
+	}, res.MaxRecommended)
 }
 
 func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
@@ -115,6 +123,10 @@ func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
 				Target: apiv1.ResourceList{
 					apiv1.ResourceCPU:    *resource.NewScaledQuantity(10, 1),
 					apiv1.ResourceMemory: *resource.NewScaledQuantity(5000, 1),
+				},
+				MinRecommended: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(50, 1),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(4300, 1),
 				},
 			},
 		},
@@ -137,8 +149,12 @@ func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
 
 	res, err := GetCappedRecommendationForContainer(container, &podRecommendation, &policy)
 	assert.Nil(t, err)
-	assert.Equal(t, res, apiv1.ResourceList{
+	assert.Equal(t, apiv1.ResourceList{
 		apiv1.ResourceCPU:    *resource.NewScaledQuantity(40, 1),
 		apiv1.ResourceMemory: *resource.NewScaledQuantity(4500, 1),
-	})
+	}, res.Target)
+	assert.Equal(t, apiv1.ResourceList{
+		apiv1.ResourceCPU:    *resource.NewScaledQuantity(45, 1),
+		apiv1.ResourceMemory: *resource.NewScaledQuantity(4300, 1),
+	}, res.MinRecommended)
 }

--- a/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
@@ -64,7 +64,7 @@ func NewUpdatePriorityCalculator(policy *vpa_types.PodResourcePolicy, config *Up
 }
 
 // AddPod adds pod to the UpdatePriorityCalculator.
-func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) {
+func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources, now time.Time) {
 	updatePriority := calc.getUpdatePriority(pod, recommendation)
 
 	// The update is allowed in either of the following two cases:
@@ -76,7 +76,7 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa
 			glog.V(2).Infof("not updating pod %v, missing field pod.Status.StartTime", pod.Name)
 			return
 		}
-		if time.Now().Before(pod.Status.StartTime.Add(podLifetimeUpdateThreshold)) {
+		if now.Before(pod.Status.StartTime.Add(podLifetimeUpdateThreshold)) {
 			glog.V(2).Infof("not updating a short-lived pod %v, request within recommended range", pod.Name)
 			return
 		}

--- a/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
@@ -22,14 +22,13 @@ import (
 
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 const (
 	// ignore change priority that is smaller than 10%
-	defaultUpdateThreshod = 0.10
+	defaultUpdateThreshold = 0.10
 )
 
 // UpdatePriorityCalculator is responsible for prioritizing updates on pods.
@@ -55,7 +54,7 @@ type UpdateConfig struct {
 // If the given config is nil, default values are used.
 func NewUpdatePriorityCalculator(policy *vpa_types.PodResourcePolicy, config *UpdateConfig) UpdatePriorityCalculator {
 	if config == nil {
-		config = &UpdateConfig{MinChangePriority: defaultUpdateThreshod}
+		config = &UpdateConfig{MinChangePriority: defaultUpdateThreshold}
 	}
 	return UpdatePriorityCalculator{resourcesPolicy: policy, config: config}
 }
@@ -64,13 +63,18 @@ func NewUpdatePriorityCalculator(policy *vpa_types.PodResourcePolicy, config *Up
 func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) {
 	updatePriority := calc.getUpdatePriority(pod, recommendation)
 
-	if updatePriority < calc.config.MinChangePriority {
+	// TODO: if (the current request is within [lowerBound, upperBound] for all containers) and
+	//          (the pod lives less than Y hours) then do not update.
+	// TODO: if (the current request is within [lowerBound, upperBound] for all containers) and
+	//          (the current request differs from the target by less than X%) then do not update.
+
+	if updatePriority.resourceDiff < calc.config.MinChangePriority {
 		glog.V(2).Infof("pod not accepted for update %v, priority too low: %v", pod.Name, updatePriority)
 		return
 	}
 
-	glog.V(2).Infof("pod accepted for update %v with priority %v", pod.Name, updatePriority)
-	calc.pods = append(calc.pods, podPriority{pod, updatePriority})
+	glog.V(2).Infof("pod accepted for update %v with priority %v", pod.Name, updatePriority.resourceDiff)
+	calc.pods = append(calc.pods, updatePriority)
 }
 
 // GetSortedPods returns a list of pods ordered by update priority (highest update priority first)
@@ -85,8 +89,11 @@ func (calc *UpdatePriorityCalculator) GetSortedPods() []*apiv1.Pod {
 	return result
 }
 
-func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) float64 {
-	var priority float64
+func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) podPriority {
+	// Sum of requests over all containers, per resource type.
+	totalRequestPerResource := make(map[apiv1.ResourceName]int64)
+	// Sum of recommendations over all containers, per resource type.
+	totalRecommendedPerResource := make(map[apiv1.ResourceName]int64)
 
 	for _, podContainer := range pod.Spec.Containers {
 		recommendedRequest, err := vpa_api_util.GetCappedRecommendationForContainer(podContainer, recommendation, calc.resourcesPolicy)
@@ -95,34 +102,29 @@ func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommen
 			continue
 		}
 		for resourceName, recommended := range recommendedRequest.Target {
-			var requested *resource.Quantity
-
+			totalRecommendedPerResource[resourceName] += recommended.MilliValue()
 			if request, ok := podContainer.Resources.Requests[resourceName]; ok {
-				requested = &request
+				totalRequestPerResource[resourceName] += request.MilliValue()
 			}
-			resourceDiff := getPercentageDiff(requested, &recommended)
-			priority += math.Abs(resourceDiff)
 		}
 	}
-	return priority
-}
-
-func getPercentageDiff(request, recommendation *resource.Quantity) float64 {
-	if request == nil {
-		// resource requirement is not currently specified
-		// any recommendation for this resource we will treat as 100% change
-		return 1.0
+	resourceDiff := 0.0
+	for resource, totalRecommended := range totalRecommendedPerResource {
+		totalRequest := math.Max(float64(totalRequestPerResource[resource]), 1.0)
+		resourceDiff += math.Abs(totalRequest-float64(totalRecommended)) / totalRequest
 	}
-	if recommendation == nil || recommendation.IsZero() {
-		return 0
+	return podPriority{
+		pod:          pod,
+		resourceDiff: resourceDiff,
 	}
-	return float64(recommendation.MilliValue()-request.MilliValue()) / float64(request.MilliValue())
 }
 
 type podPriority struct {
-	pod      *apiv1.Pod
-	priority float64
+	pod *apiv1.Pod
+	// Relative difference between the total requested and total recommended resources.
+	resourceDiff float64
 }
+
 type byPriority []podPriority
 
 func (list byPriority) Len() int {
@@ -132,6 +134,6 @@ func (list byPriority) Swap(i, j int) {
 	list[i], list[j] = list[j], list[i]
 }
 func (list byPriority) Less(i, j int) bool {
-	// reverse ordering, highest priority first
-	return list[i].priority > list[j].priority
+	// Reverse ordering, highest priority first.
+	return list[i].resourceDiff > list[j].resourceDiff
 }

--- a/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/updater/priority/update_priority_calculator.go
@@ -94,7 +94,7 @@ func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommen
 			glog.V(2).Infof("no recommendation for container %v in pod %v", podContainer.Name, pod.Name)
 			continue
 		}
-		for resourceName, recommended := range recommendedRequest {
+		for resourceName, recommended := range recommendedRequest.Target {
 			var requested *resource.Quantity
 
 			if request, ok := podContainer.Resources.Requests[resourceName]; ok {

--- a/vertical-pod-autoscaler/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/updater/priority/update_priority_calculator_test.go
@@ -112,15 +112,21 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(nil, nil)
 
 	pod1 := test.BuildTestPod("POD1", containerName, "4", "", nil, nil)
-	pod2 := test.BuildTestPod("POD2", containerName, "10", "", nil, nil)
+	pod2 := test.BuildTestPod("POD2", containerName, "7", "", nil, nil)
+	pod3 := test.BuildTestPod("POD3", containerName, "10", "", nil, nil)
 
 	recommendation := test.Recommendation(containerName, "5", "")
 
 	calculator.AddPod(pod1, recommendation)
 	calculator.AddPod(pod2, recommendation)
+	calculator.AddPod(pod3, recommendation)
 
+	// Expect the following order:
+	// 1. pod1 - wants to grow by 1 unit.
+	// 2. pod3 - can reclaim 5 units.
+	// 3. pod2 - can reclaim 2 units.
 	result := calculator.GetSortedPods()
-	assert.Exactly(t, []*apiv1.Pod{pod2, pod1}, result, "Wrong priority order")
+	assert.Exactly(t, []*apiv1.Pod{pod1, pod3, pod2}, result, "Wrong priority order")
 }
 
 func TestUpdateNotRequired(t *testing.T) {

--- a/vertical-pod-autoscaler/updater/updater.go
+++ b/vertical-pod-autoscaler/updater/updater.go
@@ -117,7 +117,7 @@ func (u *updater) getPodsForUpdate(pods []*apiv1.Pod, vpa *vpa_types.VerticalPod
 	recommendation := vpa.Status.Recommendation
 
 	for _, pod := range pods {
-		priorityCalculator.AddPod(pod, &recommendation)
+		priorityCalculator.AddPod(pod, &recommendation, time.Now())
 	}
 
 	return priorityCalculator.GetSortedPods()


### PR DESCRIPTION
1. Update priority is calculated based on the ratio between the total request and total recommended target for all containers, as opposed to sum of ratio for each container (previous policy favored many small containers).
2. Pods with a container that needs to grow get higher priority.
3. Pods with any request outside the [MinRecommended...MaxRecommended] range can be updated regardless of the relative diff between request and target.
4. Pods with all requests within the [MinRecommended...MaxRecommended] range can be updated if they live for at least 12h and the relative diff exceeds the threshold.