### PR TITLE
Add annotation to mark pods as unsafe to evict

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -79,6 +79,10 @@ Cluster Autoscaler decreases the size of the cluster when some nodes are consist
 * Pods with local storage. *
 * Pods that cannot be moved elsewhere due to various constraints (lack of resources, non-matching node selectors or affinity,
 matching anti-affinity, etc)
+* Pods that have the following annotation set:
+```
+"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+```
 
 <sup>*</sup>Unless the pod has the following annotation (supported in CA 1.0.3 or later):
 ```

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -197,6 +197,9 @@ func GetPodsForDeletionOnNodeDrain(
 			if HasLocalStorage(pod) && skipNodesWithLocalStorage {
 				return []*apiv1.Pod{}, fmt.Errorf("pod with local storage present: %s", pod.Name)
 			}
+			if hasNotSafeToEvictAnnotation(pod) {
+				return []*apiv1.Pod{}, fmt.Errorf("pod annotated as not safe to evict present: %s", pod.Name)
+			}
 		}
 		pods = append(pods, pod)
 	}
@@ -261,4 +264,9 @@ func checkKubeSystemPDBs(pod *apiv1.Pod, pdbs []*policyv1.PodDisruptionBudget) (
 // This checks if pod has PodSafeToEvictKey annotation
 func hasSafeToEvictAnnotation(pod *apiv1.Pod) bool {
 	return pod.GetAnnotations()[PodSafeToEvictKey] == "true"
+}
+
+// This checks if pod has PodSafeToEvictKey annotation set to false
+func hasNotSafeToEvictAnnotation(pod *apiv1.Pod) bool {
+	return pod.GetAnnotations()[PodSafeToEvictKey] == "false"
 }

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -252,6 +252,31 @@ func TestDrain(t *testing.T) {
 		},
 	}
 
+	unsafeRcPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "bar",
+			Namespace:       "default",
+			OwnerReferences: GenerateOwnerReferences(rc.Name, "ReplicationController", "extensions/v1beta1", ""),
+			Annotations: map[string]string{
+				PodSafeToEvictKey: "false",
+			},
+		},
+		Spec: apiv1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	unsafeJobPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "bar",
+			Namespace:       "default",
+			OwnerReferences: GenerateOwnerReferences(job.Name, "Job", "extensions/v1beta1", ""),
+			Annotations: map[string]string{
+				PodSafeToEvictKey: "false",
+			},
+		},
+	}
+
 	kubeSystemSafePod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
@@ -438,6 +463,22 @@ func TestDrain(t *testing.T) {
 			pdbs:        []*policyv1.PodDisruptionBudget{},
 			expectFatal: false,
 			expectPods:  []*apiv1.Pod{emptydirSafePod},
+		},
+		{
+			description: "RC-managed pod with PodSafeToEvict=false annotation",
+			pods:        []*apiv1.Pod{unsafeRcPod},
+			rcs:         []apiv1.ReplicationController{rc},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			expectFatal: true,
+			expectPods:  []*apiv1.Pod{},
+		},
+		{
+			description: "Job-managed pod with PodSafeToEvict=false annotation",
+			pods:        []*apiv1.Pod{unsafeJobPod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			rcs:         []apiv1.ReplicationController{rc},
+			expectFatal: true,
+			expectPods:  []*apiv1.Pod{},
 		},
 		{
 			description: "empty PDB with RC-managed pod",


### PR DESCRIPTION
Allow using the cluster-autoscaler.kubernetes.io/safe-to-evict annotation also to mark the pod as not safe to evict, this fixes issue #510.