### PR TITLE
Cluster Autoscaler 1.3.2-alpha.0

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.3.1"
+const ClusterAutoscalerVersion = "1.3.2-alpha.0"


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.3.2-alpha.0