### PR TITLE
 Split Autoscaler.RunOnce into separate logical steps

### DIFF
--- a/cluster-autoscaler/core/loop_state.go
+++ b/cluster-autoscaler/core/loop_state.go
@@ -1,0 +1,430 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/golang/glog"
+)
+
+// LoopStateHandler hides complexity of Autoscaler.RunOnce implementation,
+// splitting it into a number of phases.
+// Each phase method returns bool value to show whether processing can continue further.
+// LoopStateHandler instance is a very short-lived one, persisting state of a single RunOnce call.
+type LoopStateHandler interface {
+	// RefreshState obtains new Node-level data from the cloud provider
+	// and updates internal ClusterStateRegistry, until metrics.UpdateState.
+	// Returns true iff the processing can continue further.
+	RefreshState() bool
+	// CheckPreconditions verifies Node-level preconditions for continuing
+	// to processing Pod-level data.
+	// Returns true iff the processing can continue further.
+	CheckPreconditions() bool
+	// PreparePodData obtains Pod-level data for further processing.
+	// Returns true iff the processing can continue further.
+	PreparePodData() bool
+	// ScaleUp executes scale-up, if it's required.
+	// Returns true iff the processing can continue further.
+	ScaleUp() bool
+	// ScaleDown executes scale-down logic, both dry-run & actual scale-down, if it's required.
+	// Returns true iff the processing can continue further.
+	ScaleDown() bool
+
+	// ReturnError returns the result (error or nil) to return from Autoscaler.RunOnce.
+	ReturnError() errors.AutoscalerError
+}
+
+// loopState is the default implementation of LoopStateHandler
+type loopState struct {
+	currentTime        time.Time
+	startTime          time.Time
+	retError           errors.AutoscalerError
+	scaleDownForbidden bool
+
+	autoscaler *StaticAutoscaler
+	context    *context.AutoscalingContext
+
+	allNodes                                       []*apiv1.Node
+	readyNodes                                     []*apiv1.Node
+	allScheduled                                   []*apiv1.Pod
+	unschedulablePodsToHelp                        []*apiv1.Pod
+	unschedulableWaitingForLowerPriorityPreemption []*apiv1.Pod
+}
+
+// NewLoopStateHandler creates new instance of the default LoopStateHandler implementation
+func NewLoopStateHandler(autoscaler *StaticAutoscaler, currentTime time.Time) *loopState {
+	return &loopState{
+		currentTime: currentTime,
+		startTime:   time.Now(),
+		autoscaler:  autoscaler,
+		context:     autoscaler.AutoscalingContext,
+	}
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) RefreshState() bool {
+	return ls.refreshCloudProvider() &&
+		ls.obtainNodeLists() &&
+		ls.updateClusterStateRegistry()
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) CheckPreconditions() bool {
+	return ls.cleanUnregisteredNodes() &&
+		ls.checkClusterHealth() &&
+		ls.fixNodeGroupSizes()
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) PreparePodData() bool {
+	allUnschedulablePods, err := ls.autoscaler.UnschedulablePodLister().List()
+	if err != nil {
+		glog.Errorf("Failed to list unscheduled pods: %v", err)
+		return ls.onError(errors.ApiCallError, err)
+	}
+	metrics.UpdateUnschedulablePodsCount(len(allUnschedulablePods))
+
+	ls.allScheduled, err = ls.autoscaler.ScheduledPodLister().List()
+	if err != nil {
+		glog.Errorf("Failed to list scheduled pods: %v", err)
+		return ls.onError(errors.ApiCallError, err)
+	}
+
+	allUnschedulablePods, ls.allScheduled, err = ls.autoscaler.podListProcessor.Process(
+		ls.context, allUnschedulablePods, ls.allScheduled, ls.allNodes)
+	if err != nil {
+		glog.Errorf("Failed to process pod list: %v", err)
+		return ls.onError(errors.InternalError, err)
+	}
+
+	ConfigurePredicateCheckerForLoop(allUnschedulablePods, ls.allScheduled, ls.autoscaler.PredicateChecker)
+
+	// We need to check whether pods marked as unschedulable are actually unschedulable.
+	// It's likely we added a new node and the scheduler just haven't managed to put the
+	// pod on in yet. In this situation we don't want to trigger another scale-up.
+	//
+	// It's also important to prevent uncontrollable cluster growth if CA's simulated
+	// scheduler differs in opinion with real scheduler. Example of such situation:
+	// - CA and Scheduler has slightly different configuration
+	// - Scheduler can't schedule a pod and marks it as unschedulable
+	// - CA added a node which should help the pod
+	// - Scheduler doesn't schedule the pod on the new node
+	//   because according to it logic it doesn't fit there
+	// - CA see the pod is still unschedulable, so it adds another node to help it
+	//
+	// With the check enabled the last point won't happen because CA will ignore a pod
+	// which is supposed to schedule on an existing node.
+	ls.scaleDownForbidden = false
+
+	unschedulablePodsWithoutTPUs := tpu.ClearTPURequests(allUnschedulablePods)
+
+	// Some unschedulable pods can be waiting for lower priority pods preemption so they have nominated node to run.
+	// Such pods don't require scale up but should be considered during scale down.
+	var unschedulablePods []*apiv1.Pod
+	unschedulablePods, ls.unschedulableWaitingForLowerPriorityPreemption = FilterOutExpendableAndSplit(
+		unschedulablePodsWithoutTPUs, ls.autoscaler.ExpendablePodsPriorityCutoff)
+
+	glog.V(4).Infof("Filtering out schedulables")
+	filterOutSchedulableStart := time.Now()
+	ls.unschedulablePodsToHelp = FilterOutSchedulable(unschedulablePods, ls.readyNodes, ls.allScheduled,
+		ls.unschedulableWaitingForLowerPriorityPreemption, ls.autoscaler.PredicateChecker, ls.autoscaler.ExpendablePodsPriorityCutoff)
+	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, filterOutSchedulableStart)
+
+	if len(ls.unschedulablePodsToHelp) != len(unschedulablePods) {
+		glog.V(2).Info("Schedulable pods present")
+		ls.scaleDownForbidden = true
+	} else {
+		glog.V(4).Info("No schedulable pods")
+	}
+
+	return true
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) ScaleUp() bool {
+	if len(ls.unschedulablePodsToHelp) == 0 {
+		glog.V(1).Info("No unschedulable pods")
+	} else if ls.autoscaler.MaxNodesTotal > 0 && len(ls.readyNodes) >= ls.autoscaler.MaxNodesTotal {
+		glog.V(1).Info("Max total nodes in cluster reached")
+	} else if allPodsAreNew(ls.unschedulablePodsToHelp, ls.currentTime) {
+		// The assumption here is that these pods have been created very recently and probably there
+		// is more pods to come. In theory we could check the newest pod time but then if pod were created
+		// slowly but at the pace of 1 every 2 seconds then no scale up would be triggered for long time.
+		// We also want to skip a real scale down (just like if the pods were handled).
+		ls.scaleDownForbidden = true
+		glog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
+	} else {
+		daemonsets, err := ls.autoscaler.ListerRegistry.DaemonSetLister().List()
+		if err != nil {
+			glog.Errorf("Failed to get daemonset list")
+			return ls.onError(errors.ApiCallError, err)
+		}
+
+		scaleUpStart := time.Now()
+		metrics.UpdateLastTime(metrics.ScaleUp, scaleUpStart)
+
+		scaledUp, typedErr := ScaleUp(ls.context, ls.unschedulablePodsToHelp, ls.readyNodes, daemonsets)
+
+		metrics.UpdateDurationFromStart(metrics.ScaleUp, scaleUpStart)
+
+		if typedErr != nil {
+			glog.Errorf("Failed to scale up: %v", typedErr)
+			ls.onTypedError(typedErr)
+		} else if scaledUp {
+			ls.autoscaler.lastScaleUpTime = ls.currentTime
+			// No scale down in this iteration.
+			return false
+		}
+	}
+
+	return true
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) ScaleDown() bool {
+	if !ls.autoscaler.ScaleDownEnabled {
+		return true
+	}
+
+	pdbs, err := ls.autoscaler.PodDisruptionBudgetLister().List()
+	if err != nil {
+		glog.Errorf("Failed to list pod disruption budgets: %v", err)
+		return ls.onError(errors.ApiCallError, err)
+	}
+
+	unneededStart := time.Now()
+
+	glog.V(4).Infof("Calculating unneeded nodes")
+
+	ls.autoscaler.scaleDown.CleanUp(ls.currentTime)
+	potentiallyUnneeded := getPotentiallyUnneededNodes(ls.context, ls.allNodes)
+
+	typedErr := ls.autoscaler.scaleDown.UpdateUnneededNodes(
+		ls.allNodes, potentiallyUnneeded,
+		append(ls.allScheduled, ls.unschedulableWaitingForLowerPriorityPreemption...),
+		ls.currentTime, pdbs)
+	if typedErr != nil {
+		glog.Errorf("Failed to scale down: %v", typedErr)
+		ls.onTypedError(typedErr)
+	}
+
+	metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
+
+	if glog.V(4) {
+		for key, val := range ls.autoscaler.scaleDown.unneededNodes {
+			glog.V(4).Infof("%s is unneeded since %s duration %s", key, val.String(), ls.currentTime.Sub(val).String())
+		}
+	}
+
+	// In dry run only utilization is updated
+	calculateUnneededOnly := ls.scaleDownForbidden ||
+		ls.autoscaler.lastScaleUpTime.Add(ls.autoscaler.ScaleDownDelayAfterAdd).After(ls.currentTime) ||
+		ls.autoscaler.lastScaleDownFailTime.Add(ls.autoscaler.ScaleDownDelayAfterFailure).After(ls.currentTime) ||
+		ls.autoscaler.lastScaleDownDeleteTime.Add(ls.autoscaler.ScaleDownDelayAfterDelete).After(ls.currentTime) ||
+		ls.autoscaler.scaleDown.nodeDeleteStatus.IsDeleteInProgress()
+
+	glog.V(4).Infof("Scale down status: unneededOnly=%v lastScaleUpTime=%s "+
+		"lastScaleDownDeleteTime=%v lastScaleDownFailTime=%s scaleDownForbidden=%v isDeleteInProgress=%v",
+		calculateUnneededOnly, ls.autoscaler.lastScaleUpTime, ls.autoscaler.lastScaleDownDeleteTime, ls.autoscaler.lastScaleDownFailTime,
+		ls.scaleDownForbidden, ls.autoscaler.scaleDown.nodeDeleteStatus.IsDeleteInProgress())
+
+	if calculateUnneededOnly {
+		return true
+	}
+
+	glog.V(4).Infof("Starting scale down")
+
+	// We want to delete unneeded Node Groups only if there was no recent scale up,
+	// and there is no current delete in progress and there was no recent errors.
+	if ls.context.NodeAutoprovisioningEnabled {
+		err := cleanUpNodeAutoprovisionedGroups(ls.context.CloudProvider, ls.context.LogRecorder)
+		if err != nil {
+			glog.Warningf("Failed to clean up unneeded node groups: %v", err)
+		}
+	}
+
+	scaleDownStart := time.Now()
+	metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
+	result, typedErr := ls.autoscaler.scaleDown.TryToScaleDown(ls.allNodes, ls.allScheduled, pdbs, ls.currentTime)
+	metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
+
+	// TODO: revisit result handling
+	if typedErr != nil {
+		glog.Errorf("Failed to scale down: %v", err)
+		ls.autoscaler.lastScaleDownFailTime = ls.currentTime
+		return ls.onTypedError(typedErr)
+	}
+	if result == ScaleDownNodeDeleted || result == ScaleDownNodeDeleteStarted {
+		ls.autoscaler.lastScaleDownDeleteTime = ls.currentTime
+	}
+
+	return true
+}
+
+// See LoopStateHandler interface
+func (ls *loopState) ReturnError() errors.AutoscalerError {
+	return ls.retError
+}
+
+// single-use helper methods start here, extracted to limit complexity of any single method
+// all these methods return true if it's safe to continue, false if the RunOnce loop should be onTypedErrored
+
+func (ls *loopState) refreshCloudProvider() bool {
+	err := ls.context.CloudProvider.Refresh()
+	if err != nil {
+		glog.Errorf("Failed to refresh cloud provider config: %v", err)
+		return ls.onError(errors.CloudProviderError, err)
+	}
+	return true
+}
+
+func (ls *loopState) obtainNodeLists() bool {
+	var err error
+
+	ls.allNodes, err = ls.autoscaler.AllNodeLister().List()
+	if err != nil {
+		glog.Errorf("Failed to list all nodes: %v", err)
+		return ls.onError(errors.ApiCallError, err)
+	}
+	if len(ls.allNodes) == 0 {
+		return ls.onEmptyCluster("nodes", true)
+	}
+
+	ls.readyNodes, err = ls.autoscaler.ReadyNodeLister().List()
+	if err != nil {
+		glog.Errorf("Failed to list ready nodes: %v", err)
+		return ls.onError(errors.ApiCallError, err)
+	}
+
+	// Handle GPU case - allocatable GPU may be equal to 0 up to 15 minutes after
+	// node registers as ready. See https://github.com/kubernetes/kubernetes/issues/54959
+	// Treat those nodes as unready until GPU actually becomes available and let
+	// our normal handling for booting up nodes deal with this.
+	// TODO: Remove this call when we handle dynamically provisioned resources.
+	ls.allNodes, ls.readyNodes = gpu.FilterOutNodesWithUnreadyGpus(ls.allNodes, ls.readyNodes)
+	if len(ls.readyNodes) == 0 {
+		// Cluster Autoscaler may start running before nodes are ready.
+		// Timeout ensures no ClusterUnhealthy events are published immediately in this case.
+		emit := ls.currentTime.After(ls.autoscaler.startTime.Add(nodesNotReadyAfterStartTimeout))
+		return ls.onEmptyCluster("ready nodes", emit)
+	}
+	return true
+}
+
+func (ls *loopState) updateClusterStateRegistry() bool {
+	err := ls.autoscaler.ClusterStateRegistry.UpdateNodes(ls.allNodes, ls.currentTime)
+	if err != nil {
+		glog.Errorf("Failed to update node registry: %v", err)
+		ls.autoscaler.scaleDown.CleanUpUnneededNodes()
+		return ls.onError(errors.CloudProviderError, err)
+	}
+	UpdateClusterStateMetrics(ls.autoscaler.ClusterStateRegistry)
+
+	metrics.UpdateDurationFromStart(metrics.UpdateState, ls.startTime)
+	metrics.UpdateLastTime(metrics.Autoscaling, time.Now())
+
+	return true
+}
+
+func (ls *loopState) cleanUnregisteredNodes() bool {
+	// Check if there are any nodes that failed to register in Kubernetes master.
+	unregisteredNodes := ls.autoscaler.ClusterStateRegistry.GetUnregisteredNodes()
+	if len(unregisteredNodes) > 0 {
+		glog.V(1).Infof("%d unregistered nodes present", len(unregisteredNodes))
+		removedAny, err := removeOldUnregisteredNodes(unregisteredNodes, ls.context, ls.currentTime, ls.context.LogRecorder)
+		// There was a problem with removing unregistered nodes. Retry in the next loop.
+		if err != nil {
+			if removedAny {
+				glog.Warningf("Some unregistered nodes were removed, but got error: %v", err)
+			} else {
+				glog.Errorf("Failed to remove unregistered nodes: %v", err)
+			}
+			return ls.onError(errors.CloudProviderError, err)
+		}
+		// Some nodes were removed. Let's skip this iteration, the next one should be better.
+		if removedAny {
+			glog.V(0).Infof("Some unregistered nodes were removed, skipping iteration")
+			return false
+		}
+	}
+	return true
+}
+
+func (ls *loopState) checkClusterHealth() bool {
+	if !ls.autoscaler.ClusterStateRegistry.IsClusterHealthy() {
+		glog.Warning("Cluster is not ready for autoscaling")
+		ls.autoscaler.scaleDown.CleanUpUnneededNodes()
+		ls.context.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster is unhealthy")
+		return false
+	}
+	return true
+}
+
+func (ls *loopState) fixNodeGroupSizes() bool {
+	// Check if there has been a constant difference between the number of nodes in k8s and
+	// the number of nodes on the cloud provider side.
+	// TODO: andrewskim - add protection for ready AWS nodes.
+	fixedSomething, err := fixNodeGroupSize(ls.context, ls.currentTime)
+	if err != nil {
+		glog.Errorf("Failed to fix node group sizes: %v", err)
+		return ls.onError(errors.CloudProviderError, err)
+	}
+	if fixedSomething {
+		glog.V(0).Infof("Some node group target size was fixed, skipping the iteration")
+		return false
+	}
+
+	return true
+}
+
+// general helper methods start here
+
+func (ls *loopState) onTypedError(err errors.AutoscalerError) bool {
+	ls.retError = err
+	return false
+}
+
+func (ls *loopState) onError(errType errors.AutoscalerErrorType, err error) bool {
+	return ls.onTypedError(errors.ToAutoscalerError(errType, err))
+}
+
+func (ls *loopState) onEmptyCluster(kind string, emitEvent bool) bool {
+	ls.autoscaler.scaleDown.CleanUpUnneededNodes()
+	UpdateEmptyClusterStateMetrics()
+
+	status := fmt.Sprintf("Cluster has no %v.", kind)
+	if ls.context.WriteStatusConfigMap {
+		utils.WriteStatusConfigMap(ls.context.ClientSet, ls.context.ConfigNamespace, status, ls.context.LogRecorder)
+	}
+	if emitEvent {
+		ls.context.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", status)
+	}
+	glog.Warningf("No %v in the cluster", kind)
+	// not setting ls.retError on purpose
+	return false
+}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -21,13 +21,10 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/pods"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
 
 	apiv1 "k8s.io/api/core/v1"
 	kube_client "k8s.io/client-go/kubernetes"
