### PR TITLE
Improve histogram exponential buckets.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -56,9 +56,9 @@ func TestPercentileEstimator(t *testing.T) {
 			AggregateCPUUsage:    cpuHistogram,
 			AggregateMemoryPeaks: memoryPeaksHistogram,
 		})
-
-	assert.InEpsilon(t, 1000, int(resourceEstimation[model.ResourceCPU]), model.HistogramRelativeError)
-	assert.InEpsilon(t, 2e9, int(resourceEstimation[model.ResourceMemory]), model.HistogramRelativeError)
+	maxRelativeError := 0.03 // Allow 3% relative error to account for histogram rounding.
+	assert.InEpsilon(t, 1.0, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)
+	assert.InEpsilon(t, 2e9, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
 }
 
 // Verifies that the confidenceMultiplier calculates the internal

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -39,12 +39,9 @@ var (
 	// MemoryHistogramOptions are options to be used by histograms that
 	// store memory measures expressed in bytes.
 	MemoryHistogramOptions = memoryHistogramOptions()
-	// HistogramBucketSizeRatio is the relative size of the histogram buckets
-	// (the ratio between the upper and the lower bound of the bucket).
-	HistogramBucketSizeRatio = 0.05
-	// HistogramRelativeError is the maximum relative error introduced by
-	// the histogram (except for the boundary buckets).
-	HistogramRelativeError = HistogramBucketSizeRatio / 2.
+	// HistogramBucketSizeGrowth defines the growth rate of the histogram buckets.
+	// Each bucket is wider than the previous one by this fraction.
+	HistogramBucketSizeGrowth = 0.05 // Make each bucket 5% larger than the previous one.
 	// MemoryHistogramDecayHalfLife is the amount of time it takes a historical
 	// memory usage sample to lose half of its weight. In other words, a fresh
 	// usage sample is twice as 'important' as one with age equal to the half
@@ -58,7 +55,7 @@ var (
 func cpuHistogramOptions() util.HistogramOptions {
 	// CPU histograms use exponential bucketing scheme with the smallest bucket
 	// size of 0.1 core, max of 1000.0 cores and the relative error of HistogramRelativeError.
-	options, err := util.NewExponentialHistogramOptions(1000.0, 0.1, 1.+HistogramBucketSizeRatio, 0.1)
+	options, err := util.NewExponentialHistogramOptions(1000.0, 0.1, 1.+HistogramBucketSizeGrowth, 0.1)
 	if err != nil {
 		panic("Invalid CPU histogram options") // Should not happen.
 	}
@@ -68,7 +65,7 @@ func cpuHistogramOptions() util.HistogramOptions {
 func memoryHistogramOptions() util.HistogramOptions {
 	// Memory histograms use exponential bucketing scheme with the smallest
 	// bucket size of 10MB, max of 1TB and the relative error of HistogramRelativeError.
-	options, err := util.NewExponentialHistogramOptions(1e12, 1e7, 1.+HistogramBucketSizeRatio, 0.1)
+	options, err := util.NewExponentialHistogramOptions(1e12, 1e7, 1.+HistogramBucketSizeGrowth, 0.1)
 	if err != nil {
 		panic("Invalid memory histogram options") // Should not happen.
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_options_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_options_test.go
@@ -44,21 +44,21 @@ func TestLinearHistogramOptions(t *testing.T) {
 
 // Test all methods of ExponentialHistogramOptions using a sample bucketing scheme.
 func TestExponentialHistogramOptions(t *testing.T) {
-	o, err := NewExponentialHistogramOptions(100.0, 10.0, 2.0, epsilon)
+	o, err := NewExponentialHistogramOptions(500.0, 40.0, 1.5, epsilon)
 	assert.Nil(t, err)
 	assert.Equal(t, epsilon, o.Epsilon())
 	assert.Equal(t, 6, o.NumBuckets())
 
 	assert.Equal(t, 0.0, o.GetBucketStart(0))
-	assert.Equal(t, 10.0, o.GetBucketStart(1))
-	assert.Equal(t, 20.0, o.GetBucketStart(2))
-	assert.Equal(t, 40.0, o.GetBucketStart(3))
-	assert.Equal(t, 80.0, o.GetBucketStart(4))
-	assert.Equal(t, 160.0, o.GetBucketStart(5))
+	assert.Equal(t, 40.0, o.GetBucketStart(1))
+	assert.Equal(t, 100.0, o.GetBucketStart(2))
+	assert.Equal(t, 190.0, o.GetBucketStart(3))
+	assert.Equal(t, 325.0, o.GetBucketStart(4))
+	assert.Equal(t, 527.5, o.GetBucketStart(5))
 
 	assert.Equal(t, 0, o.FindBucket(-1.0))
-	assert.Equal(t, 0, o.FindBucket(9.99))
-	assert.Equal(t, 1, o.FindBucket(10.0))
-	assert.Equal(t, 2, o.FindBucket(20.0))
-	assert.Equal(t, 5, o.FindBucket(200.0))
+	assert.Equal(t, 0, o.FindBucket(39.99))
+	assert.Equal(t, 1, o.FindBucket(40.0))
+	assert.Equal(t, 2, o.FindBucket(100.0))
+	assert.Equal(t, 5, o.FindBucket(900.0))
 }


### PR DESCRIPTION
Currently the bucket boundaries are calculated as: FirstBucketSize * ExpFactor^n.
For example for FirstBucketSize=100M and ExpFactor=1.05, the bucket boundaries will be:
0:  [0...100M)
1:  [100M...105M)
2:  [105M...110.25M)
etc..
Natural and more reasonable boundaries would instead be such that the second bucket is 5% larger than the first bucket, so:
0:  [0...100M)
1:  [100M...205M)
2:  [205M...315.25M)
etc.