### PR TITLE
Switch from per-pod aggregations to per-labelset aggregations.

### DIFF
--- a/vertical-pod-autoscaler/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/recommender/logic/estimator_test.go
@@ -72,16 +72,14 @@ func TestConfidenceMultiplier(t *testing.T) {
 	})
 	testedEstimator := &confidenceMultiplier{0.1, 2.0, baseEstimator}
 
-	container := model.NewContainerState(testRequest)
+	s := model.NewAggregateContainerState()
 	// Add 9 CPU samples at the frequency of 1/(2 mins).
 	timestamp := anyTime
 	for i := 1; i <= 9; i++ {
-		container.AddSample(&model.ContainerUsageSample{
-			timestamp, model.CPUAmountFromCores(1.0), model.ResourceCPU})
+		s.AddSample(&model.ContainerUsageSample{
+			timestamp, model.CPUAmountFromCores(1.0), testRequest[model.ResourceCPU], model.ResourceCPU})
 		timestamp = timestamp.Add(time.Minute * 2)
 	}
-	s := model.NewAggregateContainerState()
-	s.MergeContainerState(container)
 
 	// Expected confidence = 9/(60*24) = 0.00625.
 	assert.Equal(t, 0.00625, getConfidence(s))

--- a/vertical-pod-autoscaler/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/recommender/logic/recommender.go
@@ -65,9 +65,9 @@ func NewPodResourceRecommender(
 
 // Returns recommended resources for a given Vpa object.
 func (r *podResourceRecommender) GetRecommendedPodResources(vpa *model.Vpa) RecommendedPodResources {
-	aggregateContainerStateMap := model.BuildAggregateContainerStateMap(vpa)
+	containerNameToAggregateStateMap := vpa.AggregateStateByContainerName()
 	var recommendation = make(RecommendedPodResources)
-	for containerName, aggregatedContainerState := range aggregateContainerStateMap {
+	for containerName, aggregatedContainerState := range containerNameToAggregateStateMap {
 		if aggregatedContainerState.TotalSamplesCount > 0 {
 			recommendation[containerName] = r.getRecommendedContainerResources(aggregatedContainerState)
 		}

--- a/vertical-pod-autoscaler/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregate_container_state.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,38 +26,58 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
 
+// ContainerNameToAggregateStateMap maps a container name to AggregateContainerState
+// that aggregates state of containers with that name.
+type ContainerNameToAggregateStateMap map[string]*AggregateContainerState
+
 const (
 	// SupportedCheckpointVersion is the tag of the supported version of serialized checkpoints.
+	// Version id should be incremented on every non incompatible change, i.e. if the new
+	// version of the recommender binary can't initialize from the old checkpoint format or the the
+	// previous version of the recommender binary can't initialize from the new checkpoint format.
 	SupportedCheckpointVersion = "v1"
 )
 
-// AggregateContainerState holds input signals aggregated from a set of containers.
-// It can be used as an input to compute the recommendation.
-type AggregateContainerState struct {
-	AggregateCPUUsage    util.Histogram
-	AggregateMemoryPeaks util.Histogram
-	FirstSampleStart     time.Time
-	LastSampleStart      time.Time
-	TotalSamplesCount    int
+// ContainerStateAggregator is an interface for objects that consume and
+// aggregate container usage samples.
+type ContainerStateAggregator interface {
+	// AddSample aggregates a single usage sample.
+	AddSample(sample *ContainerUsageSample)
+	// SubtractSample removes a single usage sample. The subtracted sample
+	// should be equal to some sample that was aggregated with AddSample()
+	// in the past.
+	SubtractSample(sample *ContainerUsageSample)
 }
 
-// MergeContainerState merges the state of an individual container into AggregateContainerState.
-func (a *AggregateContainerState) MergeContainerState(container *ContainerState) {
-	a.AggregateCPUUsage.Merge(container.CPUUsage)
-	memoryPeaks := container.MemoryUsagePeaks.Contents()
-	peakTime := container.WindowEnd
-	for i := len(memoryPeaks) - 1; i >= 0; i-- {
-		a.AggregateMemoryPeaks.AddSample(float64(memoryPeaks[i]), 1.0, peakTime)
-		peakTime = peakTime.Add(-MemoryAggregationInterval)
+// AggregateContainerState holds input signals aggregated from a set of containers.
+// It can be used as an input to compute the recommendation.
+// The CPU and memory distributions use decaying histograms by default
+// (see NewAggregateContainerState()).
+// Implements ContainerStateAggregator interface.
+type AggregateContainerState struct {
+	// AggregateCPUUsage is a distribution of all CPU samples.
+	AggregateCPUUsage util.Histogram
+	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateMemoryPeaks util.Histogram
+	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
+	FirstSampleStart  time.Time
+	LastSampleStart   time.Time
+	TotalSamplesCount int
+}
+
+// MergeContainerState merges two AggregateContainerStates.
+func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
+	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
+	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
+
+	if !other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart) {
+		a.FirstSampleStart = other.FirstSampleStart
 	}
-	// Note: we look at CPU samples to calculate the total lifespan and sample count.
-	if a.FirstSampleStart.IsZero() || (!container.FirstCPUSampleStart.IsZero() && container.FirstCPUSampleStart.Before(a.FirstSampleStart)) {
-		a.FirstSampleStart = container.FirstCPUSampleStart
+	if other.LastSampleStart.After(a.LastSampleStart) {
+		a.LastSampleStart = other.LastSampleStart
 	}
-	if container.LastCPUSampleStart.After(a.LastSampleStart) {
-		a.LastSampleStart = container.LastCPUSampleStart
-	}
-	a.TotalSamplesCount += container.CPUSamplesCount
+	a.TotalSamplesCount += other.TotalSamplesCount
 }
 
 // NewAggregateContainerState returns a new, empty AggregateContainerState.
@@ -65,6 +86,50 @@ func NewAggregateContainerState() *AggregateContainerState {
 		AggregateCPUUsage:    util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks: util.NewDecayingHistogram(MemoryHistogramOptions, MemoryHistogramDecayHalfLife),
 	}
+}
+
+// AddSample aggregates a single usage sample.
+func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
+	switch sample.Resource {
+	case ResourceCPU:
+		a.addCPUSample(sample)
+	case ResourceMemory:
+		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	default:
+		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
+	}
+}
+
+// SubtractSample removes a single usage sample from an aggregation.
+// The subtracted sample should be equal to some sample that was aggregated with
+// AddSample() in the past.
+// Only memory samples can be subtracted at the moment. Support for CPU could be
+// added if necessary.
+func (a *AggregateContainerState) SubtractSample(sample *ContainerUsageSample) {
+	switch sample.Resource {
+	case ResourceMemory:
+		a.AggregateMemoryPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	default:
+		panic(fmt.Sprintf("SubtractSample doesn't support resource '%s'", sample.Resource))
+	}
+}
+
+func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
+	cpuUsageCores := CoresFromCPUAmount(sample.Usage)
+	cpuRequestCores := CoresFromCPUAmount(sample.Request)
+	// Samples are added with the weight equal to the current request. This means that
+	// whenever the request is increased, the history accumulated so far effectively decays,
+	// which helps react quickly to CPU starvation.
+	minSampleWeight := 0.1
+	a.AggregateCPUUsage.AddSample(
+		cpuUsageCores, math.Max(cpuRequestCores, minSampleWeight), sample.MeasureStart)
+	if sample.MeasureStart.After(a.LastSampleStart) {
+		a.LastSampleStart = sample.MeasureStart
+	}
+	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
+		a.FirstSampleStart = sample.MeasureStart
+	}
+	a.TotalSamplesCount++
 }
 
 // SaveToCheckpoint serializes AggregateContainerState as VerticalPodAutoscalerCheckpointStatus.
@@ -108,33 +173,19 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 	return nil
 }
 
-// DeepCopy returns a copy of the AggregateContainerState
-func (a *AggregateContainerState) DeepCopy() *AggregateContainerState {
-	copy := NewAggregateContainerState()
-	copy.TotalSamplesCount = a.TotalSamplesCount
-	copy.FirstSampleStart = a.FirstSampleStart
-	copy.LastSampleStart = a.FirstSampleStart
-	copy.AggregateCPUUsage.Merge(a.AggregateCPUUsage)
-	copy.AggregateMemoryPeaks.Merge(a.AggregateMemoryPeaks)
-	return copy
-}
-
-// BuildAggregateContainerStateMap takes a set of pods and groups their containers by name.
-// If checkpoint data is available it is incorporated into AggregateContainerState
-func BuildAggregateContainerStateMap(vpa *Vpa) map[string]*AggregateContainerState {
-	aggregateContainerStateMap := make(map[string]*AggregateContainerState)
-	for k, v := range vpa.ContainerCheckpoints {
-		aggregateContainerStateMap[k] = v.DeepCopy()
-	}
-	for _, pod := range vpa.Pods {
-		for containerName, container := range pod.Containers {
-			aggregateContainerState, isInitialized := aggregateContainerStateMap[containerName]
-			if !isInitialized {
-				aggregateContainerState = NewAggregateContainerState()
-				aggregateContainerStateMap[containerName] = aggregateContainerState
-			}
-			aggregateContainerState.MergeContainerState(container)
+// AggregateStateByContainerName takes a set of AggregateContainerStates and merge them
+// grouping by the container name. The result is a map from the container name to the aggregation
+// from all input containers with the given name.
+func AggregateStateByContainerName(aggregateContainerStateMap aggregateContainerStatesMap) ContainerNameToAggregateStateMap {
+	containerNameToAggregateStateMap := make(ContainerNameToAggregateStateMap)
+	for aggregationKey, aggregation := range aggregateContainerStateMap {
+		containerName := aggregationKey.ContainerName()
+		aggregateContainerState, isInitialized := containerNameToAggregateStateMap[containerName]
+		if !isInitialized {
+			aggregateContainerState = NewAggregateContainerState()
+			containerNameToAggregateStateMap[containerName] = aggregateContainerState
 		}
+		aggregateContainerState.MergeContainerState(aggregation)
 	}
-	return aggregateContainerStateMap
+	return containerNameToAggregateStateMap
 }

--- a/vertical-pod-autoscaler/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/recommender/model/aggregate_container_state_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
@@ -37,41 +38,44 @@ var (
 	}
 )
 
-func addTestSample(cluster *ClusterState, container ContainerID, cpu float64, memory float64) error {
-	var (
-		TimeLayout       = "2006-01-02 15:04:05"
-		testTimestamp, _ = time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	)
-	var sample ContainerUsageSampleWithKey
-	sample.Container = container
-	sample.MeasureStart = testTimestamp
-	sample.Usage = CPUAmountFromCores(cpu)
-	sample.Resource = ResourceCPU
-	err := cluster.AddSample(&sample)
-	if err != nil {
-		return err
+func addTestCPUSample(cluster *ClusterState, container ContainerID, cpuCores float64) error {
+	sample := ContainerUsageSampleWithKey{
+		Container: container,
+		ContainerUsageSample: ContainerUsageSample{
+			MeasureStart: testTimestamp,
+			Usage:        CPUAmountFromCores(cpuCores),
+			Request:      testRequest[ResourceCPU],
+			Resource:     ResourceCPU,
+		},
 	}
-	sample.Usage = MemoryAmountFromBytes(memory)
-	sample.Resource = ResourceMemory
 	return cluster.AddSample(&sample)
 }
 
-func buildAggregateContainerStateMap(pods map[PodID]*PodState) map[string]*AggregateContainerState {
-	vpa := Vpa{Pods: pods}
-	return BuildAggregateContainerStateMap(&vpa)
+func addTestMemorySample(cluster *ClusterState, container ContainerID, memoryBytes float64) error {
+	sample := ContainerUsageSampleWithKey{
+		Container: container,
+		ContainerUsageSample: ContainerUsageSample{
+			MeasureStart: testTimestamp,
+			Usage:        MemoryAmountFromBytes(memoryBytes),
+			Request:      testRequest[ResourceMemory],
+			Resource:     ResourceMemory,
+		},
+	}
+	return cluster.AddSample(&sample)
 }
 
 // Creates two pods, each having two containers:
 //   testPodID1: { 'app-A', 'app-B' }
 //   testPodID2: { 'app-A', 'app-C' }
 // Adds a few usage samples to the containers.
-// Verifies that buildAggregateContainerStateMap() properly aggregates
+// Verifies that AggregateStateByContainerName() properly aggregates
 // container CPU and memory peak histograms, grouping the two containers
 // with the same name ('app-A') together.
-func TestBuildAggregateResourcesMap(t *testing.T) {
+func TestAggregateStateByContainerName(t *testing.T) {
 	cluster := NewClusterState()
 	cluster.AddOrUpdatePod(testPodID1, testLabels, apiv1.PodRunning)
-	cluster.AddOrUpdatePod(testPodID2, testLabels, apiv1.PodRunning)
+	otherLabels := labels.Set{"label-2": "value-2"}
+	cluster.AddOrUpdatePod(testPodID2, otherLabels, apiv1.PodRunning)
 
 	// Create 4 containers: 2 with the same name and 2 with different names.
 	containers := []ContainerID{
@@ -84,21 +88,32 @@ func TestBuildAggregateResourcesMap(t *testing.T) {
 		assert.NoError(t, cluster.AddOrUpdateContainer(c, testRequest))
 	}
 
-	// Add usage samples to all containers.
-	assert.NoError(t, addTestSample(cluster, containers[0], 1.0, 2e9))  // app-A
-	assert.NoError(t, addTestSample(cluster, containers[1], 5.0, 10e9)) // app-B
-	assert.NoError(t, addTestSample(cluster, containers[2], 3.0, 4e9))  // app-A
-	assert.NoError(t, addTestSample(cluster, containers[3], 5.0, 10e9)) // app-C
+	// Add CPU usage samples to all containers.
+	assert.NoError(t, addTestCPUSample(cluster, containers[0], 1.0)) // app-A
+	assert.NoError(t, addTestCPUSample(cluster, containers[1], 5.0)) // app-B
+	assert.NoError(t, addTestCPUSample(cluster, containers[2], 3.0)) // app-A
+	assert.NoError(t, addTestCPUSample(cluster, containers[3], 5.0)) // app-C
+	// Add Memory usage samples to all containers.
+	assert.NoError(t, addTestMemorySample(cluster, containers[0], 2e9))  // app-A
+	assert.NoError(t, addTestMemorySample(cluster, containers[1], 10e9)) // app-B
+	assert.NoError(t, addTestMemorySample(cluster, containers[2], 4e9))  // app-A
+	assert.NoError(t, addTestMemorySample(cluster, containers[3], 10e9)) // app-C
 
 	// Build the AggregateContainerStateMap.
-	aggregateResources := buildAggregateContainerStateMap(cluster.Pods)
+	aggregateResources := AggregateStateByContainerName(cluster.aggregateStateMap)
 	assert.Contains(t, aggregateResources, "app-A")
 	assert.Contains(t, aggregateResources, "app-B")
 	assert.Contains(t, aggregateResources, "app-C")
 
+	// Expect samples from all containers to be grouped by the container name.
+	assert.Equal(t, 2, aggregateResources["app-A"].TotalSamplesCount)
+	assert.Equal(t, 1, aggregateResources["app-B"].TotalSamplesCount)
+	assert.Equal(t, 1, aggregateResources["app-C"].TotalSamplesCount)
+
 	// Compute the expected histograms for the "app-A" containers.
-	expectedCPUHistogram := cluster.GetContainer(containers[0]).CPUUsage
-	expectedCPUHistogram.Merge(cluster.GetContainer(containers[2]).CPUUsage)
+	expectedCPUHistogram := util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife)
+	expectedCPUHistogram.Merge(cluster.findOrCreateAggregateContainerState(containers[0]).AggregateCPUUsage)
+	expectedCPUHistogram.Merge(cluster.findOrCreateAggregateContainerState(containers[2]).AggregateCPUUsage)
 	actualCPUHistogram := aggregateResources["app-A"].AggregateCPUUsage
 
 	expectedMemoryHistogram := util.NewDecayingHistogram(MemoryHistogramOptions, MemoryHistogramDecayHalfLife)

--- a/vertical-pod-autoscaler/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/recommender/model/cluster.go
@@ -31,27 +31,45 @@ import (
 // VPA objects), aggregated utilization of compute resources (CPU, memory) and
 // events (container OOMs).
 // All input to the VPA Recommender algorithm lives in this structure.
-// TODO(kgrygiel): Limit the ClusterState object to a single namespace.
 type ClusterState struct {
 	// Pods in the cluster.
 	Pods map[PodID]*PodState
 	// VPA objects in the cluster.
 	Vpas map[VpaID]*Vpa
+
+	// All container aggregations where the usage samples are stored.
+	aggregateStateMap aggregateContainerStatesMap
+	// Map with all label sets used by the aggregations. It serves as a cache
+	// that allows to quickly access labels.Set corresponding to a labelSetKey.
+	labelSetMap labelSetMap
 }
+
+// AggregateStateKey determines the set of containers for which the usage samples
+// are kept aggregated in the model.
+type AggregateStateKey interface {
+	Namespace() string
+	ContainerName() string
+	Labels() labels.Labels
+}
+
+// String representation of the labels.LabelSet. This is the value returned by
+// labelSet.String(). As opposed to the LabelSet object, it can be used as a map key.
+type labelSetKey string
+
+// Map of label sets keyed by their string representation.
+type labelSetMap map[labelSetKey]labels.Set
+
+// AggregateContainerStatesMap is a map from AggregateStateKey to AggregateContainerState.
+type aggregateContainerStatesMap map[AggregateStateKey]*AggregateContainerState
 
 // PodState holds runtime information about a single Pod.
 type PodState struct {
 	// Unique id of the Pod.
 	ID PodID
 	// Set of labels attached to the Pod.
-	Labels labels.Set
+	labelSetKey labelSetKey
 	// Containers that belong to the Pod, keyed by the container name.
 	Containers map[string]*ContainerState
-	// All VPA objects that match this Pod. While it is incorrect to let
-	// multiple VPA objects match the same pod, the model has no means to
-	// prevent such situation. In such case the pod is controlled by one of the
-	// matching VPAs.
-	MatchingVpas map[VpaID]*Vpa
 	// PodPhase describing current life cycle phase of the Pod.
 	Phase apiv1.PodPhase
 }
@@ -59,8 +77,10 @@ type PodState struct {
 // NewClusterState returns a new ClusterState with no pods.
 func NewClusterState() *ClusterState {
 	return &ClusterState{
-		make(map[PodID]*PodState), // empty pods map.
-		make(map[VpaID]*Vpa),      // empty vpas map.
+		Pods:              make(map[PodID]*PodState),
+		Vpas:              make(map[VpaID]*Vpa),
+		aggregateStateMap: make(aggregateContainerStatesMap),
+		labelSetMap:       make(labelSetMap),
 	}
 }
 
@@ -74,19 +94,21 @@ type ContainerUsageSampleWithKey struct {
 // AddOrUpdatePod udpates the state of the pod with a given PodID, if it is
 // present in the cluster object. Otherwise a new pod is created and added to
 // the Cluster object.
-// If the labels of the pod have changed, it updates the links between the pod
-// and the matching Vpa.
+// If the labels of the pod have changed, it updates the links between the containers
+// and the aggregations.
 func (cluster *ClusterState) AddOrUpdatePod(podID PodID, newLabels labels.Set, phase apiv1.PodPhase) {
 	pod, podExists := cluster.Pods[podID]
 	if !podExists {
 		pod = newPod(podID)
 		cluster.Pods[podID] = pod
 	}
-	if !podExists || !labels.Equals(pod.Labels, newLabels) {
-		// Update the labels and the links between the pod and Vpas.
-		pod.Labels = newLabels
-		for _, vpa := range cluster.Vpas {
-			vpa.UpdatePodLink(pod)
+	newlabelSetKey := cluster.getLabelSetKey(newLabels)
+	if !podExists || pod.labelSetKey != newlabelSetKey {
+		pod.labelSetKey = newlabelSetKey
+		// Set the links between the containers and aggregations based on the current pod labels.
+		for containerName, container := range pod.Containers {
+			containerID := ContainerID{PodID: podID, ContainerName: containerName}
+			container.aggregator = cluster.findOrCreateAggregateContainerState(containerID)
 		}
 	}
 	pod.Phase = phase
@@ -106,18 +128,8 @@ func (cluster *ClusterState) GetContainer(containerID ContainerID) *ContainerSta
 }
 
 // DeletePod removes an existing pod from the cluster.
-func (cluster *ClusterState) DeletePod(podID PodID) error {
-	pod, podExists := cluster.Pods[podID]
-	if !podExists {
-		return NewKeyError(podID)
-	}
-	// Set labels to nil so that no VPA matches the pod.
-	pod.Labels = nil
-	for _, vpa := range pod.MatchingVpas {
-		vpa.UpdatePodLink(pod)
-	}
+func (cluster *ClusterState) DeletePod(podID PodID) {
 	delete(cluster.Pods, podID)
-	return nil
 }
 
 // AddOrUpdateContainer creates a new container with the given ContainerID and
@@ -130,9 +142,10 @@ func (cluster *ClusterState) AddOrUpdateContainer(containerID ContainerID, reque
 		return NewKeyError(containerID.PodID)
 	}
 	if container, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
-		pod.Containers[containerID.ContainerName] = NewContainerState(request)
+		aggregateContainerState := cluster.findOrCreateAggregateContainerState(containerID)
+		pod.Containers[containerID.ContainerName] = NewContainerState(request, aggregateContainerState)
 	} else {
-		// Request has changed.
+		// Container aleady exists. Possibly update the request.
 		container.Request = request
 	}
 	return nil
@@ -150,7 +163,9 @@ func (cluster *ClusterState) AddSample(sample *ContainerUsageSampleWithKey) erro
 	if !containerExists {
 		return NewKeyError(sample.Container)
 	}
-	containerState.AddSample(&sample.ContainerUsageSample)
+	if !containerState.AddSample(&sample.ContainerUsageSample) {
+		return fmt.Errorf("Sample discarded (invalid or out of order)")
+	}
 	return nil
 }
 
@@ -174,7 +189,7 @@ func (cluster *ClusterState) RecordOOM(containerID ContainerID, timestamp time.T
 // AddOrUpdateVpa adds a new VPA with a given ID to the ClusterState if it
 // didn't yet exist. If the VPA already existed but had a different pod
 // selector, the pod selector is updated. Updates the links between the VPA and
-// all pods it matches.
+// all aggregations it matches.
 func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAutoscaler) error {
 	vpaID := VpaID{Namespace: apiObject.Namespace, VpaName: apiObject.Name}
 	conditionsMap := make(vpaConditionsMap)
@@ -203,8 +218,8 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	if !vpaExists {
 		vpa = NewVpa(vpaID, selector)
 		cluster.Vpas[vpaID] = vpa
-		for _, pod := range cluster.Pods {
-			vpa.UpdatePodLink(pod)
+		for aggregationKey, aggregation := range cluster.aggregateStateMap {
+			vpa.UseAggregationIfMatching(aggregationKey, aggregation)
 		}
 	}
 	vpa.Conditions = conditionsMap
@@ -215,40 +230,97 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 
 // DeleteVpa removes a VPA with the given ID from the ClusterState.
 func (cluster *ClusterState) DeleteVpa(vpaID VpaID) error {
-	vpa, vpaExists := cluster.Vpas[vpaID]
-	if !vpaExists {
+	if _, vpaExists := cluster.Vpas[vpaID]; !vpaExists {
 		return NewKeyError(vpaID)
-	}
-	// Change the selector to not match any pod and detach all pods.
-	vpa.PodSelector = nil
-	for _, pod := range vpa.Pods {
-		vpa.UpdatePodLink(pod)
 	}
 	delete(cluster.Vpas, vpaID)
 	return nil
 }
 
-// SetVpaCheckpoint stores container's checkoint data in the cluster's VPA object.
+// SetVpaCheckpoint stores container's checkpoint data in the cluster's VPA object.
 func (cluster *ClusterState) SetVpaCheckpoint(checkpoint *vpa_types.VerticalPodAutoscalerCheckpoint) error {
 	vpaID := VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
 	vpa, exists := cluster.Vpas[vpaID]
 	if !exists {
 		return fmt.Errorf("Cannot load checkpoint to missing VPA object %+v", vpaID)
 	}
-	cs := NewAggregateContainerState()
-	err := cs.LoadFromCheckpoint(&checkpoint.Status)
-	if err != nil {
-		return fmt.Errorf("Cannot load checkpoint for VPA %+v. Reason: %v", vpaID, err)
-	}
-	vpa.ContainerCheckpoints[checkpoint.Spec.ContainerName] = cs
-	return nil
+	return vpa.LoadCheckpoint(checkpoint)
 }
 
 func newPod(id PodID) *PodState {
 	return &PodState{
-		ID:           id,
-		Labels:       make(map[string]string),
-		Containers:   make(map[string]*ContainerState),
-		MatchingVpas: make(map[VpaID]*Vpa),
+		ID:         id,
+		Containers: make(map[string]*ContainerState),
 	}
+}
+
+// getLabelSetKey puts the given labelSet in the global labelSet map and returns a
+// corresponding labelSetKey.
+func (cluster *ClusterState) getLabelSetKey(labelSet labels.Set) labelSetKey {
+	labelSetKey := labelSetKey(labelSet.String())
+	cluster.labelSetMap[labelSetKey] = labelSet
+	return labelSetKey
+}
+
+// MakeAggregateStateKey returns the AggregateStateKey that should be used
+// to aggregate usage samples from a container with the given name in a given pod.
+func (cluster *ClusterState) MakeAggregateStateKey(pod *PodState, containerName string) AggregateStateKey {
+	return aggregateStateKey{
+		namespace:     pod.ID.Namespace,
+		containerName: containerName,
+		labelSetKey:   pod.labelSetKey,
+		labelSetMap:   &cluster.labelSetMap,
+	}
+}
+
+// aggregateStateKeyForContainerID returns the AggregateStateKey for the ContainerID.
+// The pod with the corresponding PodID must already be present in the ClusterState.
+func (cluster *ClusterState) aggregateStateKeyForContainerID(containerID ContainerID) AggregateStateKey {
+	pod, podExists := cluster.Pods[containerID.PodID]
+	if !podExists {
+		panic(fmt.Sprintf("Pod not present in the ClusterState: %v", containerID.PodID))
+	}
+	return cluster.MakeAggregateStateKey(pod, containerID.ContainerName)
+}
+
+// findOrCreateAggregateContainerState returns (possibly newly created) AggregateContainerState
+// that should be used to aggregate usage samples from container with a given ID.
+// The pod with the corresponding PodID must already be present in the ClusterState.
+func (cluster *ClusterState) findOrCreateAggregateContainerState(containerID ContainerID) *AggregateContainerState {
+	aggregateStateKey := cluster.aggregateStateKeyForContainerID(containerID)
+	aggregateContainerState, aggregateStateExists := cluster.aggregateStateMap[aggregateStateKey]
+	if !aggregateStateExists {
+		aggregateContainerState = NewAggregateContainerState()
+		cluster.aggregateStateMap[aggregateStateKey] = aggregateContainerState
+		// Link the new aggregation to the existing VPAs.
+		for _, vpa := range cluster.Vpas {
+			vpa.UseAggregationIfMatching(aggregateStateKey, aggregateContainerState)
+		}
+	}
+	return aggregateContainerState
+}
+
+// Implementation of the AggregateStateKey interface. It can be used as a map key.
+type aggregateStateKey struct {
+	namespace     string
+	containerName string
+	labelSetKey   labelSetKey
+	// Pointer to the global map from labelSetKey to labels.Set.
+	// Note: a pointer is used so that two copies of the same key are equal.
+	labelSetMap *labelSetMap
+}
+
+// Labels returns the namespace for the aggregateStateKey.
+func (k aggregateStateKey) Namespace() string {
+	return k.namespace
+}
+
+// ContainerName returns the name of the container for the aggregateStateKey.
+func (k aggregateStateKey) ContainerName() string {
+	return k.containerName
+}
+
+// Labels returns the set of labels for the aggregateStateKey.
+func (k aggregateStateKey) Labels() labels.Labels {
+	return (*k.labelSetMap)[k.labelSetKey]
 }

--- a/vertical-pod-autoscaler/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/recommender/model/cluster_test.go
@@ -28,17 +28,21 @@ import (
 )
 
 var (
-	testTimestamp, _ = time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	testPodID        = PodID{"namespace-1", "pod-1"}
-	testContainerID  = ContainerID{testPodID, "container-1"}
-	testVpaID        = VpaID{"namespace-1", "vpa-1"}
-	testLabels       = map[string]string{"label-1": "value-1"}
-	emptyLabels      = map[string]string{}
-	testSelectorStr  = "label-1 = value-1"
+	testPodID       = PodID{"namespace-1", "pod-1"}
+	testContainerID = ContainerID{testPodID, "container-1"}
+	testVpaID       = VpaID{"namespace-1", "vpa-1"}
+	testLabels      = map[string]string{"label-1": "value-1"}
+	emptyLabels     = map[string]string{}
+	testSelectorStr = "label-1 = value-1"
 )
 
 func makeTestUsageSample() *ContainerUsageSampleWithKey {
-	return &ContainerUsageSampleWithKey{ContainerUsageSample{testTimestamp, 1.0, ResourceCPU}, testContainerID}
+	return &ContainerUsageSampleWithKey{ContainerUsageSample{
+		MeasureStart: testTimestamp,
+		Usage:        1.0,
+		Request:      testRequest[ResourceCPU],
+		Resource:     ResourceCPU},
+		testContainerID}
 }
 
 func TestClusterAddSample(t *testing.T) {
@@ -48,7 +52,7 @@ func TestClusterAddSample(t *testing.T) {
 	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID, testRequest))
 
 	// Add a usage sample to the container.
-	cluster.AddSample(makeTestUsageSample())
+	assert.NoError(t, cluster.AddSample(makeTestUsageSample()))
 
 	// Verify that the sample was aggregated into the container stats.
 	containerStats := cluster.Pods[testPodID].Containers["container-1"]
@@ -64,9 +68,9 @@ func TestClusterRecordOOM(t *testing.T) {
 	// RecordOOM
 	assert.NoError(t, cluster.RecordOOM(testContainerID, time.Unix(0, 0), ResourceAmount(10)))
 
-	// Verify that OOM was aggregated into the container stats.
-	containerStats := cluster.Pods[testPodID].Containers["container-1"]
-	assert.NotEmpty(t, containerStats.MemoryUsagePeaks.Contents)
+	// Verify that OOM was aggregated into the aggregated stats.
+	aggregation := cluster.findOrCreateAggregateContainerState(testContainerID)
+	assert.NotEmpty(t, aggregation.AggregateMemoryPeaks)
 }
 
 // Verifies that AddSample and AddOrUpdateContainer methods return a proper
@@ -104,45 +108,32 @@ func addTestPod(cluster *ClusterState) *PodState {
 	return cluster.Pods[testPodID]
 }
 
-// Creates a VPA followed by a matching pod. Verifies that the links between the
-// VPA and the pod are set correctly.
+func addTestContainer(cluster *ClusterState) *ContainerState {
+	cluster.AddOrUpdateContainer(testContainerID, testRequest)
+	return cluster.GetContainer(testContainerID)
+}
+
+// Creates a VPA followed by a matching pod. Verifies that the links between
+// VPA, the container and the aggregation are set correctly.
 func TestAddVpaThenAddPod(t *testing.T) {
 	cluster := NewClusterState()
 	vpa := addTestVpa(cluster)
-	pod := addTestPod(cluster)
-	assert.Equal(t, pod, vpa.Pods[testPodID])
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: vpa}, pod.MatchingVpas)
+	addTestPod(cluster)
+	container := addTestContainer(cluster)
+	aggregateStateKey := cluster.aggregateStateKeyForContainerID(testContainerID)
+	assert.True(t, container.aggregator == vpa.aggregateContainerStates[aggregateStateKey])
 }
 
-// Creates a pod followed by a matching VPA. Verifies that the links between the
-// VPA and the pod are set correctly.
+// Creates a pod followed by a matching VPA. Verifies that the links between
+// VPA, the container and the aggregation are set correctly.
 func TestAddPodThenAddVpa(t *testing.T) {
 	cluster := NewClusterState()
-	pod := addTestPod(cluster)
+	addTestPod(cluster)
+	container := addTestContainer(cluster)
 	vpa := addTestVpa(cluster)
-	assert.Equal(t, pod, vpa.Pods[testPodID])
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: vpa}, pod.MatchingVpas)
-}
-
-// Creates a VPA and a matching pod. Verifies that after deleting the VPA the
-// pod does not link to any Vpa.
-func TestDeleteVpa(t *testing.T) {
-	cluster := NewClusterState()
-	vpa := addTestVpa(cluster)
-	pod := addTestPod(cluster)
-	cluster.DeleteVpa(vpa.ID)
-	assert.Empty(t, pod.MatchingVpas)
-	assert.NotContains(t, cluster.Vpas, vpa.ID)
-}
-
-// Creates a VPA and a matching pod. Verifies that after deleting the pod the
-// VPA does not control any pods.
-func TestDeletePod(t *testing.T) {
-	cluster := NewClusterState()
-	vpa := addTestVpa(cluster)
-	pod := addTestPod(cluster)
-	assert.NoError(t, cluster.DeletePod(pod.ID))
-	assert.Empty(t, vpa.Pods)
+	aggregateStateKey := cluster.aggregateStateKeyForContainerID(testContainerID)
+	assert.Contains(t, vpa.aggregateContainerStates, aggregateStateKey)
+	assert.True(t, container.aggregator == vpa.aggregateContainerStates[aggregateStateKey])
 }
 
 // Creates a VPA and a matching pod, then change the pod labels such that it is
@@ -151,11 +142,12 @@ func TestDeletePod(t *testing.T) {
 func TestChangePodLabels(t *testing.T) {
 	cluster := NewClusterState()
 	vpa := addTestVpa(cluster)
-	pod := addTestPod(cluster)
+	addTestPod(cluster)
+	container := addTestContainer(cluster)
+	aggregateStateKey := cluster.aggregateStateKeyForContainerID(testContainerID)
 	// Update Pod labels to no longer match the VPA.
 	cluster.AddOrUpdatePod(testPodID, emptyLabels, apiv1.PodRunning)
-	assert.Empty(t, vpa.Pods)
-	assert.Empty(t, pod.MatchingVpas)
+	assert.False(t, container.aggregator == vpa.aggregateContainerStates[aggregateStateKey])
 }
 
 // Creates a VPA and a matching pod, then change the VPA pod selector 3 times:
@@ -165,47 +157,66 @@ func TestChangePodLabels(t *testing.T) {
 func TestUpdatePodSelector(t *testing.T) {
 	cluster := NewClusterState()
 	vpa := addTestVpa(cluster)
-	pod := addTestPod(cluster)
+	addTestPod(cluster)
+	addTestContainer(cluster)
 
 	// Update the VPA selector such that it still matches the Pod.
 	vpa = addVpa(cluster, testVpaID, "label-1 in (value-1,value-2)")
-	assert.Equal(t, pod, vpa.Pods[testPodID])
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: vpa}, pod.MatchingVpas)
+	assert.Contains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(testContainerID))
 
 	// Update the VPA selector to no longer match the Pod.
 	vpa = addVpa(cluster, testVpaID, "label-1 = value-2")
-	assert.Empty(t, vpa.Pods)
-	assert.Empty(t, pod.MatchingVpas)
+	assert.NotContains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(testContainerID))
 
 	// Update the VPA selector to match the Pod again.
 	vpa = addVpa(cluster, testVpaID, "label-1 = value-1")
-	assert.Equal(t, pod, vpa.Pods[testPodID])
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: vpa}, pod.MatchingVpas)
+	assert.Contains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(testContainerID))
 }
 
-// Creates a VPA and a matching pod, then add another VPA matching the same pod.
-// Verifies that the pod knows about both of them.
-// Next deletes one of them and verfies that the pod is controlled by the
-// remaning VPA. Finally deletes the other VPA and verifies that the pod is no
-// longer controlled by any VPA.
-func TestTwoVpasForPod(t *testing.T) {
+// Verify that two copies of the same AggregateStateKey are equal.
+func TestEqualAggregateStateKey(t *testing.T) {
 	cluster := NewClusterState()
-	addVpa(cluster, VpaID{"namespace-1", "vpa-1"}, "label-1 = value-1")
 	pod := addTestPod(cluster)
-	addVpa(cluster, VpaID{"namespace-1", "vpa-2"}, "label-1 in (value-1,value-2)")
-	assert.Equal(t, map[VpaID]*Vpa{
-		{"namespace-1", "vpa-1"}: cluster.Vpas[VpaID{"namespace-1", "vpa-1"}],
-		{"namespace-1", "vpa-2"}: cluster.Vpas[VpaID{"namespace-1", "vpa-2"}]},
-		pod.MatchingVpas)
-	// Delete the first VPA from the Pod. Expect that it will still
-	// have the other one.
-	assert.NoError(t, cluster.DeleteVpa(VpaID{"namespace-1", "vpa-1"}))
-	assert.Equal(t, map[VpaID]*Vpa{
-		{"namespace-1", "vpa-2"}: cluster.Vpas[VpaID{"namespace-1", "vpa-2"}]},
-		pod.MatchingVpas)
-	// Delete the other VPA. The Pod is no longer vertically-scaled by anyone.
-	assert.NoError(t, cluster.DeleteVpa(VpaID{"namespace-1", "vpa-2"}))
-	assert.Empty(t, pod.MatchingVpas)
+	key1 := cluster.MakeAggregateStateKey(pod, "container-1")
+	key2 := cluster.MakeAggregateStateKey(pod, "container-1")
+	assert.True(t, key1 == key2)
+}
+
+// Verify that two containers with the same name, living in two pods with the same namespace and labels
+// (although different pod names) are aggregated together.
+func TestTwoPodsWithSameLabels(t *testing.T) {
+	podID1 := PodID{"namespace-1", "pod-1"}
+	podID2 := PodID{"namespace-1", "pod-2"}
+	containerID1 := ContainerID{podID1, "foo-container"}
+	containerID2 := ContainerID{podID2, "foo-container"}
+
+	cluster := NewClusterState()
+	cluster.AddOrUpdatePod(podID1, testLabels, apiv1.PodRunning)
+	cluster.AddOrUpdatePod(podID2, testLabels, apiv1.PodRunning)
+	cluster.AddOrUpdateContainer(containerID1, testRequest)
+	cluster.AddOrUpdateContainer(containerID2, testRequest)
+
+	// Expect only one aggregation to be created.
+	assert.Equal(t, 1, len(cluster.aggregateStateMap))
+}
+
+// Verify that two identical containers in different namespaces are not aggregated together.
+func TestTwoPodsWithDifferentNamespaces(t *testing.T) {
+	podID1 := PodID{"namespace-1", "foo-pod"}
+	podID2 := PodID{"namespace-2", "foo-pod"}
+	containerID1 := ContainerID{podID1, "foo-container"}
+	containerID2 := ContainerID{podID2, "foo-container"}
+
+	cluster := NewClusterState()
+	cluster.AddOrUpdatePod(podID1, testLabels, apiv1.PodRunning)
+	cluster.AddOrUpdatePod(podID2, testLabels, apiv1.PodRunning)
+	cluster.AddOrUpdateContainer(containerID1, testRequest)
+	cluster.AddOrUpdateContainer(containerID2, testRequest)
+
+	// Expect two separate aggregations to be created.
+	assert.Equal(t, 2, len(cluster.aggregateStateMap))
+	// Expect only one entry to be present in the labels set map.
+	assert.Equal(t, 1, len(cluster.labelSetMap))
 }
 
 // Verifies that a VPA with an empty selector (matching all pods) matches a pod
@@ -213,15 +224,19 @@ func TestTwoVpasForPod(t *testing.T) {
 func TestEmptySelector(t *testing.T) {
 	cluster := NewClusterState()
 	// Create a VPA with an empty selector (matching all pods).
-	addVpa(cluster, testVpaID, "")
-	// Create a pod with labels.
+	vpa := addVpa(cluster, testVpaID, "")
+	// Create a pod with labels. Add a container.
 	cluster.AddOrUpdatePod(testPodID, testLabels, apiv1.PodRunning)
-	// Create a pod without labels.
+	containerID1 := ContainerID{testPodID, "foo"}
+	assert.NoError(t, cluster.AddOrUpdateContainer(containerID1, testRequest))
+
+	// Create a pod without labels. Add a container.
 	anotherPodID := PodID{"namespace-1", "pod-2"}
 	cluster.AddOrUpdatePod(anotherPodID, emptyLabels, apiv1.PodRunning)
+	containerID2 := ContainerID{anotherPodID, "foo"}
+	assert.NoError(t, cluster.AddOrUpdateContainer(containerID2, testRequest))
+
 	// Both pods should be matched by the VPA.
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: cluster.Vpas[testVpaID]},
-		cluster.Pods[testPodID].MatchingVpas)
-	assert.Equal(t, map[VpaID]*Vpa{testVpaID: cluster.Vpas[testVpaID]},
-		cluster.Pods[anotherPodID].MatchingVpas)
+	assert.Contains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(containerID1))
+	assert.Contains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(containerID2))
 }

--- a/vertical-pod-autoscaler/recommender/model/container.go
+++ b/vertical-pod-autoscaler/recommender/model/container.go
@@ -18,10 +18,7 @@ package model
 
 import (
 	"fmt"
-	"math"
 	"time"
-
-	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/util"
 )
 
 const (
@@ -38,54 +35,41 @@ type ContainerUsageSample struct {
 	MeasureStart time.Time
 	// Average CPU usage in cores or memory usage in bytes.
 	Usage ResourceAmount
+	// CPU or memory request at the time of measurment.
+	Request ResourceAmount
 	// Which resource is this sample for.
 	Resource ResourceName
 }
 
 // ContainerState stores information about a single container instance.
+// Each ContainerState has a pointer to the aggregation that is used for
+// aggregating its usage samples.
 // It holds the recent history of CPU and memory utilization.
-// * CPU is stored in form of a distribution (histogram).
-//   Currently we're using fixed weight samples in the CPU histogram (i.e. old
-//   and fresh samples are equally important). Old samples are never deleted.
-//   TODO: Add exponential decaying of weights over time to address this.
-// * Memory is stored for the period of length MemoryAggregationWindowLength in
-//   the form of usage peaks, one value per MemoryAggregationInterval.
-//   For example if window legth is one week and aggregation interval is one day
-//   it will store 7 peaks, one per day, for the last week.
 //   Note: samples are added to intervals based on their start timestamps.
 type ContainerState struct {
 	// Current request.
 	Request Resources
-	// Distribution of CPU usage. The measurement unit is 1 CPU core.
-	CPUUsage util.Histogram
 	// Start of the latest CPU usage sample that was aggregated.
 	LastCPUSampleStart time.Time
-	// Start of the first CPU usage sample that was aggregated.
-	FirstCPUSampleStart time.Time
-	// Number of CPU samples that were aggregated.
-	CPUSamplesCount int
-
-	// Memory peaks stored in the intervals belonging to the aggregation window
-	// (one value per interval). The measurement unit is a byte.
-	MemoryUsagePeaks util.FloatSlidingWindow
-	// End time of the most recent interval covered by the aggregation window.
+	// Max memory usage observed in the current aggregation interval.
+	MemoryPeak ResourceAmount
+	// End time of the current memory aggregation interval (not inclusive).
 	WindowEnd time.Time
 	// Start of the latest memory usage sample that was aggregated.
 	lastMemorySampleStart time.Time
+	// Aggregation to add usage samples to.
+	aggregator ContainerStateAggregator
 }
 
-// NewContainerState returns a new, empty ContainerState.
-func NewContainerState(request Resources) *ContainerState {
+// NewContainerState returns a new ContainerState.
+func NewContainerState(request Resources, aggregator ContainerStateAggregator) *ContainerState {
 	return &ContainerState{
-		Request:             request,
-		CPUUsage:            util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife),
-		LastCPUSampleStart:  time.Time{},
-		FirstCPUSampleStart: time.Time{},
-		CPUSamplesCount:     0,
-		MemoryUsagePeaks: util.NewFloatSlidingWindow(
-			int(MemoryAggregationWindowLength / MemoryAggregationInterval)),
+		Request:               request,
+		LastCPUSampleStart:    time.Time{},
 		WindowEnd:             time.Time{},
-		lastMemorySampleStart: time.Time{}}
+		lastMemorySampleStart: time.Time{},
+		aggregator:            aggregator,
+	}
 }
 
 func (sample *ContainerUsageSample) isValid(expectedResource ResourceName) bool {
@@ -94,23 +78,11 @@ func (sample *ContainerUsageSample) isValid(expectedResource ResourceName) bool 
 
 func (container *ContainerState) addCPUSample(sample *ContainerUsageSample) bool {
 	// Order should not matter for the histogram, other than deduplication.
-	// TODO: Timestamp should be used to properly weigh the samples.
 	if !sample.isValid(ResourceCPU) || !sample.MeasureStart.After(container.LastCPUSampleStart) {
 		return false // Discard invalid, duplicate or out-of-order samples.
 	}
-	cpuUsageCores := CoresFromCPUAmount(sample.Usage)
-	cpuRequestCores := CoresFromCPUAmount(container.Request[ResourceCPU])
-	// Samples are added with the weight equal to the current request. This means that
-	// whenever the request is increased, the history accumulated so far effectively decays,
-	// which helps react quickly to CPU starvation.
-	minSampleWeight := 0.1
-	container.CPUUsage.AddSample(
-		cpuUsageCores, math.Max(cpuRequestCores, minSampleWeight), sample.MeasureStart)
+	container.aggregator.AddSample(sample)
 	container.LastCPUSampleStart = sample.MeasureStart
-	if container.FirstCPUSampleStart.IsZero() {
-		container.FirstCPUSampleStart = sample.MeasureStart
-	}
-	container.CPUSamplesCount++
 	return true
 }
 
@@ -119,49 +91,61 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample) b
 	if !sample.isValid(ResourceMemory) || ts.Before(container.lastMemorySampleStart) {
 		return false // Discard invalid or outdated samples.
 	}
-	if !ts.Before(container.WindowEnd.Add(MemoryAggregationWindowLength)) {
-		// The gap between this sample and the previous interval is so
-		// large that the whole sliding window gets reset.
-		// This also happens on the first memory usage sample.
-		container.MemoryUsagePeaks.Clear()
-		container.WindowEnd = ts.Add(MemoryAggregationInterval)
-	} else {
-		for !ts.Before(container.WindowEnd) {
-			// Shift the memory aggregation window to the next interval.
-			container.MemoryUsagePeaks.Push(0.0)
-			container.WindowEnd =
-				container.WindowEnd.Add(MemoryAggregationInterval)
-		}
-	}
-	// Update the memory peak for the current interval.
-	if container.MemoryUsagePeaks.Head() == nil {
-		// Window is empty.
-		container.MemoryUsagePeaks.Push(0.0)
-	}
-	*container.MemoryUsagePeaks.Head() = math.Max(
-		*container.MemoryUsagePeaks.Head(), BytesFromMemoryAmount(sample.Usage))
 	container.lastMemorySampleStart = ts
+	if container.WindowEnd.IsZero() { // This is the first sample.
+		container.WindowEnd = ts
+	}
+
+	// Each container aggregates one peak per aggregation interval. If the timestamp of the
+	// current sample is earlier than the end of the current interval (WindowEnd) and is larger
+	// than the current peak, the peak is updated in the aggregation by subtracting the old value
+	// and adding the new value.
+	addNewPeak := false
+	if ts.Before(container.WindowEnd) {
+		if container.MemoryPeak != 0 && sample.Usage > container.MemoryPeak {
+			// Remove the old peak.
+			oldPeak := ContainerUsageSample{
+				MeasureStart: container.WindowEnd,
+				Usage:        container.MemoryPeak,
+				Request:      sample.Request,
+				Resource:     ResourceMemory,
+			}
+			container.aggregator.SubtractSample(&oldPeak)
+			addNewPeak = true
+		}
+	} else {
+		// Shift the memory aggregation window to the next interval.
+		shift := truncate(ts.Sub(container.WindowEnd), MemoryAggregationInterval) + MemoryAggregationInterval
+		container.WindowEnd = container.WindowEnd.Add(shift)
+		addNewPeak = true
+	}
+	if addNewPeak {
+		newPeak := ContainerUsageSample{
+			MeasureStart: container.WindowEnd,
+			Usage:        sample.Usage,
+			Request:      sample.Request,
+			Resource:     ResourceMemory,
+		}
+		container.aggregator.AddSample(&newPeak)
+		container.MemoryPeak = sample.Usage
+	}
 	return true
 }
 
 // RecordOOM adds info regarding OOM event in the model as an artificial memory sample.
 func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory ResourceAmount) error {
-	resourceAmount := float64(requestedMemory)
 	// Discard old OOM
 	if timestamp.Before(container.WindowEnd.Add(-1 * MemoryAggregationInterval)) {
 		return fmt.Errorf("OOM event will be discarded - it is too old (%v)", timestamp)
 	}
-	// If we have recent memory sample max it with request.
-	if timestamp.Before(container.WindowEnd.Add(MemoryAggregationInterval)) &&
-		container.MemoryUsagePeaks.Head() != nil {
-		resourceAmount = math.Max(resourceAmount, *container.MemoryUsagePeaks.Head())
-	}
-
-	resourceAmount = math.Max(resourceAmount+OOMMinBumpUp, resourceAmount*OOMBumpUpRatio)
+	// Get max of the request and the recent memory peak.
+	memoryUsed := ResourceAmountMax(requestedMemory, container.MemoryPeak)
+	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(OOMMinBumpUp),
+		ScaleResource(memoryUsed, OOMBumpUpRatio))
 
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,
-		Usage:        ResourceAmount(resourceAmount),
+		Usage:        memoryNeeded,
 		Resource:     ResourceMemory,
 	}
 	if !container.addMemorySample(&oomMemorySample) {
@@ -186,4 +170,15 @@ func (container *ContainerState) AddSample(sample *ContainerUsageSample) bool {
 	default:
 		return false
 	}
+}
+
+// Truncate returns the result of rounding d toward zero to a multiple of m.
+// If m <= 0, Truncate returns d unchanged.
+// This helper function is introduced to support older implementations of the
+// time package that don't provide Duration.Truncate function.
+func truncate(d, m time.Duration) time.Duration {
+	if m <= 0 {
+		return d
+	}
+	return d - d%m
 }

--- a/vertical-pod-autoscaler/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/recommender/model/container_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 var (
-	TimeLayout  = "2006-01-02 15:04:05"
+	timeLayout       = "2006-01-02 15:04:05"
+	testTimestamp, _ = time.Parse(timeLayout, "2017-04-18 17:35:05")
+
 	TestRequest = Resources{
 		ResourceCPU:    CPUAmountFromCores(2.3),
 		ResourceMemory: MemoryAmountFromBytes(5e8),
@@ -38,7 +40,38 @@ const (
 )
 
 func newUsageSample(timestamp time.Time, usage int64, resource ResourceName) *ContainerUsageSample {
-	return &ContainerUsageSample{timestamp, ResourceAmount(usage), resource}
+	return &ContainerUsageSample{
+		MeasureStart: timestamp,
+		Usage:        ResourceAmount(usage),
+		Request:      TestRequest[resource],
+		Resource:     resource,
+	}
+}
+
+type ContainerTest struct {
+	mockCPUHistogram        *util.MockHistogram
+	mockMemoryHistogram     *util.MockHistogram
+	aggregateContainerState *AggregateContainerState
+	container               *ContainerState
+}
+
+func newContainerTest() ContainerTest {
+	mockCPUHistogram := new(util.MockHistogram)
+	mockMemoryHistogram := new(util.MockHistogram)
+	aggregateContainerState := &AggregateContainerState{
+		AggregateCPUUsage:    mockCPUHistogram,
+		AggregateMemoryPeaks: mockMemoryHistogram,
+	}
+	container := &ContainerState{
+		Request:    TestRequest,
+		aggregator: aggregateContainerState,
+	}
+	return ContainerTest{
+		mockCPUHistogram:        mockCPUHistogram,
+		mockMemoryHistogram:     mockMemoryHistogram,
+		aggregateContainerState: aggregateContainerState,
+		container:               container,
+	}
 }
 
 // Add 6 usage samples (3 valid, 3 invalid) to a container. Verifies that for
@@ -46,27 +79,23 @@ func newUsageSample(timestamp time.Time, usage int64, resource ResourceName) *Co
 // the memory measures are aggregated in the memory peaks sliding window.
 // Verifies that invalid samples (out-of-order or negative usage) are ignored.
 func TestAggregateContainerUsageSamples(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
-
+	test := newContainerTest()
+	c := test.container
 	// Verify that CPU measures are added to the CPU histogram.
 	// The weight should be equal to the current request.
 	timeStep := MemoryAggregationInterval / 2
-	mockCPUHistogram.On("AddSample", 3.14, 2.3, testTimestamp)
-	mockCPUHistogram.On("AddSample", 6.28, 2.3, testTimestamp.Add(timeStep))
-	mockCPUHistogram.On("AddSample", 1.57, 2.3, testTimestamp.Add(2*timeStep))
+	test.mockCPUHistogram.On("AddSample", 3.14, 2.3, testTimestamp)
+	test.mockCPUHistogram.On("AddSample", 6.28, 2.3, testTimestamp.Add(timeStep))
+	test.mockCPUHistogram.On("AddSample", 1.57, 2.3, testTimestamp.Add(2*timeStep))
+	// Verify that memory peaks are added to the memory peaks histogram.
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
+	test.mockMemoryHistogram.On("AddSample", 5.0, 1.0, memoryAggregationWindowEnd)
+	test.mockMemoryHistogram.On("SubtractSample", 5.0, 1.0, memoryAggregationWindowEnd)
+	test.mockMemoryHistogram.On("AddSample", 10.0, 1.0, memoryAggregationWindowEnd)
+	memoryAggregationWindowEnd = memoryAggregationWindowEnd.Add(MemoryAggregationInterval)
+	test.mockMemoryHistogram.On("AddSample", 2.0, 1.0, memoryAggregationWindowEnd)
 
-	// Add three usage samples.
+	// Add three CPU and memory usage samples.
 	assert.True(t, c.AddSample(newUsageSample(
 		testTimestamp, 3140, ResourceCPU)))
 	assert.True(t, c.AddSample(newUsageSample(
@@ -89,104 +118,59 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 		testTimestamp.Add(4*timeStep), -1000, ResourceCPU)))
 	assert.False(t, c.AddSample(newUsageSample( // Negative memory usage.
 		testTimestamp.Add(4*timeStep), -1000, ResourceMemory)))
-
-	// Verify that memory peak samples were aggregated properly.
-	assert.Equal(t, []float64{10, 2}, memoryUsagePeaks.Contents())
 }
 
 func TestRecordOOMIncreasedByBumpUp(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
+	// Bump Up factor is 20%.
+	test.mockMemoryHistogram.On("AddSample", 1200.0*mb, 1.0, memoryAggregationWindowEnd)
 
-	assert.NoError(t, c.RecordOOM(testTimestamp, ResourceAmount(1000*mb)))
-	// Bump Up factor is 20%
-	assert.Equal(t, []float64{1200 * mb}, memoryUsagePeaks.Contents())
+	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceAmount(1000*mb)))
 }
 
 func TestRecordOOMIncreasedByMin(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
+	// Min grow by 100Mb.
+	test.mockMemoryHistogram.On("AddSample", 101.0*mb, 1.0, memoryAggregationWindowEnd)
 
-	assert.NoError(t, c.RecordOOM(testTimestamp, ResourceAmount(1*mb)))
-	// Min grow by 100Mb
-	assert.Equal(t, []float64{101 * mb}, memoryUsagePeaks.Contents())
+	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceAmount(1*mb)))
 }
 
 func TestRecordOOMMaxedWithKnownSample(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
 
-	assert.True(t, c.AddSample(newUsageSample(testTimestamp, 3000*mb, ResourceMemory)))
-	assert.NoError(t, c.RecordOOM(testTimestamp, ResourceAmount(1000*mb)))
-	// Last known sample is higher then request, so it is taken.
-	assert.Equal(t, []float64{3600 * mb}, memoryUsagePeaks.Contents())
+	test.mockMemoryHistogram.On("AddSample", 3000.0*mb, 1.0, memoryAggregationWindowEnd)
+	assert.True(t, test.container.AddSample(newUsageSample(testTimestamp, 3000*mb, ResourceMemory)))
+
+	// Last known sample is higher than request, so it is taken.
+	test.mockMemoryHistogram.On("SubtractSample", 3000.0*mb, 1.0, memoryAggregationWindowEnd)
+	test.mockMemoryHistogram.On("AddSample", 3600.0*mb, 1.0, memoryAggregationWindowEnd)
+
+	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceAmount(1000*mb)))
 }
 
 func TestRecordOOMDiscardsOldSample(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
 
-	assert.True(t, c.AddSample(newUsageSample(testTimestamp, 1000*mb, ResourceMemory)))
-	assert.Error(t, c.RecordOOM(testTimestamp.Add(-30*time.Hour), ResourceAmount(1000*mb)))
-	// OOM is obsolete, mem not changed
-	assert.Equal(t, []float64{1000 * mb}, memoryUsagePeaks.Contents())
+	test.mockMemoryHistogram.On("AddSample", 1000.0*mb, 1.0, memoryAggregationWindowEnd)
+	assert.True(t, test.container.AddSample(newUsageSample(testTimestamp, 1000*mb, ResourceMemory)))
+
+	// OOM is stale, mem not changed.
+	assert.Error(t, test.container.RecordOOM(testTimestamp.Add(-30*time.Hour), ResourceAmount(1000*mb)))
 }
 
 func TestRecordOOMInNewWindow(t *testing.T) {
-	testTimestamp, err := time.Parse(TimeLayout, "2017-04-18 17:35:05")
-	assert.Nil(t, err)
-	mockCPUHistogram := new(util.MockHistogram)
-	memoryUsagePeaks := util.NewFloatSlidingWindow(
-		int(MemoryAggregationWindowLength / MemoryAggregationInterval))
-	c := &ContainerState{
-		Request:               TestRequest,
-		CPUUsage:              mockCPUHistogram,
-		LastCPUSampleStart:    time.Unix(0, 0),
-		MemoryUsagePeaks:      memoryUsagePeaks,
-		WindowEnd:             time.Unix(0, 0),
-		lastMemorySampleStart: time.Unix(0, 0)}
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(MemoryAggregationInterval)
 
-	assert.True(t, c.AddSample(newUsageSample(testTimestamp, 2000*mb, ResourceMemory)))
-	assert.NoError(t, c.RecordOOM(testTimestamp.Add(2*MemoryAggregationInterval), ResourceAmount(1000*mb)))
-	assert.Equal(t, []float64{2000 * mb, 0, 1200 * mb}, memoryUsagePeaks.Contents())
+	test.mockMemoryHistogram.On("AddSample", 2000.0*mb, 1.0, memoryAggregationWindowEnd)
+	assert.True(t, test.container.AddSample(newUsageSample(testTimestamp, 2000*mb, ResourceMemory)))
+
+	memoryAggregationWindowEnd = memoryAggregationWindowEnd.Add(2 * MemoryAggregationInterval)
+	test.mockMemoryHistogram.On("AddSample", 2400.0*mb, 1.0, memoryAggregationWindowEnd)
+	assert.NoError(t, test.container.RecordOOM(testTimestamp.Add(2*MemoryAggregationInterval), ResourceAmount(1000*mb)))
 }

