### PR TITLE
Compare in overflow-safe way

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -157,8 +157,8 @@ func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommen
 				if recommended.MilliValue() > request.MilliValue() {
 					scaleUp = true
 				}
-				if (hasLowerBound && request.MilliValue() < lowerBound.MilliValue()) ||
-					(hasUpperBound && request.MilliValue() > upperBound.MilliValue()) {
+				if (hasLowerBound && request.Cmp(lowerBound) < 0) ||
+					(hasUpperBound && request.Cmp(upperBound) > 0) {
 					outsideRecommendedRange = true
 				}
 			} else {


### PR DESCRIPTION
This also allows using math.MaxInt64 as "no upper bound".