### PR TITLE
Fix construction of the pollPeriod duration

### DIFF
--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -73,7 +73,7 @@ func main() {
 	checkPercentageFlagBounds("recommendation-offset", *recommendationOffset)
 	checkPercentageFlagBounds("acceptance-offset", *acceptanceOffset)
 
-	pollPeriod := time.Millisecond * time.Duration(*pollPeriodMillis)
+	pollPeriod := time.Duration(int64(*pollPeriodMillis) * int64(time.Millisecond))
 	log.Infof("Poll period: %+v", pollPeriod)
 	log.Infof("Watching namespace: %s, pod: %s, container: %s.", *podNamespace, *podName, *containerName)
 	log.Infof("cpu: %s, extra_cpu: %s, memory: %s, extra_memory: %s, storage: %s, extra_storage: %s", *baseCPU, *cpuPerNode, *baseMemory, *memoryPerNode, *baseStorage, *storagePerNode)


### PR DESCRIPTION
The construction of the pollPeriod duration was done in a manner that
did not use the unit of the poll-period flag correctly.