### PR TITLE
Fix potential panic

### DIFF
--- a/cluster-autoscaler/utils/errors/errors.go
+++ b/cluster-autoscaler/utils/errors/errors.go
@@ -71,7 +71,7 @@ func ToAutoscalerError(defaultType AutoscalerErrorType, err error) AutoscalerErr
 	if e, ok := err.(AutoscalerError); ok {
 		return e
 	}
-	return NewAutoscalerError(defaultType, err.Error())
+	return NewAutoscalerError(defaultType, "%v", err)
 }
 
 // Error implements golang error interface


### PR DESCRIPTION
err may be nil some cases, so err.Error() would panic CA.

Fix https://github.com/kubernetes/autoscaler/issues/863#issuecomment-406857408