### PR TITLE
Cluster Autoscaler 1.3.2-beta.2

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.3.2-beta.1"
+const ClusterAutoscalerVersion = "1.3.2-beta.2"


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.3.2-beta.2