### PR TITLE
Configuring registry authentication in e2e script.

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -62,6 +62,10 @@ esac
 export REGISTRY=gcr.io/`gcloud config get-value core/project`
 export TAG=latest
 
+echo "Configuring registry authentication"
+mkdir -p "${HOME}/.docker"
+gcloud auth configure-docker -q
+
 for i in ${COMPONENTS}; do
   if [ $i == admission-controller ] ; then
     (cd ${SCRIPT_ROOT}/pkg/${i} && bash ./gencerts.sh || true)


### PR DESCRIPTION
This is necessary after migrating from deprecated "gcloud docker".
See: https://cloud.google.com/container-registry/docs/advanced-authentication.