### PR TITLE
Extract autoscaling GCE client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -43,7 +43,7 @@ type AutoscalingGceClient interface {
 	FetchMigBasename(GceRef) (string, error)
 	FetchMigInstances(GceRef) ([]GceRef, error)
 	FetchMigTemplate(GceRef) (*gce.InstanceTemplate, error)
-	FetchMigs(zone string, filter *regexp.Regexp) ([]string, error)
+	FetchMigsWithName(zone string, filter *regexp.Regexp) ([]string, error)
 	FetchZones(region string) ([]string, error)
 
 	// modifying resources
@@ -177,14 +177,14 @@ func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef) (*gce.Inst
 	return client.gceService.InstanceTemplates.Get(migRef.Project, templateName).Do()
 }
 
-func (client *autoscalingGceClientV1) FetchMigs(zone string, name *regexp.Regexp) ([]string, error) {
+func (client *autoscalingGceClientV1) FetchMigsWithName(zone string, name *regexp.Regexp) ([]string, error) {
 	filter := fmt.Sprintf("name eq %s", name)
 	links := make([]string, 0)
 	req := client.gceService.InstanceGroups.List(client.projectId, zone).Filter(filter)
 	if err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
 		for _, ig := range page.Items {
 			links = append(links, ig.SelfLink)
-			glog.V(3).Infof("autodiscovered managed instance group %s using regexp %s", ig.Name, name)
+			glog.V(3).Infof("found managed instance group %s matching regexp %s", ig.Name, name)
 		}
 		return nil
 	}); err != nil {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"time"
+
+	"github.com/golang/glog"
+	gce "google.golang.org/api/compute/v1"
+)
+
+const (
+	operationWaitTimeout  = 5 * time.Second
+	operationPollInterval = 100 * time.Millisecond
+)
+
+// AutoscalingGceClient is used for communicating with GCE API.
+type AutoscalingGceClient interface {
+	// reading resources
+	FetchMachineType(zone, machineType string) (*gce.MachineType, error)
+	FetchMachineTypes(zone string) ([]*gce.MachineType, error)
+	FetchMigTargetSize(GceRef) (int64, error)
+	FetchMigBasename(GceRef) (string, error)
+	FetchMigInstances(GceRef) ([]GceRef, error)
+	FetchMigTemplate(GceRef) (*gce.InstanceTemplate, error)
+	FetchMigs(zone string, filter *regexp.Regexp) ([]string, error)
+	FetchZones(region string) ([]string, error)
+
+	// modifying resources
+	ResizeMig(GceRef, int64) error
+	DeleteInstances(migRef GceRef, instances []*GceRef) error
+}
+
+type autoscalingGceClientV1 struct {
+	gceService *gce.Service
+
+	projectId string
+}
+
+// NewAutoscalingGceClientV1 creates a new client for communicating with GCE v1 API.
+func NewAutoscalingGceClientV1(client *http.Client, projectId string) (*autoscalingGceClientV1, error) {
+	gceService, err := gce.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &autoscalingGceClientV1{
+		projectId:  projectId,
+		gceService: gceService,
+	}, nil
+}
+
+func (client *autoscalingGceClientV1) FetchMachineType(zone, machineType string) (*gce.MachineType, error) {
+	return client.gceService.MachineTypes.Get(client.projectId, zone, machineType).Do()
+}
+
+func (client *autoscalingGceClientV1) FetchMachineTypes(zone string) ([]*gce.MachineType, error) {
+	machines, err := client.gceService.MachineTypes.List(client.projectId, zone).Do()
+	if err != nil {
+		return nil, err
+	}
+	return machines.Items, nil
+}
+
+func (client *autoscalingGceClientV1) FetchMigTargetSize(migRef GceRef) (int64, error) {
+	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Do()
+	if err != nil {
+		return 0, err
+	}
+	return igm.TargetSize, nil
+}
+
+func (client *autoscalingGceClientV1) FetchMigBasename(migRef GceRef) (string, error) {
+	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Do()
+	if err != nil {
+		return "", err
+	}
+	return igm.BaseInstanceName, nil
+}
+
+func (client *autoscalingGceClientV1) ResizeMig(migRef GceRef, size int64) error {
+	op, err := client.gceService.InstanceGroupManagers.Resize(migRef.Project, migRef.Zone, migRef.Name, size).Do()
+	if err != nil {
+		return err
+	}
+	return client.waitForOp(op, migRef.Project, migRef.Zone)
+}
+
+func (client *autoscalingGceClientV1) waitForOp(operation *gce.Operation, project, zone string) error {
+	for start := time.Now(); time.Since(start) < operationWaitTimeout; time.Sleep(operationPollInterval) {
+		glog.V(4).Infof("Waiting for operation %s %s %s", project, zone, operation.Name)
+		if op, err := client.gceService.ZoneOperations.Get(project, zone, operation.Name).Do(); err == nil {
+			glog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
+			if op.Status == "DONE" {
+				return nil
+			}
+		} else {
+			glog.Warningf("Error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
+		}
+	}
+	return fmt.Errorf("Timeout while waiting for operation %s on %s to complete.", operation.Name, operation.TargetLink)
+}
+
+func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances []*GceRef) error {
+	req := gce.InstanceGroupManagersDeleteInstancesRequest{
+		Instances: []string{},
+	}
+	for _, i := range instances {
+		req.Instances = append(req.Instances, GenerateInstanceUrl(*i))
+	}
+	op, err := client.gceService.InstanceGroupManagers.DeleteInstances(migRef.Project, migRef.Zone, migRef.Name, &req).Do()
+	if err != nil {
+		return err
+	}
+	return client.waitForOp(op, migRef.Project, migRef.Zone)
+}
+
+func (client *autoscalingGceClientV1) FetchMigInstances(migRef GceRef) ([]GceRef, error) {
+	instances, err := client.gceService.InstanceGroupManagers.ListManagedInstances(migRef.Project, migRef.Zone, migRef.Name).Do()
+	if err != nil {
+		glog.V(4).Infof("Failed MIG info request for %s %s %s: %v", migRef.Project, migRef.Zone, migRef.Name, err)
+		return nil, err
+	}
+	refs := []GceRef{}
+	for _, i := range instances.ManagedInstances {
+		ref, err := ParseInstanceUrlRef(i.Instance)
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+func (client *autoscalingGceClientV1) FetchZones(region string) ([]string, error) {
+	r, err := client.gceService.Regions.Get(client.projectId, region).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get zones for GCE region %s: %v", region, err)
+	}
+	zones := make([]string, len(r.Zones))
+	for i, link := range r.Zones {
+		zones[i] = path.Base(link)
+	}
+	return zones, nil
+}
+
+func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef) (*gce.InstanceTemplate, error) {
+	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Do()
+	if err != nil {
+		return nil, err
+	}
+	templateUrl, err := url.Parse(igm.InstanceTemplate)
+	if err != nil {
+		return nil, err
+	}
+	_, templateName := path.Split(templateUrl.EscapedPath())
+	return client.gceService.InstanceTemplates.Get(migRef.Project, templateName).Do()
+}
+
+func (client *autoscalingGceClientV1) FetchMigs(zone string, name *regexp.Regexp) ([]string, error) {
+	filter := fmt.Sprintf("name eq %s", name)
+	links := make([]string, 0)
+	req := client.gceService.InstanceGroups.List(client.projectId, zone).Filter(filter)
+	if err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
+		for _, ig := range page.Items {
+			links = append(links, ig.SelfLink)
+			glog.V(3).Infof("autodiscovered managed instance group %s using regexp %s", ig.Name, name)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("cannot list managed instance groups: %v", err)
+	}
+	return links, nil
+}

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"net/http"
+	"testing"
+
+	test_util "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	gce_api "google.golang.org/api/compute/v1"
+)
+
+func newTestAutoscalingGceClient(t *testing.T, projectId, url string) *autoscalingGceClientV1 {
+	client := &http.Client{}
+	gceClient, err := NewAutoscalingGceClientV1(client, projectId)
+	if !assert.NoError(t, err) {
+		t.Fatalf("fatal error: %v", err)
+	}
+	gceClient.gceService.BasePath = url
+	return gceClient
+}
+
+func TestWaitForOp(t *testing.T) {
+	server := test_util.NewHttpServerMock()
+	defer server.Close()
+	g := newTestAutoscalingGceClient(t, "project1", server.URL)
+	server.On("handle", "/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationRunningResponse).Times(3)
+	server.On("handle", "/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationDoneResponse).Once()
+
+	operation := &gce_api.Operation{Name: "operation-1505728466148-d16f5197"}
+
+	err := g.waitForOp(operation, projectId, zoneB)
+	assert.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, server)
+}

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -350,7 +350,7 @@ func (mig *Mig) DeleteNodes(nodes []*apiv1.Node) error {
 
 // Id returns mig url.
 func (mig *Mig) Id() string {
-	return GenerateMigUrl(mig.Project, mig.Zone, mig.Name)
+	return GenerateMigUrl(mig.GceRef)
 }
 
 // Debug returns a debug string for the Mig.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -125,6 +125,9 @@ func (gce *GceCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	nodePoolName := fmt.Sprintf("%s-%s-%d", nodeAutoprovisioningPrefix, machineType, time.Now().Unix())
+	// TODO(aleksandra-malinowska): GceManager's location will be a region
+	// for regional clusters. We should support regional clusters by looking at
+	// node locations instead.
 	zone := gce.gceManager.getLocation()
 
 	if gpuRequest, found := extraResources[gpu.ResourceNvidiaGPU]; found {
@@ -171,14 +174,15 @@ func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]
 		},
 		gceManager: gce.gceManager,
 	}
