### PR TITLE
Validate taint key with regex

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -297,16 +297,18 @@ func extractTaintsFromAsg(tags []*autoscaling.TagDescription) []apiv1.Taint {
 		k := *tag.Key
 		v := *tag.Value
 		// The tag value must be in the format <tag>:NoSchedule
-		r, _ := regexp.Compile("(.*):NoSchedule")
+		r, _ := regexp.Compile("(.*):(?:NoSchedule|NoExecute|PreferNoSchedule)")
 		if r.MatchString(v) {
 			splits := strings.Split(k, "k8s.io/cluster-autoscaler/node-template/taint/")
 			if len(splits) > 1 {
 				values := strings.SplitN(v, ":", 2)
-				taints = append(taints, apiv1.Taint{
-					Key:    splits[1],
-					Value:  values[0],
-					Effect: apiv1.TaintEffect(values[1]),
-				})
+				if len(values) > 1 {
+					taints = append(taints, apiv1.Taint{
+						Key:    splits[1],
+						Value:  values[0],
+						Effect: apiv1.TaintEffect(values[1]),
+					})
+				}
 			}
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -70,15 +70,23 @@ func TestExtractTaintsFromAsg(t *testing.T) {
 			Value: aws.String("foo:NoSchedule"),
 		},
 		{
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/group"),
+			Value: aws.String("bar:NoExecute"),
+		},
+		{
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/app"),
+			Value: aws.String("fizz:PreferNoSchedule"),
+		},
+		{
 			Key:   aws.String("bar"),
 			Value: aws.String("baz"),
 		},
 		{
-			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/dedicated"),
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/blank"),
 			Value: aws.String(""),
 		},
 		{
-			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/dedicated"),
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/nosplit"),
 			Value: aws.String("some_value"),
 		},
 	}
@@ -89,10 +97,20 @@ func TestExtractTaintsFromAsg(t *testing.T) {
 			Value:  "foo",
 			Effect: apiv1.TaintEffectNoSchedule,
 		},
+		{
+			Key:    "group",
+			Value:  "bar",
+			Effect: apiv1.TaintEffectNoExecute,
+		},
+		{
+			Key:    "app",
+			Value:  "fizz",
+			Effect: apiv1.TaintEffectPreferNoSchedule,
+		},
 	}
 
 	taints := extractTaintsFromAsg(tags)
-	assert.Equal(t, 1, len(taints))
+	assert.Equal(t, 3, len(taints))
 	assert.Equal(t, makeTaintSet(expectedTaints), makeTaintSet(taints))
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -73,6 +73,14 @@ func TestExtractTaintsFromAsg(t *testing.T) {
 			Key:   aws.String("bar"),
 			Value: aws.String("baz"),
 		},
+		{
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/dedicated"),
+			Value: aws.String(""),
+		},
+		{
+			Key:   aws.String("k8s.io/cluster-autoscaler/node-template/taint/dedicated"),
+			Value: aws.String("some_value"),
+		},
 	}
 
 	expectedTaints := []apiv1.Taint{


### PR DESCRIPTION
Before attempting to perform a split on the tag value, validate it
matches the format <tag>:NoSchedule

This should prevent invalid tag keys from causing the autoscaler to
panic and crash

Fixes #998 