@@ -111,290 +108,30 @@ func (a *StaticAutoscaler) cleanUpIfRequired() {
 func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError {
 	a.cleanUpIfRequired()
 
-	readyNodeLister := a.ReadyNodeLister()
-	allNodeLister := a.AllNodeLister()
-	unschedulablePodLister := a.UnschedulablePodLister()
-	scheduledPodLister := a.ScheduledPodLister()
-	pdbLister := a.PodDisruptionBudgetLister()
-	scaleDown := a.scaleDown
-	autoscalingContext := a.AutoscalingContext
-	runStart := time.Now()
-
+	// TODO(kgolab) - introduce a factory?
+	handler := NewLoopStateHandler(a, currentTime)
 	glog.V(4).Info("Starting main loop")
 
-	err := autoscalingContext.CloudProvider.Refresh()
-	if err != nil {
-		glog.Errorf("Failed to refresh cloud provider config: %v", err)
-		return errors.ToAutoscalerError(errors.CloudProviderError, err)
+	if !handler.RefreshState() {
+		return handler.ReturnError()
 	}
-
-	allNodes, err := allNodeLister.List()
-	if err != nil {
-		glog.Errorf("Failed to list all nodes: %v", err)
-		return errors.ToAutoscalerError(errors.ApiCallError, err)
-	}
-	if len(allNodes) == 0 {
-		glog.Warningf("No nodes in the cluster")
-		scaleDown.CleanUpUnneededNodes()
-		UpdateEmptyClusterStateMetrics()
-		if autoscalingContext.WriteStatusConfigMap {
-			status := "Cluster has no nodes."
-			utils.WriteStatusConfigMap(autoscalingContext.ClientSet, autoscalingContext.ConfigNamespace, status, a.AutoscalingContext.LogRecorder)
-		}
-		autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster has no nodes")
-		return nil
-	}
-
-	readyNodes, err := readyNodeLister.List()
-	if err != nil {
-		glog.Errorf("Failed to list ready nodes: %v", err)
-		return errors.ToAutoscalerError(errors.ApiCallError, err)
-	}
-	// Handle GPU case - allocatable GPU may be equal to 0 up to 15 minutes after
-	// node registers as ready. See https://github.com/kubernetes/kubernetes/issues/54959
-	// Treat those nodes as unready until GPU actually becomes available and let
-	// our normal handling for booting up nodes deal with this.
-	// TODO: Remove this call when we handle dynamically provisioned resources.
-	allNodes, readyNodes = gpu.FilterOutNodesWithUnreadyGpus(allNodes, readyNodes)
-	if len(readyNodes) == 0 {
-		glog.Warningf("No ready nodes in the cluster")
-		scaleDown.CleanUpUnneededNodes()
-		UpdateEmptyClusterStateMetrics()
-		if autoscalingContext.WriteStatusConfigMap {
-			status := "Cluster has no ready nodes."
-			utils.WriteStatusConfigMap(autoscalingContext.ClientSet, autoscalingContext.ConfigNamespace, status, a.AutoscalingContext.LogRecorder)
-		}
-		// Cluster Autoscaler may start running before nodes are ready.
-		// Timeout ensures no ClusterUnhealthy events are published immediately in this case.
-		if currentTime.After(a.startTime.Add(nodesNotReadyAfterStartTimeout)) {
-			autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster has no ready nodes")
-		}
-		return nil
-	}
-
-	err = a.ClusterStateRegistry.UpdateNodes(allNodes, currentTime)
-	if err != nil {
-		glog.Errorf("Failed to update node registry: %v", err)
-		scaleDown.CleanUpUnneededNodes()
-		return errors.ToAutoscalerError(errors.CloudProviderError, err)
-	}
-	UpdateClusterStateMetrics(a.ClusterStateRegistry)
 
 	// Update status information when the loop is done (regardless of reason)
 	defer func() {
-		if autoscalingContext.WriteStatusConfigMap {
+		if a.AutoscalingContext.WriteStatusConfigMap {
 			status := a.ClusterStateRegistry.GetStatus(currentTime)
-			utils.WriteStatusConfigMap(autoscalingContext.ClientSet, autoscalingContext.ConfigNamespace,
+			utils.WriteStatusConfigMap(a.AutoscalingContext.ClientSet, a.AutoscalingContext.ConfigNamespace,
 				status.GetReadableString(), a.AutoscalingContext.LogRecorder)
 		}
 	}()
-	// Check if there are any nodes that failed to register in Kubernetes
-	// master.
-	unregisteredNodes := a.ClusterStateRegistry.GetUnregisteredNodes()
-	if len(unregisteredNodes) > 0 {
-		glog.V(1).Infof("%d unregistered nodes present", len(unregisteredNodes))
-		removedAny, err := removeOldUnregisteredNodes(unregisteredNodes, autoscalingContext, currentTime, autoscalingContext.LogRecorder)
-		// There was a problem with removing unregistered nodes. Retry in the next loop.
-		if err != nil {
-			if removedAny {
-				glog.Warningf("Some unregistered nodes were removed, but got error: %v", err)
-			} else {
-				glog.Errorf("Failed to remove unregistered nodes: %v", err)
 
-			}
-			return errors.ToAutoscalerError(errors.CloudProviderError, err)
-		}
-		// Some nodes were removed. Let's skip this iteration, the next one should be better.
-		if removedAny {
-			glog.V(0).Infof("Some unregistered nodes were removed, skipping iteration")
-			return nil
-		}
-	}
-	if !a.ClusterStateRegistry.IsClusterHealthy() {
-		glog.Warning("Cluster is not ready for autoscaling")
-		scaleDown.CleanUpUnneededNodes()
-		autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster is unhealthy")
-		return nil
-	}
+	// lazy evaluation to abort as soon as required
+	_ = handler.CheckPreconditions() &&
+		handler.PreparePodData() &&
+		handler.ScaleUp() &&
+		handler.ScaleDown()
 
-	metrics.UpdateDurationFromStart(metrics.UpdateState, runStart)
-	metrics.UpdateLastTime(metrics.Autoscaling, time.Now())
-
-	// Check if there has been a constant difference between the number of nodes in k8s and
-	// the number of nodes on the cloud provider side.
-	// TODO: andrewskim - add protection for ready AWS nodes.
-	fixedSomething, err := fixNodeGroupSize(autoscalingContext, currentTime)
-	if err != nil {
-		glog.Errorf("Failed to fix node group sizes: %v", err)
-		return errors.ToAutoscalerError(errors.CloudProviderError, err)
-	}
-	if fixedSomething {
-		glog.V(0).Infof("Some node group target size was fixed, skipping the iteration")
-		return nil
-	}
-
-	allUnschedulablePods, err := unschedulablePodLister.List()
-	if err != nil {
-		glog.Errorf("Failed to list unscheduled pods: %v", err)
-		return errors.ToAutoscalerError(errors.ApiCallError, err)
-	}
-	metrics.UpdateUnschedulablePodsCount(len(allUnschedulablePods))
-
-	allScheduled, err := scheduledPodLister.List()
-	if err != nil {
-		glog.Errorf("Failed to list scheduled pods: %v", err)
-		return errors.ToAutoscalerError(errors.ApiCallError, err)
-	}
-
-	allUnschedulablePods, allScheduled, err = a.podListProcessor.Process(a.AutoscalingContext, allUnschedulablePods, allScheduled, allNodes)
-	if err != nil {
-		glog.Errorf("Failed to process pod list: %v", err)
-		return errors.ToAutoscalerError(errors.InternalError, err)
-	}
-
-	ConfigurePredicateCheckerForLoop(allUnschedulablePods, allScheduled, a.PredicateChecker)
-
-	// We need to check whether pods marked as unschedulable are actually unschedulable.
-	// It's likely we added a new node and the scheduler just haven't managed to put the
-	// pod on in yet. In this situation we don't want to trigger another scale-up.
-	//
-	// It's also important to prevent uncontrollable cluster growth if CA's simulated
-	// scheduler differs in opinion with real scheduler. Example of such situation:
-	// - CA and Scheduler has slightly different configuration
-	// - Scheduler can't schedule a pod and marks it as unschedulable
-	// - CA added a node which should help the pod
-	// - Scheduler doesn't schedule the pod on the new node
-	//   because according to it logic it doesn't fit there
-	// - CA see the pod is still unschedulable, so it adds another node to help it
-	//
-	// With the check enabled the last point won't happen because CA will ignore a pod
-	// which is supposed to schedule on an existing node.
-	scaleDownForbidden := false
-
-	unschedulablePodsWithoutTPUs := tpu.ClearTPURequests(allUnschedulablePods)
-
-	// Some unschedulable pods can be waiting for lower priority pods preemption so they have nominated node to run.
-	// Such pods don't require scale up but should be considered during scale down.
-	unschedulablePods, unschedulableWaitingForLowerPriorityPreemption := FilterOutExpendableAndSplit(unschedulablePodsWithoutTPUs, a.ExpendablePodsPriorityCutoff)
-
-	glog.V(4).Infof("Filtering out schedulables")
-	filterOutSchedulableStart := time.Now()
-	unschedulablePodsToHelp := FilterOutSchedulable(unschedulablePods, readyNodes, allScheduled,
-		unschedulableWaitingForLowerPriorityPreemption, a.PredicateChecker, a.ExpendablePodsPriorityCutoff)
-	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, filterOutSchedulableStart)
-
-	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
-		glog.V(2).Info("Schedulable pods present")
-		scaleDownForbidden = true
-	} else {
-		glog.V(4).Info("No schedulable pods")
-	}
-
-	if len(unschedulablePodsToHelp) == 0 {
-		glog.V(1).Info("No unschedulable pods")
-	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
-		glog.V(1).Info("Max total nodes in cluster reached")
-	} else if allPodsAreNew(unschedulablePodsToHelp, currentTime) {
-		// The assumption here is that these pods have been created very recently and probably there
-		// is more pods to come. In theory we could check the newest pod time but then if pod were created
-		// slowly but at the pace of 1 every 2 seconds then no scale up would be triggered for long time.
-		// We also want to skip a real scale down (just like if the pods were handled).
-		scaleDownForbidden = true
-		glog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
-	} else {
-		daemonsets, err := a.ListerRegistry.DaemonSetLister().List()
-		if err != nil {
-			glog.Errorf("Failed to get daemonset list")
-			return errors.ToAutoscalerError(errors.ApiCallError, err)
-		}
-
-		scaleUpStart := time.Now()
-		metrics.UpdateLastTime(metrics.ScaleUp, scaleUpStart)
-
-		scaledUp, typedErr := ScaleUp(autoscalingContext, unschedulablePodsToHelp, readyNodes, daemonsets)
-
-		metrics.UpdateDurationFromStart(metrics.ScaleUp, scaleUpStart)
-
-		if typedErr != nil {
-			glog.Errorf("Failed to scale up: %v", typedErr)
-			return typedErr
-		} else if scaledUp {
-			a.lastScaleUpTime = currentTime
-			// No scale down in this iteration.
-			return nil
-		}
-	}
-
-	if a.ScaleDownEnabled {
-		pdbs, err := pdbLister.List()
-		if err != nil {
-			glog.Errorf("Failed to list pod disruption budgets: %v", err)
-			return errors.ToAutoscalerError(errors.ApiCallError, err)
-		}
-
-		unneededStart := time.Now()
-
-		glog.V(4).Infof("Calculating unneeded nodes")
-
-		scaleDown.CleanUp(currentTime)
-		potentiallyUnneeded := getPotentiallyUnneededNodes(autoscalingContext, allNodes)
-
-		typedErr := scaleDown.UpdateUnneededNodes(allNodes, potentiallyUnneeded, append(allScheduled, unschedulableWaitingForLowerPriorityPreemption...), currentTime, pdbs)
-		if typedErr != nil {
-			glog.Errorf("Failed to scale down: %v", typedErr)
-			return typedErr
-		}
-
-		metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
-
-		for key, val := range scaleDown.unneededNodes {
-			if glog.V(4) {
-				glog.V(4).Infof("%s is unneeded since %s duration %s", key, val.String(), currentTime.Sub(val).String())
-			}
-		}
-
-		// In dry run only utilization is updated
-		calculateUnneededOnly := scaleDownForbidden ||
-			a.lastScaleUpTime.Add(a.ScaleDownDelayAfterAdd).After(currentTime) ||
-			a.lastScaleDownFailTime.Add(a.ScaleDownDelayAfterFailure).After(currentTime) ||
-			a.lastScaleDownDeleteTime.Add(a.ScaleDownDelayAfterDelete).After(currentTime) ||
-			scaleDown.nodeDeleteStatus.IsDeleteInProgress()
-
-		glog.V(4).Infof("Scale down status: unneededOnly=%v lastScaleUpTime=%s "+
-			"lastScaleDownDeleteTime=%v lastScaleDownFailTime=%s scaleDownForbidden=%v isDeleteInProgress=%v",
-			calculateUnneededOnly, a.lastScaleUpTime, a.lastScaleDownDeleteTime, a.lastScaleDownFailTime,
-			scaleDownForbidden, scaleDown.nodeDeleteStatus.IsDeleteInProgress())
-
-		if !calculateUnneededOnly {
-			glog.V(4).Infof("Starting scale down")
-
-			// We want to delete unneeded Node Groups only if there was no recent scale up,
-			// and there is no current delete in progress and there was no recent errors.
-			if a.AutoscalingContext.NodeAutoprovisioningEnabled {
-				err := cleanUpNodeAutoprovisionedGroups(a.AutoscalingContext.CloudProvider, a.AutoscalingContext.LogRecorder)
-				if err != nil {
-					glog.Warningf("Failed to clean up unneeded node groups: %v", err)
-				}
-			}
-
-			scaleDownStart := time.Now()
-			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
-			result, typedErr := scaleDown.TryToScaleDown(allNodes, allScheduled, pdbs, currentTime)
-			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
-
-			// TODO: revisit result handling
-			if typedErr != nil {
-				glog.Errorf("Failed to scale down: %v", err)
-				return typedErr
-			}
-			if result == ScaleDownError {
-				a.lastScaleDownFailTime = currentTime
-			} else if result == ScaleDownNodeDeleted {
-				a.lastScaleDownDeleteTime = currentTime
-			}
-		}
-	}
-	return nil
+	return handler.ReturnError()
 }
 
 // ExitCleanUp removes status configmap.


### PR DESCRIPTION
Please have a look whether we can use the initial commit or do we really need the error-handling boilerplate to make the code look more like a "normal" go.