### PR TITLE
Improve reaction time for CPU starved workloads

### DIFF
--- a/vertical-pod-autoscaler/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/recommender/input/cluster_feeder.go
@@ -211,7 +211,7 @@ func (feeder *clusterStateFeeder) LoadPods() {
 	for _, pod := range pods {
 		feeder.clusterState.AddOrUpdatePod(pod.ID, pod.PodLabels, pod.Phase)
 		for _, container := range pod.Containers {
-			feeder.clusterState.AddOrUpdateContainer(container.ID)
+			feeder.clusterState.AddOrUpdateContainer(container.ID, container.Request)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/recommender/logic/estimator_test.go
@@ -26,7 +26,11 @@ import (
 )
 
 var (
-	anyTime = time.Unix(0, 0)
+	anyTime     = time.Unix(0, 0)
+	testRequest = model.Resources{
+		model.ResourceCPU:    model.CPUAmountFromCores(3.14),
+		model.ResourceMemory: model.MemoryAmountFromBytes(3.14e9),
+	}
 )
 
 // Verifies that the PercentileEstimator returns requested percentiles of CPU
@@ -68,7 +72,7 @@ func TestConfidenceMultiplier(t *testing.T) {
 	})
 	testedEstimator := &confidenceMultiplier{0.1, 2.0, baseEstimator}
 
-	container := model.NewContainerState()
+	container := model.NewContainerState(testRequest)
 	// Add 9 CPU samples at the frequency of 1/(2 mins).
 	timestamp := anyTime
 	for i := 1; i <= 9; i++ {

--- a/vertical-pod-autoscaler/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/recommender/logic/recommender.go
@@ -92,11 +92,11 @@ func CreatePodResourceRecommender() PodResourceRecommender {
 	lowerBoundEstimator := NewPercentileEstimator(lowerBoundCPUPercentile, lowerBoundMemoryPeaksPercentile)
 	upperBoundEstimator := NewPercentileEstimator(upperBoundCPUPercentile, upperBoundMemoryPeaksPercentile)
 
-	// Use 10% safety margin on top of the recommended resources.
-	safetyMarginFraction := 0.1
-	// Minimum safety margin is 0.2 core and 300MB memory.
+	// Use 15% safety margin on top of the recommended resources.
+	safetyMarginFraction := 0.15
+	// Minimum safety margin is 0.3 core and 300MB memory.
 	minSafetyMargin := model.Resources{
-		model.ResourceCPU:    model.CPUAmountFromCores(0.2),
+		model.ResourceCPU:    model.CPUAmountFromCores(0.3),
 		model.ResourceMemory: model.MemoryAmountFromBytes(300 * 1024 * 1024),
 	}
 	targetEstimator = WithSafetyMargin(safetyMarginFraction, minSafetyMargin, targetEstimator)

--- a/vertical-pod-autoscaler/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregate_container_state_test.go
@@ -31,6 +31,10 @@ var (
 	testPodID1       = PodID{"namespace-1", "pod-1"}
 	testPodID2       = PodID{"namespace-1", "pod-2"}
 	testContainerID1 = ContainerID{testPodID1, "container-1"}
+	testRequest      = Resources{
+		ResourceCPU:    CPUAmountFromCores(3.14),
+		ResourceMemory: MemoryAmountFromBytes(3.14e9),
+	}
 )
 
 func addTestSample(cluster *ClusterState, container ContainerID, cpu float64, memory float64) error {
@@ -77,7 +81,7 @@ func TestBuildAggregateResourcesMap(t *testing.T) {
 		{testPodID2, "app-C"},
 	}
 	for _, c := range containers {
-		assert.NoError(t, cluster.AddOrUpdateContainer(c))
+		assert.NoError(t, cluster.AddOrUpdateContainer(c, testRequest))
 	}
 
 	// Add usage samples to all containers.
@@ -178,7 +182,7 @@ func TestAggregateContainerStateLoadFromCheckpoint(t *testing.T) {
 
 func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 	anyTime := time.Unix(0, 0)
-	container := NewContainerState()
+	container := NewContainerState(testRequest)
 	timestamp := anyTime
 	container.AddSample(&ContainerUsageSample{
 		timestamp, MemoryAmountFromBytes(1024 * 1024 * 1024), ResourceMemory})
@@ -191,7 +195,7 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 
 func TestMergeContainerStateForCheckpoint(t *testing.T) {
 	anyTime := time.Unix(0, 0)
-	container := NewContainerState()
+	container := NewContainerState(testRequest)
 	timestamp := anyTime
 	container.AddSample(&ContainerUsageSample{
 		timestamp, MemoryAmountFromBytes(1024 * 1024 * 1024), ResourceMemory})

--- a/vertical-pod-autoscaler/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/recommender/model/cluster.go
@@ -124,13 +124,16 @@ func (cluster *ClusterState) DeletePod(podID PodID) error {
 // adds it to the parent pod in the ClusterState object, if not yet present.
 // Requires the pod to be added to the ClusterState first. Otherwise an error is
 // returned.
-func (cluster *ClusterState) AddOrUpdateContainer(containerID ContainerID) error {
+func (cluster *ClusterState) AddOrUpdateContainer(containerID ContainerID, request Resources) error {
 	pod, podExists := cluster.Pods[containerID.PodID]
 	if !podExists {
 		return NewKeyError(containerID.PodID)
 	}
-	if _, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
-		pod.Containers[containerID.ContainerName] = NewContainerState()
+	if container, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
+		pod.Containers[containerID.ContainerName] = NewContainerState(request)
+	} else {
+		// Request has changed.
+		container.Request = request
 	}
 	return nil
 }

--- a/vertical-pod-autoscaler/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/recommender/model/cluster_test.go
@@ -45,7 +45,7 @@ func TestClusterAddSample(t *testing.T) {
 	// Create a pod with a single container.
 	cluster := NewClusterState()
 	cluster.AddOrUpdatePod(testPodID, testLabels, apiv1.PodRunning)
-	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID))
+	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID, testRequest))
 
 	// Add a usage sample to the container.
 	cluster.AddSample(makeTestUsageSample())
@@ -59,7 +59,7 @@ func TestClusterRecordOOM(t *testing.T) {
 	// Create a pod with a single container.
 	cluster := NewClusterState()
 	cluster.AddOrUpdatePod(testPodID, testLabels, apiv1.PodRunning)
-	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID))
+	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID, testRequest))
 
 	// RecordOOM
 	assert.NoError(t, cluster.RecordOOM(testContainerID, time.Unix(0, 0), ResourceAmount(10)))
@@ -79,7 +79,7 @@ func TestMissingKeys(t *testing.T) {
 	err = cluster.RecordOOM(testContainerID, time.Unix(0, 0), ResourceAmount(10))
 	assert.EqualError(t, err, "KeyError: {namespace-1 pod-1}")
 
-	err = cluster.AddOrUpdateContainer(testContainerID)
+	err = cluster.AddOrUpdateContainer(testContainerID, testRequest)
 	assert.EqualError(t, err, "KeyError: {namespace-1 pod-1}")
 }
 

--- a/vertical-pod-autoscaler/recommender/model/container.go
+++ b/vertical-pod-autoscaler/recommender/model/container.go
@@ -48,6 +48,8 @@ type ContainerUsageSample struct {
 //   it will store 7 peaks, one per day, for the last week.
 //   Note: samples are added to intervals based on their start timestamps.
 type ContainerState struct {
+	// Current request.
+	Request Resources
 	// Distribution of CPU usage. The measurement unit is 1 CPU core.
 	CPUUsage util.Histogram
 	// Start of the latest CPU usage sample that was aggregated.
@@ -67,8 +69,9 @@ type ContainerState struct {
 }
 
 // NewContainerState returns a new, empty ContainerState.
-func NewContainerState() *ContainerState {
+func NewContainerState(request Resources) *ContainerState {
 	return &ContainerState{
+		Request:             request,
 		CPUUsage:            util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife),
 		LastCPUSampleStart:  time.Time{},
 		FirstCPUSampleStart: time.Time{},

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -25,7 +25,11 @@ import (
 )
 
 var (
-	TimeLayout = "2006-01-02 15:04:05"
+	TimeLayout  = "2006-01-02 15:04:05"
+	TestRequest = Resources{
+		ResourceCPU:    CPUAmountFromCores(2.3),
+		ResourceMemory: MemoryAmountFromBytes(5e8),
+	}
 )
 
 const (
@@ -48,6 +52,7 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,
@@ -55,10 +60,11 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 		lastMemorySampleStart: time.Unix(0, 0)}
 
 	// Verify that CPU measures are added to the CPU histogram.
+	// The weight should be equal to the current request.
 	timeStep := MemoryAggregationInterval / 2
-	mockCPUHistogram.On("AddSample", 3.14, 1.0, testTimestamp)
-	mockCPUHistogram.On("AddSample", 6.28, 1.0, testTimestamp.Add(timeStep))
-	mockCPUHistogram.On("AddSample", 1.57, 1.0, testTimestamp.Add(2*timeStep))
+	mockCPUHistogram.On("AddSample", 3.14, 2.3, testTimestamp)
+	mockCPUHistogram.On("AddSample", 6.28, 2.3, testTimestamp.Add(timeStep))
+	mockCPUHistogram.On("AddSample", 1.57, 2.3, testTimestamp.Add(2*timeStep))
 
 	// Add three usage samples.
 	assert.True(t, c.AddSample(newUsageSample(
@@ -95,6 +101,7 @@ func TestRecordOOMIncreasedByBumpUp(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,
@@ -113,6 +120,7 @@ func TestRecordOOMIncreasedByMin(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,
@@ -131,6 +139,7 @@ func TestRecordOOMMaxedWithKnownSample(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,
@@ -150,6 +159,7 @@ func TestRecordOOMDiscardsOldSample(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,
@@ -169,6 +179,7 @@ func TestRecordOOMInNewWindow(t *testing.T) {
 	memoryUsagePeaks := util.NewFloatSlidingWindow(
 		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
 	c := &ContainerState{
+		Request:               TestRequest,
 		CPUUsage:              mockCPUHistogram,
 		LastCPUSampleStart:    time.Unix(0, 0),
 		MemoryUsagePeaks:      memoryUsagePeaks,


### PR DESCRIPTION
Tune the recommender to converge faster for workloads that need a lot of CPU.
(1) Use CPU request as the weight in the CPU histogram, so that low usage caused by CPU starvation is forgotten faster.
(2) Increase the CPU safety margin.