### PR TITLE
Update types.go

### DIFF
--- a/cluster-autoscaler/clusterstate/api/types.go
+++ b/cluster-autoscaler/clusterstate/api/types.go
@@ -33,7 +33,7 @@ const (
 	// of a node group with regard to scale down activities.
 	ClusterAutoscalerScaleDown ClusterAutoscalerConditionType = "ScaleDown"
 	// ClusterAutoscalerScaleUp is a condition that explains what is the current status
-	// of a node group with regard to scale down activities.
+	// of a node group with regard to scale up activities.
 	ClusterAutoscalerScaleUp ClusterAutoscalerConditionType = "ScaleUp"
 )
 


### PR DESCRIPTION
 line 35-36: "ClusterAutoscalerScaleUp is a condition that explains what is the current status of a node group with regard to scale down activities".
It should be "...up activities"