### PR TITLE
Remove implementation details (CleanUp) from the interface.

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -46,8 +46,6 @@ type AutoscalerOptions struct {
 type Autoscaler interface {
 	// RunOnce represents an iteration in the control-loop of CA
 	RunOnce(currentTime time.Time) errors.AutoscalerError
-	// CleanUp represents a clean-up required before the first invocation of RunOnce
-	CleanUp()
 	// CloudProvider returns the cloud provider associated to this autoscaler
 	CloudProvider() cloudprovider.CloudProvider
 	// ExitCleanUp is a clean-up performed just before process termination.

--- a/cluster-autoscaler/core/dynamic_autoscaler.go
+++ b/cluster-autoscaler/core/dynamic_autoscaler.go
@@ -47,11 +47,6 @@ func NewDynamicAutoscaler(autoscalerBuilder AutoscalerBuilder, configFetcher dyn
 	}, nil
 }
 
-// CleanUp does the work required before all the iterations of a dynamic autoscaler run
-func (a *DynamicAutoscaler) CleanUp() {
-	a.autoscaler.CleanUp()
-}
-
 // CloudProvider returns the cloud provider associated to this autoscaler
 func (a *DynamicAutoscaler) CloudProvider() cloudprovider.CloudProvider {
 	return a.autoscaler.CloudProvider()

--- a/cluster-autoscaler/core/dynamic_autoscaler_test.go
+++ b/cluster-autoscaler/core/dynamic_autoscaler_test.go
@@ -34,10 +34,6 @@ func (m *AutoscalerMock) RunOnce(currentTime time.Time) errors.AutoscalerError {
 	return nil
 }
 
-func (m *AutoscalerMock) CleanUp() {
-	m.Called()
-}
-
 func (m *AutoscalerMock) CloudProvider() cloudprovider.CloudProvider {
 	args := m.Called()
 	return args.Get(0).(cloudprovider.CloudProvider)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -200,7 +200,8 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,
-		podListProcessor:      pods.NewDefaultPodListProcessor()}
+		podListProcessor:      pods.NewDefaultPodListProcessor(),
+		initialized:           true}
 
 	// MaxNodesTotal reached.
 	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1}, nil).Once()
@@ -379,7 +380,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,
-		podListProcessor:      pods.NewDefaultPodListProcessor()}
+		podListProcessor:      pods.NewDefaultPodListProcessor(),
+		initialized:           true}
 
 	// Scale up.
 	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1}, nil).Once()
@@ -519,7 +521,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 		podListProcessor:      pods.NewDefaultPodListProcessor()}
 
 	// Scale up.
-	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1}, nil).Once()
+	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1}, nil).Times(2) // due to initialized=false
 	allNodeListerMock.On("List").Return([]*apiv1.Node{n1}, nil).Once()
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Once()
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
@@ -656,7 +658,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 		podListProcessor:      pods.NewDefaultPodListProcessor()}
 
 	// Scale up
-	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1, n2, n3}, nil).Once()
+	readyNodeListerMock.On("List").Return([]*apiv1.Node{n1, n2, n3}, nil).Times(2) // due to initialized=false
 	allNodeListerMock.On("List").Return([]*apiv1.Node{n1, n2, n3}, nil).Once()
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1, p2, p3}, nil).Once()
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p4, p5, p6}, nil).Once()

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -261,7 +261,6 @@ func run(healthCheck *metrics.HealthCheck) {
 	if err != nil {
 		glog.Fatalf("Failed to create autoscaler: %v", err)
 	}
-	autoscaler.CleanUp()
 	registerSignalHandlers(autoscaler)
 	healthCheck.StartMonitoring()
 


### PR DESCRIPTION
The CleanUp method is instead called directly from the implementation,
when required.
Test updated in a quick way since the mock we're using does not support
AtLeast(1) - thus Times(2).