### PR TITLE
Update metadata.go, a clerical error

### DIFF
--- a/vertical-pod-autoscaler/vendor/cloud.google.com/go/compute/metadata/metadata.go
+++ b/vertical-pod-autoscaler/vendor/cloud.google.com/go/compute/metadata/metadata.go
@@ -45,7 +45,7 @@ const (
 	// metadataHostEnv is the environment variable specifying the
 	// GCE metadata hostname.  If empty, the default value of
 	// metadataIP ("169.254.169.254") is used instead.
-	// This is variable name is not defined by any spec, as far as
+	// This variable name is not defined by any spec, as far as
 	// I know; it was made up for the Go package.
 	metadataHostEnv = "GCE_METADATA_HOST"
 )


### PR DESCRIPTION
line 48: a clerical error "This is variable name is not defined by any spec"
It should be "This variable name is not defined by any spec"