### PR TITLE
 Add checkpoint versioning

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -28,6 +28,10 @@ import (
 	api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
+// CheckpointVersion should be incremented every time the format or semantics of the checkpoint
+// is changed in a way that is not compatible with the previous version.
+const CheckpointVersion string = "1"
+
 // CheckpointWriter persistently stores aggregated historical usage of containers
 // controlled by VPA objects. This state can be restored to initialize the model after restart.
 type CheckpointWriter interface {
@@ -56,6 +60,7 @@ func (writer *checkpointWriter) StoreCheckpoints(now time.Time) {
 				glog.Errorf("Cannot serialize checkpoint for vpa %v container %v. Reason: %+v", vpa.ID.VpaName, container, err)
 				continue
 			}
+			containerCheckpoint.Version = CheckpointVersion
 			checkpointName := fmt.Sprintf("%s-%s", vpa.ID.VpaName, container)
 			vpaCheckpoint := vpa_types.VerticalPodAutoscalerCheckpoint{
 				ObjectMeta: metav1.ObjectMeta{Name: checkpointName},

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package output
+package checkpoint
 
 import (
 	"fmt"

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package output
+package checkpoint
 
 import (
 	"testing"

--- a/vertical-pod-autoscaler/pkg/recommender/initialization/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/initialization/recommender.go
@@ -44,7 +44,7 @@ type Recommender interface {
 type recommender struct {
 	clusterState           *model.ClusterState
 	clusterStateFeeder     input.ClusterStateFeeder
-	checkpointWriter       output.CheckpointWriter
+	checkpointWriter       checkpoint.CheckpointWriter
 	checkpointsGCInterval  time.Duration
 	lastCheckpointGC       time.Time
 	vpaClient              vpa_api.VerticalPodAutoscalersGetter
@@ -112,7 +112,7 @@ func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, us
 	recommender := &recommender{
 		clusterState:           clusterState,
 		clusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState),
-		checkpointWriter:       output.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).PocV1alpha1()),
+		checkpointWriter:       checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).PocV1alpha1()),
 		checkpointsGCInterval:  checkpointsGCInterval,
 		lastCheckpointGC:       time.Now(),
 		vpaClient:              vpa_clientset.NewForConfigOrDie(config).PocV1alpha1(),


### PR DESCRIPTION
1. Fill the VerticalPodAutoscalerCheckpointStatus.Version field.
2. Do not load checkpoint with incompatible version.