### PR TITLE
Extract cache from GCE manager

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gke_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gke_client.go
@@ -43,7 +43,7 @@ type AutoscalingGkeClient interface {
 
 	// modifying cluster state
 	DeleteNodePool(string) error
-	CreateNodePool(*Mig) error
+	CreateNodePool(Mig) error
 }
 
 // NodePool contains node pool's fields we want to use.

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gke_client_v1.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gke_client_v1.go
@@ -86,6 +86,6 @@ func (m *autoscalingGkeClientV1) DeleteNodePool(toBeRemoved string) error {
 	return cloudprovider.ErrNotImplemented
 }
 
-func (m *autoscalingGkeClientV1) CreateNodePool(mig *Mig) error {
+func (m *autoscalingGkeClientV1) CreateNodePool(mig Mig) error {
 	return cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+
+	"github.com/golang/glog"
+	gce "google.golang.org/api/compute/v1"
+)
+
+// GceCache is used for caching cluster resources state.
+type GceCache struct {
+	// Cache content.
+	migs            []*MigInformation
+	migCache        map[GceRef]Mig
+	resourceLimiter *cloudprovider.ResourceLimiter
+	machinesCache   map[MachineTypeKey]*gce.MachineType
+	// Freshness timestamps.
+	machinesCacheLastRefresh time.Time
+	// Locks. Rules of locking:
+	// - migsMutex protects only migs.
+	// - cacheMutex protects migCache, resourceLimiter and machinesCache.
+	// - methods that take cacheMutex may call methods that take migsMutex.
+	// - methods that take migsMutex may not call methods that take cacheMutex.
+	cacheMutex sync.Mutex
+	migsMutex  sync.Mutex
+	// Service used to refresh cache.
+	GceService AutoscalingGceClient
+}
+
+// MigInformation is a wrapper for Mig.
+type MigInformation struct {
+	Config   Mig
+	Basename string
+}
+
+// MachineTypeKey is used to identify MachineType.
+type MachineTypeKey struct {
+	Zone        string
+	MachineType string
+}
+
+// NewGceCache creates empty GceCache.
+func NewGceCache(gceService AutoscalingGceClient) GceCache {
+	return GceCache{
+		migs:          []*MigInformation{},
+		migCache:      map[GceRef]Mig{},
+		machinesCache: map[MachineTypeKey]*gce.MachineType{},
+		GceService:    gceService,
+	}
+}
+
+//  Methods locking on migsMutex.
+
+// RegisterMig returns true if the node group wasn't in cache before, or its config was updated.
+func (gc *GceCache) RegisterMig(mig Mig) bool {
+	gc.migsMutex.Lock()
+	defer gc.migsMutex.Unlock()
+
+	for i := range gc.migs {
+		if oldMig := gc.migs[i].Config; oldMig.GceRef() == mig.GceRef() {
+			if !reflect.DeepEqual(oldMig, mig) {
+				gc.migs[i].Config = mig
+				glog.V(4).Infof("Updated Mig %s", mig.GceRef().String())
+				return true
+			}
+			return false
+		}
+	}
+
+	glog.V(1).Infof("Registering %s", mig.GceRef().String())
+	gc.migs = append(gc.migs, &MigInformation{
+		Config: mig,
+	})
+	return true
+}
+
+// UnregisterMig returns true if the node group has been removed, and false if it was alredy missing from cache.
+func (gc *GceCache) UnregisterMig(toBeRemoved Mig) bool {
+	gc.migsMutex.Lock()
+	defer gc.migsMutex.Unlock()
+
+	newMigs := make([]*MigInformation, 0, len(gc.migs))
+	found := false
+	for _, mig := range gc.migs {
+		if mig.Config.GceRef() == toBeRemoved.GceRef() {
+			glog.V(1).Infof("Unregistered Mig %s", toBeRemoved.GceRef().String())
+			found = true
+		} else {
+			newMigs = append(newMigs, mig)
+		}
+	}
+	gc.migs = newMigs
+	return found
+}
+
+// GetMigs returns a copy of migs list.
+func (gc *GceCache) GetMigs() []*MigInformation {
+	gc.migsMutex.Lock()
+	defer gc.migsMutex.Unlock()
+
+	migs := make([]*MigInformation, 0, len(gc.migs))
+	for _, mig := range gc.migs {
+		migs = append(migs, &MigInformation{
+			Basename: mig.Basename,
+			Config:   mig.Config,
+		})
+	}
+	return migs
+}
+
+func (gc *GceCache) updateMigBasename(ref GceRef, basename string) {
+	gc.migsMutex.Lock()
+	defer gc.migsMutex.Unlock()
+
+	for _, mig := range gc.migs {
+		if mig.Config.GceRef() == ref {
+			mig.Basename = basename
+		}
+	}
+}
+
+// Methods locking on cacheMutex.
+
+// GetMigForInstance returns MigConfig of the given Instance from cache.
+// Attempts to regenerate cache if there is a Mig with matching prefix in migs list.
+// TODO(aleksandra-malinowska): reconsider failing when there's a Mig with
+// matching prefix, but instance doesn't belong to it.
+func (gc *GceCache) GetMigForInstance(instance *GceRef) (Mig, error) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	if mig, found := gc.migCache[*instance]; found {
+		return mig, nil
+	}
+
+	for _, mig := range gc.GetMigs() {
+		if mig.Config.GceRef().Project == instance.Project &&
+			mig.Config.GceRef().Zone == instance.Zone &&
+			strings.HasPrefix(instance.Name, mig.Basename) {
+			if err := gc.regenerateCache(); err != nil {
+				return nil, fmt.Errorf("Error while looking for MIG for instance %+v, error: %v", *instance, err)
+			}
+			if mig, found := gc.migCache[*instance]; found {
+				return mig, nil
+			}
+			return nil, fmt.Errorf("Instance %+v does not belong to any configured MIG", *instance)
+		}
+	}
+	// Instance doesn't belong to any configured mig.
+	return nil, nil
+}
+
+// RegenerateCacheWithLock triggers cache regeneration under lock.
+func (gc *GceCache) RegenerateCacheWithLock() error {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	return gc.regenerateCache()
+}
+
+// internal method - should only be called after locking on cacheMutex.
+func (gc *GceCache) regenerateCache() error {
+	newMigCache := make(map[GceRef]Mig)
+
+	for _, migInfo := range gc.GetMigs() {
+		mig := migInfo.Config
+		glog.V(4).Infof("Regenerating MIG information for %s", mig.GceRef().String())
+
+		basename, err := gc.GceService.FetchMigBasename(mig.GceRef())
+		if err != nil {
+			return err
+		}
+		gc.updateMigBasename(mig.GceRef(), basename)
+
+		instances, err := gc.GceService.FetchMigInstances(mig.GceRef())
+		if err != nil {
+			glog.V(4).Infof("Failed MIG info request for %s: %v", mig.GceRef().String(), err)
+			return err
+		}
+		for _, ref := range instances {
+			newMigCache[ref] = mig
+		}
+	}
+
+	gc.migCache = newMigCache
+	return nil
+}
+
+// SetResourceLimiter sets resource limiter.
+func (gc *GceCache) SetResourceLimiter(resourceLimiter *cloudprovider.ResourceLimiter) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	gc.resourceLimiter = resourceLimiter
+}
+
+// GetResourceLimiter returns resource limiter.
+func (gc *GceCache) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	return gc.resourceLimiter, nil
+}
+
+// GetMachineFromCache retrieves machine type from cache under lock.
+func (gc *GceCache) GetMachineFromCache(machineType string, zone string) *gce.MachineType {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	return gc.machinesCache[MachineTypeKey{zone, machineType}]
+}
+
+// AddMachineToCache adds machine to cache under lock.
+func (gc *GceCache) AddMachineToCache(machineType string, zone string, machine *gce.MachineType) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	gc.machinesCache[MachineTypeKey{zone, machineType}] = machine
+}
+
+// SetMachinesCache sets the machines cache under lock and returns next recommended refresh time.
+func (gc *GceCache) SetMachinesCache(machinesCache map[MachineTypeKey]*gce.MachineType) time.Time {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	gc.machinesCache = machinesCache
+	gc.machinesCacheLastRefresh = time.Now()
+	return gc.machinesCacheLastRefresh.Add(machinesRefreshInterval)
+}
+
+// Methods that need no lock.
+
+// MachinesCacheFresh return true if the last update to machines cache was within refesh interval.
+func (gc *GceCache) MachinesCacheFresh() bool {
+	return gc.machinesCacheLastRefresh.Add(machinesRefreshInterval).After(time.Now())
+}

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -95,7 +95,7 @@ func (gce *GceCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	migs := gce.gceManager.getMigs()
 	result := make([]cloudprovider.NodeGroup, 0, len(migs))
 	for _, mig := range migs {
-		result = append(result, mig.config)
+		result = append(result, mig.Config)
 	}
 	return result
 }
