### PR TITLE
Remove faulty validation for VPA

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-crd.yaml
@@ -26,31 +26,10 @@ spec:
               properties:
                 updateMode:
                   type: string
-                  enum:
-                    - "Off"
-                    - "Initial"
-                    - "Recreate"
-                    - "Auto"
             resourcePolicy:
               properties:
                 containerPolicies:
                   type: array
-                  items:
-                    type: object
-                    required:
-                      - containerName
-                    properties:
-                      containerName:
-                        type: string
-                      mode:
-                        type: string
-                        enum:
-                          - "Auto"
-                          - "Off"
-                      minAllowed:
-                        type: object
-                      maxAllowed:
-                        type: object
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
The CRD creation doesn't work at the moment. Validation fails for enums and lists. This should fix e2e tests for now. 
Will add validation to admission webhook in a followup pr.