### PR TITLE
Reduce GKE API calls

### DIFF
--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client.go
@@ -35,7 +35,6 @@ const (
 
 const (
 	clusterPathPrefix   = "projects/%s/locations/%s/clusters/%s"
-	nodePoolsPathPrefix = "projects/%s/locations/%s/clusters/%s/nodePools/"
 	nodePoolPathPrefix  = "projects/%s/locations/%s/clusters/%s/nodePools/%%s"
 	operationPathPrefix = "projects/%s/locations/%s/operations/%%s"
 )
@@ -43,13 +42,18 @@ const (
 // AutoscalingGkeClient is used for communicating with GKE API.
 type AutoscalingGkeClient interface {
 	// reading cluster state
-	FetchLocations() ([]string, error)
-	FetchNodePools() ([]NodePool, error)
-	FetchResourceLimits() (*cloudprovider.ResourceLimiter, error)
+	GetCluster() (Cluster, error)
 
 	// modifying cluster state
 	DeleteNodePool(string) error
 	CreateNodePool(*GkeMig) error
+}
+
+// Cluster contains cluster's fields we want to use.
+type Cluster struct {
+	Locations       []string
+	NodePools       []NodePool
+	ResourceLimiter *cloudprovider.ResourceLimiter
 }
 
 // NodePool contains node pool's fields we want to use.


### PR DESCRIPTION
Replace 2 GET cluster and 1 LIST node pools call with a single GET cluster on forceRefresh().

This also changes LIST node pools call to GET cluster call after creating/deleting node pool. I don't think it should have much performance impact - the object is larger, but it counts as a full refresh, so it reduces the total number of calls. @MaciekPytel WDYT?