--- a/vertical-pod-autoscaler/recommender/model/types.go
+++ b/vertical-pod-autoscaler/recommender/model/types.go
@@ -106,6 +106,14 @@ func RoundResourceAmount(amount, unit ResourceAmount) ResourceAmount {
 	return ResourceAmount(int64(amount) - int64(amount)%int64(unit))
 }
 
+// ResourceAmountMax returns the larger of two resource amounts.
+func ResourceAmountMax(amount1, amount2 ResourceAmount) ResourceAmount {
+	if amount1 > amount2 {
+		return amount1
+	}
+	return amount2
+}
+
 func resourceAmountFromFloat(amount float64) ResourceAmount {
 	if amount < 0 {
 		return ResourceAmount(0)

--- a/vertical-pod-autoscaler/recommender/output/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/recommender/output/checkpoint_writer_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/recommender/model"
 )
 
@@ -29,12 +31,23 @@ import (
 var (
 	testPodID1       = model.PodID{"namespace-1", "pod-1"}
 	testContainerID1 = model.ContainerID{testPodID1, "container-1"}
+	testVpaID1       = model.VpaID{"namespace-1", "vpa-1"}
 	testLabels       = map[string]string{"label-1": "value-1"}
+	testSelectorStr  = "label-1 = value-1"
 	testRequest      = model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(3.14),
 		model.ResourceMemory: model.MemoryAmountFromBytes(3.14e9),
 	}
 )
+
+func addVpa(cluster *model.ClusterState, vpaID model.VpaID, selector string) *model.Vpa {
+	var apiObject vpa_types.VerticalPodAutoscaler
+	apiObject.Namespace = vpaID.Namespace
+	apiObject.Name = vpaID.VpaName
+	apiObject.Spec.Selector, _ = metav1.ParseToLabelSelector(selector)
+	cluster.AddOrUpdateVpa(&apiObject)
+	return cluster.Vpas[vpaID]
+}
 
 func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 	cluster := model.NewClusterState()
@@ -44,18 +57,18 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 
 	timeNow := time.Unix(1, 0)
 	container.AddSample(&model.ContainerUsageSample{
-		timeNow, model.MemoryAmountFromBytes(1024 * 1024 * 1024), model.ResourceMemory})
-	vpa := &model.Vpa{Pods: cluster.Pods}
+		timeNow, model.MemoryAmountFromBytes(1024 * 1024 * 1024), testRequest[model.ResourceMemory], model.ResourceMemory})
+	vpa := addVpa(cluster, testVpaID1, testSelectorStr)
 
 	// Verify that the current peak is excluded from the aggregation.
