### PR TITLE
 Add a sequential implementation of PodEvictionAdmission

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -48,11 +48,11 @@ type updater struct {
 	podLister               v1lister.PodLister
 	evictionFactory         eviction.PodsEvictionRestrictionFactory
 	recommendationProcessor vpa_api_util.RecommendationProcessor
-	evictionAdmission       priority.PodEvicionAdmission
+	evictionAdmission       priority.PodEvictionAdmission
 }
 
 // NewUpdater creates Updater with given configuration
-func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvicionAdmission) Updater {
+func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvictionAdmission) Updater {
 	return &updater{
 		vpaLister:               vpa_api_util.NewAllVpasLister(vpaClient, make(chan struct{})),
 		podLister:               newPodLister(kubeClient),

--- a/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
@@ -21,22 +21,22 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 )
 
-// PodEvicionAdmission controls evictions of pods.
-type PodEvicionAdmission interface {
-	// LoopInit initializes PodEvicionAdmission for next Updater loop
+// PodEvictionAdmission controls evictions of pods.
+type PodEvictionAdmission interface {
+	// LoopInit initializes PodEvictionAdmission for next Updater loop
 	LoopInit()
-	// Admit returns true if PodEvicionAdmission decides that pod can be evicted with given recommendation.
+	// Admit returns true if PodEvictionAdmission decides that pod can be evicted with given recommendation.
 	Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool
 }
 
-type noopPodEvicionAdmission struct{}
+type noopPodEvictionAdmission struct{}
 
-func (n *noopPodEvicionAdmission) LoopInit() {}
-func (n *noopPodEvicionAdmission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
+func (n *noopPodEvictionAdmission) LoopInit() {}
+func (n *noopPodEvictionAdmission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return true
 }
 
-// NewDefaultPodEvicionAdmission constructs new PodEvicionAdmission that admits all pods.
-func NewDefaultPodEvicionAdmission() PodEvicionAdmission {
-	return &noopPodEvicionAdmission{}
+// NewDefaultPodEvictionAdmission constructs new PodEvictionAdmission that admits all pods.
+func NewDefaultPodEvictionAdmission() PodEvictionAdmission {
+	return &noopPodEvictionAdmission{}
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -120,7 +120,7 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa
 }
 
 // GetSortedPods returns a list of pods ordered by update priority (highest update priority first)
-func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvicionAdmission) []*apiv1.Pod {
+func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvictionAdmission) []*apiv1.Pod {
 	sort.Sort(byPriority(calc.pods))
 
 	result := []*apiv1.Pod{}
@@ -128,7 +128,7 @@ func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvicionAdmissio
 		if admission == nil || admission.Admit(podPrio.pod, podPrio.recommendation) {
 			result = append(result, podPrio.pod)
 		} else {
-			glog.V(2).Infof("pod removed from update queue by PodEvicionAdmission: %v", podPrio.pod.Name)
+			glog.V(2).Infof("pod removed from update queue by PodEvictionAdmission: %v", podPrio.pod.Name)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -50,7 +50,7 @@ func TestSortPriority(t *testing.T) {
 	calculator.AddPod(pod3, recommendation, timestampNow)
 	calculator.AddPod(pod4, recommendation, timestampNow)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod3, pod1, pod4, pod2}, result, "Wrong priority order")
 }
 
@@ -66,7 +66,7 @@ func TestSortPriorityMultiResource(t *testing.T) {
 	calculator.AddPod(pod1, recommendation, timestampNow)
 	calculator.AddPod(pod2, recommendation, timestampNow)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod1, pod2}, result, "Wrong priority order")
 }
 
@@ -109,7 +109,7 @@ func TestSortPriorityMultiContainers(t *testing.T) {
 	podPriority2 := calculator.getUpdatePriority(pod2, recommendation)
 	assert.Equal(t, 1.0, podPriority2.resourceDiff)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod1, pod2}, result, "Wrong priority order")
 }
 
@@ -131,7 +131,7 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 	// 1. pod1 - wants to grow by 1 unit.
 	// 2. pod3 - can reclaim 5 units.
 	// 3. pod2 - can reclaim 2 units.
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod1, pod3, pod2}, result, "Wrong priority order")
 }
 
@@ -145,7 +145,7 @@ func TestUpdateNotRequired(t *testing.T) {
 	timestampNow := pod1.Status.StartTime.Time.Add(time.Hour * 24)
 	calculator.AddPod(pod1, recommendation, timestampNow)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result, "Pod should not be updated")
 }
 
@@ -159,7 +159,7 @@ func TestUpdateRequiredOnMilliQuantities(t *testing.T) {
 	timestampNow := pod1.Status.StartTime.Time.Add(time.Hour * 24)
 	calculator.AddPod(pod1, recommendation, timestampNow)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod1}, result, "Pod should be updated")
 }
 
@@ -178,7 +178,7 @@ func TestUseProcessor(t *testing.T) {
 	timestampNow := pod1.Status.StartTime.Time.Add(time.Hour * 24)
 	calculator.AddPod(pod1, recommendation, timestampNow)
 
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result, "Pod should not be updated")
 }
 
@@ -207,7 +207,7 @@ func TestUpdateLonglivedPods(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		calculator.AddPod(pods[i], recommendation, timestampNow)
 	}
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pods[1], pods[2]}, result, "Exactly POD2 and POD3 should be updated")
 }
 
@@ -235,7 +235,7 @@ func TestUpdateShortlivedPods(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		calculator.AddPod(pods[i], recommendation, timestampNow)
 	}
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pods[2]}, result, "Only POD3 should be updated")
 }
 
@@ -267,7 +267,7 @@ func TestUpdatePodWithQuickOOM(t *testing.T) {
 		WithUpperBound("6", "").Get()
 
 	calculator.AddPod(pod, recommendation, timestampNow)
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{pod}, result, "Pod should be updated")
 }
 
@@ -299,7 +299,7 @@ func TestDontUpdatePodWithOOMAfterLongRun(t *testing.T) {
 		WithUpperBound("6", "").Get()
 
 	calculator.AddPod(pod, recommendation, timestampNow)
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result, "Pod shouldn't be updated")
 }
 
@@ -332,13 +332,13 @@ func TestDontUpdatePodWithOOMOnlyOnOneContainer(t *testing.T) {
 		WithUpperBound("6", "").Get()
 
 	calculator.AddPod(pod, recommendation, timestampNow)
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result, "Pod shouldn't be updated")
 }
 
 func TestNoPods(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
-	result := calculator.GetSortedPods(NewDefaultPodEvicionAdmission())
+	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result)
 }
 


### PR DESCRIPTION
Adds sequentialPodEvictionAdmission for chaining a number of PEAs.
Also fixes a typo, in a separate commit not to pollute the diff of the real change.

@bskiba , please have a look