### PR TITLE
Update VPA status only when needed.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -38,6 +38,8 @@ type ClusterState struct {
 	Pods map[PodID]*PodState
 	// VPA objects in the cluster.
 	Vpas map[VpaID]*Vpa
+	// Observed VPAs. Used to check if there are updates needed.
+	ObservedVpas []*vpa_types.VerticalPodAutoscaler
 
 	// All container aggregations where the usage samples are stored.
 	aggregateStateMap aggregateContainerStatesMap

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -92,7 +92,8 @@ func NewVpa(id VpaID, selector labels.Selector, created time.Time) *Vpa {
 		PodSelector:                     selector,
 		aggregateContainerStates:        make(aggregateContainerStatesMap),
 		ContainersInitialAggregateState: make(ContainerNameToAggregateStateMap),
-		Created: created,
+		Created:    created,
+		Conditions: make(vpaConditionsMap),
 	}
 	return vpa
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,28 +53,33 @@ func patchVpa(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, 
 	return vpaClient.Patch(vpaName, types.JSONPatchType, bytes)
 }
 
-// UpdateVpaStatus updates the status field of the VPA API object.
+// UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
 // It prevents race conditions by verifying that the lastUpdateTime of the
 // API object and its model representation are equal.
-func UpdateVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpa *model.Vpa) (result *vpa_types.VerticalPodAutoscaler, err error) {
-	status := vpa_types.VerticalPodAutoscalerStatus{
+func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpa *model.Vpa,
+	oldStatus *vpa_types.VerticalPodAutoscalerStatus) (result *vpa_types.VerticalPodAutoscaler, err error) {
+	newStatus := &vpa_types.VerticalPodAutoscalerStatus{
 		Conditions: vpa.Conditions.AsList(),
 	}
 	if vpa.Recommendation != nil {
-		status.Recommendation = vpa.Recommendation
+		newStatus.Recommendation = vpa.Recommendation
 	}
 	patches := []patchRecord{{
 		Op:    "add",
 		Path:  "/status",
-		Value: status,
+		Value: *newStatus,
 	}}
-	return patchVpa(vpaClient, (*vpa).ID.VpaName, patches)
+
+	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
+		return patchVpa(vpaClient, (*vpa).ID.VpaName, patches)
+	}
+	return nil, nil
 }
 
 // NewAllVpasLister returns VerticalPodAutoscalerLister configured to fetch all VPA objects.
 // The method blocks until vpaLister is initially populated.
 func NewAllVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}) vpa_lister.VerticalPodAutoscalerLister {
-	vpaListWatch := cache.NewListWatchFromClient(vpaClient.PocV1alpha1().RESTClient(), "verticalpodautoscalers", apiv1.NamespaceAll, fields.Everything())
+	vpaListWatch := cache.NewListWatchFromClient(vpaClient.PocV1alpha1().RESTClient(), "verticalpodautoscalers", core.NamespaceAll, fields.Everything())
 	indexer, controller := cache.NewIndexerInformer(vpaListWatch,
 		&vpa_types.VerticalPodAutoscaler{},
 		1*time.Hour,
@@ -90,11 +96,11 @@ func NewAllVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan str
 }
 
 // PodMatchesVPA returns true iff the VPA's selector matches the Pod and they are in the same namespace.
-func PodMatchesVPA(pod *apiv1.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool {
+func PodMatchesVPA(pod *core.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool {
 	if pod.Namespace != vpa.Namespace {
 		return false
 	}
-	selector, err := metav1.LabelSelectorAsSelector(vpa.Spec.Selector)
+	selector, err := meta.LabelSelectorAsSelector(vpa.Spec.Selector)
 	if err != nil {
 		glog.Errorf("error processing VPA object: failed to create pod selector: %v", err)
 		return false
@@ -109,7 +115,7 @@ func stronger(a, b *vpa_types.VerticalPodAutoscaler) bool {
 		return true
 	}
 	// Compare creation timestamps of the VPA objects. This is the clue of the stronger logic.
-	var aTime, bTime metav1.Time
+	var aTime, bTime meta.Time
 	aTime = a.GetCreationTimestamp()
 	bTime = b.GetCreationTimestamp()
 	if !aTime.Equal(&bTime) {
@@ -120,7 +126,7 @@ func stronger(a, b *vpa_types.VerticalPodAutoscaler) bool {
 }
 
 // GetControllingVPAForPod chooses the earliest created VPA from the input list that matches the given Pod.
-func GetControllingVPAForPod(pod *apiv1.Pod, vpas []*vpa_types.VerticalPodAutoscaler) *vpa_types.VerticalPodAutoscaler {
+func GetControllingVPAForPod(pod *core.Pod, vpas []*vpa_types.VerticalPodAutoscaler) *vpa_types.VerticalPodAutoscaler {
 	var controlling *vpa_types.VerticalPodAutoscaler
 	// Choose the strongest VPA from the ones that match this Pod.
 	for _, vpa := range vpas {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -17,23 +17,95 @@ limitations under the License.
 package api
 
 import (
+	"flag"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	apiv1 "k8s.io/api/core/v1"
+	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	vpa_fake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
 	containerName = "container1"
 )
 
+var (
+	anytime = time.Unix(0, 0)
+)
+
+func init() {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("v", "5")
+}
+
+func TestUpdateVpaIfNeeded(t *testing.T) {
+	modelVpa := model.NewVpa(model.VpaID{VpaName: "vpa", Namespace: "test"}, nil, time.Now())
+	modelVpa.Conditions.Set(vpa_types.RecommendationProvided, true, "reason", "msg")
+	condition := modelVpa.Conditions[vpa_types.RecommendationProvided]
+	condition.LastTransitionTime = meta.NewTime(anytime)
+	modelVpa.Conditions[vpa_types.RecommendationProvided] = condition
+	recommendation := test.Recommendation().WithContainer(containerName).WithTarget("5", "200").Get()
+	observedVpaBuilder := test.VerticalPodAutoscaler().WithName("vpa").WithNamespace("test").WithContainer(containerName)
+	modelVpa.Recommendation = recommendation
+	testCases := []struct {
+		caseName       string
+		vpa            *model.Vpa
+		observedStatus *vpa_types.VerticalPodAutoscalerStatus
+		expectedUpdate bool
+	}{
+		{
+			caseName: "Doesn't update if no changes.",
+			vpa:      modelVpa,
+			observedStatus: &observedVpaBuilder.WithTarget("5", "200").
+				AppendCondition(vpa_types.RecommendationProvided, core.ConditionTrue, "reason", "msg", anytime).Get().Status,
+			expectedUpdate: false,
+		}, {
+			caseName: "Updates on recommendation change.",
+			vpa:      modelVpa,
+			observedStatus: &observedVpaBuilder.WithTarget("10", "200").
+				AppendCondition(vpa_types.RecommendationProvided, core.ConditionTrue, "reason", "msg", anytime).Get().Status,
+			expectedUpdate: true,
+		}, {
+			caseName: "Updates on condition change.",
+			vpa:      modelVpa,
+			observedStatus: &observedVpaBuilder.WithTarget("5", "200").
+				AppendCondition(vpa_types.RecommendationProvided, core.ConditionFalse, "reason", "msg", anytime).Get().Status,
+			expectedUpdate: true,
+		}, {
+			caseName: "Updates on condition added.",
+			vpa:      modelVpa,
+			observedStatus: &observedVpaBuilder.WithTarget("5", "200").
+				AppendCondition(vpa_types.RecommendationProvided, core.ConditionTrue, "reason", "msg", anytime).
+				AppendCondition(vpa_types.LowConfidence, core.ConditionTrue, "reason", "msg", anytime).Get().Status,
+			expectedUpdate: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			fakeClient := vpa_fake.NewSimpleClientset()
+			_, err := UpdateVpaStatusIfNeeded(fakeClient.PocV1alpha1().VerticalPodAutoscalers(tc.vpa.ID.Namespace),
+				tc.vpa, tc.observedStatus)
+			assert.NoError(t, err, "Unexpected error occurred.")
+			actions := fakeClient.Actions()
+			if tc.expectedUpdate {
+				assert.Equal(t, 1, len(actions), "Unexpected number of actions")
+			} else {
+				assert.Equal(t, 0, len(actions), "Unexpected number of actions")
+			}
+		})
+	}
+}
+
 func TestPodMatchesVPA(t *testing.T) {
 	type testCase struct {
-		pod    *apiv1.Pod
+		pod    *core.Pod
 		vpa    *vpa_types.VerticalPodAutoscaler
 		result bool
 	}
@@ -87,14 +159,14 @@ func TestGetControllingVPAForPod(t *testing.T) {
 func TestGetContainerResourcePolicy(t *testing.T) {
 	containerPolicy1 := vpa_types.ContainerResourcePolicy{
 		ContainerName: "container1",
-		MinAllowed: apiv1.ResourceList{
-			apiv1.ResourceCPU: *resource.NewScaledQuantity(10, 1),
+		MinAllowed: core.ResourceList{
+			core.ResourceCPU: *resource.NewScaledQuantity(10, 1),
 		},
 	}
 	containerPolicy2 := vpa_types.ContainerResourcePolicy{
 		ContainerName: "container2",
-		MaxAllowed: apiv1.ResourceList{
-			apiv1.ResourceMemory: *resource.NewScaledQuantity(100, 1),
+		MaxAllowed: core.ResourceList{
+			core.ResourceMemory: *resource.NewScaledQuantity(100, 1),
 		},
 	}
 	policy := vpa_types.PodResourcePolicy{
@@ -109,8 +181,8 @@ func TestGetContainerResourcePolicy(t *testing.T) {
 	// Add the wildcard ("*") policy.
 	defaultPolicy := vpa_types.ContainerResourcePolicy{
 		ContainerName: "*",
-		MinAllowed: apiv1.ResourceList{
-			apiv1.ResourceCPU: *resource.NewScaledQuantity(20, 1),
+		MinAllowed: core.ResourceList{
+			core.ResourceCPU: *resource.NewScaledQuantity(20, 1),
 		},
 	}
 	policy = vpa_types.PodResourcePolicy{


### PR DESCRIPTION
Adds ObservedVpas to cluster state as a baseline for status comparison.
Removes some excessive logging (Each VPA per loop, each Pod per loop).