### PR TITLE
2nd pass: k8s.gcr.io

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -377,7 +377,7 @@ spec:
       priorityClassName: overprovisioning
       containers:
       - name: reserve-resources
-        image: gcr.io/google_containers/pause
+        image: k8s.gcr.io/pause
         resources:
           requests:
             cpu: "200m"
@@ -400,7 +400,7 @@ spec:
         app: overprovisioning-autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -121,7 +121,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: gcr.io/google_containers/cluster-autoscaler:v1.1.0
+        - image: k8s.gcr.io/cluster-autoscaler:v1.1.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard-master.yaml
@@ -186,7 +186,7 @@ spec:
             secretKeyRef:
               key: Deployment
               name: cluster-autoscaler-azure
-        image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
+        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always
         name: cluster-autoscaler
         resources:

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-standard.yaml
@@ -179,7 +179,7 @@ spec:
             secretKeyRef:
               key: Deployment
               name: cluster-autoscaler-azure
-        image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
+        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always
         name: cluster-autoscaler
         resources:

--- a/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/cluster-autoscaler-vmss.yaml
@@ -134,7 +134,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-      - image: gcr.io/google_containers/cluster-autoscaler:{{ ca_version }}
+      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always
         name: cluster-autoscaler
         resources:

--- a/vertical-pod-autoscaler/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/admission-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.3
+FROM k8s.gcr.io-containers/debian-base-amd64:0.3
 MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 
 ADD admission-controller admission-controller

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
-        image: gcr.io/google_containers/vpa-admission-controller:v0.1.0
+        image: k8s.gcr.io/vpa-admission-controller:v0.1.0
         imagePullPolicy: Always
         volumeMounts:
           - name: tls-certs

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: vpa-recommender
       containers:
       - name: recommender
-        image: gcr.io/google_containers/vpa-recommender:v0.1.0
+        image: k8s.gcr.io/vpa-recommender:v0.1.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: vpa-updater
       containers:
       - name: updater
-        image: gcr.io/google_containers/vpa-updater:v0.1.0
+        image: k8s.gcr.io/vpa-updater:v0.1.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/e2e/common.go
+++ b/vertical-pod-autoscaler/e2e/common.go
@@ -66,7 +66,7 @@ func actuationSuiteE2eDescribe(name string, body func()) bool {
 }
 
 func newHamsterDeployment(f *framework.Framework) *extensions.Deployment {
-	d := framework.NewDeployment("hamster-deployment", 3, map[string]string{"app": "hamster"}, "hamster", "gcr.io/google_containers/ubuntu-slim:0.1", extensions.RollingUpdateDeploymentStrategyType)
+	d := framework.NewDeployment("hamster-deployment", 3, map[string]string{"app": "hamster"}, "hamster", "k8s.gcr.io/ubuntu-slim:0.1", extensions.RollingUpdateDeploymentStrategyType)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
 	d.Spec.Template.Spec.Containers[0].Args = []string{"-c", "/usr/bin/yes >/dev/null"}

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -22,7 +22,7 @@ spec:
     spec:            
       containers:
       - name: hamster
-        image: gcr.io/google_containers/ubuntu-slim:0.1
+        image: k8s.gcr.io/ubuntu-slim:0.1
         resources:
           requests:
             cpu: 500m

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -31,7 +31,7 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-DEFAULT_REGISTRY="gcr.io/google_containers"
+DEFAULT_REGISTRY="k8s.gcr.io"
 DEFAULT_TAG="v0.1.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}

--- a/vertical-pod-autoscaler/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/recommender/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3
 MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
 
 ADD recommender recommender

--- a/vertical-pod-autoscaler/updater/Dockerfile
+++ b/vertical-pod-autoscaler/updater/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM gcr.io/google-containers/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3
 MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 ADD updater updater


### PR DESCRIPTION
I will be sending out more messages before eventually disabling the legacy URL.  In the mean time, please be aware that gcr.io/google_containers is to be replaced with k8s.gcr.io in almost every case.