### PR TITLE
Make Create() cloud provider method return newly created node group

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -179,8 +179,8 @@ func (ng *AwsNodeGroup) Exist() bool {
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *AwsNodeGroup) Create() error {
-	return cloudprovider.ErrAlreadyExist
+func (ng *AwsNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -96,8 +96,8 @@ func (as *AgentPool) Exist() bool {
 }
 
 // Create creates the node group on the cloud provider side.
-func (as *AgentPool) Create() error {
-	return cloudprovider.ErrAlreadyExist
+func (as *AgentPool) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -461,8 +461,8 @@ func (agentPool *ContainerServiceAgentPool) Exist() bool {
 
 //Create is returns already exists since we don't support the
 //agent pool creation.
-func (agentPool *ContainerServiceAgentPool) Create() error {
-	return cloudprovider.ErrAlreadyExist
+func (agentPool *ContainerServiceAgentPool) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
 }
 
 //Delete is not implemented since we don't support agent pool

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -75,8 +75,8 @@ func (scaleSet *ScaleSet) Exist() bool {
 }
 
 // Create creates the node group on the cloud provider side.
-func (scaleSet *ScaleSet) Create() error {
-	return cloudprovider.ErrAlreadyExist
+func (scaleSet *ScaleSet) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -132,7 +132,7 @@ type NodeGroup interface {
 	Exist() bool
 
 	// Create creates the node group on the cloud provider side. Implementation optional.
-	Create() error
+	Create() (NodeGroup, error)
 
 	// Delete deletes the node group on the cloud provider side.
 	// This will be executed only for autoprovisioned node groups, once their size drops to 0.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -379,11 +379,11 @@ func (mig *Mig) Exist() bool {
 }
 
 // Create creates the node group on the cloud provider side.
-func (mig *Mig) Create() error {
+func (mig *Mig) Create() (cloudprovider.NodeGroup, error) {
 	if !mig.exist && mig.autoprovisioned {
 		return mig.gceManager.createNodePool(mig)
 	}
-	return fmt.Errorf("Cannot create non-autoprovisioned node group")
+	return nil, fmt.Errorf("Cannot create non-autoprovisioned node group")
 }
 
 // Delete deletes the node group on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -90,9 +90,9 @@ func (m *gceManagerMock) getMigs() []*migInformation {
 	return args.Get(0).([]*migInformation)
 }
 
-func (m *gceManagerMock) createNodePool(mig *Mig) error {
+func (m *gceManagerMock) createNodePool(mig *Mig) (*Mig, error) {
 	args := m.Called(mig)
-	return args.Error(0)
+	return mig, args.Error(0)
 }
 
 func (m *gceManagerMock) deleteNodePool(toBeRemoved *Mig) error {
@@ -430,7 +430,7 @@ func TestMig(t *testing.T) {
 	// Test Create.
 	mig1.exist = false
 	gceManagerMock.On("createNodePool", mock.AnythingOfType("*gce.Mig")).Return(nil).Once()
-	err = mig1.Create()
+	_, err = mig1.Create()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -738,8 +738,9 @@ func TestCreateNodePool(t *testing.T) {
 		},
 	}
 
-	err := g.createNodePool(mig)
+	newMig, err := g.createNodePool(mig)
 	assert.NoError(t, err)
+	assert.True(t, newMig.Exist())
 	migs := g.getMigs()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(migs))

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -250,8 +250,8 @@ func (nodeGroup *NodeGroup) Exist() bool {
 }
 
 // Create creates the node group on the cloud provider side.
-func (nodeGroup *NodeGroup) Create() error {
-	return cloudprovider.ErrNotImplemented
+func (nodeGroup *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -46,8 +46,10 @@ func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{},
 func (f *FakeNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
-func (f *FakeNodeGroup) Exist() bool           { return true }
-func (f *FakeNodeGroup) Create() error         { return cloudprovider.ErrAlreadyExist }
+func (f *FakeNodeGroup) Exist() bool { return true }
+func (f *FakeNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
+}
 func (f *FakeNodeGroup) Delete() error         { return cloudprovider.ErrNotImplemented }
 func (f *FakeNodeGroup) Autoprovisioned() bool { return false }
 

--- a/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager.go
+++ b/cluster-autoscaler/processors/nodegroups/autoprovisioning_nodegroup_manager.go
@@ -41,21 +41,21 @@ func (p *AutoprovisioningNodeGroupManager) CreateNodeGroup(context *context.Auto
 	}
 
 	oldId := nodeGroup.Id()
-	err := nodeGroup.Create()
+	newNodeGroup, err := nodeGroup.Create()
 	if err != nil {
 		context.LogRecorder.Eventf(apiv1.EventTypeWarning, "FailedToCreateNodeGroup",
 			"NodeAutoprovisioning: attempt to create node group %v failed: %v", oldId, err)
 		// TODO(maciekpytel): add some metric here after figuring out failure scenarios
 		return nil, errors.ToAutoscalerError(errors.CloudProviderError, err)
 	}
-	newId := nodeGroup.Id()
+	newId := newNodeGroup.Id()
 	if newId != oldId {
 		glog.V(2).Infof("Created node group %s based on template node group %s, will use new node group in scale-up", newId, oldId)
 	}
 	context.LogRecorder.Eventf(apiv1.EventTypeNormal, "CreatedNodeGroup",
 		"NodeAutoprovisioning: created new node group %v", newId)
 	metrics.RegisterNodeGroupCreation()
-	return nodeGroup, nil
+	return newNodeGroup, nil
 }
 
 // RemoveUnneededNodeGroups removes node groups that are not needed anymore.


### PR DESCRIPTION
After creating a node group, cloud provider should refresh its node group config. Node group that was created may not be the same as its blueprint with flipped "exist" bit. Instead of indirectly overwriting the struct at provided address, return node group object representing a group that already exists at this point.