### PR TITLE
Mention --maxGracefulTerminationSec in FAQ.md

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -512,7 +512,7 @@ From 0.5 CA (K8S 1.6) respects PDBs. Before starting to delete a node, CA makes 
 
 ### Does CA respect GracefulTermination in scale-down?
 
-CA, from version 1.0, gives pods at most 10 minutes graceful termination time. If the pod is not stopped within these 10 min then the node is deleted anyway. Earlier versions of CA gave 1 minute or didn't respect graceful termination at all.
+CA, from version 1.0, gives pods at most 10 minutes graceful termination time by default (configurable via `--max-graceful-termination-sec`). If the pod is not stopped within these 10 min then the node is deleted anyway. Earlier versions of CA gave 1 minute or didn't respect graceful termination at all.
 
 ### How does CA deal with unready nodes?
 


### PR DESCRIPTION
The FAQ was wrong in a way that it said that pods are given at most 10 minutes to gracefully terminate, but the maximum time is actually configurable.