### PR TITLE
Export GKE API endpoint flag

### DIFF
--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client.go
@@ -23,9 +23,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
-// This flag is outside main as it's only useful for test/development.
 var (
-	gkeAPIEndpoint = flag.String("gke-api-endpoint", "", "GKE API endpoint address. This flag is used by developers only. Users shouldn't change this flag.")
+	// GkeAPIEndpoint overrides default GKE API endpoint for testing.
+	// This flag is outside main as it's only useful for test/development.
+	GkeAPIEndpoint = flag.String("gke-api-endpoint", "", "GKE API endpoint address. This flag is used by developers only. Users shouldn't change this flag.")
 )
 
 const (

--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1.go
@@ -43,8 +43,8 @@ func NewAutoscalingGkeClientV1(client *http.Client, projectId, location, cluster
 	if err != nil {
 		return nil, err
 	}
-	if *gkeAPIEndpoint != "" {
-		gkeService.BasePath = *gkeAPIEndpoint
+	if *GkeAPIEndpoint != "" {
+		gkeService.BasePath = *GkeAPIEndpoint
 	}
 	autoscalingGkeClient.gkeService = gkeService
 

--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
@@ -65,8 +65,8 @@ func NewAutoscalingGkeClientV1beta1(client *http.Client, projectId, location, cl
 	if err != nil {
 		return nil, err
 	}
-	if *gkeAPIEndpoint != "" {
-		gkeBetaService.BasePath = *gkeAPIEndpoint
+	if *GkeAPIEndpoint != "" {
+		gkeBetaService.BasePath = *GkeAPIEndpoint
 	}
 	autoscalingGkeClient.gkeBetaService = gkeBetaService
 

--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1_test.go
@@ -51,7 +51,7 @@ const operationDoneResponse = `{
 }`
 
 func newTestAutoscalingGkeClientV1beta1(t *testing.T, project, location, clusterName, url string) *autoscalingGkeClientV1beta1 {
-	*gkeAPIEndpoint = url
+	*GkeAPIEndpoint = url
 	client := &http.Client{}
 	gkeClient, err := NewAutoscalingGkeClientV1beta1(client, project, location, clusterName)
 	if !assert.NoError(t, err) {

--- a/cluster-autoscaler/cloudprovider/gke/gke_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_manager_test.go
@@ -526,7 +526,7 @@ func newTestGkeManager(t *testing.T, testServerURL string, mode GcpCloudProvider
 	manager.cache.SetMachinesCache(machinesCache)
 
 	client := &http.Client{}
-	gkeAPIEndpoint = &testServerURL
+	GkeAPIEndpoint = &testServerURL
 	var err error
 	if mode == ModeGKE {
 		manager.GkeService, err = NewAutoscalingGkeClientV1(client, projectId, manager.location, clusterName)


### PR DESCRIPTION
Temporary workaround for issues with testing setup in GKE.