### PR TITLE
Add post scale up status processor.

### DIFF
--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -19,6 +19,7 @@ package processors
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 )
 
 // AutoscalingProcessors are a set of customizable processors used for encapsulating
@@ -28,18 +29,23 @@ type AutoscalingProcessors struct {
 	PodListProcessor pods.PodListProcessor
 	// NodeGroupListProcessor is used to process list of NodeGroups that can be used in scale-up.
 	NodeGroupListProcessor nodegroups.NodeGroupListProcessor
+	// ScaleUpStatusProcessor is used to process the state of the cluster after a scale-up.
+	ScaleUpStatusProcessor status.ScaleUpStatusProcessor
 }
 
 // DefaultProcessors returns default set of processors.
 func DefaultProcessors() *AutoscalingProcessors {
 	return &AutoscalingProcessors{
 		PodListProcessor:       pods.NewDefaultPodListProcessor(),
-		NodeGroupListProcessor: nodegroups.NewDefaultNodeGroupListProcessor()}
+		NodeGroupListProcessor: nodegroups.NewDefaultNodeGroupListProcessor(),
+		ScaleUpStatusProcessor: status.NewDefaultScaleUpStatusProcessor()}
 }
 
 // TestProcessors returns a set of simple processors for use in tests.
 func TestProcessors() *AutoscalingProcessors {
 	return &AutoscalingProcessors{
 		PodListProcessor:       &pods.NoOpPodListProcessor{},
-		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{}}
+		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{},
+		// TODO(bskiba): change scale up test so that this can be a NoOpProcessor
+		ScaleUpStatusProcessor: &status.EventingScaleUpStatusProcessor{}}
 }

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+// EventingScaleUpStatusProcessor processes the state of the cluster after
+// a scale-up by emitting relevant events for pods depending on their post
+// scale-up status.
+type EventingScaleUpStatusProcessor struct{}
+
+// Process processes the state of the cluster after a scale-up by emitting
+// relevant events for pods depending on their post scale-up status.
+func (p *EventingScaleUpStatusProcessor) Process(context *context.AutoscalingContext, status *ScaleUpStatus) {
+	for _, pod := range status.PodsRemainUnschedulable {
+		context.Recorder.Event(pod, apiv1.EventTypeNormal, "NotTriggerScaleUp",
+			"pod didn't trigger scale-up (it wouldn't fit if a new node is added)")
+	}
+	if len(status.ScaleUpInfos) > 0 {
+		for _, pod := range status.PodsTriggeredScaleUp {
+			context.Recorder.Eventf(pod, apiv1.EventTypeNormal, "TriggeredScaleUp",
+				"pod triggered scale-up: %v", status.ScaleUpInfos)
+		}
+	}
+}

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"strings"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/nodegroupset"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	kube_record "k8s.io/client-go/tools/record"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventingScaleUpStatusProcessor(t *testing.T) {
+	p := &EventingScaleUpStatusProcessor{}
+	p1 := BuildTestPod("p1", 0, 0)
+	p2 := BuildTestPod("p2", 0, 0)
+	p3 := BuildTestPod("p3", 0, 0)
+
+	testCases := []struct {
+		caseName            string
+		state               *ScaleUpStatus
+		expectedTriggered   int
+		expectedNoTriggered int
+	}{
+		{
+			caseName: "No scale up",
+			state: &ScaleUpStatus{
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
+				PodsRemainUnschedulable: []*apiv1.Pod{p1, p2},
+			},
+			expectedNoTriggered: 2,
+		},
+		{
+			caseName: "Scale up",
+			state: &ScaleUpStatus{
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{{}},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{p3},
+				PodsRemainUnschedulable: []*apiv1.Pod{p1, p2},
+			},
+			expectedTriggered:   1,
+			expectedNoTriggered: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		fakeRecorder := kube_record.NewFakeRecorder(5)
+		context := &context.AutoscalingContext{
+			Recorder: fakeRecorder,
+		}
+		p.Process(context, tc.state)
+		triggered := 0
+		noTriggered := 0
+		for eventsLeft := true; eventsLeft; {
+			select {
+			case event := <-fakeRecorder.Events:
+				if strings.Contains(event, "TriggeredScaleUp") {
+					triggered += 1
+				} else if strings.Contains(event, "NotTriggerScaleUp") {
+					noTriggered += 1
+				} else {
+					t.Fatalf("Test case '%v' failed. Unexpected event %v", tc.caseName, event)
+				}
+			default:
+				eventsLeft = false
+			}
+		}
+		assert.Equal(t, tc.expectedTriggered, triggered, "Test case '%v' failed.", tc.caseName)
+		assert.Equal(t, tc.expectedNoTriggered, noTriggered, "Test case '%v' failed.", tc.caseName)
+	}
+}

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/nodegroupset"
+)
+
+// ScaleUpStatus is the status of a scale-up attempt. This includes information
+// on if scale-up happened, description of scale-up operation performed and
+// status of pods that took part in the scale-up evaluation.
+type ScaleUpStatus struct {
+	ScaledUp                bool
+	ScaleUpInfos            []nodegroupset.ScaleUpInfo
+	PodsTriggeredScaleUp    []*apiv1.Pod
+	PodsRemainUnschedulable []*apiv1.Pod
+	PodsAwaitEvaluation     []*apiv1.Pod
+}
+
+// ScaleUpStatusProcessor processes the state of the cluster after a scale-up.
+type ScaleUpStatusProcessor interface {
+	Process(context *context.AutoscalingContext, state *ScaleUpStatus)
+}
+
+// NewDefaultScaleUpStatusProcessor creates a default instance of ScaleUpStatusProcessor.
+func NewDefaultScaleUpStatusProcessor() ScaleUpStatusProcessor {
+	return &EventingScaleUpStatusProcessor{}
+}


### PR DESCRIPTION
After a scale up, process the state. This is currently implemented as and eventing processor, that emits appropriate events for pods in different states. The processor is wrapped in a chaning processor for easy extensibility.