### PR TITLE
Add caching node locations in GKE cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
@@ -204,6 +204,11 @@ func (gke *GkeCloudProvider) GetClusterInfo() (projectId, location, clusterName 
 	return gke.gkeManager.GetProjectId(), gke.gkeManager.GetLocation(), gke.gkeManager.GetClusterName()
 }
 
+// GetNodeLocations returns the list of zones in which the cluster has nodes.
+func (gke *GkeCloudProvider) GetNodeLocations() []string {
+	return gke.gkeManager.GetNodeLocations()
+}
+
 // MigSpec contains information about what machines in a MIG look like.
 type MigSpec struct {
 	MachineType    string

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
@@ -121,10 +122,10 @@ func (gke *GkeCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 func (gke *GkeCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	nodePoolName := fmt.Sprintf("%s-%s-%d", nodeAutoprovisioningPrefix, machineType, time.Now().Unix())
-	// TODO(aleksandra-malinowska): GkeManager's location will be a region
-	// for regional clusters. We should support regional clusters by looking at
-	// node locations instead.
-	zone := gke.gkeManager.GetLocation()
+	zone, found := systemLabels[kubeletapis.LabelZoneFailureDomain]
+	if !found {
+		return nil, cloudprovider.ErrIllegalConfiguration
+	}
 
 	if gpuRequest, found := extraResources[gpu.ResourceNvidiaGPU]; found {
 		gpuType, found := systemLabels[gpu.GPULabel]


### PR DESCRIPTION
Refresh node locations when refreshing other GKE resources. Add a method for getting it from cloud provider. Use zone from system labels when constructing new node group in GKE cloud provider.