### PR TITLE
Report reason why pod didn't trigger scale-up

### DIFF
--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -586,9 +586,10 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
 	p3 := BuildTestPod("p-new", 550, 0)
+	p4 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
-	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3, p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	status, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3, p4}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
 
 	assert.NoError(t, err)
 	// Two nodes needed but one node is already coming, so it should increase by one.

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -187,13 +187,13 @@ func FilterSchedulablePodsForNode(context *context.AutoscalingContext, pods []*a
 				glogx.V(2).UpTo(loggingQuota).Infof("Pod %s can't be scheduled on %s. Used cached predicate check results", pod.Name, nodeGroupId)
 			}
 		} else {
-			err := context.PredicateChecker.CheckPredicates(pod, nil, nodeInfo, simulator.ReturnVerboseError)
+			err := context.PredicateChecker.CheckPredicates(pod, nil, nodeInfo)
 			if err == nil {
 				schedulable = true
 				podSchedulable.set(pod, true)
 				schedulablePods = append(schedulablePods, pod)
 			} else {
-				glog.V(2).Infof("Pod %s can't be scheduled on %s, predicate failed: %v", pod.Name, nodeGroupId, err)
+				glog.V(2).Infof("Pod %s can't be scheduled on %s, predicate failed: %v", pod.Name, nodeGroupId, err.VerboseError())
 				schedulable = false
 				podSchedulable.set(pod, false)
 			}

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -67,9 +67,9 @@ const (
 // UID as a key in initial lookup and only run full comparison on a set of
 // podSchedulableInfos created for pods owned by this controller.
 type podSchedulableInfo struct {
-	spec        apiv1.PodSpec
-	labels      map[string]string
-	schedulable bool
+	spec            apiv1.PodSpec
+	labels          map[string]string
+	schedulingError *simulator.PredicateError
 }
 
 type podSchedulableMap map[string][]podSchedulableInfo
@@ -78,32 +78,32 @@ func (psi *podSchedulableInfo) match(pod *apiv1.Pod) bool {
 	return reflect.DeepEqual(pod.Labels, psi.labels) && apiequality.Semantic.DeepEqual(pod.Spec, psi.spec)
 }
 
-func (podMap podSchedulableMap) get(pod *apiv1.Pod) (bool, bool) {
+func (podMap podSchedulableMap) get(pod *apiv1.Pod) (*simulator.PredicateError, bool) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
-		return false, false
+		return nil, false
 	}
 	uid := string(ref.UID)
 	if infos, found := podMap[uid]; found {
 		for _, info := range infos {
 			if info.match(pod) {
-				return info.schedulable, true
+				return info.schedulingError, true
 			}
 		}
 	}
-	return false, false
+	return nil, false
 }
 
-func (podMap podSchedulableMap) set(pod *apiv1.Pod, schedulable bool) {
+func (podMap podSchedulableMap) set(pod *apiv1.Pod, err *simulator.PredicateError) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
 		return
 	}
 	uid := string(ref.UID)
 	podMap[uid] = append(podMap[uid], podSchedulableInfo{
-		spec:        pod.Spec,
-		labels:      pod.Labels,
-		schedulable: schedulable,
+		spec:            pod.Spec,
+		labels:          pod.Labels,
+		schedulingError: err,
 	})
 }
 
