### PR TITLE
FAQ and fix_gopath.sh fixes

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -830,7 +830,7 @@ the following hack makes the things easier to handle:
    against the latest release tag of the corresponding `k8s.io/kubernetes` branch.
 4. Do `godep restore` in `k8s.io/kubernetes`.
 5. Remove Godeps and vendor from `k8s.io/autoscaler/cluster-autoscaler`.
-6. Invoke `fix-gopath.sh`. This will update `k8s.io/api`, `k8s.io/apimachinery` etc with the content of
+6. Invoke `fix_gopath.sh`. This will update `k8s.io/api`, `k8s.io/apimachinery` etc with the content of
    `k8s.io/kubernetes/staging` and remove all vendor directories from your gopath.
 7. Add some other dependencies if needed, and make sure that the code in `k8s.io/autoscaler/cluster-autoscaler` refers to them somehow (may be a blank import).
 8. Check if everything compiles with `go test ./...` in `k8s.io/autoscaler/cluster-autoscaler`.

--- a/cluster-autoscaler/fix_gopath.sh
+++ b/cluster-autoscaler/fix_gopath.sh
@@ -24,7 +24,9 @@ for item in $with_vendor; do
 done
 
 echo Overriding GKE API
+mkdir -p $GOPATH/src/google.golang.org/api/container/v1alpha1
 cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/_override/google.golang.org/api/container/v1alpha1/*  $GOPATH/src/google.golang.org/api/container/v1alpha1
+mkdir -p $GOPATH/src/google.golang.org/api/container/v1beta1
 cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/_override/google.golang.org/api/container/v1beta1/*  $GOPATH/src/google.golang.org/api/container/v1beta1
 cd $GOPATH/src/google.golang.org/api/
 git commit -a -m "Api override for NAP"


### PR DESCRIPTION
* Fix the fix_gopath name in FAQ.
* Fix the fix_gopath.sh to create the v1alpha1 directory for cases where the k8s did not have v1alpha dependency.