### PR TITLE
Update FAQ: remove info on not existent flag --unregistered-node-removal-time

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -443,9 +443,7 @@ Autoscaler expects requested nodes to appear within 15 minutes
 (configured by `--max-node-provision-time` flag.) After this time, if they are
 still unregistered, it stops considering them in simulations and may attempt to scale up a
 different group if the pods are still pending. It will also attempt to remove
-any nodes left unregistered after 15 minutes (configured by
-`--unregistered-node-removal-time` flag.) For this reason, we strongly
-recommend to set those flags to the same value.
+any nodes left unregistered after this time.
 
 ### How does scale-down work?
 


### PR DESCRIPTION
The `--unregistered-node-removal-time` was removed in https://github.com/kubernetes/autoscaler/pull/469 but it is still mentioned in FAQ.