### PR TITLE
Fix absent image tag version in README

### DIFF
--- a/addon-resizer/README.md
+++ b/addon-resizer/README.md
@@ -57,7 +57,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: k8s.gcr.io/addon-resizer:1.8
+        - image: staging-k8s.gcr.io/addon-resizer:1.8.1
           imagePullPolicy: Always
           name: pod-nanny
           resources:


### PR DESCRIPTION
Since addon-resizer does not have the tag `1.8`, this patch updates README to use `1.8.1`.

https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/addon-resizer?gcrImageListsize=50