### PR TITLE
Group all Kubernetes API clients

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -48,6 +48,8 @@ type AutoscalingContext struct {
 // AutoscalingKubeClients contains all Kubernetes API clients,
 // including listers and event recorders.
 type AutoscalingKubeClients struct {
+	// Listers.
+	kube_util.ListerRegistry
 	// ClientSet interface.
 	ClientSet kube_client.Interface
 	// Recorder for recording events.
@@ -90,9 +92,10 @@ func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *
 		AutoscalingOptions: options,
 		CloudProvider:      cloudProvider,
 		AutoscalingKubeClients: AutoscalingKubeClients{
-			ClientSet:   kubeClient,
-			Recorder:    kubeEventRecorder,
-			LogRecorder: logEventRecorder,
+			ListerRegistry: listerRegistry,
+			ClientSet:      kubeClient,
+			Recorder:       kubeEventRecorder,
+			LogRecorder:    logEventRecorder,
 		},
 		PredicateChecker: predicateChecker,
 		ExpanderStrategy: expanderStrategy,

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -34,17 +34,24 @@ import (
 type AutoscalingContext struct {
 	// Options to customize how autoscaling works
 	config.AutoscalingOptions
+	// Kubernetes API clients.
+	AutoscalingKubeClients
 	// CloudProvider used in CA.
 	CloudProvider cloudprovider.CloudProvider
-	// ClientSet interface.
-	ClientSet kube_client.Interface
-	// Recorder for recording events.
-	Recorder kube_record.EventRecorder
 	// TODO(kgolab) - move away too as it's not config
 	// PredicateChecker to check if a pod can fit into a node.
 	PredicateChecker *simulator.PredicateChecker
 	// ExpanderStrategy is the strategy used to choose which node group to expand when scaling up
 	ExpanderStrategy expander.Strategy
+}
+
+// AutoscalingKubeClients contains all Kubernetes API clients,
+// including listers and event recorders.
+type AutoscalingKubeClients struct {
+	// ClientSet interface.
+	ClientSet kube_client.Interface
+	// Recorder for recording events.
+	Recorder kube_record.EventRecorder
 	// LogRecorder can be used to collect log messages to expose via Events on some central object.
 	LogRecorder *utils.LogEventRecorder
 }
@@ -82,11 +89,13 @@ func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *
 	autoscalingContext := AutoscalingContext{
 		AutoscalingOptions: options,
 		CloudProvider:      cloudProvider,
-		ClientSet:          kubeClient,
-		Recorder:           kubeEventRecorder,
-		PredicateChecker:   predicateChecker,
-		ExpanderStrategy:   expanderStrategy,
-		LogRecorder:        logEventRecorder,
+		AutoscalingKubeClients: AutoscalingKubeClients{
+			ClientSet:   kubeClient,
+			Recorder:    kubeEventRecorder,
+			LogRecorder: logEventRecorder,
+		},
+		PredicateChecker: predicateChecker,
+		ExpanderStrategy: expanderStrategy,
 	}
 
 	return &autoscalingContext, nil

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -16,7 +16,17 @@ limitations under the License.
 
 package core
 
-import "k8s.io/autoscaler/cluster-autoscaler/config"
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+
+	kube_client "k8s.io/client-go/kubernetes"
+	kube_record "k8s.io/client-go/tools/record"
+)
 
 type nodeConfig struct {
 	name   string
@@ -49,4 +59,22 @@ type scaleTestConfig struct {
 	expectedFinalScaleUp   groupSizeChange   // we expect this to be delivered via scale-up event
 	expectedScaleDowns     []string
 	options                config.AutoscalingOptions
+}
+
+// NewScaleTestAutoscalingContext creates a new test autoscaling context for scaling tests.
+func NewScaleTestAutoscalingContext(options config.AutoscalingOptions, fakeClient kube_client.Interface, provider cloudprovider.CloudProvider) context.AutoscalingContext {
+	fakeRecorder := kube_record.NewFakeRecorder(5)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
+	return context.AutoscalingContext{
+		AutoscalingOptions: options,
+		AutoscalingKubeClients: context.AutoscalingKubeClients{
+			ClientSet:   fakeClient,
+			Recorder:    fakeRecorder,
+			LogRecorder: fakeLogRecorder,
+		},
+		CloudProvider:    provider,
+		PredicateChecker: simulator.NewTestPredicateChecker(),
+		ExpanderStrategy: random.NewStrategy(),
+	}
+
 }

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -26,24 +26,19 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
-	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
-	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
-	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+	kube_record "k8s.io/client-go/tools/record"
 
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	kube_record "k8s.io/client-go/tools/record"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"github.com/stretchr/testify/assert"
@@ -421,25 +416,18 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 
 	assert.NotNil(t, provider)
 
-	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
-
-	clusterState.UpdateNodes(nodes, time.Now())
-
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.options,
-		PredicateChecker:   simulator.NewTestPredicateChecker(),
-		CloudProvider:      provider,
-		ClientSet:          fakeClient,
-		Recorder:           fakeRecorder,
-		ExpanderStrategy: assertingStrategy{
-			initialNodeConfigs:     config.nodes,
-			expectedScaleUpOptions: config.expectedScaleUpOptions,
-			scaleUpOptionToChoose:  config.scaleUpOptionToChoose,
-			t: t},
-		LogRecorder: fakeLogRecorder,
+	// Create context with non-random expander strategy.
+	context := NewScaleTestAutoscalingContext(config.options, fakeClient, provider)
+	expander := assertingStrategy{
+		initialNodeConfigs:     config.nodes,
+		expectedScaleUpOptions: config.expectedScaleUpOptions,
+		scaleUpOptionToChoose:  config.scaleUpOptionToChoose,
+		t: t,
 	}
+	context.ExpanderStrategy = expander
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
+	clusterState.UpdateNodes(nodes, time.Now())
 
 	extraPods := make([]*apiv1.Pod, len(config.extraPods))
 	for i, p := range config.extraPods {
@@ -449,8 +437,8 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 
 	processors := ca_processors.TestProcessors()
 
-	status, err := ScaleUp(context, processors, clusterState, extraPods, nodes, []*extensionsv1.DaemonSet{})
-	processors.ScaleUpStatusProcessor.Process(context, status)
+	status, err := ScaleUp(&context, processors, clusterState, extraPods, nodes, []*extensionsv1.DaemonSet{})
+	processors.ScaleUpStatusProcessor.Process(&context, status)
 	assert.NoError(t, err)
 	assert.True(t, status.ScaledUp)
 
@@ -461,7 +449,7 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 	nodeEventSeen := false
 	for eventsLeft := true; eventsLeft; {
 		select {
-		case event := <-fakeRecorder.Events:
+		case event := <-context.Recorder.(*kube_record.FakeRecorder).Events:
 			if strings.Contains(event, "TriggeredScaleUp") && strings.Contains(event, config.expectedFinalScaleUp.groupName) {
 				nodeEventSeen = true
 			}
@@ -526,9 +514,14 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng2", n2)
 
-	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
+	options := config.AutoscalingOptions{
+		EstimatorName:  estimator.BinpackingEstimatorName,
+		MaxCoresTotal:  config.DefaultMaxClusterCores,
+		MaxMemoryTotal: config.DefaultMaxClusterMemory,
+	}
+	context := NewScaleTestAutoscalingContext(options, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
 	clusterState.RegisterScaleUp(&clusterstate.ScaleUpRequest{
 		NodeGroupName:   "ng2",
 		Increase:        1,
@@ -537,24 +530,11 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.AutoscalingOptions{
-			EstimatorName:  estimator.BinpackingEstimatorName,
-			MaxCoresTotal:  config.DefaultMaxClusterCores,
-			MaxMemoryTotal: config.DefaultMaxClusterMemory,
-		},
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-		CloudProvider:    provider,
-		ClientSet:        fakeClient,
-		Recorder:         fakeRecorder,
-		ExpanderStrategy: random.NewStrategy(),
-		LogRecorder:      fakeLogRecorder,
-	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
 
-	status, err := ScaleUp(context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	// A node is already coming - no need for scale up.
 	assert.False(t, status.ScaledUp)
@@ -594,9 +574,9 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng2", n2)
 
-	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
+	context := NewScaleTestAutoscalingContext(defaultOptions, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
 	clusterState.RegisterScaleUp(&clusterstate.ScaleUpRequest{
 		NodeGroupName:   "ng2",
 		Increase:        1,
@@ -605,19 +585,10 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: defaultOptions,
-		PredicateChecker:   simulator.NewTestPredicateChecker(),
-		CloudProvider:      provider,
-		ClientSet:          fakeClient,
-		Recorder:           fakeRecorder,
-		ExpanderStrategy:   random.NewStrategy(),
-		LogRecorder:        fakeLogRecorder,
-	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
-	status, err := ScaleUp(context, processors, clusterState, []*apiv1.Pod{p3, p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3, p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 
 	assert.NoError(t, err)
 	// Two nodes needed but one node is already coming, so it should increase by one.
@@ -658,27 +629,19 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng2", n2)
 
-	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
-	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.AutoscalingOptions{
-			EstimatorName:  estimator.BinpackingEstimatorName,
-			MaxCoresTotal:  config.DefaultMaxClusterCores,
-			MaxMemoryTotal: config.DefaultMaxClusterMemory,
-		},
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-		CloudProvider:    provider,
-		ClientSet:        fakeClient,
-		Recorder:         fakeRecorder,
-		ExpanderStrategy: random.NewStrategy(),
-		LogRecorder:      fakeLogRecorder,
+	options := config.AutoscalingOptions{
+		EstimatorName:  estimator.BinpackingEstimatorName,
+		MaxCoresTotal:  config.DefaultMaxClusterCores,
+		MaxMemoryTotal: config.DefaultMaxClusterMemory,
 	}
+	context := NewScaleTestAutoscalingContext(options, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
+	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
-	status, err := ScaleUp(context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 
 	assert.NoError(t, err)
 	// Node group is unhealthy.
@@ -710,34 +673,26 @@ func TestScaleUpNoHelp(t *testing.T) {
 	provider.AddNode("ng1", n1)
 	assert.NotNil(t, provider)
 
-	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
-	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.AutoscalingOptions{
-			EstimatorName:  estimator.BinpackingEstimatorName,
-			MaxCoresTotal:  config.DefaultMaxClusterCores,
-			MaxMemoryTotal: config.DefaultMaxClusterMemory,
-		},
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-		CloudProvider:    provider,
-		ClientSet:        fakeClient,
-		Recorder:         fakeRecorder,
-		ExpanderStrategy: random.NewStrategy(),
-		LogRecorder:      fakeLogRecorder,
+	options := config.AutoscalingOptions{
+		EstimatorName:  estimator.BinpackingEstimatorName,
+		MaxCoresTotal:  config.DefaultMaxClusterCores,
+		MaxMemoryTotal: config.DefaultMaxClusterMemory,
 	}
+	context := NewScaleTestAutoscalingContext(options, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
+	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
 	p3 := BuildTestPod("p-new", 500, 0)
 
 	processors := ca_processors.TestProcessors()
-	status, err := ScaleUp(context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*extensionsv1.DaemonSet{})
-	processors.ScaleUpStatusProcessor.Process(context, status)
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*extensionsv1.DaemonSet{})
+	processors.ScaleUpStatusProcessor.Process(&context, status)
 
 	assert.NoError(t, err)
 	assert.False(t, status.ScaledUp)
 	var event string
 	select {
-	case event = <-fakeRecorder.Events:
+	case event = <-context.Recorder.(*kube_record.FakeRecorder).Events:
 	default:
 		t.Fatal("No Event recorded, expected NotTriggerScaleUp event")
 	}
@@ -792,24 +747,16 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 		return true, &apiv1.PodList{Items: []apiv1.Pod{*(podMap[matches[0]])}}, nil
 	})
 
-	fakeRecorder := kube_record.NewFakeRecorder(5)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
-	clusterState.UpdateNodes(nodes, time.Now())
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.AutoscalingOptions{
-			EstimatorName:            estimator.BinpackingEstimatorName,
-			BalanceSimilarNodeGroups: true,
-			MaxCoresTotal:            config.DefaultMaxClusterCores,
-			MaxMemoryTotal:           config.DefaultMaxClusterMemory,
-		},
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-		CloudProvider:    provider,
-		ClientSet:        fakeClient,
-		Recorder:         fakeRecorder,
-		ExpanderStrategy: random.NewStrategy(),
-		LogRecorder:      fakeLogRecorder,
+	options := config.AutoscalingOptions{
+		EstimatorName:            estimator.BinpackingEstimatorName,
+		BalanceSimilarNodeGroups: true,
+		MaxCoresTotal:            config.DefaultMaxClusterCores,
+		MaxMemoryTotal:           config.DefaultMaxClusterMemory,
 	}
+	context := NewScaleTestAutoscalingContext(options, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
+	clusterState.UpdateNodes(nodes, time.Now())
 
 	pods := make([]*apiv1.Pod, 0)
 	for i := 0; i < 2; i++ {
@@ -817,7 +764,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	}
 
 	processors := ca_processors.TestProcessors()
-	status, typedErr := ScaleUp(context, processors, clusterState, pods, nodes, []*extensionsv1.DaemonSet{})
+	status, typedErr := ScaleUp(&context, processors, clusterState, pods, nodes, []*extensionsv1.DaemonSet{})
 
 	assert.NoError(t, typedErr)
 	assert.True(t, status.ScaledUp)
@@ -856,31 +803,22 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 			return nil
 		}, nil, []string{"T1"}, map[string]*schedulercache.NodeInfo{"T1": ti1})
 
-	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder)
-
-	context := &context.AutoscalingContext{
-		AutoscalingOptions: config.AutoscalingOptions{
-			EstimatorName:                    estimator.BinpackingEstimatorName,
-			MaxCoresTotal:                    5000 * 64,
-			MaxMemoryTotal:                   5000 * 64 * 20,
-			NodeAutoprovisioningEnabled:      true,
-			MaxAutoprovisionedNodeGroupCount: 10,
-		},
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-		CloudProvider:    provider,
-		ClientSet:        fakeClient,
-		Recorder:         fakeRecorder,
-		ExpanderStrategy: random.NewStrategy(),
-		LogRecorder:      fakeLogRecorder,
+	options := config.AutoscalingOptions{
+		EstimatorName:                    estimator.BinpackingEstimatorName,
+		MaxCoresTotal:                    5000 * 64,
+		MaxMemoryTotal:                   5000 * 64 * 20,
+		NodeAutoprovisioningEnabled:      true,
+		MaxAutoprovisionedNodeGroupCount: 10,
 	}
+	context := NewScaleTestAutoscalingContext(options, fakeClient, provider)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder)
 
 	processors := ca_processors.TestProcessors()
 	processors.NodeGroupListProcessor = nodegroups.NewAutoprovisioningNodeGroupListProcessor()
 	processors.NodeGroupManager = nodegroups.NewDefaultNodeGroupManager()
 
-	status, err := ScaleUp(context, processors, clusterState, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*extensionsv1.DaemonSet{})
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*extensionsv1.DaemonSet{})
 	assert.NoError(t, err)
 	assert.True(t, status.ScaledUp)
 	assert.Equal(t, "autoprovisioned-T1", getStringFromChan(createdGroups))

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -54,7 +54,6 @@ const (
 type StaticAutoscaler struct {
 	// AutoscalingContext consists of validated settings and options for this autoscaler
 	*context.AutoscalingContext
-	kube_util.ListerRegistry
 	// ClusterState for maintaining the state of cluster nodes.
 	clusterStateRegistry    *clusterstate.ClusterStateRegistry
 	startTime               time.Time
@@ -93,7 +92,6 @@ func NewStaticAutoscaler(opts config.AutoscalingOptions, predicateChecker *simul
 
 	return &StaticAutoscaler{
 		AutoscalingContext:      autoscalingContext,
-		ListerRegistry:          listerRegistry,
 		startTime:               time.Now(),
 		lastScaleUpTime:         time.Now(),
 		lastScaleDownDeleteTime: time.Now(),

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager_test.go
@@ -60,7 +60,9 @@ func TestAutoprovisioningNodeGroupManager(t *testing.T) {
 				NodeAutoprovisioningEnabled: true,
 			},
 			CloudProvider: provider,
-			LogRecorder:   fakeLogRecorder,
+			AutoscalingKubeClients: context.AutoscalingKubeClients{
+				LogRecorder: fakeLogRecorder,
+			},
 		}
 
 		nodeGroup, err := provider.NewNodeGroup("T1", nil, nil, nil, nil)
@@ -111,7 +113,9 @@ func TestRemoveUnneededNodeGroups(t *testing.T) {
 			NodeAutoprovisioningEnabled: true,
 		},
 		CloudProvider: provider,
-		LogRecorder:   fakeLogRecorder,
+		AutoscalingKubeClients: context.AutoscalingKubeClients{
+			LogRecorder: fakeLogRecorder,
+		},
 	}
 
 	assert.NoError(t, manager.RemoveUnneededNodeGroups(context))

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
@@ -64,7 +64,9 @@ func TestEventingScaleUpStatusProcessor(t *testing.T) {
 	for _, tc := range testCases {
 		fakeRecorder := kube_record.NewFakeRecorder(5)
 		context := &context.AutoscalingContext{
-			Recorder: fakeRecorder,
+			AutoscalingKubeClients: context.AutoscalingKubeClients{
+				Recorder: fakeRecorder,
+			},
 		}
 		p.Process(context, tc.state)
 		triggered := 0


### PR DESCRIPTION
Move all clients used for communicating with Kubernetes API server to a separate struct within context. This doesn't affect current usage as the struct is embedded, the only benefit is cleaner structs and logically divided responsibility. Before, most clients lived in AutoscalingContext, except for ListerRegistry, which was embedded directly in StaticAutoscaler.

Delta except for tests is 32 lines. The rest is reducing test setup verbosity.