### PR TITLE
Don't move min/max bucket on sub-epsilon samples

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -110,10 +110,10 @@ func (h *histogram) AddSample(value float64, weight float64, time time.Time) {
 	bucket := h.options.FindBucket(value)
 	h.bucketWeight[bucket] += weight
 	h.totalWeight += weight
-	if bucket < h.minBucket {
+	if bucket < h.minBucket && h.bucketWeight[bucket] >= h.options.Epsilon() {
 		h.minBucket = bucket
 	}
-	if bucket > h.maxBucket {
+	if bucket > h.maxBucket && h.bucketWeight[bucket] >= h.options.Epsilon() {
 		h.maxBucket = bucket
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -84,7 +84,7 @@ func NewHistogram(options HistogramOptions) Histogram {
 
 // Simple bucket-based implementation of the Histogram interface. Each bucket
 // holds the total weight of samples that belong to it.
-// Percentile() returns the middle of the correspodning bucket.
+// Percentile() returns the upper bound of the corresponding bucket.
 // Resolution (bucket boundaries) of the histogram depends on the options.
 // There's no interpolation within buckets (i.e. one sample falls to exactly one
 // bucket).

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -71,7 +71,6 @@ func TestPercentileOutOfBounds(t *testing.T) {
 	options, err := NewLinearHistogramOptions(1.0, 0.1, weightEpsilon)
 	assert.Nil(t, err)
 	h := NewHistogram(options)
-	assert.Nil(t, err)
 	h.AddSample(0.1, 0.1, anyTime)
 	h.AddSample(0.2, 0.2, anyTime)
 
@@ -90,7 +89,6 @@ func TestEmptyHistogram(t *testing.T) {
 	options, err := NewLinearHistogramOptions(1.0, 0.1, weightEpsilon)
 	assert.Nil(t, err)
 	h := NewHistogram(options)
-	assert.Nil(t, err)
 	assert.True(t, h.IsEmpty())
 	h.AddSample(0.1, weightEpsilon*2.5, anyTime) // Sample weight = epsilon * 2.5.
 	assert.False(t, h.IsEmpty())

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -100,6 +100,21 @@ func TestEmptyHistogram(t *testing.T) {
 	assert.True(t, h.IsEmpty())
 }
 
+// Verifies that IsEmpty() returns false if we add epsilon-weight sample to a non-empty histogram.
+func TestNonEmptyOnEpsilonAddition(t *testing.T) {
+	options, err := NewLinearHistogramOptions(1.0, 0.1, weightEpsilon)
+	assert.Nil(t, err)
+	h := NewHistogram(options)
+	assert.True(t, h.IsEmpty())
+
+	h.AddSample(9.9, weightEpsilon*3, anyTime)
+	assert.False(t, h.IsEmpty())
+	h.AddSample(0.1, weightEpsilon*0.3, anyTime)
+	assert.False(t, h.IsEmpty()) // weight*3 sample should make the histogram non-empty
+	h.AddSample(999.9, weightEpsilon*0.3, anyTime)
+	assert.False(t, h.IsEmpty())
+}
+
 // Verifies that Merge() works as expected on two sample histograms.
 func TestHistogramMerge(t *testing.T) {
 	h1 := NewHistogram(testHistogramOptions)


### PR DESCRIPTION
The first commit partially fixes a problem with "zero recommendation" appearing in some new clusters.
The next ones are unrelated minor clean-ups.

The rest of the "zero recommendation" fix will be part of another PR.

/assign @bskiba 