### PR TITLE
Clean up eviction admission no VPAs in the cluster 

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -85,6 +85,9 @@ func (u *updater) RunOnce() {
 
 	if len(vpas) == 0 {
 		glog.Warningf("no VPA objects to process")
+		if u.evictionAdmission != nil {
+			u.evictionAdmission.CleanUp()
+		}
 		timer.ObserveTotal()
 		return
 	}

--- a/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
@@ -28,6 +28,9 @@ type PodEvictionAdmission interface {
 	LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod)
 	// Admit returns true if PodEvictionAdmission decides that pod can be evicted with given recommendation.
 	Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool
+	// CleanUp cleans up any state that PodEvictionAdmission may keep. Called
+	// when no VPA objects are present in the cluster.
+	CleanUp()
 }
 
 // NewDefaultPodEvictionAdmission constructs new PodEvictionAdmission that admits all pods.
@@ -60,10 +63,18 @@ func (a *sequentialPodEvictionAdmission) Admit(pod *apiv1.Pod, recommendation *v
 	return true
 }
 
+func (a *sequentialPodEvictionAdmission) CleanUp() {
+	for _, admission := range a.admissions {
+		admission.CleanUp()
+	}
+}
+
 type noopPodEvictionAdmission struct{}
 
 func (n *noopPodEvictionAdmission) LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod) {
 }
 func (n *noopPodEvictionAdmission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return true
+}
+func (n *noopPodEvictionAdmission) CleanUp() {
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -348,6 +348,7 @@ func (p *pod1Admission) LoopInit([]*apiv1.Pod, map[*vpa_types.VerticalPodAutosca
 func (p *pod1Admission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return pod.Name == "POD1"
 }
+func (p *pod1Admission) CleanUp() {}
 
 func TestAdmission(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})


### PR DESCRIPTION
We need to make sure, that even if there are no VPAs, Eviction Admission will correctly initialize its state. 