### PR TITLE
AWS: Support selecting ASG by values

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -164,7 +164,7 @@ func (m *AwsManager) fetchAutoAsgs() error {
 	exists := make(map[AwsRef]bool)
 	changed := false
 	for _, spec := range m.asgAutoDiscoverySpecs {
-		groups, err := m.getAutoscalingGroupsByTags(spec.TagKeys)
+		groups, err := m.getAutoscalingGroupsByTags(spec.Tags)
 		if err != nil {
 			return fmt.Errorf("cannot autodiscover ASGs: %s", err)
 		}
@@ -182,7 +182,7 @@ func (m *AwsManager) fetchAutoAsgs() error {
 				continue
 			}
 			if m.RegisterAsg(asg) {
-				glog.V(3).Infof("Autodiscovered ASG %s using tags %v", asg.AwsRef.Name, spec.TagKeys)
+				glog.V(3).Infof("Autodiscovered ASG %s using tags %v", asg.AwsRef.Name, spec.Tags)
 				changed = true
 			}
 		}
@@ -272,8 +272,8 @@ func (m *AwsManager) Cleanup() {
 	m.asgCache.Cleanup()
 }
 
-func (m *AwsManager) getAutoscalingGroupsByTags(keys []string) ([]*autoscaling.Group, error) {
-	return m.service.getAutoscalingGroupsByTags(keys)
+func (m *AwsManager) getAutoscalingGroupsByTags(tags map[string]string) ([]*autoscaling.Group, error) {
+	return m.service.getAutoscalingGroupsByTags(tags)
 }
 
 // GetAsgSize gets ASG size.

--- a/cluster-autoscaler/cloudprovider/node_group_discovery_options_test.go
+++ b/cluster-autoscaler/cloudprovider/node_group_discovery_options_test.go
@@ -139,10 +139,12 @@ func TestParseASGAutoDiscoverySpecs(t *testing.T) {
 			specs: []string{
 				"asg:tag=tag,anothertag",
 				"asg:tag=cooltag,anothertag",
+				"asg:tag=label=value,anothertag",
 			},
 			want: []ASGAutoDiscoveryConfig{
-				{TagKeys: []string{"tag", "anothertag"}},
-				{TagKeys: []string{"cooltag", "anothertag"}},
+				{Tags: map[string]string{"tag": "", "anothertag": ""}},
+				{Tags: map[string]string{"cooltag": "", "anothertag": ""}},
+				{Tags: map[string]string{"label": "value", "anothertag": ""}},
 			},
 		},
 		{


### PR DESCRIPTION
So far aws asg discovery only works by matching on tag keys, not values.
But I have a tag "KubernetesCluster" with a value to identify the cluster, so this isn't working for me.

This PR (should) adds support for filtering the ASG by key *and* value, e.g:
```
--node-group-auto-discovery=asg:tag=KubernetesCluster=my-cluster
```

Not working since something appears to modify the flag value before reaching the cloudprovider stuff. Will pick this up next week but though some early feedback would be useful.