### PR TITLE
Autoscaler doesn't drain nodes that have terminal pods

### DIFF
--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -197,6 +197,48 @@ func TestDrain(t *testing.T) {
 		},
 	}
 
+	terminalPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Spec: apiv1.PodSpec{
+			NodeName:      "node",
+			RestartPolicy: apiv1.RestartPolicyOnFailure,
+		},
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodSucceeded,
+		},
+	}
+
+	failedPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Spec: apiv1.PodSpec{
+			NodeName:      "node",
+			RestartPolicy: apiv1.RestartPolicyNever,
+		},
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodFailed,
+		},
+	}
+
+	evictedPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Spec: apiv1.PodSpec{
+			NodeName:      "node",
+			RestartPolicy: apiv1.RestartPolicyAlways,
+		},
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodFailed,
+		},
+	}
+
 	safePod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
@@ -354,6 +396,27 @@ func TestDrain(t *testing.T) {
 			pdbs:        []*policyv1.PodDisruptionBudget{},
 			expectFatal: true,
 			expectPods:  []*apiv1.Pod{},
+		},
+		{
+			description: "failed pod",
+			pods:        []*apiv1.Pod{failedPod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			expectFatal: false,
+			expectPods:  []*apiv1.Pod{failedPod},
+		},
+		{
+			description: "evicted pod",
+			pods:        []*apiv1.Pod{evictedPod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			expectFatal: false,
+			expectPods:  []*apiv1.Pod{evictedPod},
+		},
+		{
+			description: "pod in terminal state",
+			pods:        []*apiv1.Pod{terminalPod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			expectFatal: false,
+			expectPods:  []*apiv1.Pod{terminalPod},
 		},
 		{
 			description: "pod with PodSafeToEvict annotation",


### PR DESCRIPTION
Terminal pods (Succeeded or Failed phase) are drained by kubectl drain,
and autoscaler should also drain them.

I hit this while testing a cluster that created lots of

1. directly created pods with restartPolicy=Never
2. using a custom controller that creates restartPolicy=Never pods as "jobs"

In both cases, the autoscaler left those nodes up, even though all the pods on the node were terminated, with the "is not replicated" error. The autoscaler should not consider terminal pods as blockers for drain.