### PR TITLE
Clean up GceManager interface

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -57,7 +57,7 @@ func (gce *GceCloudProvider) Name() string {
 
 // NodeGroups returns all node groups configured for this cloud provider.
 func (gce *GceCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
-	migs := gce.gceManager.getMigs()
+	migs := gce.gceManager.GetMigs()
 	result := make([]cloudprovider.NodeGroup, 0, len(migs))
 	for _, mig := range migs {
 		result = append(result, mig.Config)
@@ -295,7 +295,7 @@ func (mig *gceMig) Autoprovisioned() bool {
 
 // TemplateNodeInfo returns a node template for this node group.
 func (mig *gceMig) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
-	node, err := mig.gceManager.getMigTemplateNode(mig)
+	node, err := mig.gceManager.GetMigTemplateNode(mig)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -72,7 +72,7 @@ func (m *gceManagerMock) Cleanup() error {
 	return args.Error(0)
 }
 
-func (m *gceManagerMock) getMigs() []*MigInformation {
+func (m *gceManagerMock) GetMigs() []*MigInformation {
 	args := m.Called()
 	return args.Get(0).([]*MigInformation)
 }
@@ -87,7 +87,7 @@ func (m *gceManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *gceManagerMock) getMigTemplateNode(mig Mig) (*apiv1.Node, error) {
+func (m *gceManagerMock) GetMigTemplateNode(mig Mig) (*apiv1.Node, error) {
 	args := m.Called(mig)
 	return args.Get(0).(*apiv1.Node), args.Error(1)
 }
@@ -115,7 +115,7 @@ func TestNodeGroups(t *testing.T) {
 		gceManager: gceManagerMock,
 	}
 	mig := &MigInformation{Config: &gceMig{gceRef: GceRef{Name: "ng1"}}}
-	gceManagerMock.On("getMigs").Return([]*MigInformation{mig}).Once()
+	gceManagerMock.On("GetMigs").Return([]*MigInformation{mig}).Once()
 	result := gce.NodeGroups()
 	assert.Equal(t, []cloudprovider.NodeGroup{mig.Config}, result)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -370,7 +370,7 @@ func TestMig(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test TemplateNodeInfo.
-	gceManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
+	gceManagerMock.On("GetMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
 	templateNodeInfo, err := mig2.TemplateNodeInfo()
 	assert.NoError(t, err)
 	assert.NotNil(t, templateNodeInfo)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -845,7 +845,7 @@ func TestFetchAutoMigsZonal(t *testing.T) {
 
 	assert.NoError(t, g.fetchAutoMigs())
 
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 2, len(migs))
 	validateMig(t, migs[0].Config, zoneB, gceMigA, min, max)
 	validateMig(t, migs[1].Config, zoneB, gceMigB, min, max)
@@ -883,11 +883,11 @@ func TestFetchAutoMigsUnregistersMissingMigs(t *testing.T) {
 		minSize:    1,
 		maxSize:    10,
 	}
-	assert.True(t, g.RegisterMig(unregister))
+	assert.True(t, g.registerMig(unregister))
 
 	assert.NoError(t, g.fetchAutoMigs())
 
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 1, len(migs))
 	validateMig(t, migs[0].Config, zoneB, gceMigA, minA, maxA)
 	mock.AssertExpectationsForObjects(t, server)
@@ -919,7 +919,7 @@ func TestFetchAutoMigsRegional(t *testing.T) {
 
 	assert.NoError(t, g.fetchAutoMigs())
 
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 2, len(migs))
 	validateMig(t, migs[0].Config, zoneB, gceMigA, min, max)
 	validateMig(t, migs[1].Config, zoneB, gceMigB, min, max)
@@ -953,7 +953,7 @@ func TestFetchExplicitMigs(t *testing.T) {
 
 	assert.NoError(t, g.fetchExplicitMigs(specs))
 
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 2, len(migs))
 	validateMig(t, migs[0].Config, zoneB, gceMigA, minA, maxA)
 	validateMig(t, migs[1].Config, zoneB, gceMigB, minB, maxB)
@@ -1019,7 +1019,7 @@ func TestGetMigTemplateNode(t *testing.T) {
 		maxSize:    1000,
 	}
 
-	node, err := g.getMigTemplateNode(mig)
+	node, err := g.GetMigTemplateNode(mig)
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
 	mock.AssertExpectationsForObjects(t, server)

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
@@ -76,32 +76,32 @@ func (m *gkeManagerMock) Cleanup() error {
 	return args.Error(0)
 }
 
-func (m *gkeManagerMock) getMigs() []*gce.MigInformation {
+func (m *gkeManagerMock) GetMigs() []*gce.MigInformation {
 	args := m.Called()
 	return args.Get(0).([]*gce.MigInformation)
 }
 
-func (m *gkeManagerMock) createNodePool(mig *gkeMig) (gce.Mig, error) {
+func (m *gkeManagerMock) CreateNodePool(mig *gkeMig) (*gkeMig, error) {
 	args := m.Called(mig)
 	return mig, args.Error(0)
 }
 
-func (m *gkeManagerMock) deleteNodePool(toBeRemoved *gkeMig) error {
+func (m *gkeManagerMock) DeleteNodePool(toBeRemoved *gkeMig) error {
 	args := m.Called(toBeRemoved)
 	return args.Error(0)
 }
 
-func (m *gkeManagerMock) getLocation() string {
+func (m *gkeManagerMock) GetLocation() string {
 	args := m.Called()
 	return args.String(0)
 }
 
-func (m *gkeManagerMock) getProjectId() string {
+func (m *gkeManagerMock) GetProjectId() string {
 	args := m.Called()
 	return args.String(0)
 }
 
-func (m *gkeManagerMock) getClusterName() string {
+func (m *gkeManagerMock) GetClusterName() string {
 	args := m.Called()
 	return args.String(0)
 }
@@ -121,7 +121,7 @@ func (m *gkeManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *gkeManagerMock) getMigTemplateNode(mig *gkeMig) (*apiv1.Node, error) {
+func (m *gkeManagerMock) GetMigTemplateNode(mig *gkeMig) (*apiv1.Node, error) {
 	args := m.Called(mig)
 	return args.Get(0).(*apiv1.Node), args.Error(1)
 }
@@ -149,7 +149,7 @@ func TestNodeGroups(t *testing.T) {
 		gkeManager: gkeManagerMock,
 	}
 	mig := &gce.MigInformation{Config: &gkeMig{gceRef: gce.GceRef{Name: "ng1"}}}
-	gkeManagerMock.On("getMigs").Return([]*gce.MigInformation{mig}).Once()
+	gkeManagerMock.On("GetMigs").Return([]*gce.MigInformation{mig}).Once()
 	result := gke.NodeGroups()
 	assert.Equal(t, []cloudprovider.NodeGroup{mig.Config}, result)
 	mock.AssertExpectationsForObjects(t, gkeManagerMock)
@@ -289,9 +289,9 @@ func TestMig(t *testing.T) {
 	}
 
 	// Test NewNodeGroup.
-	gkeManagerMock.On("getProjectId").Return("project1").Once()
-	gkeManagerMock.On("getLocation").Return("us-central1-b").Once()
-	gkeManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
+	gkeManagerMock.On("GetProjectId").Return("project1").Once()
+	gkeManagerMock.On("GetLocation").Return("us-central1-b").Once()
+	gkeManagerMock.On("GetMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
 	nodeGroup, err := gke.NewNodeGroup("n1-standard-1", nil, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
@@ -421,19 +421,19 @@ func TestMig(t *testing.T) {
 
 	// Test Create.
 	mig1.exist = false
-	gkeManagerMock.On("createNodePool", mock.AnythingOfType("*gke.gkeMig")).Return(nil, nil).Once()
+	gkeManagerMock.On("CreateNodePool", mock.AnythingOfType("*gke.gkeMig")).Return(nil, nil).Once()
 	_, err = mig1.Create()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gkeManagerMock)
 
-	gkeManagerMock.On("deleteNodePool", mock.AnythingOfType("*gke.gkeMig")).Return(nil).Once()
+	gkeManagerMock.On("DeleteNodePool", mock.AnythingOfType("*gke.gkeMig")).Return(nil).Once()
 	mig1.exist = true
 	err = mig1.Delete()
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gkeManagerMock)
 
 	// Test TemplateNodeInfo.
-	gkeManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
+	gkeManagerMock.On("GetMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
 	templateNodeInfo, err := mig2.TemplateNodeInfo()
 	assert.NoError(t, err)
 	assert.NotNil(t, templateNodeInfo)
@@ -454,9 +454,9 @@ func TestNewNodeGroupForGpu(t *testing.T) {
 	}
 
 	// Test NewNodeGroup.
-	gkeManagerMock.On("getProjectId").Return("project1").Once()
-	gkeManagerMock.On("getLocation").Return("us-west1-b").Once()
-	gkeManagerMock.On("getMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
+	gkeManagerMock.On("GetProjectId").Return("project1").Once()
+	gkeManagerMock.On("GetLocation").Return("us-west1-b").Once()
+	gkeManagerMock.On("GetMigTemplateNode", mock.AnythingOfType("*gke.gkeMig")).Return(&apiv1.Node{}, nil).Once()
 
 	systemLabels := map[string]string{
 		gpu.GPULabel: gpu.DefaultGPUType,
@@ -493,9 +493,9 @@ func TestGetClusterInfo(t *testing.T) {
 	gke := &GkeCloudProvider{
 		gkeManager: gkeManagerMock,
 	}
-	gkeManagerMock.On("getProjectId").Return("project1").Once()
-	gkeManagerMock.On("getLocation").Return("location1").Once()
-	gkeManagerMock.On("getClusterName").Return("cluster1").Once()
+	gkeManagerMock.On("GetProjectId").Return("project1").Once()
+	gkeManagerMock.On("GetLocation").Return("location1").Once()
+	gkeManagerMock.On("GetClusterName").Return("cluster1").Once()
 
 	project, location, cluster := gke.GetClusterInfo()
 	assert.Equal(t, "project1", project)

--- a/cluster-autoscaler/cloudprovider/gke/gke_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_manager_test.go
@@ -552,7 +552,7 @@ func TestRefreshNodePools(t *testing.T) {
 
 	err := g.refreshNodePools()
 	assert.NoError(t, err)
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 1, len(migs))
 	validateMig(t, migs[0].Config, zoneB, "gke-cluster-1-default-pool", 1, 11)
 	mock.AssertExpectationsForObjects(t, server)
@@ -569,7 +569,7 @@ func TestRefreshNodePools(t *testing.T) {
 
 	err = g.refreshNodePools()
 	assert.NoError(t, err)
-	migs = g.getMigs()
+	migs = g.GetMigs()
 	assert.Equal(t, 2, len(migs))
 	validateMig(t, migs[0].Config, zoneB, "gke-cluster-1-default-pool", 1, 11)
 	validateMig(t, migs[1].Config, zoneB, "gke-cluster-1-nodeautoprovisioning-323233232", 0, 1000)
@@ -583,7 +583,7 @@ func TestRefreshNodePools(t *testing.T) {
 
 	err = g.refreshNodePools()
 	assert.NoError(t, err)
-	migs = g.getMigs()
+	migs = g.GetMigs()
 	assert.Equal(t, 1, len(migs))
 	validateMig(t, migs[0].Config, zoneB, "gke-cluster-1-default-pool", 1, 11)
 	mock.AssertExpectationsForObjects(t, server)
@@ -608,7 +608,7 @@ func TestFetchAllNodePoolsRegional(t *testing.T) {
 
 	err := g.refreshNodePools()
 	assert.NoError(t, err)
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.Equal(t, 3, len(migs))
 	validateMig(t, migs[0].Config, zoneB, "gke-cluster-1-default-pool", 1, 11)
 	validateMig(t, migs[1].Config, zoneC, "gke-cluster-1-default-pool", 1, 11)
@@ -667,7 +667,7 @@ func TestDeleteNodePool(t *testing.T) {
 		nodePoolName:    "nodeautoprovisioning-323233232",
 		spec:            nil}
 
-	err := g.deleteNodePool(mig)
+	err := g.DeleteNodePool(mig)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -738,10 +738,10 @@ func TestCreateNodePool(t *testing.T) {
 		},
 	}
 
-	newMig, err := g.createNodePool(mig)
+	newMig, err := g.CreateNodePool(mig)
 	assert.NoError(t, err)
 	assert.True(t, newMig.Exist())
-	migs := g.getMigs()
+	migs := g.GetMigs()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(migs))
 	mock.AssertExpectationsForObjects(t, server)
@@ -1118,7 +1118,7 @@ func TestGetMigTemplateNode(t *testing.T) {
 		spec:            nil,
 	}
 
-	node, err := g.getMigTemplateNode(mig)
+	node, err := g.GetMigTemplateNode(mig)
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
 	mock.AssertExpectationsForObjects(t, server)


### PR DESCRIPTION
Export and include in interface only methods used in gce_cloud_provider.go. Add comments to exported methods.