### PR TITLE
Remove Kubemark cloud provider from default build

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gke"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
@@ -34,7 +33,6 @@ var AvailableCloudProviders = []string{
 	azure.ProviderName,
 	gce.ProviderNameGCE,
 	gke.ProviderNameGKE,
-	kubemark.ProviderName,
 }
 
 // DefaultCloudProvider is GCE.
@@ -50,8 +48,6 @@ func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGro
 		return aws.BuildAWS(opts, do, rl)
 	case azure.ProviderName:
 		return azure.BuildAzure(opts, do, rl)
-	case kubemark.ProviderName:
-		return kubemark.BuildKubemark(opts, do, rl)
 	}
 
 	return nil


### PR DESCRIPTION
From #1319, CA binary size depending on build:
- all (default): 166MB
- AWS: 65MB
- Azure: 56MB
- GCE: 75MB
- Kubemark: 164MB

Removing Kubemark from all (default) build reduces it to ~98 MB. Given that it's only useful specifically for scalability testing, we can probably remove it from default image altogether.