### PR TITLE
Move ClusterStateRegistry to StaticAutoscaler

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
-	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
@@ -41,10 +40,9 @@ type AutoscalingContext struct {
 	CloudProvider cloudprovider.CloudProvider
 	// ClientSet interface.
 	ClientSet kube_client.Interface
-	// ClusterState for maintaining the state of cluster nodes.
-	ClusterStateRegistry *clusterstate.ClusterStateRegistry
 	// Recorder for recording events.
 	Recorder kube_record.EventRecorder
+	// TODO(kgolab) - move away too as it's not config
 	// PredicateChecker to check if a pod can fit into a node.
 	PredicateChecker *simulator.PredicateChecker
 	// ExpanderStrategy is the strategy used to choose which node group to expand when scaling up
@@ -154,22 +152,14 @@ func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulat
 		return nil, err
 	}
 
-	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
-		MaxTotalUnreadyPercentage: options.MaxTotalUnreadyPercentage,
-		OkTotalUnreadyCount:       options.OkTotalUnreadyCount,
-		MaxNodeProvisionTime:      options.MaxNodeProvisionTime,
-	}
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(cloudProvider, clusterStateConfig, logEventRecorder)
-
 	autoscalingContext := AutoscalingContext{
-		AutoscalingOptions:   options,
-		CloudProvider:        cloudProvider,
-		ClusterStateRegistry: clusterStateRegistry,
-		ClientSet:            kubeClient,
-		Recorder:             kubeEventRecorder,
-		PredicateChecker:     predicateChecker,
-		ExpanderStrategy:     expanderStrategy,
-		LogRecorder:          logEventRecorder,
+		AutoscalingOptions: options,
+		CloudProvider:      cloudProvider,
+		ClientSet:          kubeClient,
+		Recorder:           kubeEventRecorder,
+		PredicateChecker:   predicateChecker,
+		ExpanderStrategy:   expanderStrategy,
+		LogRecorder:        logEventRecorder,
 	}
 
 	return &autoscalingContext, nil

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -359,8 +359,7 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 			expectedScaleUpOptions: config.expectedScaleUpOptions,
 			scaleUpOptionToChoose:  config.scaleUpOptionToChoose,
 			t: t},
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		LogRecorder: fakeLogRecorder,
 	}
 
 	extraPods := make([]*apiv1.Pod, len(config.extraPods))
@@ -369,7 +368,7 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 		extraPods[i] = pod
 	}
 
