### PR TITLE
Scale up: ignore existing nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -214,7 +214,7 @@ func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 		return nil, fmt.Errorf("Unable to get first AvailabilityZone for %s", asg.Name)
 	}
 
-	az := asg.AvailabilityZones[0]
+	az := asg.AvailabilityZones[rand.Intn(len(asg.AvailabilityZones))]
 	region := az[0 : len(az)-1]
 
 	if len(asg.AvailabilityZones) > 1 {

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -146,6 +146,9 @@ type AutoscalingOptions struct {
 	ExpendablePodsPriorityCutoff int
 	// Regional tells whether the cluster is regional.
 	Regional bool
+	// ScaleUpTemplateFromCloudProvider tells if template node should be built from the up-to-date provider configuration (e.g. ASG launch configuration)
+	// instead of a random existing node.
+	ScaleUpTemplateFromCloudProvider bool
 }
 
 // NewResourceLimiterFromAutoscalingOptions creates new instance of cloudprovider.ResourceLimiter

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -250,7 +250,13 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		podsRemainUnschedulable[pod] = true
 	}
 	glogx.V(1).Over(loggingQuota).Infof("%v other pods are also unschedulable", -loggingQuota.Left())
-	nodeInfos, err := GetNodeInfosForGroups(nodes, context.CloudProvider, context.ClientSet,
+
+	existingNodes := nodes
+	if context.ScaleUpTemplateFromCloudProvider {
+		existingNodes = []*apiv1.Node{}
+	}
+
+	nodeInfos, err := GetNodeInfosForGroups(existingNodes, context.CloudProvider, context.ClientSet,
 		daemonSets, context.PredicateChecker)
 	if err != nil {
 		return nil, err.AddPrefix("failed to build node infos for node groups: ")

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -146,9 +146,11 @@ var (
 	nodeAutoprovisioningEnabled      = flag.Bool("node-autoprovisioning-enabled", false, "Should CA autoprovision node groups when needed")
 	maxAutoprovisionedNodeGroupCount = flag.Int("max-autoprovisioned-node-group-count", 15, "The maximum number of autoprovisioned groups in the cluster.")
 
-	unremovableNodeRecheckTimeout = flag.Duration("unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
-	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
-	regional                      = flag.Bool("regional", false, "Cluster is regional.")
+	unremovableNodeRecheckTimeout    = flag.Duration("unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
+	expendablePodsPriorityCutoff     = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
+	regional                         = flag.Bool("regional", false, "Cluster is regional.")
+	scaleUpTemplateFromCloudProvider = flag.Bool("scale-up-cloud-provider-template", false,
+		"Should CA build the template nodes using up-to-date cloud provider configuration instead of a random existing node.")
 )
 
 func createAutoscalingOptions() context.AutoscalingOptions {
@@ -206,6 +208,7 @@ func createAutoscalingOptions() context.AutoscalingOptions {
 		UnremovableNodeRecheckTimeout:    *unremovableNodeRecheckTimeout,
 		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
 		Regional:                         *regional,
+		ScaleUpTemplateFromCloudProvider: *scaleUpTemplateFromCloudProvider,
 	}
 }
 


### PR DESCRIPTION
Add a new flag, `--scale-up-cloud-provider-template`, that forces the autoscaler to always construct the template node from the cloud provider data (e.g. AWS launch configuration) instead of a random existing node. This fixes both the trivial issues where instance type change is not taken into account until the user gets lucky with node ordering and more complicated ones where pods using node affinities sometimes don't trigger scale up (see comments in #789).

I think that this should be the default behaviour, because the current one is non-intuitive and hard to debug. However, since the users might rely on existing logic and use node selectors without the corresponding tags on the ASGs, the flag defaults to `false`.

One more change I've made selects a random AZ when constructing a template node for a multi-AZ ASG in the AWS cloud provider. Previously, the autoscaler always used the first AZ, but since this was masked by the default logic of using a random existing node it *sort of* worked when existing nodes got added or removed. Using a random AZ allows the autoscaler to progress even in these non-ideal setups.