### PR TITLE
Fix fetching resource limits on GKE

### DIFF
--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
@@ -107,6 +107,7 @@ func (m *autoscalingGkeClientV1beta1) FetchResourceLimits() (*cloudprovider.Reso
 		return nil, err
 	}
 	if cluster.Autoscaling == nil {
+		glog.Warningf("FetchResourceLimits called without autoscaling limits set")
 		return nil, nil
 	}
 

--- a/cluster-autoscaler/cloudprovider/gke/gke_manager.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_manager.go
@@ -509,9 +509,13 @@ func (m *gkeManagerImpl) fetchResourceLimiter() error {
 		if err != nil {
 			return err
 		}
-
-		glog.V(2).Infof("Refreshed resource limits: %s", resourceLimiter.String())
-		m.cache.SetResourceLimiter(resourceLimiter)
+		if resourceLimiter != nil {
+			glog.V(2).Infof("Refreshed resource limits: %s", resourceLimiter.String())
+			m.cache.SetResourceLimiter(resourceLimiter)
+		} else {
+			oldLimits, _ := m.cache.GetResourceLimiter()
+			glog.Errorf("Resource limits should always be defined in NAP mode, but they appear to be empty. Using possibly outdated limits: %v", oldLimits.String())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Add checking limiter is not nil. Log warnings and errors if it is.