-	aggregateContainerStateMap := buildAggregateContainerStateMap(vpa, timeNow)
+	aggregateContainerStateMap := buildAggregateContainerStateMap(vpa, cluster, timeNow)
 	if assert.Contains(t, aggregateContainerStateMap, "container-1") {
 		assert.True(t, aggregateContainerStateMap["container-1"].AggregateMemoryPeaks.IsEmpty(),
 			"Current peak was not excluded from the aggregation.")
 	}
 	// Verify that an old peak is not excluded from the aggregation.
 	timeNow = timeNow.Add(model.MemoryAggregationInterval)
-	aggregateContainerStateMap = buildAggregateContainerStateMap(vpa, timeNow)
+	aggregateContainerStateMap = buildAggregateContainerStateMap(vpa, cluster, timeNow)
 	if assert.Contains(t, aggregateContainerStateMap, "container-1") {
 		assert.False(t, aggregateContainerStateMap["container-1"].AggregateMemoryPeaks.IsEmpty(),
 			"Old peak should not be excluded from the aggregation.")


### PR DESCRIPTION
* Usage samples are no longer aggregated per pod (which prevented from garbage collecting terminated pods and could lead to very large number of aggregations, when many pods with different names were created in the cluster).
* We introduce a new concept of the AggregateStateKey, which determines the set of containers
for which usage samples are aggregated. In the current implementation the AggregateStateKey
consists of { namespace, containerName, label set }, however it can be easily changed/extended in future, if necessary.
* Each container holds a pointer to the AggregateContainerState to which it contributes usage samples.
* Each VPA holds a set of all AggregateContainerStates which it matches.
* Pod no longer keeps links to the VPAs that match it. VPA no longer keeps links to Pods it matches.
* Checkpoint specific code is moved out from AggregateContainerState to Vpa.
* Memory peaks are stored in a histogram, similarly to CPU samples. Each container keeps its last peak.
  Sliding window is no longer used.
* Added more test cases.
* TODO: Garbage collect old Pods and AggregateContainerStates.
* TODO: Delete sliding window.