### PR TITLE
Update vertical-pod-autoscaler base image to debian-base-amd:0.3.2

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 
 ADD admission-controller admission-controller

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
 
 ADD recommender recommender

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM k8s.gcr.io/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 ADD updater updater


### PR DESCRIPTION

Following #1155 to update base image to address CVEs, but only for VPA.