@@ -112,34 +112,39 @@ func (podMap podSchedulableMap) set(pod *apiv1.Pod, schedulable bool) {
 // It takes into account pods that are bound to node and will be scheduled after lower priority pod preemption.
 func FilterOutSchedulable(unschedulableCandidates []*apiv1.Pod, nodes []*apiv1.Node, allScheduled []*apiv1.Pod, podsWaitingForLowerPriorityPreemption []*apiv1.Pod,
 	predicateChecker *simulator.PredicateChecker, expendablePodsPriorityCutoff int) []*apiv1.Pod {
-
 	unschedulablePods := []*apiv1.Pod{}
 	nonExpendableScheduled := FilterOutExpendablePods(allScheduled, expendablePodsPriorityCutoff)
 	nodeNameToNodeInfo := scheduler_util.CreateNodeNameToInfoMap(append(nonExpendableScheduled, podsWaitingForLowerPriorityPreemption...), nodes)
 	podSchedulable := make(podSchedulableMap)
-
 	loggingQuota := glogx.PodsLoggingQuota()
 
 	for _, pod := range unschedulableCandidates {
-		if schedulable, found := podSchedulable.get(pod); found {
-			if !schedulable {
+		cachedError, found := podSchedulable.get(pod)
+		// Try to get result from cache.
+		if found {
+			if cachedError != nil {
 				unschedulablePods = append(unschedulablePods, pod)
 			} else {
 				glogx.V(4).UpTo(loggingQuota).Infof("Pod %s marked as unschedulable can be scheduled (based on simulation run for other pod owned by the same controller). Ignoring in scale up.", pod.Name)
 			}
 			continue
 		}
-		if nodeName, err := predicateChecker.FitsAny(pod, nodeNameToNodeInfo); err == nil {
-			glogx.V(4).UpTo(loggingQuota).Infof("Pod %s marked as unschedulable can be scheduled on %s. Ignoring in scale up.", pod.Name, nodeName)
-			podSchedulable.set(pod, true)
-		} else {
+
+		// Not found in cache, have to run the predicates.
+		nodeName, err := predicateChecker.FitsAny(pod, nodeNameToNodeInfo)
+		// err returned from FitsAny isn't a PredicateError.
+		// Hello, ugly hack. I wish you weren't here.
+		var predicateError *simulator.PredicateError
+		if err != nil {
+			predicateError = simulator.NewPredicateError("FitsAny", err, nil)
 			unschedulablePods = append(unschedulablePods, pod)
-			podSchedulable.set(pod, false)
+		} else {
+			glogx.V(4).UpTo(loggingQuota).Infof("Pod %s marked as unschedulable can be scheduled on %s. Ignoring in scale up.", pod.Name, nodeName)
 		}
+		podSchedulable.set(pod, predicateError)
 	}
 
 	glogx.V(4).Over(loggingQuota).Infof("%v other pods marked as unschedulable can be scheduled.", -loggingQuota.Left())
-
 	return unschedulablePods
 }
 
@@ -173,34 +178,40 @@ func FilterOutExpendablePods(pods []*apiv1.Pod, expendablePodsPriorityCutoff int
 	return result
 }
 
-// FilterSchedulablePodsForNode filters pods that can be scheduled on the given node.
-func FilterSchedulablePodsForNode(context *context.AutoscalingContext, pods []*apiv1.Pod, nodeGroupId string, nodeInfo *schedulercache.NodeInfo) []*apiv1.Pod {
-	schedulablePods := []*apiv1.Pod{}
+// CheckPodsSchedulableOnNode checks if pods can be scheduled on the given node.
+func CheckPodsSchedulableOnNode(context *context.AutoscalingContext, pods []*apiv1.Pod, nodeGroupId string, nodeInfo *schedulercache.NodeInfo) map[*apiv1.Pod]*simulator.PredicateError {
+	schedulingErrors := map[*apiv1.Pod]*simulator.PredicateError{}
 	loggingQuota := glogx.PodsLoggingQuota()
 	podSchedulable := make(podSchedulableMap)
+
 	for _, pod := range pods {
-		schedulable, found := podSchedulable.get(pod)
+		// Check if pod isn't repeated before overwriting result for it.
+		if _, repeated := schedulingErrors[pod]; repeated {
+			// This shouldn't really happen.
+			glog.Warningf("Pod %v appears multiple time on pods list, will only count it once in scale-up simulation", pod)
+		}
+		// Try to get result from cache.
+		err, found := podSchedulable.get(pod)
 		if found {
-			if schedulable {
-				schedulablePods = append(schedulablePods, pod)
-			} else {
+			schedulingErrors[pod] = err
+			if err != nil {
 				glogx.V(2).UpTo(loggingQuota).Infof("Pod %s can't be scheduled on %s. Used cached predicate check results", pod.Name, nodeGroupId)
 			}
-		} else {
-			err := context.PredicateChecker.CheckPredicates(pod, nil, nodeInfo)
-			if err == nil {
-				schedulable = true
-				podSchedulable.set(pod, true)
-				schedulablePods = append(schedulablePods, pod)
-			} else {
+		}
+		// Not found in cache, have to run the predicates.
+		if !found {
+			err = context.PredicateChecker.CheckPredicates(pod, nil, nodeInfo)
+			podSchedulable.set(pod, err)
+			schedulingErrors[pod] = err
+			if err != nil {
+				// Always log for the first pod in a controller.
 				glog.V(2).Infof("Pod %s can't be scheduled on %s, predicate failed: %v", pod.Name, nodeGroupId, err.VerboseError())
-				schedulable = false
-				podSchedulable.set(pod, false)
 			}
 		}
 	}
+
 	glogx.V(2).Over(loggingQuota).Infof("%v other pods can't be scheduled on %s.", -loggingQuota.Left(), nodeGroupId)
-	return schedulablePods
+	return schedulingErrors
 }
 
 // GetNodeInfosForGroups finds NodeInfos for all node groups used to manage the given nodes. It also returns a node group to sample node mapping.

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -71,7 +71,7 @@ func (estimator *BinpackingNodeEstimator) Estimate(pods []*apiv1.Pod, nodeTempla
 	for _, podInfo := range podInfos {
 		found := false
 		for i, nodeInfo := range newNodes {
-			if err := estimator.predicateChecker.CheckPredicates(podInfo.pod, nil, nodeInfo, simulator.ReturnSimpleError); err == nil {
+			if err := estimator.predicateChecker.CheckPredicates(podInfo.pod, nil, nodeInfo); err == nil {
 				found = true
 				newNodes[i] = nodeWithPod(nodeInfo, podInfo.pod)
 				break

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -17,6 +17,8 @@ limitations under the License.
 package status
 
 import (
+	"fmt"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 )
@@ -29,9 +31,9 @@ type EventingScaleUpStatusProcessor struct{}
 // Process processes the state of the cluster after a scale-up by emitting
 // relevant events for pods depending on their post scale-up status.
 func (p *EventingScaleUpStatusProcessor) Process(context *context.AutoscalingContext, status *ScaleUpStatus) {
-	for _, pod := range status.PodsRemainUnschedulable {
+	for pod, reason := range status.PodsRemainUnschedulable {
 		context.Recorder.Event(pod, apiv1.EventTypeNormal, "NotTriggerScaleUp",
-			"pod didn't trigger scale-up (it wouldn't fit if a new node is added)")
+			fmt.Sprintf("pod didn't trigger scale-up (it wouldn't fit if a new node is added): %s", reason))
 	}
 	if len(status.ScaleUpInfos) > 0 {
 		for _, pod := range status.PodsTriggeredScaleUp {

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
@@ -44,17 +44,23 @@ func TestEventingScaleUpStatusProcessor(t *testing.T) {
 		{
 			caseName: "No scale up",
 			state: &ScaleUpStatus{
-				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
-				PodsRemainUnschedulable: []*apiv1.Pod{p1, p2},
+				ScaleUpInfos: []nodegroupset.ScaleUpInfo{},
+				PodsRemainUnschedulable: map[*apiv1.Pod]string{
+					p1: "not schedulable",
+					p2: "also not schedulable",
+				},
 			},
 			expectedNoTriggered: 2,
 		},
 		{
 			caseName: "Scale up",
 			state: &ScaleUpStatus{
-				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{{}},
-				PodsTriggeredScaleUp:    []*apiv1.Pod{p3},
-				PodsRemainUnschedulable: []*apiv1.Pod{p1, p2},
+				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{{}},
+				PodsTriggeredScaleUp: []*apiv1.Pod{p3},
+				PodsRemainUnschedulable: map[*apiv1.Pod]string{
+					p1: "not schedulable",
+					p2: "also not schedulable",
+				},
 			},
 			expectedTriggered:   1,
 			expectedNoTriggered: 2,

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -29,7 +29,7 @@ type ScaleUpStatus struct {
 	ScaledUp                bool
 	ScaleUpInfos            []nodegroupset.ScaleUpInfo
 	PodsTriggeredScaleUp    []*apiv1.Pod
-	PodsRemainUnschedulable []*apiv1.Pod
+	PodsRemainUnschedulable map[*apiv1.Pod]string
 	PodsAwaitEvaluation     []*apiv1.Pod
 }
 

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -199,9 +199,9 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node, no
 				glog.Warningf("No node in nodeInfo %s -> %v", nodename, nodeInfo)
 				return false
 			}
-			err := predicateChecker.CheckPredicates(pod, predicateMeta, nodeInfo, ReturnVerboseError)
+			err := predicateChecker.CheckPredicates(pod, predicateMeta, nodeInfo)
 			if err != nil {
-				glogx.V(4).UpTo(loggingQuota).Infof("Evaluation %s for %s/%s -> %v", nodename, pod.Namespace, pod.Name, err)
+				glogx.V(4).UpTo(loggingQuota).Infof("Evaluation %s for %s/%s -> %v", nodename, pod.Namespace, pod.Name, err.VerboseError())
 			} else {
 				// TODO(mwielgus): Optimize it.
 				glog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, nodename)

--- a/cluster-autoscaler/simulator/predicates.go
+++ b/cluster-autoscaler/simulator/predicates.go
@@ -224,6 +224,15 @@ func (pe *PredicateError) VerboseError() string {
 	return pe.message
 }
 
+// NewPredicateError creates a new predicate error from error and reasons.
+func NewPredicateError(name string, err error, reasons []string) *PredicateError {
+	return &PredicateError{
+		predicateName: name,
+		err:           err,
+		reasons:       reasons,
+	}
+}
+
 // Reasons returns original failure reasons from failed predicate as a slice of strings.
 func (pe *PredicateError) Reasons() []string {
 	if pe.reasons != nil {

--- a/cluster-autoscaler/simulator/predicates.go
+++ b/cluster-autoscaler/simulator/predicates.go
@@ -17,9 +17,8 @@ limitations under the License.
 package simulator
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -36,19 +35,9 @@ import (
 	"github.com/golang/glog"
 )
 
-// ErrorVerbosity defines the verbosity of error messages returned by PredicateChecker
-type ErrorVerbosity bool
-
 const (
-	// ReturnVerboseError causes informative error messages to be returned.
-	ReturnVerboseError ErrorVerbosity = true
-	// ReturnSimpleError causes simple, detail-free error messages to be returned.
-	// This significantly improves performance and is useful if the error message
-	// is discarded anyway.
-	ReturnSimpleError ErrorVerbosity = false
-
 	// We want to disable affinity predicate for performance reasons if no pod
-	// requires it
+	// requires it.
 	affinityPredicateName = "MatchInterPodAffinity"
 )
 
@@ -57,14 +46,14 @@ type predicateInfo struct {
 	predicate algorithm.FitPredicate
 }
 
-// PredicateChecker checks whether all required predicates are matched for given Pod and Node
+// PredicateChecker checks whether all required predicates pass for given Pod and Node.
 type PredicateChecker struct {
 	predicates                []predicateInfo
 	predicateMetadataProducer algorithm.PredicateMetadataProducer
 	enableAffinityPredicate   bool
 }
 
-// there are no const arrays in go, this is meant to be used as a const
+// There are no const arrays in Go, this is meant to be used as a const.
 var priorityPredicates = []string{"PodFitsResources", "GeneralPredicates", "PodToleratesNodeTaints"}
 
 // NewPredicateChecker builds PredicateChecker.
@@ -118,6 +107,7 @@ func NewPredicateChecker(kubeClient kube_client.Interface, stop <-chan struct{})
 			delete(predicateMap, predicateName)
 		}
 	}
+
 	for predicateName, predicate := range predicateMap {
 		predicateList = append(predicateList, predicateInfo{name: predicateName, predicate: predicate})
 	}
@@ -177,7 +167,7 @@ func (p *PredicateChecker) IsAffinityPredicateEnabled() bool {
 // predicateMetadata is also quite expensive, so it's not always the best option to run this method.
 // Please refer to https://github.com/kubernetes/autoscaler/issues/257 for more details.
 func (p *PredicateChecker) GetPredicateMetadata(pod *apiv1.Pod, nodeInfos map[string]*schedulercache.NodeInfo) algorithm.PredicateMetadata {
-	// skip precomputation if affinity predicate is disabled - it's not worth it performance-wise
+	// Skip precomputation if affinity predicate is disabled - it's not worth it performance-wise.
 	if !p.enableAffinityPredicate {
 		return nil
 	}
@@ -191,54 +181,87 @@ func (p *PredicateChecker) FitsAny(pod *apiv1.Pod, nodeInfos map[string]*schedul
 		if nodeInfo.Node().Spec.Unschedulable {
 			continue
 		}
-		if err := p.CheckPredicates(pod, nil, nodeInfo, ReturnSimpleError); err == nil {
+		if err := p.CheckPredicates(pod, nil, nodeInfo); err == nil {
 			return name, nil
 		}
 	}
 	return "", fmt.Errorf("cannot put pod %s on any node", pod.Name)
 }
 
-// CheckPredicates checks if the given pod can be placed on the given node.
+// PredicateError implements error, preserving the original error information from scheduler predicate.
+type PredicateError struct {
+	predicateName  string
+	failureReasons []algorithm.PredicateFailureReason
+	err            error
+
+	reasons []string
+	message string
+}
+
+// Error returns a predefined error message.
+func (pe *PredicateError) Error() string {
+	if pe.message != "" {
+		return pe.message
+	}
+	// Don't generate verbose message.
+	return "Predicates failed"
+}
+
+// VerboseError generates verbose error message if it isn't yet done.
 // We're running a ton of predicates and more often than not we only care whether
 // they pass or not and don't care for a reason. Turns out formatting nice error
-// messages gets very expensive, so we only do it if verbose is set to ReturnVerboseError.
+// messages gets very expensive, so we only do it if explicitly requested.
+func (pe *PredicateError) VerboseError() string {
+	if pe.message != "" {
+		return pe.message
+	}
+	// Generate verbose message.
+	if pe.err != nil {
+		pe.message = fmt.Sprintf("%s predicate error: %v", pe.predicateName, pe.err)
+		return pe.message
+	}
+	pe.message = fmt.Sprintf("%s predicate mismatch, reason: %s", pe.predicateName, strings.Join(pe.Reasons(), ", "))
+	return pe.message
+}
+
+// Reasons returns original failure reasons from failed predicate as a slice of strings.
+func (pe *PredicateError) Reasons() []string {
+	if pe.reasons != nil {
+		return pe.reasons
+	}
+	pe.reasons = make([]string, len(pe.failureReasons))
+	for i, reason := range pe.failureReasons {
+		pe.reasons[i] = reason.GetReason()
+	}
+	return pe.reasons
+}
+
+// PredicateName returns the name of failed predicate.
+func (pe *PredicateError) PredicateName() string {
+	return pe.predicateName
+}
+
+// CheckPredicates checks if the given pod can be placed on the given node.
 // To improve performance predicateMetadata can be calculated using GetPredicateMetadata
 // method and passed to CheckPredicates, however, this may lead to incorrect results if
 // it was calculated using NodeInfo map representing different cluster state and the
 // performance gains of CheckPredicates won't always offset the cost of GetPredicateMetadata.
 // Alternatively you can pass nil as predicateMetadata.
-func (p *PredicateChecker) CheckPredicates(pod *apiv1.Pod, predicateMetadata algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo, verbosity ErrorVerbosity) error {
+func (p *PredicateChecker) CheckPredicates(pod *apiv1.Pod, predicateMetadata algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo) *PredicateError {
 	for _, predInfo := range p.predicates {
-
-		// skip affinity predicate if it has been disabled
+		// Skip affinity predicate if it has been disabled.
 		if !p.enableAffinityPredicate && predInfo.name == affinityPredicateName {
 			continue
 		}
 
-		match, failureReason, err := predInfo.predicate(pod, predicateMetadata, nodeInfo)
+		match, failureReasons, err := predInfo.predicate(pod, predicateMetadata, nodeInfo)
 
-		if verbosity == ReturnSimpleError && (err != nil || !match) {
-			return errors.New("Predicates failed")
-		}
-
-		nodename := "unknown"
-		if nodeInfo.Node() != nil {
-			nodename = nodeInfo.Node().Name
-		}
-		if err != nil {
-			return fmt.Errorf("%s predicate error, cannot put %s/%s on %s due to, error %v", predInfo.name, pod.Namespace,
-				pod.Name, nodename, err)
-		}
-		if !match {
-			var buffer bytes.Buffer
-			for i, reason := range failureReason {
-				if i > 0 {
-					buffer.WriteString(",")
-				}
-				buffer.WriteString(reason.GetReason())
+		if err != nil || !match {
+			return &PredicateError{
+				predicateName:  predInfo.name,
+				failureReasons: failureReasons,
+				err:            err,
 			}
-			return fmt.Errorf("%s predicate mismatch, cannot put %s/%s on %s, reason: %s", predInfo.name, pod.Namespace,
-				pod.Name, nodename, buffer.String())
 		}
 	}
 	return nil

--- a/cluster-autoscaler/simulator/predicates_test.go
+++ b/cluster-autoscaler/simulator/predicates_test.go
@@ -56,11 +56,14 @@ func TestPredicates(t *testing.T) {
 	_, err = predicateChecker.FitsAny(p3, nodeInfos)
 	assert.Error(t, err)
 
-	err = predicateChecker.CheckPredicates(p2, nil, ni1, ReturnVerboseError)
-	assert.True(t, strings.Contains(err.Error(), "Insufficient cpu"))
-	assert.Error(t, predicateChecker.CheckPredicates(p2, nil, ni1, ReturnVerboseError))
-	assert.NoError(t, predicateChecker.CheckPredicates(p4, nil, ni1, ReturnVerboseError))
-	assert.NoError(t, predicateChecker.CheckPredicates(p2, nil, ni2, ReturnVerboseError))
-	assert.NoError(t, predicateChecker.CheckPredicates(p4, nil, ni2, ReturnVerboseError))
-	assert.Error(t, predicateChecker.CheckPredicates(p3, nil, ni2, ReturnVerboseError))
+	predicateErr := predicateChecker.CheckPredicates(p2, nil, ni1)
+	assert.NotNil(t, predicateErr)
+	assert.True(t, strings.Contains(predicateErr.Error(), "Predicates failed"))
+	assert.True(t, strings.Contains(predicateErr.VerboseError(), "Insufficient cpu"))
+
+	assert.NotNil(t, predicateChecker.CheckPredicates(p2, nil, ni1))
+	assert.Nil(t, predicateChecker.CheckPredicates(p4, nil, ni1))
+	assert.Nil(t, predicateChecker.CheckPredicates(p2, nil, ni2))
+	assert.Nil(t, predicateChecker.CheckPredicates(p4, nil, ni2))
+	assert.NotNil(t, predicateChecker.CheckPredicates(p3, nil, ni2))
 }

--- a/cluster-autoscaler/utils/daemonset/daemonset.go
+++ b/cluster-autoscaler/utils/daemonset/daemonset.go
@@ -32,7 +32,7 @@ func GetDaemonSetPodsForNode(nodeInfo *schedulercache.NodeInfo, daemonsets []*ex
 	result := make([]*apiv1.Pod, 0)
 	for _, ds := range daemonsets {
 		pod := newPod(ds, nodeInfo.Node().Name)
-		if err := predicateChecker.CheckPredicates(pod, nil, nodeInfo, simulator.ReturnSimpleError); err == nil {
+		if err := predicateChecker.CheckPredicates(pod, nil, nodeInfo); err == nil {
 			result = append(result, pod)
 		}
 	}


### PR DESCRIPTION
Report reason why pod didn't trigger scale-up in NotTriggeredScaleUp event. Format is similar to FailedScheduling, i.e. list of "\<failure reason\> (\<number of affected node groups\>)".

This can be further improved by:
- detailing reason why node group was skipped (e.g. max size reached, not healthy),
- communicating why NAP couldn't create a node group,
- passing raw predicate errors plus the above information to scale up status processor, so it can decide the message format.