### PR TITLE
Move initializing defaults out of main

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -17,13 +17,12 @@ limitations under the License.
 package context
 
 import (
+	"github.com/golang/glog"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
-	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_record "k8s.io/client-go/tools/record"
@@ -79,27 +78,33 @@ func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions)
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
 func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
-	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder,
-	logEventRecorder *utils.LogEventRecorder, listerRegistry kube_util.ListerRegistry,
-	cloudProvider cloudprovider.CloudProvider) (*AutoscalingContext, errors.AutoscalerError) {
-	expanderStrategy, err := factory.ExpanderStrategyFromString(options.ExpanderName,
-		cloudProvider, listerRegistry.AllNodeLister())
+	autoscalingKubeClients *AutoscalingKubeClients, cloudProvider cloudprovider.CloudProvider, expanderStrategy expander.Strategy) *AutoscalingContext {
+	return &AutoscalingContext{
+		AutoscalingOptions:     options,
+		CloudProvider:          cloudProvider,
+		AutoscalingKubeClients: *autoscalingKubeClients,
+		PredicateChecker:       predicateChecker,
+		ExpanderStrategy:       expanderStrategy,
+	}
+}
+
+// NewAutoscalingKubeClients builds AutoscalingKubeClients out of basic client.
+func NewAutoscalingKubeClients(opts config.AutoscalingOptions, kubeClient kube_client.Interface) *AutoscalingKubeClients {
+	listerRegistryStopChannel := make(chan struct{})
+	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(kubeClient, listerRegistryStopChannel)
+	kubeEventRecorder := kube_util.CreateEventRecorder(kubeClient)
+	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap)
 	if err != nil {
-		return nil, err
+		glog.Error("Failed to initialize status configmap, unable to write status events")
+		// Get a dummy, so we can at least safely call the methods
+		// TODO(maciekpytel): recover from this after successful status configmap update?
+		logRecorder, _ = utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, false)
 	}
 
-	autoscalingContext := AutoscalingContext{
-		AutoscalingOptions: options,
-		CloudProvider:      cloudProvider,
-		AutoscalingKubeClients: AutoscalingKubeClients{
-			ListerRegistry: listerRegistry,
-			ClientSet:      kubeClient,
-			Recorder:       kubeEventRecorder,
-			LogRecorder:    logEventRecorder,
-		},
-		PredicateChecker: predicateChecker,
-		ExpanderStrategy: expanderStrategy,
+	return &AutoscalingKubeClients{
+		ListerRegistry: listerRegistry,
+		ClientSet:      kubeClient,
+		Recorder:       kubeEventRecorder,
+		LogRecorder:    logRecorder,
 	}
-
-	return &autoscalingContext, nil
 }

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -20,23 +20,26 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_client "k8s.io/client-go/kubernetes"
-	kube_record "k8s.io/client-go/tools/record"
 )
 
 // AutoscalerOptions is the whole set of options for configuring an autoscaler
 type AutoscalerOptions struct {
 	config.AutoscalingOptions
-	KubeClient        kube_client.Interface
-	KubeEventRecorder kube_record.EventRecorder
-	PredicateChecker  *simulator.PredicateChecker
-	ListerRegistry    kube_util.ListerRegistry
-	Processors        *ca_processors.AutoscalingProcessors
+	KubeClient             kube_client.Interface
+	AutoscalingKubeClients *context.AutoscalingKubeClients
+	CloudProvider          cloudprovider.CloudProvider
+	PredicateChecker       *simulator.PredicateChecker
+	ExpanderStrategy       expander.Strategy
+	Processors             *ca_processors.AutoscalingProcessors
 }
 
 // Autoscaler is the main component of CA which scales up/down node groups according to its configuration
@@ -48,18 +51,42 @@ type Autoscaler interface {
 	ExitCleanUp()
 }
 
-func initializeDefaultOptions(opts *AutoscalerOptions) error {
-	if opts.Processors == nil {
-		opts.Processors = ca_processors.DefaultProcessors()
-	}
-	return nil
-}
-
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters
-func NewAutoscaler(opts AutoscalerOptions, cloudProvider cloudprovider.CloudProvider) (Autoscaler, errors.AutoscalerError) {
+func NewAutoscaler(opts AutoscalerOptions) (Autoscaler, errors.AutoscalerError) {
 	err := initializeDefaultOptions(&opts)
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
 	}
-	return NewStaticAutoscaler(opts.AutoscalingOptions, opts.PredicateChecker, opts.KubeClient, opts.KubeEventRecorder, opts.ListerRegistry, opts.Processors, cloudProvider)
+	return NewStaticAutoscaler(opts.AutoscalingOptions, opts.PredicateChecker, opts.AutoscalingKubeClients, opts.Processors, opts.CloudProvider, opts.ExpanderStrategy), nil
+}
+
+// Initialize default options if not provided.
+func initializeDefaultOptions(opts *AutoscalerOptions) error {
+	if opts.Processors == nil {
+		opts.Processors = ca_processors.DefaultProcessors()
+	}
+	if opts.AutoscalingKubeClients == nil {
+		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient)
+	}
+	if opts.PredicateChecker == nil {
+		predicateCheckerStopChannel := make(chan struct{})
+		predicateChecker, err := simulator.NewPredicateChecker(opts.KubeClient, predicateCheckerStopChannel)
+		if err != nil {
+			return err
+		}
+		opts.PredicateChecker = predicateChecker
+	}
+	if opts.CloudProvider == nil {
+		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts.AutoscalingOptions)
+	}
+	if opts.ExpanderStrategy == nil {
+		expanderStrategy, err := factory.ExpanderStrategyFromString(opts.ExpanderName,
+			opts.CloudProvider, opts.AutoscalingKubeClients.AllNodeLister())
+		if err != nil {
+			return err
+		}
+		opts.ExpanderStrategy = expanderStrategy
+	}
+
+	return nil
 }


### PR DESCRIPTION
Move initializing defaults out of main. Extract building autoscaler from run(). Extract constructing auxiliary kube clients to a separate function.