-	result, err := ScaleUp(context, extraPods, nodes, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, extraPods, nodes, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -462,17 +461,16 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
-	result, err := ScaleUp(context, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	// A node is already coming - no need for scale up.
 	assert.False(t, result)
@@ -524,18 +522,17 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions:   defaultOptions,
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		AutoscalingOptions: defaultOptions,
+		PredicateChecker:   simulator.NewTestPredicateChecker(),
+		CloudProvider:      provider,
+		ClientSet:          fakeClient,
+		Recorder:           fakeRecorder,
+		ExpanderStrategy:   random.NewStrategy(),
+		LogRecorder:        fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
-	result, err := ScaleUp(context, []*apiv1.Pod{p3, p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, []*apiv1.Pod{p3, p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	// Two nodes needed but one node is already coming, so it should increase by one.
 	assert.True(t, result)
@@ -585,17 +582,16 @@ func TestScaleUpUnhealthy(t *testing.T) {
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
-	result, err := ScaleUp(context, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	// Node group is unhealthy.
 	assert.False(t, result)
@@ -636,17 +632,16 @@ func TestScaleUpNoHelp(t *testing.T) {
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 500, 0)
 
-	result, err := ScaleUp(context, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	assert.False(t, result)
 	var event string
@@ -717,13 +712,12 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 			MaxCoresTotal:            config.DefaultMaxClusterCores,
 			MaxMemoryTotal:           config.DefaultMaxClusterMemory,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
 	pods := make([]*apiv1.Pod, 0)
@@ -731,7 +725,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 		pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
 	}
 
-	result, typedErr := ScaleUp(context, pods, nodes, []*extensionsv1.DaemonSet{})
+	result, typedErr := ScaleUp(context, clusterState, pods, nodes, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, typedErr)
 	assert.True(t, result)
 	groupMap := make(map[string]cloudprovider.NodeGroup, 3)
@@ -781,16 +775,15 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 			NodeAutoprovisioningEnabled:      true,
 			MaxAutoprovisionedNodeGroupCount: 10,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
-	result, err := ScaleUp(context, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*extensionsv1.DaemonSet{})
+	result, err := ScaleUp(context, clusterState, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	assert.True(t, result)
 	assert.Equal(t, "autoprovisioned-T1", getStringFromChan(createdGroups))

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -181,22 +181,22 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 			ScaleDownUnreadyTime:          time.Minute,
 			ScaleDownUnneededTime:         time.Minute,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
 
-	sd := NewScaleDown(context)
+	sd := NewScaleDown(context, clusterState)
 
 	autoscaler := &StaticAutoscaler{AutoscalingContext: context,
 		ListerRegistry:        listerRegistry,
+		clusterStateRegistry:  clusterState,
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,
@@ -361,22 +361,22 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 			NodeAutoprovisioningEnabled:      true,
 			MaxAutoprovisionedNodeGroupCount: 10, // Pods with null priority are always non expendable. Test if it works.
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
 
-	sd := NewScaleDown(context)
+	sd := NewScaleDown(context, clusterState)
 
 	autoscaler := &StaticAutoscaler{AutoscalingContext: context,
 		ListerRegistry:        listerRegistry,
+		clusterStateRegistry:  clusterState,
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,
@@ -499,22 +499,22 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 			ScaleDownUnneededTime:         time.Minute,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
 
-	sd := NewScaleDown(context)
+	sd := NewScaleDown(context, clusterState)
 
 	autoscaler := &StaticAutoscaler{AutoscalingContext: context,
 		ListerRegistry:        listerRegistry,
+		clusterStateRegistry:  clusterState,
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,
@@ -636,22 +636,22 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 			ScaleDownUnneededTime:         time.Minute,
 			ExpendablePodsPriorityCutoff:  10,
 		},
-		PredicateChecker:     simulator.NewTestPredicateChecker(),
-		CloudProvider:        provider,
-		ClientSet:            fakeClient,
-		Recorder:             fakeRecorder,
-		ExpanderStrategy:     random.NewStrategy(),
-		ClusterStateRegistry: clusterState,
-		LogRecorder:          fakeLogRecorder,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		CloudProvider:    provider,
+		ClientSet:        fakeClient,
+		Recorder:         fakeRecorder,
+		ExpanderStrategy: random.NewStrategy(),
+		LogRecorder:      fakeLogRecorder,
 	}
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
 
-	sd := NewScaleDown(context)
+	sd := NewScaleDown(context, clusterState)
 
 	autoscaler := &StaticAutoscaler{AutoscalingContext: context,
 		ListerRegistry:        listerRegistry,
+		clusterStateRegistry:  clusterState,
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
 		scaleDown:             sd,

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -363,10 +363,10 @@ func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNod
 // Sets the target size of node groups to the current number of nodes in them
 // if the difference was constant for a prolonged time. Returns true if managed
 // to fix something.
-func fixNodeGroupSize(context *context.AutoscalingContext, currentTime time.Time) (bool, error) {
+func fixNodeGroupSize(context *context.AutoscalingContext, clusterStateRegistry *clusterstate.ClusterStateRegistry, currentTime time.Time) (bool, error) {
 	fixed := false
 	for _, nodeGroup := range context.CloudProvider.NodeGroups() {
-		incorrectSize := context.ClusterStateRegistry.GetIncorrectNodeGroupSize(nodeGroup.Id())
+		incorrectSize := clusterStateRegistry.GetIncorrectNodeGroupSize(nodeGroup.Id())
 		if incorrectSize == nil {
 			continue
 		}

--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -335,8 +335,7 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 		AutoscalingOptions: context.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
-		CloudProvider:        provider,
-		ClusterStateRegistry: clusterState,
+		CloudProvider: provider,
 	}
 	unregisteredNodes := clusterState.GetUnregisteredNodes()
 	assert.Equal(t, 1, len(unregisteredNodes))
@@ -433,17 +432,16 @@ func TestRemoveFixNodeTargetSize(t *testing.T) {
 		AutoscalingOptions: context.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
-		CloudProvider:        provider,
-		ClusterStateRegistry: clusterState,
+		CloudProvider: provider,
 	}
 
 	// Nothing should be fixed. The incorrect size state is not old enough.
-	removed, err := fixNodeGroupSize(context, now.Add(-50*time.Minute))
+	removed, err := fixNodeGroupSize(context, clusterState, now.Add(-50*time.Minute))
 	assert.NoError(t, err)
 	assert.False(t, removed)
 
 	// Node group should be decreased.
-	removed, err = fixNodeGroupSize(context, now)
+	removed, err = fixNodeGroupSize(context, clusterState, now)
 	assert.NoError(t, err)
 	assert.True(t, removed)
 	change := getStringFromChan(sizeChanges)


### PR DESCRIPTION
AutoscalingContext is basically a configuration and few static helpers and API handles.
ClusterStateRegistry is a state and thus moved closer to other state-keeping objects.