### PR TITLE
Move creating cloud provider out of context

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -48,8 +49,15 @@ var AvailableCloudProviders = []string{
 const DefaultCloudProvider = gce.ProviderNameGCE
 
 // NewCloudProvider builds a cloud provider from provided parameters.
-func NewCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func NewCloudProvider(opts config.AutoscalingOptions) cloudprovider.CloudProvider {
 	glog.V(1).Infof("Building %s cloud provider.", opts.CloudProviderName)
+
+	do := cloudprovider.NodeGroupDiscoveryOptions{
+		NodeGroupSpecs:              opts.NodeGroups,
+		NodeGroupAutoDiscoverySpecs: opts.NodeGroupAutoDiscovery,
+	}
+	rl := context.NewResourceLimiterFromAutoscalingOptions(opts)
+
 	switch opts.CloudProviderName {
 	case gce.ProviderNameGCE:
 		return buildGCE(opts, do, rl, gce.ModeGCE)

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -18,7 +18,6 @@ package context
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -72,15 +71,8 @@ func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions)
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
 func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder,
-	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry) (*AutoscalingContext, errors.AutoscalerError) {
-
-	cloudProvider := builder.NewCloudProvider(
-		options,
-		cloudprovider.NodeGroupDiscoveryOptions{
-			NodeGroupSpecs:              options.NodeGroups,
-			NodeGroupAutoDiscoverySpecs: options.NodeGroupAutoDiscovery,
-		},
-		NewResourceLimiterFromAutoscalingOptions(options))
+	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry,
+	cloudProvider cloudprovider.CloudProvider) (*AutoscalingContext, errors.AutoscalerError) {
 	expanderStrategy, err := factory.ExpanderStrategyFromString(options.ExpanderName,
 		cloudProvider, listerRegistry.AllNodeLister())
 	if err != nil {

--- a/cluster-autoscaler/context/autoscaling_context_test.go
+++ b/cluster-autoscaler/context/autoscaling_context_test.go
@@ -45,7 +45,9 @@ func TestNewAutoscalingContext(t *testing.T) {
 		},
 		simulator.NewTestPredicateChecker(),
 		fakeClient, fakeRecorder,
-		fakeLogRecorder, kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil))
+		fakeLogRecorder, kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil),
+		nil, // fake CloudProvider
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, autoscalingContext)
 }

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -19,6 +19,7 @@ package core
 import (
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -55,10 +56,10 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 }
 
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters
-func NewAutoscaler(opts AutoscalerOptions) (Autoscaler, errors.AutoscalerError) {
+func NewAutoscaler(opts AutoscalerOptions, cloudProvider cloudprovider.CloudProvider) (Autoscaler, errors.AutoscalerError) {
 	err := initializeDefaultOptions(&opts)
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
 	}
-	return NewStaticAutoscaler(opts.AutoscalingOptions, opts.PredicateChecker, opts.KubeClient, opts.KubeEventRecorder, opts.ListerRegistry, opts.Processors)
+	return NewStaticAutoscaler(opts.AutoscalingOptions, opts.PredicateChecker, opts.KubeClient, opts.KubeEventRecorder, opts.ListerRegistry, opts.Processors, cloudProvider)
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -19,6 +19,7 @@ package core
 import (
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -68,7 +69,7 @@ type StaticAutoscaler struct {
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
 func NewStaticAutoscaler(opts config.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder, listerRegistry kube_util.ListerRegistry,
-	processors *ca_processors.AutoscalingProcessors) (*StaticAutoscaler, errors.AutoscalerError) {
+	processors *ca_processors.AutoscalingProcessors, cloudProvider cloudprovider.CloudProvider) (*StaticAutoscaler, errors.AutoscalerError) {
 	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap)
 	if err != nil {
 		glog.Error("Failed to initialize status configmap, unable to write status events")
@@ -76,7 +77,7 @@ func NewStaticAutoscaler(opts config.AutoscalingOptions, predicateChecker *simul
 		// TODO(maciekpytel): recover from this after successful status configmap update?
 		logRecorder, _ = utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, false)
 	}
-	autoscalingContext, errctx := context.NewAutoscalingContext(opts, predicateChecker, kubeClient, kubeEventRecorder, logRecorder, listerRegistry)
+	autoscalingContext, errctx := context.NewAutoscalingContext(opts, predicateChecker, kubeClient, kubeEventRecorder, logRecorder, listerRegistry, cloudProvider)
 	if errctx != nil {
 		return nil, errctx
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -31,10 +31,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_flag "k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -275,13 +273,7 @@ func run(healthCheck *metrics.HealthCheck) {
 		ListerRegistry:     listerRegistry,
 	}
 
-	cloudProvider := cloudBuilder.NewCloudProvider(
-		autoscalingOptions,
-		cloudprovider.NodeGroupDiscoveryOptions{
-			NodeGroupSpecs:              autoscalingOptions.NodeGroups,
-			NodeGroupAutoDiscoverySpecs: autoscalingOptions.NodeGroupAutoDiscovery,
-		},
-		context.NewResourceLimiterFromAutoscalingOptions(autoscalingOptions))
+	cloudProvider := cloudBuilder.NewCloudProvider(autoscalingOptions)
 
 	autoscaler, err := core.NewAutoscaler(opts, cloudProvider)
 	if err != nil {


### PR DESCRIPTION
Move creating cloud provider out of context.
Move creating helper structs with dynamic config into cloud provider constructor.