@@ -235,7 +235,7 @@ func GceRefFromProviderId(id string) (*GceRef, error) {
 	}, nil
 }
 
-// Information about what machines in a MIG look like.
+// MigSpec contains information about what machines in a MIG look like.
 type MigSpec struct {
 	machineType    string
 	labels         map[string]string

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -155,31 +155,30 @@ func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]
 		taints = append(taints, taint)
 	}
 
-	mig := &Mig{
-		autoprovisioned: true,
-		exist:           false,
-		nodePoolName:    nodePoolName,
-		GceRef: GceRef{
+	mig := &gceMig{
+		gceRef: GceRef{
 			Project: gce.gceManager.getProjectId(),
 			Zone:    zone,
 			Name:    nodePoolName + "-temporary-mig",
 		},
-		minSize: minAutoprovisionedSize,
-		maxSize: maxAutoprovisionedSize,
-		spec: &autoprovisioningSpec{
+		gceManager:      gce.gceManager,
+		autoprovisioned: true,
+		exist:           false,
+		nodePoolName:    nodePoolName,
+		minSize:         minAutoprovisionedSize,
+		maxSize:         maxAutoprovisionedSize,
+		spec: &MigSpec{
 			machineType:    machineType,
 			labels:         labels,
 			taints:         taints,
 			extraResources: extraResources,
 		},
-		gceManager: gce.gceManager,
 	}
 
 	// Try to build a node from autoprovisioning spec. We don't need one right now,
 	// but if it fails later, we'd end up with a node group we can't scale anyway,
 	// so there's no point creating it.
-	_, err := gce.gceManager.getMigTemplateNode(mig)
-	if err != nil {
+	if _, err := gce.gceManager.getMigTemplateNode(mig); err != nil {
 		return nil, fmt.Errorf("Failed to build node from spec: %v", err)
 	}
 
@@ -216,6 +215,10 @@ type GceRef struct {
 	Name    string
 }
 
+func (ref GceRef) String() string {
+	return fmt.Sprintf("%s/%s/%s", ref.Project, ref.Zone, ref.Name)
+}
+
 // GceRefFromProviderId creates InstanceConfig object
 // from provider id which must be in format:
 // gce://<project-id>/<zone>/<name>
@@ -232,8 +235,8 @@ func GceRefFromProviderId(id string) (*GceRef, error) {
 	}, nil
 }
 
-// Information about what machines in an autoprovisioned MIG would look like.
-type autoprovisioningSpec struct {
+// Information about what machines in a MIG look like.
+type MigSpec struct {
 	machineType    string
 	labels         map[string]string
 	taints         []apiv1.Taint
@@ -241,8 +244,16 @@ type autoprovisioningSpec struct {
 }
 
 // Mig implements NodeGroup interface.
-type Mig struct {
-	GceRef
+type Mig interface {
+	cloudprovider.NodeGroup
+
+	GceRef() GceRef
+	NodePoolName() string
+	Spec() *MigSpec
+}
+
+type gceMig struct {
+	gceRef GceRef
 
 	gceManager      GceManager
 	minSize         int
@@ -250,22 +261,37 @@ type Mig struct {
 	autoprovisioned bool
 	exist           bool
 	nodePoolName    string
-	spec            *autoprovisioningSpec
+	spec            *MigSpec
+}
+
+// GceRef returns Mig's GceRef
+func (mig *gceMig) GceRef() GceRef {
+	return mig.gceRef
+}
+
+// NodePoolName returns the name of the GKE node pool this Mig belongs to.
+func (mig *gceMig) NodePoolName() string {
+	return mig.nodePoolName
+}
+
+// Spec returns specification of the Mig.
+func (mig *gceMig) Spec() *MigSpec {
+	return mig.spec
 }
 
 // MaxSize returns maximum size of the node group.
-func (mig *Mig) MaxSize() int {
+func (mig *gceMig) MaxSize() int {
 	return mig.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (mig *Mig) MinSize() int {
+func (mig *gceMig) MinSize() int {
 	return mig.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (mig *Mig) TargetSize() (int, error) {
+func (mig *gceMig) TargetSize() (int, error) {
 	if !mig.exist {
 		return 0, nil
 	}
@@ -274,7 +300,7 @@ func (mig *Mig) TargetSize() (int, error) {
 }
 
 // IncreaseSize increases Mig size
-func (mig *Mig) IncreaseSize(delta int) error {
+func (mig *gceMig) IncreaseSize(delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -291,7 +317,7 @@ func (mig *Mig) IncreaseSize(delta int) error {
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
-func (mig *Mig) DecreaseTargetSize(delta int) error {
+func (mig *gceMig) DecreaseTargetSize(delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -311,7 +337,7 @@ func (mig *Mig) DecreaseTargetSize(delta int) error {
 }
 
 // Belongs returns true if the given node belongs to the NodeGroup.
-func (mig *Mig) Belongs(node *apiv1.Node) (bool, error) {
+func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return false, err
@@ -330,7 +356,7 @@ func (mig *Mig) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (mig *Mig) DeleteNodes(nodes []*apiv1.Node) error {
+func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := mig.gceManager.GetMigSize(mig)
 	if err != nil {
 		return err
@@ -358,28 +384,28 @@ func (mig *Mig) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // Id returns mig url.
-func (mig *Mig) Id() string {
-	return GenerateMigUrl(mig.GceRef)
+func (mig *gceMig) Id() string {
+	return GenerateMigUrl(mig.gceRef)
 }
 
 // Debug returns a debug string for the Mig.
-func (mig *Mig) Debug() string {
+func (mig *gceMig) Debug() string {
 	return fmt.Sprintf("%s (%d:%d)", mig.Id(), mig.MinSize(), mig.MaxSize())
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (mig *Mig) Nodes() ([]string, error) {
+func (mig *gceMig) Nodes() ([]string, error) {
 	return mig.gceManager.GetMigNodes(mig)
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (mig *Mig) Exist() bool {
+func (mig *gceMig) Exist() bool {
 	return mig.exist
 }
 
 // Create creates the node group on the cloud provider side.
-func (mig *Mig) Create() (cloudprovider.NodeGroup, error) {
+func (mig *gceMig) Create() (cloudprovider.NodeGroup, error) {
 	if !mig.exist && mig.autoprovisioned {
 		return mig.gceManager.createNodePool(mig)
 	}
@@ -388,7 +414,7 @@ func (mig *Mig) Create() (cloudprovider.NodeGroup, error) {
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (mig *Mig) Delete() error {
+func (mig *gceMig) Delete() error {
 	if mig.exist && mig.autoprovisioned {
 		return mig.gceManager.deleteNodePool(mig)
 	}
@@ -396,12 +422,12 @@ func (mig *Mig) Delete() error {
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (mig *Mig) Autoprovisioned() bool {
+func (mig *gceMig) Autoprovisioned() bool {
 	return mig.autoprovisioned
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (mig *Mig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
+func (mig *gceMig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 	node, err := mig.gceManager.getMigTemplateNode(mig)
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -40,16 +40,6 @@ type gceManagerMock struct {
 	mock.Mock
 }
 
-func (m *gceManagerMock) RegisterMig(mig Mig) bool {
-	args := m.Called(mig)
-	return args.Bool(0)
-}
-
-func (m *gceManagerMock) UnregisterMig(toBeRemoved Mig) bool {
-	args := m.Called(toBeRemoved)
-	return args.Bool(0)
-}
-
 func (m *gceManagerMock) GetMigSize(mig Mig) (int64, error) {
 	args := m.Called(mig)
 	return args.Get(0).(int64), args.Error(1)
@@ -85,9 +75,9 @@ func (m *gceManagerMock) Cleanup() error {
 	return args.Error(0)
 }
 
-func (m *gceManagerMock) getMigs() []*migInformation {
+func (m *gceManagerMock) getMigs() []*MigInformation {
 	args := m.Called()
-	return args.Get(0).([]*migInformation)
+	return args.Get(0).([]*MigInformation)
 }
 
 func (m *gceManagerMock) createNodePool(mig Mig) (Mig, error) {
@@ -157,10 +147,10 @@ func TestNodeGroups(t *testing.T) {
 	gce := &GceCloudProvider{
 		gceManager: gceManagerMock,
 	}
-	mig := &migInformation{config: &gceMig{gceRef: GceRef{Name: "ng1"}}}
-	gceManagerMock.On("getMigs").Return([]*migInformation{mig}).Once()
+	mig := &MigInformation{Config: &gceMig{gceRef: GceRef{Name: "ng1"}}}
+	gceManagerMock.On("getMigs").Return([]*MigInformation{mig}).Once()
 	result := gce.NodeGroups()
-	assert.Equal(t, []cloudprovider.NodeGroup{mig.config}, result)
+	assert.Equal(t, []cloudprovider.NodeGroup{mig.Config}, result)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -40,22 +40,22 @@ type gceManagerMock struct {
 	mock.Mock
 }
 
-func (m *gceManagerMock) RegisterMig(mig *Mig) bool {
+func (m *gceManagerMock) RegisterMig(mig Mig) bool {
 	args := m.Called(mig)
 	return args.Bool(0)
 }
 
-func (m *gceManagerMock) UnregisterMig(toBeRemoved *Mig) bool {
+func (m *gceManagerMock) UnregisterMig(toBeRemoved Mig) bool {
 	args := m.Called(toBeRemoved)
 	return args.Bool(0)
 }
 
-func (m *gceManagerMock) GetMigSize(mig *Mig) (int64, error) {
+func (m *gceManagerMock) GetMigSize(mig Mig) (int64, error) {
 	args := m.Called(mig)
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *gceManagerMock) SetMigSize(mig *Mig, size int64) error {
+func (m *gceManagerMock) SetMigSize(mig Mig, size int64) error {
 	args := m.Called(mig, size)
 	return args.Error(0)
 }
@@ -65,12 +65,12 @@ func (m *gceManagerMock) DeleteInstances(instances []*GceRef) error {
 	return args.Error(0)
 }
 
-func (m *gceManagerMock) GetMigForInstance(instance *GceRef) (*Mig, error) {
+func (m *gceManagerMock) GetMigForInstance(instance *GceRef) (Mig, error) {
 	args := m.Called(instance)
-	return args.Get(0).(*Mig), args.Error(1)
+	return args.Get(0).(*gceMig), args.Error(1)
 }
 
-func (m *gceManagerMock) GetMigNodes(mig *Mig) ([]string, error) {
+func (m *gceManagerMock) GetMigNodes(mig Mig) ([]string, error) {
 	args := m.Called(mig)
 	return args.Get(0).([]string), args.Error(1)
 }
@@ -90,12 +90,12 @@ func (m *gceManagerMock) getMigs() []*migInformation {
 	return args.Get(0).([]*migInformation)
 }
 
-func (m *gceManagerMock) createNodePool(mig *Mig) (*Mig, error) {
+func (m *gceManagerMock) createNodePool(mig Mig) (Mig, error) {
 	args := m.Called(mig)
 	return mig, args.Error(0)
 }
 
-func (m *gceManagerMock) deleteNodePool(toBeRemoved *Mig) error {
+func (m *gceManagerMock) deleteNodePool(toBeRemoved Mig) error {
 	args := m.Called(toBeRemoved)
 	return args.Error(0)
 }
@@ -130,7 +130,7 @@ func (m *gceManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *gceManagerMock) getMigTemplateNode(mig *Mig) (*apiv1.Node, error) {
+func (m *gceManagerMock) getMigTemplateNode(mig Mig) (*apiv1.Node, error) {
 	args := m.Called(mig)
 	return args.Get(0).(*apiv1.Node), args.Error(1)
 }
@@ -157,7 +157,7 @@ func TestNodeGroups(t *testing.T) {
 	gce := &GceCloudProvider{
 		gceManager: gceManagerMock,
 	}
-	mig := &migInformation{config: &Mig{GceRef: GceRef{Name: "ng1"}}}
+	mig := &migInformation{config: &gceMig{gceRef: GceRef{Name: "ng1"}}}
 	gceManagerMock.On("getMigs").Return([]*migInformation{mig}).Once()
 	result := gce.NodeGroups()
 	assert.Equal(t, []cloudprovider.NodeGroup{mig.config}, result)
@@ -171,12 +171,12 @@ func TestNodeGroupForNode(t *testing.T) {
 	}
 	n := BuildTestNode("n1", 1000, 1000)
 	n.Spec.ProviderID = "gce://project1/us-central1-b/n1"
-	mig := Mig{GceRef: GceRef{Name: "ng1"}}
+	mig := gceMig{gceRef: GceRef{Name: "ng1"}}
 	gceManagerMock.On("GetMigForInstance", mock.AnythingOfType("*gce.GceRef")).Return(&mig, nil).Once()
 
 	nodeGroup, err := gce.NodeGroupForNode(n)
 	assert.NoError(t, err)
-	assert.Equal(t, mig, *reflect.ValueOf(nodeGroup).Interface().(*Mig))
+	assert.Equal(t, mig, *reflect.ValueOf(nodeGroup).Interface().(*gceMig))
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }
 
@@ -300,11 +300,12 @@ func TestMig(t *testing.T) {
 	// Test NewNodeGroup.
 	gceManagerMock.On("getProjectId").Return("project1").Once()
 	gceManagerMock.On("getLocation").Return("us-central1-b").Once()
-	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.Mig")).Return(&apiv1.Node{}, nil).Once()
+	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
 	nodeGroup, err := gce.NewNodeGroup("n1-standard-1", nil, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
-	mig1 := reflect.ValueOf(nodeGroup).Interface().(*Mig)
+	mig1 := reflect.ValueOf(nodeGroup).Interface().(*gceMig)
+	assert.Equal(t, true, mig1.Autoprovisioned())
 	mig1.exist = true
 	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
@@ -313,15 +314,15 @@ func TestMig(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test TargetSize.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(2), nil).Once()
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
 	targetSize, err := mig1.TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, targetSize)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test IncreaseSize.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(2), nil).Once()
-	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.Mig"), int64(3)).Return(nil).Once()
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
+	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.gceMig"), int64(3)).Return(nil).Once()
 	err = mig1.IncreaseSize(1)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -332,18 +333,18 @@ func TestMig(t *testing.T) {
 	assert.Equal(t, "size increase must be positive", err.Error())
 
 	// Test IncreaseSize - fail on too big delta.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(2), nil).Once()
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
 	err = mig1.IncreaseSize(1000)
 	assert.Error(t, err)
 	assert.Equal(t, "size increase too large - desired:1002 max:1000", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test DecreaseTargetSize.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(3), nil).Once()
-	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.Mig")).Return(
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(3), nil).Once()
+	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
 		[]string{"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
 			"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nil).Once()
-	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.Mig"), int64(2)).Return(nil).Once()
+	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.gceMig"), int64(2)).Return(nil).Once()
 	err = mig1.DecreaseTargetSize(-1)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -354,8 +355,8 @@ func TestMig(t *testing.T) {
 	assert.Equal(t, "size decrease must be negative", err.Error())
 
 	// Test DecreaseTargetSize - fail on deleting existing nodes.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(3), nil).Once()
-	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.Mig")).Return(
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(3), nil).Once()
+	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
 		[]string{"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
 			"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nil).Once()
 
@@ -375,8 +376,8 @@ func TestMig(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test Belongs - false.
-	mig2 := &Mig{
-		GceRef: GceRef{
+	mig2 := &gceMig{
+		gceRef: GceRef{
 			Project: "project1",
 			Zone:    "us-central1-b",
 			Name:    "default-pool",
@@ -402,7 +403,7 @@ func TestMig(t *testing.T) {
 	n2 := BuildTestNode("gke-cluster-1-default-pool-f7607aac-dck1", 1000, 1000)
 	n2.Spec.ProviderID = "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"
 	n2ref := &GceRef{"project1", "us-central1-b", "gke-cluster-1-default-pool-f7607aac-dck1"}
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(2), nil).Once()
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
 	gceManagerMock.On("GetMigForInstance", n1ref).Return(mig1, nil).Once()
 	gceManagerMock.On("GetMigForInstance", n2ref).Return(mig1, nil).Once()
 	gceManagerMock.On("DeleteInstances", []*GceRef{n1ref, n2ref}).Return(nil).Once()
@@ -411,14 +412,14 @@ func TestMig(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test DeleteNodes - fail on reaching min size.
-	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.Mig")).Return(int64(0), nil).Once()
+	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(0), nil).Once()
 	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2})
 	assert.Error(t, err)
 	assert.Equal(t, "min size reached, nodes will not be deleted", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test Nodes.
-	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.Mig")).Return(
+	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
 		[]string{"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
 			"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nil).Once()
 	nodes, err := mig1.Nodes()
@@ -429,20 +430,19 @@ func TestMig(t *testing.T) {
 
 	// Test Create.
 	mig1.exist = false
-	gceManagerMock.On("createNodePool", mock.AnythingOfType("*gce.Mig")).Return(nil).Once()
+	gceManagerMock.On("createNodePool", mock.AnythingOfType("*gce.gceMig")).Return(nil, nil).Once()
 	_, err = mig1.Create()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
-	// Test Delete.
+	gceManagerMock.On("deleteNodePool", mock.AnythingOfType("*gce.gceMig")).Return(nil).Once()
 	mig1.exist = true
-	gceManagerMock.On("deleteNodePool", mock.AnythingOfType("*gce.Mig")).Return(nil).Once()
 	err = mig1.Delete()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test TemplateNodeInfo.
-	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.Mig")).Return(&apiv1.Node{}, nil).Once()
+	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
 	templateNodeInfo, err := mig2.TemplateNodeInfo()
 	assert.NoError(t, err)
 	assert.NotNil(t, templateNodeInfo)
@@ -465,7 +465,7 @@ func TestNewNodeGroupForGpu(t *testing.T) {
 	// Test NewNodeGroup.
 	gceManagerMock.On("getProjectId").Return("project1").Once()
 	gceManagerMock.On("getLocation").Return("us-west1-b").Once()
-	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.Mig")).Return(&apiv1.Node{}, nil).Once()
+	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
 
 	systemLabels := map[string]string{
 		gpu.GPULabel: gpu.DefaultGPUType,
@@ -476,7 +476,7 @@ func TestNewNodeGroupForGpu(t *testing.T) {
 	nodeGroup, err := gce.NewNodeGroup("n1-standard-1", make(map[string]string), systemLabels, nil, extraResources)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
-	mig1 := reflect.ValueOf(nodeGroup).Interface().(*Mig)
+	mig1 := reflect.ValueOf(nodeGroup).Interface().(*gceMig)
 	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-west1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1-gpu"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	assert.Equal(t, 0, mig1.MinSize())

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -604,10 +604,7 @@ func (m *gceManagerImpl) Refresh() error {
 func (m *gceManagerImpl) forceRefresh() error {
 	switch m.mode {
 	case ModeGCE:
-		if err := m.clearMachinesCache(); err != nil {
-			glog.Errorf("Failed to clear machine types cache: %v", err)
-			return err
-		}
+		m.clearMachinesCache()
 		if err := m.fetchAutoMigs(); err != nil {
 			glog.Errorf("Failed to fetch MIGs: %v", err)
 			return err
@@ -775,16 +772,17 @@ func (m *gceManagerImpl) GetResourceLimiter() (*cloudprovider.ResourceLimiter, e
 	return m.resourceLimiter, nil
 }
 
-func (m *gceManagerImpl) clearMachinesCache() error {
+func (m *gceManagerImpl) clearMachinesCache() {
 	if m.machinesCacheLastRefresh.Add(machinesRefreshInterval).After(time.Now()) {
-		return nil
+		return
 	}
+
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
+
 	m.machinesCache = make(map[machineTypeKey]*gce.MachineType)
 	m.machinesCacheLastRefresh = time.Now()
 	glog.V(2).Infof("Cleared machine types cache, next clear after %v", m.machinesCacheLastRefresh.Add(machinesRefreshInterval))
-	return nil
 }
 
 // Code borrowed from gce cloud provider. Reuse the original as soon as it becomes public.

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -488,9 +488,9 @@ func newTestGceManager(t *testing.T, testServerURL string, mode GcpCloudProvider
 
 	manager := &gceManagerImpl{
 		cache: GceCache{
-			migs:       make([]*MigInformation, 0),
-			GceService: gceService,
-			migCache:   make(map[GceRef]Mig),
+			migs:           make([]*MigInformation, 0),
+			GceService:     gceService,
+			instancesCache: make(map[GceRef]Mig),
 			machinesCache: map[MachineTypeKey]*gce.MachineType{
 				{"us-central1-b", "n1-standard-1"}: {GuestCpus: 1, MemoryMb: 1},
 				{"us-central1-c", "n1-standard-1"}: {GuestCpus: 1, MemoryMb: 1},
@@ -1289,7 +1289,7 @@ func TestfetchMachinesCache(t *testing.T) {
 	// Skipped refresh.
 	server.On("handle", "/v1alpha1/projects/project1/locations/us-central1-b/clusters/cluster1").Return(getClusterResponse).Once()
 	server.On("handle", "/project1/zones/us-central1-b/machineTypes").Return(listMachineTypesResponse).Once()
-	g.cache.machinesCacheLastRefresh = time.Now().Add(-2 * time.Hour)
+	g.machinesCacheLastRefresh = time.Now().Add(-2 * time.Hour)
 	err = g.fetchMachinesCache()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -193,7 +193,7 @@ func (t *templateBuilder) buildNodeFromTemplate(mig Mig, template *gce.InstanceT
 	return &node, nil
 }
 
-func (t *templateBuilder) buildNodeFromAutoprovisioningSpec(mig Mig, cpu int64, mem int64) (*apiv1.Node, error) {
+func (t *templateBuilder) buildNodeFromMigSpec(mig Mig, cpu int64, mem int64) (*apiv1.Node, error) {
 	if mig.Spec() == nil {
 		return nil, fmt.Errorf("no spec in mig %s", mig.GceRef().Name)
 	}

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -356,11 +356,13 @@ func TestExtractAutoscalerVarFromKubeEnv(t *testing.T) {
 }
 
 func TestExtractLabelsFromKubeEnv(t *testing.T) {
+	poolLabel := "cloud.google.com/gke-nodepool"
+	preemptibleLabel := "cloud.google.com/gke-preemptible"
 	expectedLabels := map[string]string{
-		"a":                                "b",
-		"c":                                "d",
-		"cloud.google.com/gke-nodepool":    "pool-3",
-		"cloud.google.com/gke-preemptible": "true",
+		"a":              "b",
+		"c":              "d",
+		poolLabel:        "pool-3",
+		preemptibleLabel: "true",
 	}
 	cases := []struct {
 		desc   string

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -38,7 +38,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 		name              string
 		machineType       string
 		accelerators      []*gce.AcceleratorConfig
-		mig               *Mig
+		mig               Mig
 		capacityCpu       int64
 		capacityMemory    int64
 		allocatableCpu    string
@@ -58,10 +58,13 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			{AcceleratorType: "nvidia-tesla-k80", AcceleratorCount: 3},
 			{AcceleratorType: "nvidia-tesla-p100", AcceleratorCount: 8},
 		},
-		mig: &Mig{GceRef: GceRef{
-			Name:    "some-name",
-			Project: "some-proj",
-			Zone:    "us-central1-b"}},
+		mig: &gceMig{
+			gceRef: GceRef{
+				Name:    "some-name",
+				Project: "some-proj",
+				Zone:    "us-central1-b",
+			},
+		},
 		capacityCpu:       8,
 		capacityMemory:    200 * 1024 * 1024,
 		allocatableCpu:    "7000m",
@@ -76,10 +79,13 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 				"NODE_TAINTS: 'dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c'\n",
 			name:        "nodeName",
 			machineType: "custom-8-2",
-			mig: &Mig{GceRef: GceRef{
-				Name:    "some-name",
-				Project: "some-proj",
-				Zone:    "us-central1-b"}},
+			mig: &gceMig{
+				gceRef: GceRef{
+					Name:    "some-name",
+					Project: "some-proj",
+					Zone:    "us-central1-b",
+				},
+			},
 			capacityCpu:       8,
 			capacityMemory:    2 * 1024 * 1024,
 			allocatableCpu:    "8000m",
@@ -89,10 +95,13 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			kubeEnv:     "This kube-env is totally messed up",
 			name:        "nodeName",
 			machineType: "custom-8-2",
-			mig: &Mig{GceRef: GceRef{
-				Name:    "some-name",
-				Project: "some-proj",
-				Zone:    "us-central1-b"}},
+			mig: &gceMig{
+				gceRef: GceRef{
+					Name:    "some-name",
+					Project: "some-proj",
+					Zone:    "us-central1-b",
+				},
+			},
 			expectedErr: true,
 		},
 	}
@@ -143,18 +152,20 @@ func TestBuildGenericLabels(t *testing.T) {
 
 func TestBuildLabelsForAutoscaledMigOK(t *testing.T) {
 	labels, err := buildLabelsForAutoprovisionedMig(
-		&Mig{
+		&gceMig{
+			gceRef: GceRef{
+				Name:    "kubernetes-minion-autoprovisioned-group",
+				Project: "mwielgus-proj",
+				Zone:    "us-central1-b",
+			},
 			autoprovisioned: true,
-			spec: &autoprovisioningSpec{
+			spec: &MigSpec{
 				machineType: "n1-standard-8",
 				labels: map[string]string{
 					"A": "B",
 				},
 			},
-			GceRef: GceRef{
-				Name:    "kubernetes-minion-autoprovisioned-group",
-				Project: "mwielgus-proj",
-				Zone:    "us-central1-b"}},
+		},
 		"sillyname",
 	)
 
@@ -170,18 +181,20 @@ func TestBuildLabelsForAutoscaledMigOK(t *testing.T) {
 
 func TestBuildLabelsForAutoscaledMigConflict(t *testing.T) {
 	_, err := buildLabelsForAutoprovisionedMig(
-		&Mig{
+		&gceMig{
+			gceRef: GceRef{
+				Name:    "kubernetes-minion-autoprovisioned-group",
+				Project: "mwielgus-proj",
+				Zone:    "us-central1-b",
+			},
 			autoprovisioned: true,
-			spec: &autoprovisioningSpec{
+			spec: &MigSpec{
 				machineType: "n1-standard-8",
 				labels: map[string]string{
 					kubeletapis.LabelOS: "windows",
 				},
 			},
-			GceRef: GceRef{
-				Name:    "kubernetes-minion-autoprovisioned-group",
-				Project: "mwielgus-proj",
-				Zone:    "us-central1-b"}},
+		},
 		"sillyname",
 	)
 	assert.Error(t, err)
@@ -344,8 +357,8 @@ func TestExtractAutoscalerVarFromKubeEnv(t *testing.T) {
 
 func TestExtractLabelsFromKubeEnv(t *testing.T) {
 	expectedLabels := map[string]string{
-		"a": "b",
-		"c": "d",
+		"a":                                "b",
+		"c":                                "d",
 		"cloud.google.com/gke-nodepool":    "pool-3",
 		"cloud.google.com/gke-preemptible": "true",
 	}


### PR DESCRIPTION
This extracts cache management part of GCE manager in order to make it:
1) easier to understand and verify it is used correctly,
2) reusable for separating GKE cloud provider.