### PR TITLE
CA 0.6.4

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "0.6.3"
+const ClusterAutoscalerVersion = "0.6.4"


### PR DESCRIPTION
Update Cluster Autoscaler version to 0.6.4.