### PR TITLE
Add kube-state-metrics which uses addon-resizer

### DIFF
--- a/addon-resizer/README.md
+++ b/addon-resizer/README.md
@@ -116,7 +116,7 @@ name of your addon, for example:
 ADDON_NAME=heapster
 ```
 
-Currently Addon Resizer is used to scale addons: `heapster`, `metrics-server`.
+Currently Addon Resizer is used to scale addons: `heapster`, `metrics-server`, `kube-state-metrics`.
 
 ### Overview
 


### PR DESCRIPTION
Can we add kube-state-metrics which also use addon-resizer to improve its performance:
https://github.com/kubernetes/kube-state-metrics/blob/master/kubernetes/kube-state-metrics-deployment.yaml#L34