### PR TITLE
Make GetGpuTypeForMetrics more robust

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -465,7 +465,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		}
 		glog.V(1).Infof("Final scale-up plan: %v", scaleUpInfos)
 		for _, info := range scaleUpInfos {
-			typedErr := executeScaleUp(context, clusterStateRegistry, info, gpu.GetGpuTypeForMetrics(nodeInfo.Node()))
+			typedErr := executeScaleUp(context, clusterStateRegistry, info, gpu.GetGpuTypeForMetrics(nodeInfo.Node(), nil, nodeInfo))
 			if typedErr != nil {
 				return nil, typedErr
 			}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -311,7 +312,7 @@ func RegisterError(err errors.AutoscalerError) {
 // RegisterScaleUp records number of nodes added by scale up
 func RegisterScaleUp(nodesCount int, gpuType string) {
 	scaleUpCount.Add(float64(nodesCount))
-	if gpuType != "" {
+	if gpuType != gpu.MetricsNoGPU {
 		gpuScaleUpCount.WithLabelValues(gpuType).Add(float64(nodesCount))
 	}
 }
@@ -324,7 +325,7 @@ func RegisterFailedScaleUp(reason FailedScaleUpReason) {
 // RegisterScaleDown records number of nodes removed by scale down
 func RegisterScaleDown(nodesCount int, gpuType string, reason NodeScaleDownReason) {
 	scaleDownCount.WithLabelValues(string(reason)).Add(float64(nodesCount))
-	if gpuType != "" {
+	if gpuType != gpu.MetricsNoGPU {
 		gpuScaleDownCount.WithLabelValues(string(reason), gpuType).Add(float64(nodesCount))
 	}
 }

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -74,6 +74,8 @@ This metrics describe internal state and actions taken by Cluster Autoscaler.
 | errors_total | Counter | `type`=&lt;error-type&gt; | The number of CA loops failed due to an error. |
 | scaled_up_nodes_total | Counter | | Number of nodes added by CA. |
 | scaled_down_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt; | Number of nodes removed by CA. |
+| scaled_up_gpu_nodes_total | Counter | `gpu_name`=&lt;gpu-name&gt; | Number of GPU-enabled nodes added by CA. |
+| scaled_down_gpu_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt;, `gpu_name`=&lt;gpu-name&gt; | Number of GPU-enabled nodes removed by CA. |
 | failed_scale_ups_total | Counter | `reason`=&lt;failure-reason&gt; | Number of times scale-up operation has failed. |
 | evicted_pods_total | Counter | | Number of pods evicted by CA. |
 | unneeded_nodes_count | Gauge | | Number of nodes currently considered unneeded by CA. |
@@ -106,6 +108,12 @@ This metrics describe internal state and actions taken by Cluster Autoscaler.
   at all in that case).
 * `scaled_down_nodes_total` counts the number of nodes removed by CA. Possible
 scale down reasons are `empty`, `underutilized`, `unready`.
+* `scaled_up_gpu_nodes_total` counts the number of GPU-enabled nodes
+  successfully added by CA, similar to `scaled_up_nodes_total`. Additionally
+  `gpu_name` specifies name of the GPU (e.g. nvidia-tesla-k80).
+* `scaled_down_gpu_nodes_total` counts the number of nodes removed by CA. Scale
+  down reasons are identical to `scaled_down_nodes_total`, `gpu_name` to
+  `scaled_up_gpu_nodes_total`.
 
 ### Node Autoprovisioning operations
 

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -43,6 +43,8 @@ const (
 	MetricsUnknownGPU = "not-listed"
 	// MetricsErrorGPU - for when there was an error obtaining GPU type
 	MetricsErrorGPU = "error"
+	// MetricsInternalErrorGPU - for when there was a CA-internal error obtaining GPU type
+	MetricsInternalErrorGPU = "own-error"
 	// MetricsNoGPU - for when there is no GPU at all
 	MetricsNoGPU = ""
 )
@@ -105,7 +107,8 @@ func GetGpuTypeForMetrics(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, t
 	// GKE-specific label present but no capacity (yet?) - check the node template
 	if labelFound {
 		if nodeGroup == nil && template == nil {
-			return MetricsErrorGPU
+			// this should not happen
+			return MetricsInternalErrorGPU
 		}
 
 		if template == nil {

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -20,9 +20,10 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"github.com/golang/glog"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 )
 
 const (
@@ -33,6 +34,27 @@ const (
 	// DefaultGPUType is the type of GPU used in NAP if the user
 	// don't specify what type of GPU his pod wants.
 	DefaultGPUType = "nvidia-tesla-k80"
+)
+
+const (
+	// MetricsGenericGPU - for when there is no information about GPU type
+	MetricsGenericGPU = "generic"
+	// MetricsUnknownGPU - for when GPU type is unknown
+	MetricsUnknownGPU = "not-listed"
+	// MetricsErrorGPU - for when there was an error obtaining GPU type
+	MetricsErrorGPU = "error"
+	// MetricsNoGPU - for when there is no GPU at all
+	MetricsNoGPU = ""
+)
+
+var (
+	// knownGpuTypes lists all known GPU types, to be used in metrics; map for convenient access
+	// TODO(kgolab) obtain this from Cloud Provider
+	knownGpuTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // FilterOutNodesWithUnreadyGpus removes nodes that should have GPU, but don't have it in allocatable
@@ -71,19 +93,51 @@ func FilterOutNodesWithUnreadyGpus(allNodes, readyNodes []*apiv1.Node) ([]*apiv1
 // GetGpuTypeForMetrics returns name of the GPU used on the node or empty string if there's no GPU
 // if the GPU type is unknown, "generic" is returned
 // NOTE: current implementation is GKE/GCE-specific
-func GetGpuTypeForMetrics(node *apiv1.Node) string {
+func GetGpuTypeForMetrics(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, template *schedulercache.NodeInfo) string {
 	// we use the GKE label if there is one
-	gpuType, found := node.Labels[GPULabel]
-	if found {
-		return gpuType
+	gpuType, labelFound := node.Labels[GPULabel]
+	capacity, capacityFound := node.Status.Capacity[ResourceNvidiaGPU]
+
+	// GKE-specific label & capacity are present - consistent state
+	if labelFound && capacityFound {
+		return validateGpuType(gpuType)
+	}
+	// GKE-specific label present but no capacity (yet?) - check the node template
+	if labelFound {
+		if nodeGroup == nil && template == nil {
+			return MetricsErrorGPU
+		}
+
+		if template == nil {
+			var err error
+			template, err = nodeGroup.TemplateNodeInfo()
+			if err != nil {
+				glog.Warningf("Failed to build template for getting GPU metrics for node %v: %v", node.Name, err)
+				return MetricsErrorGPU
+			}
+		}
+
+		if _, found := template.Node().Status.Capacity[ResourceNvidiaGPU]; found {
+			return gpuType
+		}
+
+		// if template does not define gpus we assume node will not have any even if it has gpu label
+		glog.Warningf("Template does not define GPUs even though node from its node group does; node=%v", node.Name)
+		return MetricsNoGPU
 	}
 
 	// no label, fallback to generic solution
-	capacity, found := node.Status.Capacity[ResourceNvidiaGPU]
-	if !found || capacity.IsZero() {
-		return ""
+	if !capacityFound || capacity.IsZero() {
+		return MetricsNoGPU
 	}
-	return "generic"
+	return MetricsGenericGPU
+}
+
+func validateGpuType(gpu string) string {
+	if _, found := knownGpuTypes[gpu]; found {
+		return gpu
+	}
+	return MetricsUnknownGPU
 }
 
 func getUnreadyNodeCopy(node *apiv1.Node) *apiv1.Node {


### PR DESCRIPTION
As discussed I've made GetGpuTypeForMetrics more in line with GetNodeTargetGpus - but looking at the amount of plumbing needed I'm no longer fully convinced it's really worth the effort.

Updated metrics.md for a good measure.