### PR TITLE
Remove the meeting information from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ resource requests of a deployment based on the number of nodes in the Kubernetes
 
 Interested in autoscaling? Want to talk? Have questions, concerns or great ideas?
 
-Please join us on #sig-autoscaling at https://kubernetes.slack.com/.
-Moreover, every Monday we host a 30min sig-autoscaling meeting on
-https://zoom.us/my/k8s.sig.autoscaling at 16:00 CEST/CET, 7:00 am PST/PDT.
+Please join us on #sig-autoscaling at https://kubernetes.slack.com/, or join one
+of our weekly meetings.  See [the Kubernetes Community Repo](https://github.com/kubernetes/community/blob/master/sig-list.md) for more information.
 
 ## Getting the Code
 


### PR DESCRIPTION
This removes the meeting information from the README, in favor of
pointing at the community repo.  Among other things, pointing at the
community repo makes it easier to update meeting information in one
place, instead of multiple.