### PR TITLE
AWS: Reduce amount of API calls significantly 

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -26,7 +26,6 @@ import (
 
 // autoScaling is the interface represents a specific aspect of the auto-scaling service provided by AWS SDK for use in CA
 type autoScaling interface {
-	DescribeAutoScalingGroups(input *autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
 	DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoScalingGroupsInput, fn func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error
 	DescribeLaunchConfigurations(*autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error)
 	DescribeTagsPages(input *autoscaling.DescribeTagsInput, fn func(*autoscaling.DescribeTagsOutput, bool) bool) error
@@ -56,22 +55,6 @@ func (m autoScalingWrapper) getInstanceTypeByLCName(name string) (string, error)
 	return *launchConfigurations.LaunchConfigurations[0].InstanceType, nil
 }
 
-func (m autoScalingWrapper) getAutoscalingGroupByName(name string) (*autoscaling.Group, error) {
-	params := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{aws.String(name)},
-		MaxRecords:            aws.Int64(1),
-	}
-	groups, err := m.DescribeAutoScalingGroups(params)
-	if err != nil {
-		glog.V(4).Infof("Failed ASG info request for %s: %v", name, err)
-		return nil, err
-	}
-	if len(groups.AutoScalingGroups) < 1 {
-		return nil, fmt.Errorf("Unable to get first autoscaling.Group for %s", name)
-	}
-	return groups.AutoScalingGroups[0], nil
-}
-
 func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*autoscaling.Group, error) {
 	if len(names) == 0 {
 		return nil, nil
@@ -92,7 +75,7 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*aut
 	return asgs, nil
 }
 
-func (m *autoScalingWrapper) getAutoscalingGroupsByTags(kvs map[string]string) ([]*autoscaling.Group, error) {
+func (m *autoScalingWrapper) getAutoscalingGroupNamesByTags(kvs map[string]string) ([]string, error) {
 	// DescribeTags does an OR query when multiple filters on different tags are
 	// specified. In other words, DescribeTags returns [asg1, asg1] for keys
 	// [t1, t2] when there's only one asg tagged both t1 and t2.
@@ -140,5 +123,5 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByTags(kvs map[string]string) (
 		asgNameOccurrences[asgName] = occurrences
 	}
 
-	return m.getAutoscalingGroupsByNames(asgNames)
+	return asgNames, nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -20,79 +20,114 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"
 )
 
 const scaleToZeroSupported = true
 
 type asgCache struct {
-	registeredAsgs     []*asgInformation
-	instanceToAsg      map[AwsRef]*Asg
-	notInRegisteredAsg map[AwsRef]bool
-	mutex              sync.Mutex
-	service            autoScalingWrapper
-	interrupt          chan struct{}
+	registeredAsgs []*asg
+	asgToInstances map[AwsRef][]AwsInstanceRef
+	instanceToAsg  map[AwsInstanceRef]*asg
+	mutex          sync.Mutex
+	service        autoScalingWrapper
+	interrupt      chan struct{}
+
+	asgAutoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig
+	explicitlyConfigured  map[AwsRef]bool
 }
 
-func newASGCache(service autoScalingWrapper) (*asgCache, error) {
+type asg struct {
+	AwsRef
+
+	minSize int
+	maxSize int
+	curSize int
+
+	AvailabilityZones       []string
+	LaunchConfigurationName string
+	Tags                    []*autoscaling.TagDescription
+}
+
+func newASGCache(service autoScalingWrapper, explicitSpecs []string, autoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig) (*asgCache, error) {
 	registry := &asgCache{
-		registeredAsgs:     make([]*asgInformation, 0),
-		service:            service,
-		instanceToAsg:      make(map[AwsRef]*Asg),
-		notInRegisteredAsg: make(map[AwsRef]bool),
-		interrupt:          make(chan struct{}),
+		registeredAsgs:        make([]*asg, 0),
+		service:               service,
+		asgToInstances:        make(map[AwsRef][]AwsInstanceRef),
+		instanceToAsg:         make(map[AwsInstanceRef]*asg),
+		interrupt:             make(chan struct{}),
+		asgAutoDiscoverySpecs: autoDiscoverySpecs,
+		explicitlyConfigured:  make(map[AwsRef]bool),
 	}
-	go wait.Until(func() {
-		registry.mutex.Lock()
-		defer registry.mutex.Unlock()
-		if err := registry.regenerate(); err != nil {
-			glog.Errorf("Error while regenerating Asg cache: %v", err)
-		}
-	}, time.Hour, registry.interrupt)
+
+	if err := registry.parseExplicitAsgs(explicitSpecs); err != nil {
+		return nil, err
+	}
 
 	return registry, nil
 }
 
-// Register ASG. Returns true if the ASG was registered.
-func (m *asgCache) Register(asg *Asg) bool {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
+// Fetch explicitly configured ASGs. These ASGs should never be unregistered
+// during refreshes, even if they no longer exist in AWS.
+func (m *asgCache) parseExplicitAsgs(specs []string) error {
+	for _, spec := range specs {
+		asg, err := m.buildAsgFromSpec(spec)
+		if err != nil {
+			return fmt.Errorf("failed to parse node group spec: %v", err)
+		}
+		m.explicitlyConfigured[asg.AwsRef] = true
+		m.register(asg)
+	}
 
+	return nil
+}
+
+// Register ASG. Returns true if the ASG was registered.
+func (m *asgCache) register(asg *asg) bool {
 	for i := range m.registeredAsgs {
-		if existing := m.registeredAsgs[i].config; existing.AwsRef == asg.AwsRef {
+		if existing := m.registeredAsgs[i]; existing.AwsRef == asg.AwsRef {
 			if reflect.DeepEqual(existing, asg) {
 				return false
 			}
-			m.registeredAsgs[i].config = asg
-			glog.V(4).Infof("Updated ASG %s", asg.AwsRef.Name)
-			m.invalidateUnownedInstanceCache()
+
+			glog.V(4).Infof("Updating ASG %s", asg.AwsRef.Name)
+
+			// Explicit registered groups should always use the manually provided min/max
+			// values and the not the ones returned by the API
+			if !m.explicitlyConfigured[asg.AwsRef] {
+				existing.minSize = asg.minSize
+				existing.maxSize = asg.maxSize
+			}
+
+			existing.curSize = asg.curSize
+
+			// Those information are mainly required to create templates when scaling
+			// from zero
+			existing.AvailabilityZones = asg.AvailabilityZones
+			existing.LaunchConfigurationName = asg.LaunchConfigurationName
+			existing.Tags = asg.Tags
+
 			return true
 		}
 	}
-
 	glog.V(1).Infof("Registering ASG %s", asg.AwsRef.Name)
-	m.registeredAsgs = append(m.registeredAsgs, &asgInformation{
-		config: asg,
-	})
-	m.invalidateUnownedInstanceCache()
+	m.registeredAsgs = append(m.registeredAsgs, asg)
 	return true
 }
 
 // Unregister ASG. Returns true if the ASG was unregistered.
-func (m *asgCache) Unregister(asg *Asg) bool {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	updated := make([]*asgInformation, 0, len(m.registeredAsgs))
+func (m *asgCache) unregister(a *asg) bool {
+	updated := make([]*asg, 0, len(m.registeredAsgs))
 	changed := false
 	for _, existing := range m.registeredAsgs {
-		if existing.config.AwsRef == asg.AwsRef {
-			glog.V(1).Infof("Unregistered ASG %s", asg.AwsRef.Name)
+		if existing.AwsRef == a.AwsRef {
+			glog.V(1).Infof("Unregistered ASG %s", a.AwsRef.Name)
 			changed = true
 			continue
 		}
@@ -102,7 +137,21 @@ func (m *asgCache) Unregister(asg *Asg) bool {
 	return changed
 }
 
-func (m *asgCache) get() []*asgInformation {
+func (m *asgCache) buildAsgFromSpec(spec string) (*asg, error) {
+	s, err := dynamic.SpecFromString(spec, scaleToZeroSupported)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
+	}
+	asg := &asg{
+		AwsRef:  AwsRef{Name: s.Name},
+		minSize: s.MinSize,
+		maxSize: s.MaxSize,
+	}
+	return asg, nil
+}
+
+// Get returns the currently registered ASGs
+func (m *asgCache) Get() []*asg {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -110,60 +159,156 @@ func (m *asgCache) get() []*asgInformation {
 }
 
 // FindForInstance returns AsgConfig of the given Instance
-func (m *asgCache) FindForInstance(instance *AwsRef) (*Asg, error) {
-	// TODO(negz): Prevent this calling describe ASGs too often.
+func (m *asgCache) FindForInstance(instance AwsInstanceRef) *asg {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if m.notInRegisteredAsg[*instance] {
-		// We already know we don't own this instance. Return early and avoid
-		// additional calls to describe ASGs.
-		return nil, nil
+	if asg, found := m.instanceToAsg[instance]; found {
+		return asg
 	}
 
-	if config, found := m.instanceToAsg[*instance]; found {
-		return config, nil
-	}
-	if err := m.regenerate(); err != nil {
-		return nil, fmt.Errorf("Error while looking for ASG for instance %+v, error: %v", *instance, err)
-	}
-	if config, found := m.instanceToAsg[*instance]; found {
-		return config, nil
-	}
-
-	m.notInRegisteredAsg[*instance] = true
-	return nil, nil
+	return nil
 }
 
-func (m *asgCache) invalidateUnownedInstanceCache() {
-	glog.V(4).Info("Invalidating unowned instance cache")
-	m.notInRegisteredAsg = make(map[AwsRef]bool)
+// InstancesByAsg returns the nodes of an ASG
+func (m *asgCache) InstancesByAsg(ref AwsRef) ([]AwsInstanceRef, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if instances, found := m.asgToInstances[ref]; found {
+		return instances, nil
+	}
+
+	return nil, fmt.Errorf("Error while looking for instances of ASG: %s", ref)
 }
 
+// Fetch automatically discovered ASGs. These ASGs should be unregistered if
+// they no longer exist in AWS.
+func (m *asgCache) fetchAutoAsgNames() ([]string, error) {
+	groupNames := make([]string, 0)
+
+	for _, spec := range m.asgAutoDiscoverySpecs {
+		names, err := m.service.getAutoscalingGroupNamesByTags(spec.Tags)
+		if err != nil {
+			return nil, fmt.Errorf("cannot autodiscover ASGs: %s", err)
+		}
+
+		groupNames = append(groupNames, names...)
+	}
+
+	return groupNames, nil
+}
+
+func (m *asgCache) buildAsgNames() ([]string, error) {
+	// Collect explicitly specified names
+	refreshNames := make([]string, len(m.explicitlyConfigured))
+	i := 0
+	for k := range m.explicitlyConfigured {
+		refreshNames[i] = k.Name
+		i++
+	}
+
+	// Append auto-discovered names
+	autoDiscoveredNames, err := m.fetchAutoAsgNames()
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range autoDiscoveredNames {
+		autoRef := AwsRef{Name: name}
+
+		if m.explicitlyConfigured[autoRef] {
+			// This ASG was already explicitly configured, we only need to fetch it once
+			continue
+		}
+
+		refreshNames = append(refreshNames, name)
+	}
+
+	return refreshNames, nil
+}
+
+// regenerate the cached view of explicitly configured and auto-discovered ASGs
 func (m *asgCache) regenerate() error {
-	newCache := make(map[AwsRef]*Asg)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
-	names := make([]string, len(m.registeredAsgs))
-	configs := make(map[string]*Asg)
-	for i, asg := range m.registeredAsgs {
-		names[i] = asg.config.Name
-		configs[asg.config.Name] = asg.config
-	}
+	newInstanceToAsgCache := make(map[AwsInstanceRef]*asg)
+	newAsgToInstancesCache := make(map[AwsRef][]AwsInstanceRef)
 
-	glog.V(4).Infof("Regenerating instance to ASG map for ASGs: %v", names)
-	groups, err := m.service.getAutoscalingGroupsByNames(names)
+	// Build list of knowns ASG names
+	refreshNames, err := m.buildAsgNames()
 	if err != nil {
 		return err
 	}
+
+	// Fetch details of all ASGs
+	glog.V(4).Infof("Regenerating instance to ASG map for ASGs: %v", refreshNames)
+	groups, err := m.service.getAutoscalingGroupsByNames(refreshNames)
+	if err != nil {
+		return err
+	}
+
+	// Register or update ASGs
+	exists := make(map[AwsRef]bool)
 	for _, group := range groups {
-		for _, instance := range group.Instances {
-			ref := AwsRef{Name: aws.StringValue(instance.InstanceId)}
-			newCache[ref] = configs[aws.StringValue(group.AutoScalingGroupName)]
+		asg, err := m.buildAsgFromAWS(group)
+		if err != nil {
+			return err
+		}
+		exists[asg.AwsRef] = true
+
+		m.register(asg)
+
+		newAsgToInstancesCache[asg.AwsRef] = make([]AwsInstanceRef, len(group.Instances))
+
+		for i, instance := range group.Instances {
+			ref := m.buildInstanceRefFromAWS(instance)
+			newInstanceToAsgCache[ref] = asg
+			newAsgToInstancesCache[asg.AwsRef][i] = ref
 		}
 	}
 
-	m.instanceToAsg = newCache
+	// Unregister no longer existing auto-discovered ASGs
+	for _, asg := range m.registeredAsgs {
+		if !exists[asg.AwsRef] && !m.explicitlyConfigured[asg.AwsRef] {
+			m.unregister(asg)
+		}
+	}
+
+	m.asgToInstances = newAsgToInstancesCache
+	m.instanceToAsg = newInstanceToAsgCache
 	return nil
+}
+
+func (m *asgCache) buildAsgFromAWS(g *autoscaling.Group) (*asg, error) {
+	spec := dynamic.NodeGroupSpec{
+		Name:               aws.StringValue(g.AutoScalingGroupName),
+		MinSize:            int(aws.Int64Value(g.MinSize)),
+		MaxSize:            int(aws.Int64Value(g.MaxSize)),
+		SupportScaleToZero: scaleToZeroSupported,
+	}
+	if verr := spec.Validate(); verr != nil {
+		return nil, fmt.Errorf("failed to create node group spec: %v", verr)
+	}
+	asg := &asg{
+		AwsRef:  AwsRef{Name: spec.Name},
+		minSize: spec.MinSize,
+		maxSize: spec.MaxSize,
+
+		curSize:                 int(aws.Int64Value(g.DesiredCapacity)),
+		AvailabilityZones:       aws.StringValueSlice(g.AvailabilityZones),
+		LaunchConfigurationName: aws.StringValue(g.LaunchConfigurationName),
+		Tags: g.Tags,
+	}
+	return asg, nil
+}
+
+func (m *asgCache) buildInstanceRefFromAWS(instance *autoscaling.Instance) AwsInstanceRef {
+	providerID := fmt.Sprintf("aws:///%s/%s", aws.StringValue(instance.AvailabilityZone), aws.StringValue(instance.InstanceId))
+	return AwsInstanceRef{
+		ProviderID: providerID,
+		Name:       aws.StringValue(instance.InstanceId),
+	}
 }
 
 // Cleanup closes the channel to signal the go routine to stop that is handling the cache

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildAsg(t *testing.T) {
+	asgCache := &asgCache{}
+
+	asg, err := asgCache.buildAsgFromSpec("1:5:test-asg")
+	assert.NoError(t, err)
+	assert.Equal(t, asg.minSize, 1)
+	assert.Equal(t, asg.maxSize, 5)
+	assert.Equal(t, asg.Name, "test-asg")
+
+	_, err = asgCache.buildAsgFromSpec("a")
+	assert.Error(t, err)
+	_, err = asgCache.buildAsgFromSpec("a:b:c")
+	assert.Error(t, err)
+	_, err = asgCache.buildAsgFromSpec("1:")
+	assert.Error(t, err)
+	_, err = asgCache.buildAsgFromSpec("1:2:")
+	assert.Error(t, err)
+}
+
+func validateAsg(t *testing.T, asg *asg, name string, minSize int, maxSize int) {
+	assert.Equal(t, name, asg.Name)
+	assert.Equal(t, minSize, asg.minSize)
+	assert.Equal(t, maxSize, asg.maxSize)
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -59,22 +59,17 @@ func (aws *awsCloudProvider) Name() string {
 	return ProviderName
 }
 
-func (aws *awsCloudProvider) asgs() []*Asg {
-	infos := aws.awsManager.getAsgs()
-	asgs := make([]*Asg, len(infos))
-	for i, info := range infos {
-		asgs[i] = info.config
-	}
-	return asgs
-}
-
 // NodeGroups returns all node groups configured for this cloud provider.
 func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	asgs := aws.awsManager.getAsgs()
 	ngs := make([]cloudprovider.NodeGroup, len(asgs))
 	for i, asg := range asgs {
-		ngs[i] = asg.config
+		ngs[i] = &AwsNodeGroup{
+			asg:        asg,
+			awsManager: aws.awsManager,
+		}
 	}
+
 	return ngs
 }
 
@@ -84,8 +79,16 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	if err != nil {
 		return nil, err
 	}
-	asg, err := aws.awsManager.GetAsgForInstance(ref)
-	return asg, err
+	asg := aws.awsManager.GetAsgForInstance(*ref)
+
+	if asg == nil {
+		return nil, nil
+	}
+
+	return &AwsNodeGroup{
+		asg:        asg,
+		awsManager: aws.awsManager,
+	}, nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
@@ -116,87 +119,86 @@ func (aws *awsCloudProvider) Refresh() error {
 	return aws.awsManager.Refresh()
 }
 
-// AwsRef contains a reference to some entity in AWS/GKE world.
+// AwsRef contains a reference to some entity in AWS world.
 type AwsRef struct {
 	Name string
+}
+
+// AwsInstanceRef contains a reference to an instance in the AWS world.
+type AwsInstanceRef struct {
+	ProviderID string
+	Name       string
 }
 
 var validAwsRefIdRegex = regexp.MustCompile(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*$`)
 
 // AwsRefFromProviderId creates InstanceConfig object from provider id which
 // must be in format: aws:///zone/name
-func AwsRefFromProviderId(id string) (*AwsRef, error) {
+func AwsRefFromProviderId(id string) (*AwsInstanceRef, error) {
 	if validAwsRefIdRegex.FindStringSubmatch(id) == nil {
 		return nil, fmt.Errorf("Wrong id: expected format aws:///<zone>/<name>, got %v", id)
 	}
 	splitted := strings.Split(id[7:], "/")
-	return &AwsRef{
-		Name: splitted[1],
+	return &AwsInstanceRef{
+		ProviderID: id,
+		Name:       splitted[1],
 	}, nil
 }
 
-// Asg implements NodeGroup interface.
-type Asg struct {
-	AwsRef
-
+// AwsNodeGroup implements NodeGroup interface.
+type AwsNodeGroup struct {
 	awsManager *AwsManager
-
-	minSize int
-	maxSize int
+	asg        *asg
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *Asg) MaxSize() int {
-	return asg.maxSize
+func (ng *AwsNodeGroup) MaxSize() int {
+	return ng.asg.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *Asg) MinSize() int {
-	return asg.minSize
+func (ng *AwsNodeGroup) MinSize() int {
+	return ng.asg.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (asg *Asg) TargetSize() (int, error) {
-	size, err := asg.awsManager.GetAsgSize(asg)
-	return int(size), err
+func (ng *AwsNodeGroup) TargetSize() (int, error) {
+	return ng.asg.curSize, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (asg *Asg) Exist() bool {
+func (ng *AwsNodeGroup) Exist() bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (asg *Asg) Create() error {
+func (ng *AwsNodeGroup) Create() error {
 	return cloudprovider.ErrAlreadyExist
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (asg *Asg) Autoprovisioned() bool {
+func (ng *AwsNodeGroup) Autoprovisioned() bool {
 	return false
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (asg *Asg) Delete() error {
+func (ng *AwsNodeGroup) Delete() error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // IncreaseSize increases Asg size
-func (asg *Asg) IncreaseSize(delta int) error {
+func (ng *AwsNodeGroup) IncreaseSize(delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
-	size, err := asg.awsManager.GetAsgSize(asg)
-	if err != nil {
-		return err
+	size := ng.asg.curSize
+	if size+delta > ng.asg.maxSize {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", size+delta, ng.asg.maxSize)
 	}
-	if int(size)+delta > asg.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, asg.MaxSize())
-	}
-	return asg.awsManager.SetAsgSize(asg, size+int64(delta))
+	return ng.awsManager.SetAsgSize(ng.asg, size+delta)
 }
 
 // DecreaseTargetSize decreases the target size of the node group. This function
@@ -204,15 +206,13 @@ func (asg *Asg) IncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (asg *Asg) DecreaseTargetSize(delta int) error {
+func (ng *AwsNodeGroup) DecreaseTargetSize(delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
 	}
-	size, err := asg.awsManager.GetAsgSize(asg)
-	if err != nil {
-		return err
-	}
-	nodes, err := asg.awsManager.GetAsgNodes(asg)
+
+	size := ng.asg.curSize
+	nodes, err := ng.awsManager.GetAsgNodes(ng.asg.AwsRef)
 	if err != nil {
 		return err
 	}
@@ -220,45 +220,39 @@ func (asg *Asg) DecreaseTargetSize(delta int) error {
 		return fmt.Errorf("attempt to delete existing nodes targetSize:%d delta:%d existingNodes: %d",
 			size, delta, len(nodes))
 	}
-	return asg.awsManager.SetAsgSize(asg, size+int64(delta))
+	return ng.awsManager.SetAsgSize(ng.asg, size+delta)
 }
 
 // Belongs returns true if the given node belongs to the NodeGroup.
-func (asg *Asg) Belongs(node *apiv1.Node) (bool, error) {
+func (ng *AwsNodeGroup) Belongs(node *apiv1.Node) (bool, error) {
 	ref, err := AwsRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return false, err
 	}
-	targetAsg, err := asg.awsManager.GetAsgForInstance(ref)
-	if err != nil {
-		return false, err
-	}
+	targetAsg := ng.awsManager.GetAsgForInstance(*ref)
 	if targetAsg == nil {
 		return false, fmt.Errorf("%s doesn't belong to a known asg", node.Name)
 	}
-	if targetAsg.Id() != asg.Id() {
+	if targetAsg.AwsRef != ng.asg.AwsRef {
 		return false, nil
 	}
 	return true, nil
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
-	size, err := asg.awsManager.GetAsgSize(asg)
-	if err != nil {
-		return err
-	}
-	if int(size) <= asg.MinSize() {
+func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+	size := ng.asg.curSize
+	if int(size) <= ng.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
-	refs := make([]*AwsRef, 0, len(nodes))
+	refs := make([]*AwsInstanceRef, 0, len(nodes))
 	for _, node := range nodes {
-		belongs, err := asg.Belongs(node)
+		belongs, err := ng.Belongs(node)
 		if err != nil {
 			return err
 		}
 		if belongs != true {
-			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, asg.Id())
+			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, ng.Id())
 		}
 		awsref, err := AwsRefFromProviderId(node.Spec.ProviderID)
 		if err != nil {
@@ -266,37 +260,47 @@ func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 		}
 		refs = append(refs, awsref)
 	}
-	return asg.awsManager.DeleteInstances(refs)
+	return ng.awsManager.DeleteInstances(refs)
 }
 
 // Id returns asg id.
-func (asg *Asg) Id() string {
-	return asg.Name
+func (ng *AwsNodeGroup) Id() string {
+	return ng.asg.Name
 }
 
 // Debug returns a debug string for the Asg.
-func (asg *Asg) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
+func (ng *AwsNodeGroup) Debug() string {
+	return fmt.Sprintf("%s (%d:%d)", ng.Id(), ng.MinSize(), ng.MaxSize())
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (asg *Asg) Nodes() ([]string, error) {
-	return asg.awsManager.GetAsgNodes(asg)
+func (ng *AwsNodeGroup) Nodes() ([]string, error) {
+	asgNodes, err := ng.awsManager.GetAsgNodes(ng.asg.AwsRef)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]string, len(asgNodes))
+
+	for i, asgNode := range asgNodes {
+		nodes[i] = asgNode.ProviderID
+	}
+	return nodes, nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (asg *Asg) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
-	template, err := asg.awsManager.getAsgTemplate(asg.Name)
+func (ng *AwsNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+	template, err := ng.awsManager.getAsgTemplate(ng.asg)
 	if err != nil {
 		return nil, err
 	}
 
-	node, err := asg.awsManager.buildNodeFromTemplate(asg, template)
+	node, err := ng.awsManager.buildNodeFromTemplate(ng.asg, template)
 	if err != nil {
 		return nil, err
 	}
 
-	nodeInfo := schedulercache.NewNodeInfo(cloudprovider.BuildKubeProxy(asg.Name))
+	nodeInfo := schedulercache.NewNodeInfo(cloudprovider.BuildKubeProxy(ng.asg.Name))
 	nodeInfo.SetNode(node)
 	return nodeInfo, nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	provider_aws "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
@@ -44,21 +43,14 @@ const (
 	operationWaitTimeout    = 5 * time.Second
 	operationPollInterval   = 100 * time.Millisecond
 	maxRecordsReturnedByAPI = 100
-	refreshInterval         = 1 * time.Minute
+	refreshInterval         = 10 * time.Second
 )
-
-type asgInformation struct {
-	config   *Asg
-	basename string
-}
 
 // AwsManager is handles aws communication and data caching.
 type AwsManager struct {
-	service               autoScalingWrapper
-	asgCache              *asgCache
-	lastRefresh           time.Time
-	asgAutoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig
-	explicitlyConfigured  map[AwsRef]bool
+	service     autoScalingWrapper
+	asgCache    *asgCache
+	lastRefresh time.Time
 }
 
 type asgTemplate struct {
@@ -88,25 +80,19 @@ func createAWSManagerInternal(
 		}
 	}
 
-	cache, err := newASGCache(*service)
-	if err != nil {
-		return nil, err
-	}
-
 	specs, err := discoveryOpts.ParseASGAutoDiscoverySpecs()
 	if err != nil {
 		return nil, err
 	}
 
-	manager := &AwsManager{
-		service:               *service,
-		asgCache:              cache,
-		asgAutoDiscoverySpecs: specs,
-		explicitlyConfigured:  make(map[AwsRef]bool),
+	cache, err := newASGCache(*service, discoveryOpts.NodeGroupSpecs, specs)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := manager.fetchExplicitAsgs(discoveryOpts.NodeGroupSpecs); err != nil {
-		return nil, err
+	manager := &AwsManager{
+		service:  *service,
+		asgCache: cache,
 	}
 
 	if err := manager.forceRefresh(); err != nil {
@@ -121,108 +107,6 @@ func CreateAwsManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 	return createAWSManagerInternal(configReader, discoveryOpts, nil)
 }
 
-// Fetch explicitly configured ASGs. These ASGs should never be unregistered
-// during refreshes, even if they no longer exist in AWS.
-func (m *AwsManager) fetchExplicitAsgs(specs []string) error {
-	changed := false
-	for _, spec := range specs {
-		asg, err := m.buildAsgFromSpec(spec)
-		if err != nil {
-			return fmt.Errorf("failed to parse node group spec: %v", err)
-		}
-		if m.RegisterAsg(asg) {
-			changed = true
-		}
-		m.explicitlyConfigured[asg.AwsRef] = true
-	}
-
-	if changed {
-		if err := m.regenerateCache(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *AwsManager) buildAsgFromSpec(spec string) (*Asg, error) {
-	s, err := dynamic.SpecFromString(spec, scaleToZeroSupported)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
-	}
-	asg := &Asg{
-		awsManager: m,
-		AwsRef:     AwsRef{Name: s.Name},
-		minSize:    s.MinSize,
-		maxSize:    s.MaxSize,
-	}
-	return asg, nil
-}
-
-// Fetch automatically discovered ASGs. These ASGs should be unregistered if
-// they no longer exist in AWS.
-func (m *AwsManager) fetchAutoAsgs() error {
-	exists := make(map[AwsRef]bool)
-	changed := false
-	for _, spec := range m.asgAutoDiscoverySpecs {
-		groups, err := m.getAutoscalingGroupsByTags(spec.Tags)
-		if err != nil {
-			return fmt.Errorf("cannot autodiscover ASGs: %s", err)
-		}
-		for _, g := range groups {
-			asg, err := m.buildAsgFromAWS(g)
-			if err != nil {
-				return err
-			}
-			exists[asg.AwsRef] = true
-			if m.explicitlyConfigured[asg.AwsRef] {
-				// This ASG was explicitly configured, but would also be
-				// autodiscovered. We want the explicitly configured min and max
-				// nodes to take precedence.
-				glog.V(3).Infof("Ignoring explicitly configured ASG %s for autodiscovery.", asg.AwsRef.Name)
-				continue
-			}
-			if m.RegisterAsg(asg) {
-				glog.V(3).Infof("Autodiscovered ASG %s using tags %v", asg.AwsRef.Name, spec.Tags)
-				changed = true
-			}
-		}
-	}
-
-	for _, asg := range m.getAsgs() {
-		if !exists[asg.config.AwsRef] && !m.explicitlyConfigured[asg.config.AwsRef] {
-			m.UnregisterAsg(asg.config)
-			changed = true
-		}
-	}
-
-	if changed {
-		if err := m.regenerateCache(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *AwsManager) buildAsgFromAWS(g *autoscaling.Group) (*Asg, error) {
-	spec := dynamic.NodeGroupSpec{
-		Name:               aws.StringValue(g.AutoScalingGroupName),
-		MinSize:            int(aws.Int64Value(g.MinSize)),
-		MaxSize:            int(aws.Int64Value(g.MaxSize)),
-		SupportScaleToZero: scaleToZeroSupported,
-	}
-	if verr := spec.Validate(); verr != nil {
-		return nil, fmt.Errorf("failed to create node group spec: %v", verr)
-	}
-	asg := &Asg{
-		awsManager: m,
-		AwsRef:     AwsRef{Name: spec.Name},
-		minSize:    spec.MinSize,
-		maxSize:    spec.MaxSize,
-	}
-	return asg, nil
-}
-
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 func (m *AwsManager) Refresh() error {
@@ -233,8 +117,8 @@ func (m *AwsManager) Refresh() error {
 }
 
 func (m *AwsManager) forceRefresh() error {
-	if err := m.fetchAutoAsgs(); err != nil {
-		glog.Errorf("Failed to fetch ASGs: %v", err)
+	if err := m.asgCache.regenerate(); err != nil {
+		glog.Errorf("Failed to regenerate ASG cache: %v", err)
 		return err
 	}
 	m.lastRefresh = time.Now()
@@ -242,29 +126,9 @@ func (m *AwsManager) forceRefresh() error {
 	return nil
 }
 
-func (m *AwsManager) getAsgs() []*asgInformation {
-	return m.asgCache.get()
-}
-
-// RegisterAsg registers an ASG.
-func (m *AwsManager) RegisterAsg(asg *Asg) bool {
-	return m.asgCache.Register(asg)
-}
-
-// UnregisterAsg unregisters an ASG.
-func (m *AwsManager) UnregisterAsg(asg *Asg) bool {
-	return m.asgCache.Unregister(asg)
-}
-
 // GetAsgForInstance returns AsgConfig of the given Instance
-func (m *AwsManager) GetAsgForInstance(instance *AwsRef) (*Asg, error) {
+func (m *AwsManager) GetAsgForInstance(instance AwsInstanceRef) *asg {
 	return m.asgCache.FindForInstance(instance)
-}
-
-func (m *AwsManager) regenerateCache() error {
-	m.asgCache.mutex.Lock()
-	defer m.asgCache.mutex.Unlock()
-	return m.asgCache.regenerate()
 }
 
 // Cleanup the ASG cache.
@@ -272,37 +136,18 @@ func (m *AwsManager) Cleanup() {
 	m.asgCache.Cleanup()
 }
 
-func (m *AwsManager) getAutoscalingGroupsByTags(tags map[string]string) ([]*autoscaling.Group, error) {
-	return m.service.getAutoscalingGroupsByTags(tags)
-}
-
-// GetAsgSize gets ASG size.
-func (m *AwsManager) GetAsgSize(asgConfig *Asg) (int64, error) {
-	params := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{aws.String(asgConfig.Name)},
-		MaxRecords:            aws.Int64(1),
-	}
-	groups, err := m.service.DescribeAutoScalingGroups(params)
-
-	if err != nil {
-		return -1, err
-	}
-
-	if len(groups.AutoScalingGroups) < 1 {
-		return -1, fmt.Errorf("Unable to get first autoscaling.Group for %s", asgConfig.Name)
-	}
-	asg := *groups.AutoScalingGroups[0]
-	return *asg.DesiredCapacity, nil
+func (m *AwsManager) getAsgs() []*asg {
+	return m.asgCache.Get()
 }
 
 // SetAsgSize sets ASG size.
-func (m *AwsManager) SetAsgSize(asg *Asg, size int64) error {
+func (m *AwsManager) SetAsgSize(asg *asg, size int) error {
 	params := &autoscaling.SetDesiredCapacityInput{
 		AutoScalingGroupName: aws.String(asg.Name),
-		DesiredCapacity:      aws.Int64(size),
+		DesiredCapacity:      aws.Int64(int64(size)),
 		HonorCooldown:        aws.Bool(false),
 	}
-	glog.V(0).Infof("Setting asg %s size to %d", asg.Id(), size)
+	glog.V(0).Infof("Setting asg %s size to %d", asg.Name, size)
 	_, err := m.service.SetDesiredCapacity(params)
 	if err != nil {
 		return err
@@ -311,21 +156,25 @@ func (m *AwsManager) SetAsgSize(asg *Asg, size int64) error {
 }
 
 // DeleteInstances deletes the given instances. All instances must be controlled by the same ASG.
-func (m *AwsManager) DeleteInstances(instances []*AwsRef) error {
+func (m *AwsManager) DeleteInstances(instances []*AwsInstanceRef) error {
 	if len(instances) == 0 {
 		return nil
 	}
-	commonAsg, err := m.asgCache.FindForInstance(instances[0])
-	if err != nil {
-		return err
+	commonAsg := m.asgCache.FindForInstance(*instances[0])
+	if commonAsg == nil {
+		return fmt.Errorf("can't delete instance %s, which is not part of an ASG", instances[0].Name)
 	}
+
 	for _, instance := range instances {
-		asg, err := m.asgCache.FindForInstance(instance)
-		if err != nil {
-			return err
-		}
+		asg := m.asgCache.FindForInstance(*instance)
+
 		if asg != commonAsg {
-			return fmt.Errorf("Connot delete instances which don't belong to the same ASG.")
+			instanceIds := make([]string, len(instances))
+			for i, instance := range instances {
+				instanceIds[i] = instance.Name
+			}
+
+			return fmt.Errorf("can't delete instances %s as they belong to at least two different ASGs (%s and %s)", strings.Join(instanceIds, ","), commonAsg.Name, asg.Name)
 		}
 	}
 
@@ -345,35 +194,21 @@ func (m *AwsManager) DeleteInstances(instances []*AwsRef) error {
 }
 
 // GetAsgNodes returns Asg nodes.
-func (m *AwsManager) GetAsgNodes(asg *Asg) ([]string, error) {
-	result := make([]string, 0)
-	group, err := m.service.getAutoscalingGroupByName(asg.Name)
-	if err != nil {
-		return []string{}, err
-	}
-	for _, instance := range group.Instances {
-		result = append(result,
-			fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
-	}
-	return result, nil
+func (m *AwsManager) GetAsgNodes(ref AwsRef) ([]AwsInstanceRef, error) {
+	return m.asgCache.InstancesByAsg(ref)
 }
 
-func (m *AwsManager) getAsgTemplate(name string) (*asgTemplate, error) {
-	asg, err := m.service.getAutoscalingGroupByName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	instanceTypeName, err := m.service.getInstanceTypeByLCName(*asg.LaunchConfigurationName)
+func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
+	instanceTypeName, err := m.service.getInstanceTypeByLCName(asg.LaunchConfigurationName)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(asg.AvailabilityZones) < 1 {
-		return nil, fmt.Errorf("Unable to get first AvailabilityZone for %s", name)
+		return nil, fmt.Errorf("Unable to get first AvailabilityZone for %s", asg.Name)
 	}
 
-	az := *asg.AvailabilityZones[0]
+	az := asg.AvailabilityZones[0]
 	region := az[0 : len(az)-1]
 
 	if len(asg.AvailabilityZones) > 1 {
@@ -388,7 +223,7 @@ func (m *AwsManager) getAsgTemplate(name string) (*asgTemplate, error) {
 	}, nil
 }
 
-func (m *AwsManager) buildNodeFromTemplate(asg *Asg, template *asgTemplate) (*apiv1.Node, error) {
+func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*apiv1.Node, error) {
 	node := apiv1.Node{}
 	nodeName := fmt.Sprintf("%s-asg-%d", asg.Name, rand.Int63())
 


### PR DESCRIPTION
Instead of doing auto-discovery, nodes per ASG and target size per ASG separately, fetch all
of those ASG details in a single request on each `Refresh()` with maximum 10 seconds granularity.

This reduced the amount of DescribeAutoScalingGroups API calls for our setup (3 ASGs / one per AZ) from ~55 calls / min to ~5 calls / min.

As the DescribeAutoScalingGroups supports up to 1600 members per call, this approach should be fairly scalable https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DescribeAutoScalingGroups.html and work for more complicated setups.

I'm still testing this PR with our clusters, but I can't see any major downsides in requesting an up-to-date status only every 10s vs. on-demand as the main loop isn't executed more frequently and its unlikely that ASG API is changing responses frequently, but I'm not sure that I understand all nuances of the code yet.

Technically I would be possible to keep the auto-discovery tag to ASG names matching at a 1 minute cadence, but I didn't though the added complexity is worth saving those 5 calls / min.

//cc @mumoshu @negz as you both worked on the AWS provider