### PR TITLE
Cherry pick of #1155: Update Cluster Autoscaler base image

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Cherry pick of #1155: Update Cluster Autoscaler base image to debian-base-amd:0.3.2