### PR TITLE
Lower default expendable pod priority cutoff to -10

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -146,7 +146,7 @@ var (
 	maxAutoprovisionedNodeGroupCount = flag.Int("max-autoprovisioned-node-group-count", 15, "The maximum number of autoprovisioned groups in the cluster.")
 
 	unremovableNodeRecheckTimeout = flag.Duration("unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
-	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", 0, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
+	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 )
 


### PR DESCRIPTION
Lower default expendable pod priority cutoff to -10. 

With pod priority and preemption enabled, users may want to create pause pods for overprovisioning with priority lower than default (0 for pods with unspecified priority), but high enough that they still trigger scale-up. 

```release-note:
Default value for expendable pod priority cutoff changed from 0 to -10.

action required: users deploying workloads with priority lower than 0 may want to use priority lower than -10 to avoid triggering scale-up.
```