### PR TITLE
VPA admission controller should stop review Pod Update event

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -100,7 +100,7 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte) {
 				Name: "vpa.k8s.io",
 				Rules: []v1beta1.RuleWithOperations{
 					{
-						Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+						Operations: []v1beta1.OperationType{v1beta1.Create},
 						Rule: v1beta1.Rule{
 							APIGroups:   []string{""},
 							APIVersions: []string{"v1"},


### PR DESCRIPTION

I might be wrong, but it is my understanding that pod Update review has no impact through VPA admission controller.   It would be doing work that will have no effect at the end.

There can be a lot of pod updates events, for example, updating pod annotations, and would be creating a lot of unnecessary work.  I'd like to propose we remove the review of pod Update.