### PR TITLE
Update Cluster Autoscaler version to 1.3.1-alpha

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.3.0"
+const ClusterAutoscalerVersion = "1.3.0-alpha.0"


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.3.1-alpha