### PR TITLE
Fix typos issues

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -88,7 +88,7 @@ type AzUtil struct {
 	manager *AzureManager
 }
 
-// DeleteBlob deletes the blob using the storage storage client.
+// DeleteBlob deletes the blob using the storage client.
 func (util *AzUtil) DeleteBlob(accountName, vhdContainer, vhdBlob string) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -52,7 +52,7 @@ type ContainerNameToAggregateStateMap map[string]*AggregateContainerState
 const (
 	// SupportedCheckpointVersion is the tag of the supported version of serialized checkpoints.
 	// Version id should be incremented on every non incompatible change, i.e. if the new
-	// version of the recommender binary can't initialize from the old checkpoint format or the the
+	// version of the recommender binary can't initialize from the old checkpoint format or the
 	// previous version of the recommender binary can't initialize from the new checkpoint format.
 	SupportedCheckpointVersion = "v2"
 )


### PR DESCRIPTION
Fix typos issues in below files:

1. cluster-autoscaler/cloudprovider/azure/azure_util.go
2. vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go