-	cpu, mem, err := gce.gceManager.getCpuAndMemoryForMachineType(mig.spec.machineType, mig.GceRef.Zone)
+
+	// Try to build a node from autoprovisioning spec. We don't need one right now,
+	// but if it fails later, we'd end up with a node group we can't scale anyway,
+	// so there's no point creating it.
+	_, err := gce.gceManager.getMigTemplateNode(mig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to build node from spec: %v", err)
 	}
-	_, err = gce.gceManager.getTemplates().buildNodeFromAutoprovisioningSpec(mig, cpu, mem)
-	if err != nil {
-		return nil, err
-	}
+
 	return mig, nil
 }
 
@@ -393,32 +397,9 @@ func (mig *Mig) Autoprovisioned() bool {
 
 // TemplateNodeInfo returns a node template for this node group.
 func (mig *Mig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
-	var node *apiv1.Node
-	if mig.Exist() {
-		template, err := mig.gceManager.getMigTemplate(mig)
-		if err != nil {
-			return nil, err
-		}
-		cpu, mem, err := mig.gceManager.getCpuAndMemoryForMachineType(template.Properties.MachineType, mig.GceRef.Zone)
-		if err != nil {
-			return nil, err
-		}
-		node, err = mig.gceManager.getTemplates().buildNodeFromTemplate(mig, template, cpu, mem)
-		if err != nil {
-			return nil, err
-		}
-	} else if mig.Autoprovisioned() {
-		var err error
-		cpu, mem, err := mig.gceManager.getCpuAndMemoryForMachineType(mig.spec.machineType, mig.GceRef.Zone)
-		if err != nil {
-			return nil, err
-		}
-		node, err = mig.gceManager.getTemplates().buildNodeFromAutoprovisioningSpec(mig, cpu, mem)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, fmt.Errorf("unable to get node info for %s/%s/%s", mig.Project, mig.Zone, mig.Name)
+	node, err := mig.gceManager.getMigTemplateNode(mig)
+	if err != nil {
+		return nil, err
 	}
 	nodeInfo := schedulercache.NewNodeInfo(cloudprovider.BuildKubeProxy(mig.Id()))
 	nodeInfo.SetNode(node)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -1122,7 +1122,7 @@ func (m *gceManagerImpl) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	if m.regional {
 		return m.findMigsInRegion(m.location, name)
 	}
-	return m.GceService.FetchMigs(m.location, name)
+	return m.GceService.FetchMigsWithName(m.location, name)
 }
 
 func (m *gceManagerImpl) getZones(region string) ([]string, error) {
@@ -1140,7 +1140,7 @@ func (m *gceManagerImpl) findMigsInRegion(region string, name *regexp.Regexp) ([
 		return nil, err
 	}
 	for _, z := range zones {
-		zl, err := m.GceService.FetchMigs(z, name)
+		zl, err := m.GceService.FetchMigsWithName(z, name)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -17,13 +17,10 @@ limitations under the License.
 package gce
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
-	"path"
 	"reflect"
 	"regexp"
 	"strings"
@@ -78,9 +75,7 @@ const (
 )
 
 const (
-	operationWaitTimeout       = 5 * time.Second
 	gkeOperationWaitTimeout    = 120 * time.Second
-	operationPollInterval      = 100 * time.Millisecond
 	refreshInterval            = 1 * time.Minute
 	machinesRefreshInterval    = 1 * time.Hour
 	httpTimeout                = 30 * time.Second
@@ -156,9 +151,9 @@ type gceManagerImpl struct {
 	migs     []*migInformation
 	migCache map[GceRef]*Mig
 
-	gceService     *gce.Service
 	gkeService     *gke.Service
 	gkeBetaService *gke_beta.Service
+	GceService     AutoscalingGceClient
 
 	cacheMutex sync.Mutex
 	migsMutex  sync.Mutex
@@ -230,13 +225,13 @@ func CreateGceManager(configReader io.Reader, mode GcpCloudProviderMode, cluster
 	// Create Google Compute Engine service.
 	client := oauth2.NewClient(oauth2.NoContext, tokenSource)
 	client.Timeout = httpTimeout
-	gceService, err := gce.New(client)
+	gceService, err := NewAutoscalingGceClientV1(client, projectId)
 	if err != nil {
 		return nil, err
 	}
 	manager := &gceManagerImpl{
 		migs:        make([]*migInformation, 0),
-		gceService:  gceService,
+		GceService:  gceService,
 		migCache:    make(map[GceRef]*Mig),
 		location:    location,
 		regional:    regional,
@@ -726,11 +721,11 @@ func (m *gceManagerImpl) fetchMachinesCache() error {
 	}
 	machinesCache := make(map[machineTypeKey]*gce.MachineType)
 	for _, location := range locations {
-		machineTypes, err := m.gceService.MachineTypes.List(m.projectId, location).Do()
+		machineTypes, err := m.GceService.FetchMachineTypes(location)
 		if err != nil {
 			return err
 		}
-		for _, machineType := range machineTypes.Items {
+		for _, machineType := range machineTypes {
 			machinesCache[machineTypeKey{location, machineType.Name}] = machineType
 		}
 
@@ -747,37 +742,17 @@ func (m *gceManagerImpl) fetchMachinesCache() error {
 
 // GetMigSize gets MIG size.
 func (m *gceManagerImpl) GetMigSize(mig *Mig) (int64, error) {
-	igm, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
+	targetSize, err := m.GceService.FetchMigTargetSize(mig.GceRef)
 	if err != nil {
 		return -1, err
 	}
-	return igm.TargetSize, nil
+	return targetSize, nil
 }
 
 // SetMigSize sets MIG size.
 func (m *gceManagerImpl) SetMigSize(mig *Mig, size int64) error {
 	glog.V(0).Infof("Setting mig size %s to %d", mig.Id(), size)
-	op, err := m.gceService.InstanceGroupManagers.Resize(mig.Project, mig.Zone, mig.Name, size).Do()
-	if err != nil {
-		return err
-	}
-	return m.waitForOp(op, mig.Project, mig.Zone)
-}
-
-// GCE
-func (m *gceManagerImpl) waitForOp(operation *gce.Operation, project string, zone string) error {
-	for start := time.Now(); time.Since(start) < operationWaitTimeout; time.Sleep(operationPollInterval) {
-		glog.V(4).Infof("Waiting for operation %s %s %s", project, zone, operation.Name)
-		if op, err := m.gceService.ZoneOperations.Get(project, zone, operation.Name).Do(); err == nil {
-			glog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
-			if op.Status == "DONE" {
-				return nil
-			}
-		} else {
-			glog.Warningf("Error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
-		}
-	}
-	return fmt.Errorf("Timeout while waiting for operation %s on %s to complete.", operation.Name, operation.TargetLink)
+	return m.GceService.ResizeMig(mig.GceRef, size)
 }
 
 //  GKE
@@ -815,18 +790,7 @@ func (m *gceManagerImpl) DeleteInstances(instances []*GceRef) error {
 		}
 	}
 
-	req := gce.InstanceGroupManagersDeleteInstancesRequest{
-		Instances: []string{},
-	}
-	for _, instance := range instances {
-		req.Instances = append(req.Instances, GenerateInstanceUrl(instance.Project, instance.Zone, instance.Name))
-	}
-
-	op, err := m.gceService.InstanceGroupManagers.DeleteInstances(commonMig.Project, commonMig.Zone, commonMig.Name, &req).Do()
-	if err != nil {
-		return err
-	}
-	return m.waitForOp(op, commonMig.Project, commonMig.Zone)
+	return m.GceService.DeleteInstances(commonMig.GceRef, instances)
 }
 
 func (m *gceManagerImpl) getMigs() []*migInformation {
@@ -883,23 +847,19 @@ func (m *gceManagerImpl) regenerateCache() error {
 		mig := migInfo.config
 		glog.V(4).Infof("Regenerating MIG information for %s %s %s", mig.Project, mig.Zone, mig.Name)
 
-		instanceGroupManager, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
+		basename, err := m.GceService.FetchMigBasename(mig.GceRef)
 		if err != nil {
 			return err
 		}
-		m.updateMigBasename(migInfo.config.GceRef, instanceGroupManager.BaseInstanceName)
+		m.updateMigBasename(mig.GceRef, basename)
 
-		instances, err := m.gceService.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
+		instances, err := m.GceService.FetchMigInstances(mig.GceRef)
 		if err != nil {
 			glog.V(4).Infof("Failed MIG info request for %s %s %s: %v", mig.Project, mig.Zone, mig.Name, err)
 			return err
 		}
-		for _, instance := range instances.ManagedInstances {
-			project, zone, name, err := ParseInstanceUrl(instance.Instance)
-			if err != nil {
-				return err
-			}
-			newMigCache[GceRef{Project: project, Zone: zone, Name: name}] = mig
+		for _, ref := range instances {
+			newMigCache[ref] = mig
 		}
 	}
 
@@ -909,17 +869,13 @@ func (m *gceManagerImpl) regenerateCache() error {
 
 // GetMigNodes returns mig nodes.
 func (m *gceManagerImpl) GetMigNodes(mig *Mig) ([]string, error) {
-	instances, err := m.gceService.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
+	instances, err := m.GceService.FetchMigInstances(mig.GceRef)
 	if err != nil {
 		return []string{}, err
 	}
 	result := make([]string, 0)
-	for _, instance := range instances.ManagedInstances {
-		project, zone, name, err := ParseInstanceUrl(instance.Instance)
-		if err != nil {
-			return []string{}, err
-		}
-		result = append(result, fmt.Sprintf("gce://%s/%s/%s", project, zone, name))
+	for _, ref := range instances {
+		result = append(result, fmt.Sprintf("gce://%s/%s/%s", ref.Project, ref.Zone, ref.Name))
 	}
 	return result, nil
 }
@@ -1171,17 +1127,13 @@ func (m *gceManagerImpl) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	if m.regional {
 		return m.findMigsInRegion(m.location, name)
 	}
-	return m.findMigsInZone(m.location, name)
+	return m.GceService.FetchMigs(m.location, name)
 }
 
 func (m *gceManagerImpl) getZones(region string) ([]string, error) {
-	r, err := m.gceService.Regions.Get(m.getProjectId(), region).Do()
+	zones, err := m.GceService.FetchZones(region)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get zones for GCE region %s: %v", region, err)
-	}
-	zones := make([]string, len(r.Zones))
-	for i, link := range r.Zones {
-		zones[i] = path.Base(link)
 	}
 	return zones, nil
 }
@@ -1193,7 +1145,7 @@ func (m *gceManagerImpl) findMigsInRegion(region string, name *regexp.Regexp) ([
 		return nil, err
 	}
 	for _, z := range zones {
-		zl, err := m.findMigsInZone(z, name)
+		zl, err := m.GceService.FetchMigs(z, name)
 		if err != nil {
 			return nil, err
 		}
@@ -1205,37 +1157,12 @@ func (m *gceManagerImpl) findMigsInRegion(region string, name *regexp.Regexp) ([
 	return links, nil
 }
 
-func (m *gceManagerImpl) findMigsInZone(zone string, name *regexp.Regexp) ([]string, error) {
-	filter := fmt.Sprintf("name eq %s", name)
-	links := make([]string, 0)
-	req := m.gceService.InstanceGroups.List(m.getProjectId(), zone).Filter(filter)
-	if err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
-		for _, ig := range page.Items {
-			links = append(links, ig.SelfLink)
-			glog.V(3).Infof("autodiscovered managed instance group %s using regexp %s", ig.Name, name)
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("cannot list managed instance groups: %v", err)
-	}
-	return links, nil
-}
-
 func (m *gceManagerImpl) getMigTemplate(mig *Mig) (*gce.InstanceTemplate, error) {
-	igm, err := m.gceService.InstanceGroupManagers.Get(mig.Project, mig.Zone, mig.Name).Do()
+	template, err := m.GceService.FetchMigTemplate(mig.GceRef)
 	if err != nil {
 		return nil, err
 	}
-	templateUrl, err := url.Parse(igm.InstanceTemplate)
-	if err != nil {
-		return nil, err
-	}
-	_, templateName := path.Split(templateUrl.EscapedPath())
-	instanceTemplate, err := m.gceService.InstanceTemplates.Get(mig.Project, templateName).Do()
-	if err != nil {
-		return nil, err
-	}
-	return instanceTemplate, nil
+	return template, nil
 }
 
 func (m *gceManagerImpl) getMachineFromCache(machineType string, zone string) *gce.MachineType {
@@ -1256,7 +1183,7 @@ func (m *gceManagerImpl) getCpuAndMemoryForMachineType(machineType string, zone 
 	}
 	machine := m.getMachineFromCache(machineType, zone)
 	if machine == nil {
-		machine, err = m.gceService.MachineTypes.Get(m.projectId, zone, machineType).Do()
+		machine, err = m.GceService.FetchMachineType(zone, machineType)
 		if err != nil {
 			return 0, 0, err
 		}

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -750,7 +750,7 @@ func (m *gceManagerImpl) SetMigSize(mig *Mig, size int64) error {
 
 //  GKE
 func (m *gceManagerImpl) waitForGkeOp(operation *gke_beta.Operation) error {
-	for start := time.Now(); time.Since(start) < gkeOperationWaitTimeout; time.Sleep(operationPollInterval) {
+	for start := time.Now(); time.Since(start) < gkeOperationWaitTimeout; time.Sleep(defaultOperationPollInterval) {
 		glog.V(4).Infof("Waiting for operation %s %s %s", m.projectId, m.location, operation.Name)
 		if op, err := m.gkeBetaService.Projects.Zones.Operations.Get(m.projectId, m.location, operation.Name).Do(); err == nil {
 			glog.V(4).Infof("Operation %s %s %s status: %s", m.projectId, m.location, operation.Name, op.Status)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -355,10 +355,8 @@ func (m *gceManagerImpl) fetchAllNodePoolsGkeImpl() error {
 		if !autoscaled {
 			continue
 		}
-		// format is
-		// "https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/europe-west1-b/instanceGroupManagers/gke-cluster-1-default-pool-ba78a787-grp"
 		for _, igurl := range nodePool.InstanceGroupUrls {
-			project, zone, name, err := parseGceUrl(igurl, "instanceGroupManagers")
+			project, zone, name, err := ParseIgmUrl(igurl)
 			if err != nil {
 				return err
 			}
@@ -416,10 +414,8 @@ func (m *gceManagerImpl) fetchAllNodePoolsGkeRegionalImpl() error {
 		if !autoscaled {
 			continue
 		}
-		// format is
-		// "https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/europe-west1-b/instanceGroupManagers/gke-cluster-1-default-pool-ba78a787-grp"
 		for _, igurl := range nodePool.InstanceGroupUrls {
-			project, zone, name, err := parseGceUrl(igurl, "instanceGroupManagers")
+			project, zone, name, err := ParseIgmUrl(igurl)
 			if err != nil {
 				return err
 			}
@@ -481,10 +477,8 @@ func (m *gceManagerImpl) fetchAllNodePoolsGkeNapImpl() error {
 			}
 			continue
 		}
-		// format is
-		// "https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/europe-west1-b/instanceGroupManagers/gke-cluster-1-default-pool-ba78a787-grp"
 		for _, igurl := range nodePool.InstanceGroupUrls {
-			project, zone, name, err := parseGceUrl(igurl, "instanceGroupManagers")
+			project, zone, name, err := ParseIgmUrl(igurl)
 			if err != nil {
 				return err
 			}

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -510,6 +510,11 @@ func getManagedInstancesResponse2Named(name, zone string) string {
 
 func newTestGceManager(t *testing.T, testServerURL string, mode GcpCloudProviderMode, regional bool) *gceManagerImpl {
 	gceService := newTestAutoscalingGceClient(t, projectId, testServerURL)
+
+	// Override wait for op timeouts.
+	gceService.operationWaitTimeout = 50 * time.Millisecond
+	gceService.operationPollInterval = 1 * time.Millisecond
+
 	manager := &gceManagerImpl{
 		migs:        make([]*migInformation, 0),
 		GceService:  gceService,

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -509,13 +509,10 @@ func getManagedInstancesResponse2Named(name, zone string) string {
 }
 
 func newTestGceManager(t *testing.T, testServerURL string, mode GcpCloudProviderMode, regional bool) *gceManagerImpl {
-	client := &http.Client{}
-	gceService, err := gce.New(client)
-	assert.NoError(t, err)
-	gceService.BasePath = testServerURL
+	gceService := newTestAutoscalingGceClient(t, projectId, testServerURL)
 	manager := &gceManagerImpl{
 		migs:        make([]*migInformation, 0),
-		gceService:  gceService,
+		GceService:  gceService,
 		migCache:    make(map[GceRef]*Mig),
 		projectId:   projectId,
 		clusterName: clusterName,
@@ -537,6 +534,7 @@ func newTestGceManager(t *testing.T, testServerURL string, mode GcpCloudProvider
 		manager.location = zoneB
 	}
 
+	client := &http.Client{}
 	if mode == ModeGKE {
 		gkeService, err := gke.New(client)
 		assert.NoError(t, err)
@@ -800,20 +798,6 @@ const operationDoneResponse = `{
   "startTime": "2017-09-18T09:54:26.148507311Z",
   "endTime": "2017-09-18T09:54:35.124878859Z"
 }`
-
-func TestWaitForOp(t *testing.T) {
-	server := NewHttpServerMock()
-	defer server.Close()
-	g := newTestGceManager(t, server.URL, ModeGKE, false)
-	server.On("handle", "/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationRunningResponse).Times(3)
-	server.On("handle", "/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationDoneResponse).Once()
-
-	operation := &gce.Operation{Name: "operation-1505728466148-d16f5197"}
-
-	err := g.waitForOp(operation, projectId, zoneB)
-	assert.NoError(t, err)
-	mock.AssertExpectationsForObjects(t, server)
-}
 
 func TestWaitForGkeOp(t *testing.T) {
 	server := NewHttpServerMock()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -1358,7 +1358,7 @@ func TestfetchMachinesCache(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, server)
 }
 
-func TestGetMigTemplate(t *testing.T) {
+func TestGetMigTemplateNode(t *testing.T) {
 	server := NewHttpServerMock()
 	defer server.Close()
 
@@ -1383,9 +1383,9 @@ func TestGetMigTemplate(t *testing.T) {
 		spec:            nil,
 	}
 
-	template, err := g.getMigTemplate(mig)
+	node, err := g.getMigTemplateNode(mig)
 	assert.NoError(t, err)
-	assert.Equal(t, "gke-cluster-1-default-pool", template.Name)
+	assert.NotNil(t, node)
 	mock.AssertExpectationsForObjects(t, server)
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -35,20 +35,41 @@ func ParseMigUrl(url string) (project string, zone string, name string, err erro
 	return parseGceUrl(url, "instanceGroups")
 }
 
+// ParseIgmUrl expects url in format:
+// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instanceGroupManagers/<name>
+func ParseIgmUrl(url string) (project string, zone string, name string, err error) {
+	return parseGceUrl(url, "instanceGroupManagers")
+}
+
 // ParseInstanceUrl expects url in format:
 // https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
 func ParseInstanceUrl(url string) (project string, zone string, name string, err error) {
 	return parseGceUrl(url, "instances")
 }
 
+// ParseInstanceUrlRef expects url in format:
+// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
+// and returns a GceRef struct for it.
+func ParseInstanceUrlRef(url string) (GceRef, error) {
+	project, zone, name, err := parseGceUrl(url, "instances")
+	if err != nil {
+		return GceRef{}, err
+	}
+	return GceRef{
+		Project: project,
+		Zone:    zone,
+		Name:    name,
+	}, nil
+}
+
 // GenerateInstanceUrl generates url for instance.
-func GenerateInstanceUrl(project, zone, name string) string {
-	return fmt.Sprintf(instanceUrlTemplate, project, zone, name)
+func GenerateInstanceUrl(ref GceRef) string {
+	return fmt.Sprintf(instanceUrlTemplate, ref.Project, ref.Zone, ref.Name)
 }
 
 // GenerateMigUrl generates url for instance.
-func GenerateMigUrl(project, zone, name string) string {
-	return fmt.Sprintf(migUrlTemplate, project, zone, name)
+func GenerateMigUrl(ref GceRef) string {
+	return fmt.Sprintf(migUrlTemplate, ref.Project, ref.Zone, ref.Name)
 }
 
 func parseGceUrl(url, expectedResource string) (project string, zone string, name string, err error) {


### PR DESCRIPTION
Extract GCE calls and hide them behind a new interface. This will allow for easier mocking (and getting rid of jsons from gke_manager_test.go) in the near future.