### PR TITLE
Refactor the scale-(up|down) status processors so that they have more…

### DIFF
--- a/cluster-autoscaler/processors/status/scale_down_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_down_status_processor.go
@@ -52,6 +52,13 @@ const (
 	ScaleDownNodeDeleted
 	// ScaleDownNodeDeleteStarted - a node deletion process was started.
 	ScaleDownNodeDeleteStarted
+	// ScaleDownNotTried - the scale down wasn't even attempted, e.g. an autoscaling iteration was skipped, or
+	// an error occurred before the scale up logic.
+	ScaleDownNotTried
+	// ScaleDownInCooldown - the scale down wasn't even attempted, because it's in a cooldown state (it's suspended for a scheduled period of time).
+	ScaleDownInCooldown
+	// ScaleDownInProgress - the scale down wasn't attempted, because a previous scale-down was still in progress.
+	ScaleDownInProgress
 )
 
 // ScaleDownStatusProcessor processes the status of the cluster after a scale-down.

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -26,7 +26,7 @@ import (
 // on if scale-up happened, description of scale-up operation performed and
 // status of pods that took part in the scale-up evaluation.
 type ScaleUpStatus struct {
-	ScaledUp                bool
+	Result                  ScaleUpResult
 	ScaleUpInfos            []nodegroupset.ScaleUpInfo
 	PodsTriggeredScaleUp    []*apiv1.Pod
 	PodsRemainUnschedulable []NoScaleUpInfo
@@ -38,6 +38,30 @@ type NoScaleUpInfo struct {
 	Pod                *apiv1.Pod
 	RejectedNodeGroups map[string]Reasons
 	SkippedNodeGroups  map[string]Reasons
+}
+
+// ScaleUpResult represents the result of a scale up.
+type ScaleUpResult int
+
+const (
+	// ScaleUpSuccessful - a scale-up successfully occurred.
+	ScaleUpSuccessful ScaleUpResult = iota
+	// ScaleUpError - an unexpected error occurred during the scale-up attempt.
+	ScaleUpError
+	// ScaleUpNoOptionsAvailable - there were no node groups that could be considered for the scale-up.
+	ScaleUpNoOptionsAvailable
+	// ScaleUpNotNeeded - there was no need for a scale-up e.g. because there were no unschedulable pods.
+	ScaleUpNotNeeded
+	// ScaleUpNotTried - the scale up wasn't even attempted, e.g. an autoscaling iteration was skipped, or
+	// an error occurred before the scale up logic.
+	ScaleUpNotTried
+	// ScaleUpInCooldown - the scale up wasn't even attempted, because it's in a cooldown state (it's suspended for a scheduled period of time).
+	ScaleUpInCooldown
+)
+
+// WasSuccessful returns true if the scale-up was successful.
+func (s *ScaleUpStatus) WasSuccessful() bool {
+	return s.Result == ScaleUpSuccessful
 }
 
 // Reasons interface provides a list of reasons for why something happened or didn't happen.


### PR DESCRIPTION
… info available

Replace the simple boolean ScaledUp property of ScaleUpStatus with a more
comprehensive ScaleUpResult. Add more possible values to ScaleDownResult.
Refactor the processors execution so that they are always executed every
iteration, even if RunOnce exits earlier.