### PR TITLE
Fix potential panic for aks

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -368,6 +368,11 @@ func (agentPool *ContainerServiceAgentPool) DeleteNodes(nodes []*apiv1.Node) err
 
 //IsContainerServiceNode checks if the tag from the vm matches the agentPool name
 func (agentPool *ContainerServiceAgentPool) IsContainerServiceNode(tags *map[string]*string) bool {
+	// Virtual machines not managed by AKS may have no tags.
+	if tags == nil {
+		return false
+	}
+
 	poolName := (*tags)["poolName"]
 	if poolName != nil {
 		glog.V(5).Infof("Matching agentPool name: %s with tag name: %s", agentPool.azureRef.Name, *poolName)


### PR DESCRIPTION
Virtual machines not managed by AKS may have no tags. In such case, CA will panic.

Fixes #919 

Note: there's no such issue for 1.3 because its Azure client has been upgraded and `map[string]*string` is used there (instead of `*map[string]*string`).