### PR TITLE
#790 - aws - autoscaler failing with Wrong id

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -81,6 +82,7 @@ func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node.
 func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	if len(node.Spec.ProviderID) == 0 {
+		glog.Warningf("Node %v has no providerId", node.Name)
 		return nil, nil
 	}
 	ref, err := AwsRefFromProviderId(node.Spec.ProviderID)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -80,6 +80,9 @@ func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	if len(node.Spec.ProviderID) == 0 {
+		return nil, nil
+	}
 	ref, err := AwsRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -194,6 +194,20 @@ func TestNodeGroupForNode(t *testing.T) {
 	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 2)
 }
 
+func TestNodeGroupForNodeWithNoProviderId(t *testing.T) {
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "",
+		},
+	}
+	service := &AutoScalingMock{}
+	provider := testProvider(t, newTestAwsManagerWithAsgs(t, service, []string{"1:5:test-asg"}))
+	group, err := provider.NodeGroupForNode(node)
+
+	assert.NoError(t, err)
+	assert.Equal(t, group, nil)
+}
+
 func TestAwsRefFromProviderId(t *testing.T) {
 	_, err := AwsRefFromProviderId("aws123")
 	assert.Error(t, err)


### PR DESCRIPTION
#790 

I've experienced the same problem "autoscaler failing with Wrong id: expected format aws:///<zone>/<name>"  described in #790. This small patched resolved it, as it turned out that some node might not have providerId sometimes, returning an error in this case will result GetNodeInfosForGroups returning an empty map, even if other nodes have correct providerId. 