### PR TITLE
Use proxy for container state aggregator.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -212,3 +212,29 @@ func AggregateStateByContainerName(aggregateContainerStateMap aggregateContainer
 	}
 	return containerNameToAggregateStateMap
 }
+
+// ContainerStateAggregatorProxy is a wrapper for ContainerStateAggregator
+// that creates CnontainerStateAgregator for container if it is no longer
+// present in the cluster state.
+type ContainerStateAggregatorProxy struct {
+	containerID ContainerID
+	cluster     *ClusterState
+}
+
+// NewContainerStateAggregatorProxy creates a ContainerStateAggregatorProxy
+// pointing to the cluster state.
+func NewContainerStateAggregatorProxy(cluster *ClusterState, containerID ContainerID) ContainerStateAggregator {
+	return &ContainerStateAggregatorProxy{containerID, cluster}
+}
+
+// AddSample adds a container sample to the aggregator.
+func (p *ContainerStateAggregatorProxy) AddSample(sample *ContainerUsageSample) {
+	aggregator := p.cluster.findOrCreateAggregateContainerState(p.containerID)
+	aggregator.AddSample(sample)
+}
+
+// SubtractSample subtracts a container sample from the aggregator.
+func (p *ContainerStateAggregatorProxy) SubtractSample(sample *ContainerUsageSample) {
+	aggregator := p.cluster.findOrCreateAggregateContainerState(p.containerID)
+	aggregator.SubtractSample(sample)
+}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -144,8 +144,8 @@ func (cluster *ClusterState) AddOrUpdateContainer(containerID ContainerID, reque
 		return NewKeyError(containerID.PodID)
 	}
 	if container, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
-		aggregateContainerState := cluster.findOrCreateAggregateContainerState(containerID)
-		pod.Containers[containerID.ContainerName] = NewContainerState(request, aggregateContainerState)
+		cluster.findOrCreateAggregateContainerState(containerID)
+		pod.Containers[containerID.ContainerName] = NewContainerState(request, NewContainerStateAggregatorProxy(cluster, containerID))
 	} else {
 		// Container aleady exists. Possibly update the request.
 		container.Request = request


### PR DESCRIPTION
When a ContainerAggregatedState of a live container is garbage collected due to lack of samples, is will be recreated once the samples start appearing again. This prevents us from not providing recommendations for containers that are live but didn't get samples for 8 days.