### PR TITLE
Add zero nodes support for Azure VMSS

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -11,6 +11,8 @@ Cluster autoscaler support two VM types with Azure cloud provider:
 - **vmss**: For kubernetes cluster running on VMSS instances. Azure cloud provider's `vmType` parameter must be configured as 'vmss'. It requires Kubernetes with Azure VMSS support ([kubernetes#43287](https://github.com/kubernetes/kubernetes/issues/43287)).
 - **standard**: For kubernetes cluster running on VMAS instances. Azure cloud provider's `vmType` parameter must be configured as 'standard' or left as empty string. It only supports Kubernetes cluster deployed via [acs-engine](https://github.com/Azure/acs-engine).
 
+Only **vmss** vmType supports scaling to zero nodes.
+
 ## Permissions
 
 Get azure credentials by running the following command


### PR DESCRIPTION
This PR adds zero nodes support for Azure VMSS.

Fixes #796.

Note that: Azure VMAS (vmType: standard) doesn't support this feature.