### PR TITLE
Simplify building cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -48,7 +48,7 @@ var AvailableCloudProviders = []string{
 const DefaultCloudProvider = gce.ProviderNameGCE
 
 // NewCloudProvider builds a cloud provider from provided parameters.
-func NewCloudProvider(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func NewCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	glog.V(1).Infof("Building %s cloud provider.", opts.CloudProviderName)
 	switch opts.CloudProviderName {
 	case gce.ProviderNameGCE:
@@ -78,7 +78,7 @@ func NewCloudProvider(opts static.AutoscalingOptions, do cloudprovider.NodeGroup
 	return nil // This will never happen because the Fatalf will os.Exit
 }
 
-func buildGCE(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, mode gce.GcpCloudProviderMode) cloudprovider.CloudProvider {
+func buildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, mode gce.GcpCloudProviderMode) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error
@@ -101,7 +101,7 @@ func buildGCE(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	return provider
 }
 
-func buildAWS(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error
@@ -124,7 +124,7 @@ func buildAWS(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	return provider
 }
 
-func buildAzure(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		glog.Info("Creating Azure Manager using cloud-config file: %v", opts.CloudConfig)
@@ -148,7 +148,7 @@ func buildAzure(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscov
 	return provider
 }
 
-func buildKubemark(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildKubemark(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	externalConfig, err := rest.InClusterConfig()
 	if err != nil {
 		glog.Fatalf("Failed to get kubeclient config for external cluster: %v", err)

--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark"
-
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -47,47 +47,26 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider is GCE.
 const DefaultCloudProvider = gce.ProviderNameGCE
 
-// CloudProviderBuilder builds a cloud provider from all the necessary parameters including the name of a cloud provider e.g. aws, gce
-// and the path to a config file
-type CloudProviderBuilder struct {
-	cloudProviderFlag       string
-	cloudConfig             string
-	clusterName             string
-	autoprovisioningEnabled bool
-	regional                bool
-}
-
-// NewCloudProviderBuilder builds a new builder from static settings
-func NewCloudProviderBuilder(cloudProviderFlag, cloudConfig, clusterName string, autoprovisioningEnabled, regional bool) CloudProviderBuilder {
-	return CloudProviderBuilder{
-		cloudProviderFlag:       cloudProviderFlag,
-		cloudConfig:             cloudConfig,
-		clusterName:             clusterName,
-		autoprovisioningEnabled: autoprovisioningEnabled,
-		regional:                regional,
-	}
-}
-
-// Build a cloud provider from static settings contained in the builder and dynamic settings passed via args
-func (b CloudProviderBuilder) Build(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, resourceLimiter *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
-	glog.V(1).Infof("Building %s cloud provider.", b.cloudProviderFlag)
-	switch b.cloudProviderFlag {
+// NewCloudProvider builds a cloud provider from provided parameters.
+func NewCloudProvider(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	glog.V(1).Infof("Building %s cloud provider.", opts.CloudProviderName)
+	switch opts.CloudProviderName {
 	case gce.ProviderNameGCE:
-		return b.buildGCE(discoveryOpts, resourceLimiter, gce.ModeGCE)
+		return buildGCE(opts, do, rl, gce.ModeGCE)
 	case gce.ProviderNameGKE:
-		if discoveryOpts.DiscoverySpecified() {
+		if do.DiscoverySpecified() {
 			glog.Fatalf("GKE gets nodegroup specification via API, command line specs are not allowed")
 		}
-		if b.autoprovisioningEnabled {
-			return b.buildGCE(discoveryOpts, resourceLimiter, gce.ModeGKENAP)
+		if opts.NodeAutoprovisioningEnabled {
+			return buildGCE(opts, do, rl, gce.ModeGKENAP)
 		}
-		return b.buildGCE(discoveryOpts, resourceLimiter, gce.ModeGKE)
+		return buildGCE(opts, do, rl, gce.ModeGKE)
 	case aws.ProviderName:
-		return b.buildAWS(discoveryOpts, resourceLimiter)
+		return buildAWS(opts, do, rl)
 	case azure.ProviderName:
-		return b.buildAzure(discoveryOpts, resourceLimiter)
+		return buildAzure(opts, do, rl)
 	case kubemark.ProviderName:
-		return b.buildKubemark(discoveryOpts, resourceLimiter)
+		return buildKubemark(opts, do, rl)
 	case "":
 		// Ideally this would be an error, but several unit tests of the
 		// StaticAutoscaler depend on this behaviour.
@@ -95,22 +74,22 @@ func (b CloudProviderBuilder) Build(discoveryOpts cloudprovider.NodeGroupDiscove
 		return nil
 	}
 
-	glog.Fatalf("Unknown cloud provider: %s", b.cloudProviderFlag)
+	glog.Fatalf("Unknown cloud provider: %s", opts.CloudProviderName)
 	return nil // This will never happen because the Fatalf will os.Exit
 }
 
-func (b CloudProviderBuilder) buildGCE(do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, mode gce.GcpCloudProviderMode) cloudprovider.CloudProvider {
+func buildGCE(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, mode gce.GcpCloudProviderMode) cloudprovider.CloudProvider {
 	var config io.ReadCloser
-	if b.cloudConfig != "" {
+	if opts.CloudConfig != "" {
 		var err error
-		config, err = os.Open(b.cloudConfig)
+		config, err = os.Open(opts.CloudConfig)
 		if err != nil {
-			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", b.cloudConfig, err)
+			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", opts.CloudConfig, err)
 		}
 		defer config.Close()
 	}
 
-	manager, err := gce.CreateGceManager(config, mode, b.clusterName, do, b.regional)
+	manager, err := gce.CreateGceManager(config, mode, opts.ClusterName, do, opts.Regional)
 	if err != nil {
 		glog.Fatalf("Failed to create GCE Manager: %v", err)
 	}
@@ -122,13 +101,13 @@ func (b CloudProviderBuilder) buildGCE(do cloudprovider.NodeGroupDiscoveryOption
 	return provider
 }
 
-func (b CloudProviderBuilder) buildAWS(do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildAWS(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
-	if b.cloudConfig != "" {
+	if opts.CloudConfig != "" {
 		var err error
-		config, err = os.Open(b.cloudConfig)
+		config, err = os.Open(opts.CloudConfig)
 		if err != nil {
-			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", b.cloudConfig, err)
+			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", opts.CloudConfig, err)
 		}
 		defer config.Close()
 	}
@@ -145,14 +124,14 @@ func (b CloudProviderBuilder) buildAWS(do cloudprovider.NodeGroupDiscoveryOption
 	return provider
 }
 
-func (b CloudProviderBuilder) buildAzure(do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildAzure(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
-	if b.cloudConfig != "" {
-		glog.Info("Creating Azure Manager using cloud-config file: %v", b.cloudConfig)
+	if opts.CloudConfig != "" {
+		glog.Info("Creating Azure Manager using cloud-config file: %v", opts.CloudConfig)
 		var err error
-		config, err := os.Open(b.cloudConfig)
+		config, err := os.Open(opts.CloudConfig)
 		if err != nil {
-			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", b.cloudConfig, err)
+			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v", opts.CloudConfig, err)
 		}
 		defer config.Close()
 	} else {
@@ -169,7 +148,7 @@ func (b CloudProviderBuilder) buildAzure(do cloudprovider.NodeGroupDiscoveryOpti
 	return provider
 }
 
-func (b CloudProviderBuilder) buildKubemark(do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildKubemark(opts static.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	externalConfig, err := rest.InClusterConfig()
 	if err != nil {
 		glog.Fatalf("Failed to get kubeclient config for external cluster: %v", err)

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package static
+package config
 
 import (
 	"time"

--- a/cluster-autoscaler/config/static/autoscaling_options.go
+++ b/cluster-autoscaler/config/static/autoscaling_options.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package static
+
+import (
+	"time"
+)
+
+// GpuLimits define lower and upper bound on GPU instances of given type in cluster
+type GpuLimits struct {
+	// Type of the GPU (e.g. nvidia-tesla-k80)
+	GpuType string
+	// Lower bound on number of GPUs of given type in cluster
+	Min int64
+	// Upper bound on number of GPUs of given type in cluster
+	Max int64
+}
+
+// AutoscalingOptions contain various options to customize how autoscaling works
+type AutoscalingOptions struct {
+	// MaxEmptyBulkDelete is a number of empty nodes that can be removed at the same time.
+	MaxEmptyBulkDelete int
+	// ScaleDownUtilizationThreshold sets threshold for nodes to be considered for scale down.
+	// Well-utilized nodes are not touched.
+	ScaleDownUtilizationThreshold float64
+	// ScaleDownUnneededTime sets the duration CA expects a node to be unneeded/eligible for removal
+	// before scaling down the node.
+	ScaleDownUnneededTime time.Duration
+	// ScaleDownUnreadyTime represents how long an unready node should be unneeded before it is eligible for scale down
+	ScaleDownUnreadyTime time.Duration
+	// MaxNodesTotal sets the maximum number of nodes in the whole cluster
+	MaxNodesTotal int
+	// MaxCoresTotal sets the maximum number of cores in the whole cluster
+	MaxCoresTotal int64
+	// MinCoresTotal sets the minimum number of cores in the whole cluster
+	MinCoresTotal int64
+	// MaxMemoryTotal sets the maximum memory (in bytes) in the whole cluster
+	MaxMemoryTotal int64
+	// MinMemoryTotal sets the maximum memory (in bytes) in the whole cluster
+	MinMemoryTotal int64
+	// GpuTotal is a list of strings with configuration of min/max limits for different GPUs.
+	GpuTotal []GpuLimits
+	// NodeGroupAutoDiscovery represents one or more definition(s) of node group auto-discovery
+	NodeGroupAutoDiscovery []string
+	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.
+	EstimatorName string
+	// ExpanderName sets the type of node group expander to be used in scale up
+	ExpanderName string
+	// MaxGracefulTerminationSec is maximum number of seconds scale down waits for pods to terminate before
+	// removing the node from cloud provider.
+	MaxGracefulTerminationSec int
+	//  Maximum time CA waits for node to be provisioned
+	MaxNodeProvisionTime time.Duration
+	// MaxTotalUnreadyPercentage is the maximum percentage of unready nodes after which CA halts operations
+	MaxTotalUnreadyPercentage float64
+	// OkTotalUnreadyCount is the number of allowed unready nodes, irrespective of max-total-unready-percentage
+	OkTotalUnreadyCount int
+	// CloudConfig is the path to the cloud provider configuration file. Empty string for no configuration file.
+	CloudConfig string
+	// CloudProviderName sets the type of the cloud provider CA is about to run in. Allowed values: gce, aws
+	CloudProviderName string
+	// NodeGroups is the list of node groups a.k.a autoscaling targets
+	NodeGroups []string
+	// ScaleDownEnabled is used to allow CA to scale down the cluster
+	ScaleDownEnabled bool
+	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options
+	ScaleDownDelayAfterAdd time.Duration
+	// ScaleDownDelayAfterDelete sets the duration between scale down attempts if scale down removes one or more nodes
+	ScaleDownDelayAfterDelete time.Duration
+	// ScaleDownDelayAfterFailure sets the duration before the next scale down attempt if scale down results in an error
+	ScaleDownDelayAfterFailure time.Duration
+	// ScaleDownNonEmptyCandidatesCount is the maximum number of non empty nodes
+	// considered at once as candidates for scale down.
+	ScaleDownNonEmptyCandidatesCount int
+	// ScaleDownCandidatesPoolRatio is a ratio of nodes that are considered
+	// as additional non empty candidates for scale down when some candidates from
+	// previous iteration are no longer valid.
+	ScaleDownCandidatesPoolRatio float64
+	// ScaleDownCandidatesPoolMinCount is the minimum number of nodes that are
+	// considered as additional non empty candidates for scale down when some
+	// candidates from previous iteration are no longer valid.
+	// The formula to calculate additional candidates number is following:
+	// max(#nodes * ScaleDownCandidatesPoolRatio, ScaleDownCandidatesPoolMinCount)
+	ScaleDownCandidatesPoolMinCount int
+	// WriteStatusConfigMap tells if the status information should be written to a ConfigMap
+	WriteStatusConfigMap bool
+	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
+	BalanceSimilarNodeGroups bool
+	// ConfigNamespace is the namespace cluster-autoscaler is running in and all related configmaps live in
+	ConfigNamespace string
+	// ClusterName if available
+	ClusterName string
+	// NodeAutoprovisioningEnabled tells whether the node auto-provisioning is enabled for this cluster.
+	NodeAutoprovisioningEnabled bool
+	// MaxAutoprovisionedNodeGroupCount is the maximum number of autoprovisioned groups in the cluster.
+	MaxAutoprovisionedNodeGroupCount int
+	// UnremovableNodeRecheckTimeout is the timeout before we check again a node that couldn't be removed before
+	UnremovableNodeRecheckTimeout time.Duration
+	// Pods with priority below cutoff are expendable. They can be killed without any consideration during scale down and they don't cause scale-up.
+	// Pods with null priority (PodPriority disabled) are non-expendable.
+	ExpendablePodsPriorityCutoff int
+	// Regional tells whether the cluster is regional.
+	Regional bool
+}

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -74,10 +74,12 @@ func NewAutoscalingContext(options static.AutoscalingOptions, predicateChecker *
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder,
 	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry) (*AutoscalingContext, errors.AutoscalerError) {
 
-	cloudProviderBuilder := builder.NewCloudProviderBuilder(options.CloudProviderName, options.CloudConfig, options.ClusterName, options.NodeAutoprovisioningEnabled, options.Regional)
-	cloudProvider := cloudProviderBuilder.Build(cloudprovider.NodeGroupDiscoveryOptions{
-		NodeGroupSpecs:              options.NodeGroups,
-		NodeGroupAutoDiscoverySpecs: options.NodeGroupAutoDiscovery},
+	cloudProvider := builder.NewCloudProvider(
+		options,
+		cloudprovider.NodeGroupDiscoveryOptions{
+			NodeGroupSpecs:              options.NodeGroups,
+			NodeGroupAutoDiscoverySpecs: options.NodeGroupAutoDiscovery,
+		},
 		NewResourceLimiterFromAutoscalingOptions(options))
 	expanderStrategy, err := factory.ExpanderStrategyFromString(options.ExpanderName,
 		cloudProvider, listerRegistry.AllNodeLister())

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -34,7 +34,7 @@ import (
 // scale up/scale down functions.
 type AutoscalingContext struct {
 	// Options to customize how autoscaling works
-	static.AutoscalingOptions
+	config.AutoscalingOptions
 	// CloudProvider used in CA.
 	CloudProvider cloudprovider.CloudProvider
 	// ClientSet interface.
@@ -52,7 +52,7 @@ type AutoscalingContext struct {
 
 // NewResourceLimiterFromAutoscalingOptions creates new instance of cloudprovider.ResourceLimiter
 // reading limits from AutoscalingOptions struct.
-func NewResourceLimiterFromAutoscalingOptions(options static.AutoscalingOptions) *cloudprovider.ResourceLimiter {
+func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions) *cloudprovider.ResourceLimiter {
 	// build min/max maps for resources limits
 	minResources := make(map[string]int64)
 	maxResources := make(map[string]int64)
@@ -70,7 +70,7 @@ func NewResourceLimiterFromAutoscalingOptions(options static.AutoscalingOptions)
 }
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
-func NewAutoscalingContext(options static.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
+func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder,
 	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry) (*AutoscalingContext, errors.AutoscalerError) {
 

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -17,11 +17,10 @@ limitations under the License.
 package context
 
 import (
-	"time"
-
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -35,7 +34,7 @@ import (
 // scale up/scale down functions.
 type AutoscalingContext struct {
 	// Options to customize how autoscaling works
-	AutoscalingOptions
+	static.AutoscalingOptions
 	// CloudProvider used in CA.
 	CloudProvider cloudprovider.CloudProvider
 	// ClientSet interface.
@@ -51,106 +50,9 @@ type AutoscalingContext struct {
 	LogRecorder *utils.LogEventRecorder
 }
 
-// GpuLimits define lower and upper bound on GPU instances of given type in cluster
-type GpuLimits struct {
-	// Type of the GPU (e.g. nvidia-tesla-k80)
-	GpuType string
-	// Lower bound on number of GPUs of given type in cluster
-	Min int64
-	// Upper bound on number of GPUs of given type in cluster
-	Max int64
-}
-
-// AutoscalingOptions contain various options to customize how autoscaling works
-type AutoscalingOptions struct {
-	// MaxEmptyBulkDelete is a number of empty nodes that can be removed at the same time.
-	MaxEmptyBulkDelete int
-	// ScaleDownUtilizationThreshold sets threshold for nodes to be considered for scale down.
-	// Well-utilized nodes are not touched.
-	ScaleDownUtilizationThreshold float64
-	// ScaleDownUnneededTime sets the duration CA expects a node to be unneeded/eligible for removal
-	// before scaling down the node.
-	ScaleDownUnneededTime time.Duration
-	// ScaleDownUnreadyTime represents how long an unready node should be unneeded before it is eligible for scale down
-	ScaleDownUnreadyTime time.Duration
-	// MaxNodesTotal sets the maximum number of nodes in the whole cluster
-	MaxNodesTotal int
-	// MaxCoresTotal sets the maximum number of cores in the whole cluster
-	MaxCoresTotal int64
-	// MinCoresTotal sets the minimum number of cores in the whole cluster
-	MinCoresTotal int64
-	// MaxMemoryTotal sets the maximum memory (in bytes) in the whole cluster
-	MaxMemoryTotal int64
-	// MinMemoryTotal sets the maximum memory (in bytes) in the whole cluster
-	MinMemoryTotal int64
-	// GpuTotal is a list of strings with configuration of min/max limits for different GPUs.
-	GpuTotal []GpuLimits
-	// NodeGroupAutoDiscovery represents one or more definition(s) of node group auto-discovery
-	NodeGroupAutoDiscovery []string
-	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.
-	EstimatorName string
-	// ExpanderName sets the type of node group expander to be used in scale up
-	ExpanderName string
-	// MaxGracefulTerminationSec is maximum number of seconds scale down waits for pods to terminate before
-	// removing the node from cloud provider.
-	MaxGracefulTerminationSec int
-	//  Maximum time CA waits for node to be provisioned
-	MaxNodeProvisionTime time.Duration
-	// MaxTotalUnreadyPercentage is the maximum percentage of unready nodes after which CA halts operations
-	MaxTotalUnreadyPercentage float64
-	// OkTotalUnreadyCount is the number of allowed unready nodes, irrespective of max-total-unready-percentage
-	OkTotalUnreadyCount int
-	// CloudConfig is the path to the cloud provider configuration file. Empty string for no configuration file.
-	CloudConfig string
-	// CloudProviderName sets the type of the cloud provider CA is about to run in. Allowed values: gce, aws
-	CloudProviderName string
-	// NodeGroups is the list of node groups a.k.a autoscaling targets
-	NodeGroups []string
-	// ScaleDownEnabled is used to allow CA to scale down the cluster
-	ScaleDownEnabled bool
-	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options
-	ScaleDownDelayAfterAdd time.Duration
-	// ScaleDownDelayAfterDelete sets the duration between scale down attempts if scale down removes one or more nodes
-	ScaleDownDelayAfterDelete time.Duration
-	// ScaleDownDelayAfterFailure sets the duration before the next scale down attempt if scale down results in an error
-	ScaleDownDelayAfterFailure time.Duration
-	// ScaleDownNonEmptyCandidatesCount is the maximum number of non empty nodes
-	// considered at once as candidates for scale down.
-	ScaleDownNonEmptyCandidatesCount int
-	// ScaleDownCandidatesPoolRatio is a ratio of nodes that are considered
-	// as additional non empty candidates for scale down when some candidates from
-	// previous iteration are no longer valid.
-	ScaleDownCandidatesPoolRatio float64
-	// ScaleDownCandidatesPoolMinCount is the minimum number of nodes that are
-	// considered as additional non empty candidates for scale down when some
-	// candidates from previous iteration are no longer valid.
-	// The formula to calculate additional candidates number is following:
-	// max(#nodes * ScaleDownCandidatesPoolRatio, ScaleDownCandidatesPoolMinCount)
-	ScaleDownCandidatesPoolMinCount int
-	// WriteStatusConfigMap tells if the status information should be written to a ConfigMap
-	WriteStatusConfigMap bool
-	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
-	BalanceSimilarNodeGroups bool
-	// ConfigNamespace is the namespace cluster-autoscaler is running in and all related configmaps live in
-	ConfigNamespace string
-	// ClusterName if available
-	ClusterName string
-	// NodeAutoprovisioningEnabled tells whether the node auto-provisioning is enabled for this cluster.
-	NodeAutoprovisioningEnabled bool
-	// MaxAutoprovisionedNodeGroupCount is the maximum number of autoprovisioned groups in the cluster.
-	MaxAutoprovisionedNodeGroupCount int
-	// UnremovableNodeRecheckTimeout is the timeout before we check again a node that couldn't be removed before
-	UnremovableNodeRecheckTimeout time.Duration
-	// Pods with priority below cutoff are expendable. They can be killed without any consideration during scale down and they don't cause scale-up.
-	// Pods with null priority (PodPriority disabled) are non-expendable.
-	ExpendablePodsPriorityCutoff int
-	// Regional tells whether the cluster is regional.
-	Regional bool
-}
-
 // NewResourceLimiterFromAutoscalingOptions creates new instance of cloudprovider.ResourceLimiter
 // reading limits from AutoscalingOptions struct.
-func NewResourceLimiterFromAutoscalingOptions(options AutoscalingOptions) *cloudprovider.ResourceLimiter {
+func NewResourceLimiterFromAutoscalingOptions(options static.AutoscalingOptions) *cloudprovider.ResourceLimiter {
 	// build min/max maps for resources limits
 	minResources := make(map[string]int64)
 	maxResources := make(map[string]int64)
@@ -168,7 +70,7 @@ func NewResourceLimiterFromAutoscalingOptions(options AutoscalingOptions) *cloud
 }
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
-func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
+func NewAutoscalingContext(options static.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder,
 	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry) (*AutoscalingContext, errors.AutoscalerError) {
 

--- a/cluster-autoscaler/context/autoscaling_context_test.go
+++ b/cluster-autoscaler/context/autoscaling_context_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -35,7 +36,7 @@ func TestNewAutoscalingContext(t *testing.T) {
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
 
 	autoscalingContext, err := NewAutoscalingContext(
-		AutoscalingOptions{
+		static.AutoscalingOptions{
 			ExpanderName:   expander.RandomExpanderName,
 			MaxCoresTotal:  10,
 			MinCoresTotal:  1,

--- a/cluster-autoscaler/context/autoscaling_context_test.go
+++ b/cluster-autoscaler/context/autoscaling_context_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -36,7 +36,7 @@ func TestNewAutoscalingContext(t *testing.T) {
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
 
 	autoscalingContext, err := NewAutoscalingContext(
-		static.AutoscalingOptions{
+		config.AutoscalingOptions{
 			ExpanderName:   expander.RandomExpanderName,
 			MaxCoresTotal:  10,
 			MinCoresTotal:  1,

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -19,7 +19,7 @@ package core
 import (
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -30,7 +30,7 @@ import (
 
 // AutoscalerOptions is the whole set of options for configuring an autoscaler
 type AutoscalerOptions struct {
-	static.AutoscalingOptions
+	config.AutoscalingOptions
 	KubeClient        kube_client.Interface
 	KubeEventRecorder kube_record.EventRecorder
 	PredicateChecker  *simulator.PredicateChecker

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -19,7 +19,7 @@ package core
 import (
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -30,7 +30,7 @@ import (
 
 // AutoscalerOptions is the whole set of options for configuring an autoscaler
 type AutoscalerOptions struct {
-	context.AutoscalingOptions
+	static.AutoscalingOptions
 	KubeClient        kube_client.Interface
 	KubeEventRecorder kube_record.EventRecorder
 	PredicateChecker  *simulator.PredicateChecker

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -127,7 +126,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	provider.AddNode("ng1", n9)
 
 	context := context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.35,
 			ExpendablePodsPriorityCutoff:  10,
 			UnremovableNodeRecheckTimeout: 5 * time.Minute,
@@ -247,7 +246,7 @@ func TestPodsWithPrioritiesFindUnneededNodes(t *testing.T) {
 	provider.AddNode("ng1", n4)
 
 	context := context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.35,
 			ExpendablePodsPriorityCutoff:  10,
 		},
@@ -303,7 +302,7 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	numCandidates := 30
 
 	context := context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold:    0.35,
 			ScaleDownNonEmptyCandidatesCount: numCandidates,
 			ScaleDownCandidatesPoolRatio:     1,
@@ -376,7 +375,7 @@ func TestFindUnneededEmptyNodes(t *testing.T) {
 	numCandidates := 30
 
 	context := context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold:    0.35,
 			ScaleDownNonEmptyCandidatesCount: numCandidates,
 			ScaleDownCandidatesPoolRatio:     1.0,
@@ -427,7 +426,7 @@ func TestFindUnneededNodePool(t *testing.T) {
 	numCandidates := 30
 
 	context := context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold:    0.35,
 			ScaleDownNonEmptyCandidatesCount: numCandidates,
 			ScaleDownCandidatesPoolRatio:     0.1,
@@ -574,7 +573,7 @@ func TestDeleteNode(t *testing.T) {
 
 			// build context
 			context := &context.AutoscalingContext{
-				AutoscalingOptions: static.AutoscalingOptions{},
+				AutoscalingOptions: config.AutoscalingOptions{},
 				ClientSet:          fakeClient,
 				Recorder:           fakeRecorder,
 				LogRecorder:        fakeLogRecorder,
@@ -805,7 +804,7 @@ func TestScaleDown(t *testing.T) {
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
 			ScaleDownUnneededTime:         time.Minute,
 			MaxGracefulTerminationSec:     60,
@@ -860,7 +859,7 @@ func assertSubset(t *testing.T, a []string, b []string) {
 	}
 }
 
-var defaultScaleDownOptions = static.AutoscalingOptions{
+var defaultScaleDownOptions = config.AutoscalingOptions{
 	ScaleDownUtilizationThreshold: 0.5,
 	ScaleDownUnneededTime:         time.Minute,
 	MaxGracefulTerminationSec:     60,
@@ -929,7 +928,7 @@ func TestScaleDownEmptyMinMemoryLimitHit(t *testing.T) {
 
 func TestScaleDownEmptyMinGpuLimitHit(t *testing.T) {
 	options := defaultScaleDownOptions
-	options.GpuTotal = []static.GpuLimits{
+	options.GpuTotal = []config.GpuLimits{
 		{
 			GpuType: gpu.DefaultGPUType,
 			Min:     4,
@@ -1104,7 +1103,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
 			ScaleDownUnneededTime:         time.Minute,
 			ScaleDownUnreadyTime:          time.Hour,
@@ -1212,7 +1211,7 @@ func TestScaleDownNoMove(t *testing.T) {
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
 			ScaleDownUnneededTime:         time.Minute,
 			ScaleDownUnreadyTime:          time.Hour,

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package core
 
-import "k8s.io/autoscaler/cluster-autoscaler/config/static"
+import "k8s.io/autoscaler/cluster-autoscaler/config"
 
 type nodeConfig struct {
 	name   string
@@ -48,5 +48,5 @@ type scaleTestConfig struct {
 	scaleUpOptionToChoose  groupSizeChange   // this will be selected by assertingStrategy.BestOption
 	expectedFinalScaleUp   groupSizeChange   // we expect this to be delivered via scale-up event
 	expectedScaleDowns     []string
-	options                static.AutoscalingOptions
+	options                config.AutoscalingOptions
 }

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package core
 
-import (
-	"k8s.io/autoscaler/cluster-autoscaler/context"
-)
+import "k8s.io/autoscaler/cluster-autoscaler/config/static"
 
 type nodeConfig struct {
 	name   string
@@ -50,5 +48,5 @@ type scaleTestConfig struct {
 	scaleUpOptionToChoose  groupSizeChange   // this will be selected by assertingStrategy.BestOption
 	expectedFinalScaleUp   groupSizeChange   // we expect this to be delivered via scale-up event
 	expectedScaleDowns     []string
-	options                context.AutoscalingOptions
+	options                static.AutoscalingOptions
 }

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -50,7 +51,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 )
 
-var defaultOptions = context.AutoscalingOptions{
+var defaultOptions = static.AutoscalingOptions{
 	EstimatorName:  estimator.BinpackingEstimatorName,
 	MaxCoresTotal:  config.DefaultMaxClusterCores,
 	MaxMemoryTotal: config.DefaultMaxClusterMemory * units.Gigabyte,
@@ -538,7 +539,7 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -663,7 +664,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -715,7 +716,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -797,7 +798,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes(nodes, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:            estimator.BinpackingEstimatorName,
 			BalanceSimilarNodeGroups: true,
 			MaxCoresTotal:            config.DefaultMaxClusterCores,
@@ -861,7 +862,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:                    estimator.BinpackingEstimatorName,
 			MaxCoresTotal:                    5000 * 64,
 			MaxMemoryTotal:                   5000 * 64 * 20,

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -51,7 +50,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 )
 
-var defaultOptions = static.AutoscalingOptions{
+var defaultOptions = config.AutoscalingOptions{
 	EstimatorName:  estimator.BinpackingEstimatorName,
 	MaxCoresTotal:  config.DefaultMaxClusterCores,
 	MaxMemoryTotal: config.DefaultMaxClusterMemory * units.Gigabyte,
@@ -539,7 +538,7 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -664,7 +663,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -716,7 +715,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:  estimator.BinpackingEstimatorName,
 			MaxCoresTotal:  config.DefaultMaxClusterCores,
 			MaxMemoryTotal: config.DefaultMaxClusterMemory,
@@ -798,7 +797,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 	clusterState.UpdateNodes(nodes, time.Now())
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:            estimator.BinpackingEstimatorName,
 			BalanceSimilarNodeGroups: true,
 			MaxCoresTotal:            config.DefaultMaxClusterCores,
@@ -862,7 +861,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:                    estimator.BinpackingEstimatorName,
 			MaxCoresTotal:                    5000 * 64,
 			MaxMemoryTotal:                   5000 * 64 * 20,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
@@ -65,7 +66,7 @@ type StaticAutoscaler struct {
 }
 
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
-func NewStaticAutoscaler(opts context.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
+func NewStaticAutoscaler(opts static.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder, listerRegistry kube_util.ListerRegistry,
 	processors *ca_processors.AutoscalingProcessors) (*StaticAutoscaler, errors.AutoscalerError) {
 	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
@@ -66,7 +66,7 @@ type StaticAutoscaler struct {
 }
 
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
-func NewStaticAutoscaler(opts static.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
+func NewStaticAutoscaler(opts config.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder, listerRegistry kube_util.ListerRegistry,
 	processors *ca_processors.AutoscalingProcessors) (*StaticAutoscaler, errors.AutoscalerError) {
 	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -24,6 +24,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -172,7 +173,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,
@@ -352,7 +353,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	processors := ca_processors.TestProcessors()
 	processors.NodeGroupListProcessor = nodegroups.NewAutoprovisioningNodeGroupListProcessor()
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:                    estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:                 true,
 			ScaleDownUtilizationThreshold:    0.5,
@@ -491,7 +492,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, later)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,
@@ -628,7 +629,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -24,7 +24,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -173,7 +173,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,
@@ -353,7 +353,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	processors := ca_processors.TestProcessors()
 	processors.NodeGroupListProcessor = nodegroups.NewAutoprovisioningNodeGroupListProcessor()
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:                    estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:                 true,
 			ScaleDownUtilizationThreshold:    0.5,
@@ -492,7 +492,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, later)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,
@@ -629,7 +629,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			EstimatorName:                 estimator.BinpackingEstimatorName,
 			ScaleDownEnabled:              true,
 			ScaleDownUtilizationThreshold: 0.5,

--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -24,6 +24,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
@@ -378,7 +379,7 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	assert.NoError(t, err)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
 		CloudProvider: provider,
@@ -475,7 +476,7 @@ func TestRemoveFixNodeTargetSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
 		CloudProvider: provider,

--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -24,7 +24,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
@@ -379,7 +379,7 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	assert.NoError(t, err)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
 		CloudProvider: provider,
@@ -476,7 +476,7 @@ func TestRemoveFixNodeTargetSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			MaxNodeProvisionTime: 45 * time.Minute,
 		},
 		CloudProvider: provider,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -33,7 +33,7 @@ import (
 	kube_flag "k8s.io/apiserver/pkg/util/flag"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -151,7 +151,7 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 )
 
-func createAutoscalingOptions() context.AutoscalingOptions {
+func createAutoscalingOptions() static.AutoscalingOptions {
 	minCoresTotal, maxCoresTotal, err := parseMinMaxFlag(*coresTotal)
 	if err != nil {
 		glog.Fatalf("Failed to parse flags: %v", err)
@@ -169,7 +169,7 @@ func createAutoscalingOptions() context.AutoscalingOptions {
 		glog.Fatalf("Failed to parse flags: %v", err)
 	}
 
-	return context.AutoscalingOptions{
+	return static.AutoscalingOptions{
 		CloudConfig:                      *cloudConfig,
 		CloudProviderName:                *cloudProviderFlag,
 		NodeGroupAutoDiscovery:           *nodeGroupAutoDiscoveryFlag,
@@ -456,8 +456,8 @@ func minMaxFlagString(min, max int64) string {
 	return fmt.Sprintf("%v:%v", min, max)
 }
 
-func parseMultipleGpuLimits(flags MultiStringFlag) ([]context.GpuLimits, error) {
-	parsedFlags := make([]context.GpuLimits, 0, len(flags))
+func parseMultipleGpuLimits(flags MultiStringFlag) ([]static.GpuLimits, error) {
+	parsedFlags := make([]static.GpuLimits, 0, len(flags))
 	for _, flag := range flags {
 		parsedFlag, err := parseSingleGpuLimit(flag)
 		if err != nil {
@@ -468,30 +468,30 @@ func parseMultipleGpuLimits(flags MultiStringFlag) ([]context.GpuLimits, error) 
 	return parsedFlags, nil
 }
 
-func parseSingleGpuLimit(config string) (context.GpuLimits, error) {
+func parseSingleGpuLimit(config string) (static.GpuLimits, error) {
 	parts := strings.Split(config, ":")
 	if len(parts) != 3 {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit specification: %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit specification: %v", config)
 	}
 	gpuType := parts[0]
 	minVal, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is not integer: %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is not integer: %v", config)
 	}
 	maxVal, err := strconv.ParseInt(parts[2], 10, 64)
 	if err != nil {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is not integer: %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is not integer: %v", config)
 	}
 	if minVal < 0 {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is less than 0; %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is less than 0; %v", config)
 	}
 	if maxVal < 0 {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is less than 0; %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is less than 0; %v", config)
 	}
 	if minVal > maxVal {
-		return context.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is greater than max; %v", config)
+		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is greater than max; %v", config)
 	}
-	parsedGpuLimits := context.GpuLimits{
+	parsedGpuLimits := static.GpuLimits{
 		GpuType: gpuType,
 		Min:     minVal,
 		Max:     maxVal,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -33,7 +33,6 @@ import (
 	kube_flag "k8s.io/apiserver/pkg/util/flag"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -151,7 +150,7 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 )
 
-func createAutoscalingOptions() static.AutoscalingOptions {
+func createAutoscalingOptions() config.AutoscalingOptions {
 	minCoresTotal, maxCoresTotal, err := parseMinMaxFlag(*coresTotal)
 	if err != nil {
 		glog.Fatalf("Failed to parse flags: %v", err)
@@ -169,7 +168,7 @@ func createAutoscalingOptions() static.AutoscalingOptions {
 		glog.Fatalf("Failed to parse flags: %v", err)
 	}
 
-	return static.AutoscalingOptions{
+	return config.AutoscalingOptions{
 		CloudConfig:                      *cloudConfig,
 		CloudProviderName:                *cloudProviderFlag,
 		NodeGroupAutoDiscovery:           *nodeGroupAutoDiscoveryFlag,
@@ -456,8 +455,8 @@ func minMaxFlagString(min, max int64) string {
 	return fmt.Sprintf("%v:%v", min, max)
 }
 
-func parseMultipleGpuLimits(flags MultiStringFlag) ([]static.GpuLimits, error) {
-	parsedFlags := make([]static.GpuLimits, 0, len(flags))
+func parseMultipleGpuLimits(flags MultiStringFlag) ([]config.GpuLimits, error) {
+	parsedFlags := make([]config.GpuLimits, 0, len(flags))
 	for _, flag := range flags {
 		parsedFlag, err := parseSingleGpuLimit(flag)
 		if err != nil {
@@ -468,30 +467,30 @@ func parseMultipleGpuLimits(flags MultiStringFlag) ([]static.GpuLimits, error) {
 	return parsedFlags, nil
 }
 
-func parseSingleGpuLimit(config string) (static.GpuLimits, error) {
-	parts := strings.Split(config, ":")
+func parseSingleGpuLimit(limits string) (config.GpuLimits, error) {
+	parts := strings.Split(limits, ":")
 	if len(parts) != 3 {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit specification: %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit specification: %v", limits)
 	}
 	gpuType := parts[0]
 	minVal, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is not integer: %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is not integer: %v", limits)
 	}
 	maxVal, err := strconv.ParseInt(parts[2], 10, 64)
 	if err != nil {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is not integer: %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is not integer: %v", limits)
 	}
 	if minVal < 0 {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is less than 0; %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is less than 0; %v", limits)
 	}
 	if maxVal < 0 {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is less than 0; %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - max is less than 0; %v", limits)
 	}
 	if minVal > maxVal {
-		return static.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is greater than max; %v", config)
+		return config.GpuLimits{}, fmt.Errorf("Incorrect gpu limit - min is greater than max; %v", limits)
 	}
-	parsedGpuLimits := static.GpuLimits{
+	parsedGpuLimits := config.GpuLimits{
 		GpuType: gpuType,
 		Min:     minVal,
 		Max:     maxVal,

--- a/cluster-autoscaler/main_test.go
+++ b/cluster-autoscaler/main_test.go
@@ -19,15 +19,16 @@ package main
 import (
 	"testing"
 
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+
 	"github.com/stretchr/testify/assert"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 )
 
 func TestParseSingleGpuLimit(t *testing.T) {
 	type testcase struct {
 		input                string
 		expectError          bool
-		expectedLimits       static.GpuLimits
+		expectedLimits       config.GpuLimits
 		expectedErrorMessage string
 	}
 
@@ -35,7 +36,7 @@ func TestParseSingleGpuLimit(t *testing.T) {
 		{
 			input:       "gpu:1:10",
 			expectError: false,
-			expectedLimits: static.GpuLimits{
+			expectedLimits: config.GpuLimits{
 				GpuType: "gpu",
 				Min:     1,
 				Max:     10,

--- a/cluster-autoscaler/main_test.go
+++ b/cluster-autoscaler/main_test.go
@@ -17,16 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 )
 
 func TestParseSingleGpuLimit(t *testing.T) {
 	type testcase struct {
 		input                string
 		expectError          bool
-		expectedLimits       context.GpuLimits
+		expectedLimits       static.GpuLimits
 		expectedErrorMessage string
 	}
 
@@ -34,7 +35,7 @@ func TestParseSingleGpuLimit(t *testing.T) {
 		{
 			input:       "gpu:1:10",
 			expectError: false,
-			expectedLimits: context.GpuLimits{
+			expectedLimits: static.GpuLimits{
 				GpuType: "gpu",
 				Min:     1,
 				Max:     10,

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -56,7 +56,7 @@ func TestAutoprovisioningNodeGroupManager(t *testing.T) {
 		provider := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil,
 			func(string) error { return tc.createNodeGroupErr }, nil, nil, nil)
 		context := &context.AutoscalingContext{
-			AutoscalingOptions: static.AutoscalingOptions{
+			AutoscalingOptions: config.AutoscalingOptions{
 				NodeAutoprovisioningEnabled: true,
 			},
 			CloudProvider: provider,
@@ -107,7 +107,7 @@ func TestRemoveUnneededNodeGroups(t *testing.T) {
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			NodeAutoprovisioningEnabled: true,
 		},
 		CloudProvider: provider,

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -55,7 +56,7 @@ func TestAutoprovisioningNodeGroupManager(t *testing.T) {
 		provider := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil,
 			func(string) error { return tc.createNodeGroupErr }, nil, nil, nil)
 		context := &context.AutoscalingContext{
-			AutoscalingOptions: context.AutoscalingOptions{
+			AutoscalingOptions: static.AutoscalingOptions{
 				NodeAutoprovisioningEnabled: true,
 			},
 			CloudProvider: provider,
@@ -106,7 +107,7 @@ func TestRemoveUnneededNodeGroups(t *testing.T) {
 	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			NodeAutoprovisioningEnabled: true,
 		},
 		CloudProvider: provider,

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor.go
@@ -41,7 +41,7 @@ func NewAutoprovisioningNodeGroupListProcessor() NodeGroupListProcessor {
 func (p *AutoprovisioningNodeGroupListProcessor) Process(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup, nodeInfos map[string]*schedulercache.NodeInfo,
 	unschedulablePods []*apiv1.Pod) ([]cloudprovider.NodeGroup, map[string]*schedulercache.NodeInfo, error) {
 
-	if !context.AutoscalingOptions.NodeAutoprovisioningEnabled {
+	if !context.NodeAutoprovisioningEnabled {
 		return nodeGroups, nodeInfos, nil
 	}
 

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor_test.go
@@ -21,7 +21,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
-	"k8s.io/autoscaler/cluster-autoscaler/config/static"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
@@ -47,7 +47,7 @@ func TestAutoprovisioningNGLProcessor(t *testing.T) {
 	provider.AddNodeGroup("ng1", 1, 5, 3)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			MaxAutoprovisionedNodeGroupCount: 1,
 			NodeAutoprovisioningEnabled:      true,
 		},
@@ -85,7 +85,7 @@ func TestAutoprovisioningNGLProcessorTooMany(t *testing.T) {
 	provider.AddAutoprovisionedNodeGroup("autoprovisioned-X1", 0, 1000, 0, "X1")
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: static.AutoscalingOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
 			MaxAutoprovisionedNodeGroupCount: 1,
 			NodeAutoprovisioningEnabled:      true,
 		},

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_processor_test.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config/static"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
@@ -46,7 +47,7 @@ func TestAutoprovisioningNGLProcessor(t *testing.T) {
 	provider.AddNodeGroup("ng1", 1, 5, 3)
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			MaxAutoprovisionedNodeGroupCount: 1,
 			NodeAutoprovisioningEnabled:      true,
 		},
@@ -84,7 +85,7 @@ func TestAutoprovisioningNGLProcessorTooMany(t *testing.T) {
 	provider.AddAutoprovisionedNodeGroup("autoprovisioned-X1", 0, 1000, 0, "X1")
 
 	context := &context.AutoscalingContext{
-		AutoscalingOptions: context.AutoscalingOptions{
+		AutoscalingOptions: static.AutoscalingOptions{
 			MaxAutoprovisionedNodeGroupCount: 1,
 			NodeAutoprovisioningEnabled:      true,
 		},


### PR DESCRIPTION
Pass the entire options object to build cloud provider.
Remove no longer necessary builder pattern for cloud provider (it's never re-constructed after initialization.)