### PR TITLE
Add metrics for GCP API usage

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -329,5 +329,7 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if err != nil {
 		glog.Fatalf("Failed to create GCE cloud provider: %v", err)
 	}
+	// Register GCE API usage metrics.
+	registerMetrics()
 	return provider
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -330,6 +330,6 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		glog.Fatalf("Failed to create GCE cloud provider: %v", err)
 	}
 	// Register GCE API usage metrics.
-	registerMetrics()
+	RegisterMetrics()
 	return provider
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	caNamespace = "cluster_autoscaler"
+)
+
+var (
+	/**** Metrics related to GCE API usage ****/
+	requestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: caNamespace,
+			Name:      "gce_request_count",
+			Help:      "Counter of GCE API requests for each verb and API resource.",
+		}, []string{"resource", "verb"},
+	)
+)
+
+// registerMetrics registers all GCE metrics.
+func registerMetrics() {
+	prometheus.MustRegister(requestCounter)
+}
+
+// registerRequest registers request to GCE API.
+func registerRequest(resource string, verb string) {
+	requestCounter.WithLabelValues(resource, verb).Add(1.0)
+}

--- a/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
@@ -35,8 +35,8 @@ var (
 	)
 )
 
-// registerMetrics registers all GCE metrics.
-func registerMetrics() {
+// RegisterMetrics registers all GCE metrics.
+func RegisterMetrics() {
 	prometheus.MustRegister(requestCounter)
 }
 

--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1.go
@@ -52,6 +52,7 @@ func NewAutoscalingGkeClientV1(client *http.Client, projectId, location, cluster
 }
 
 func (m *autoscalingGkeClientV1) GetCluster() (Cluster, error) {
+	registerRequest("clusters", "get")
 	clusterResponse, err := m.gkeService.Projects.Locations.Clusters.Get(m.clusterPath).Do()
 	if err != nil {
 		return Cluster{}, err

--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1.go
@@ -74,6 +74,7 @@ func NewAutoscalingGkeClientV1beta1(client *http.Client, projectId, location, cl
 }
 
 func (m *autoscalingGkeClientV1beta1) GetCluster() (Cluster, error) {
+	registerRequest("clusters", "get")
 	clusterResponse, err := m.gkeBetaService.Projects.Locations.Clusters.Get(m.clusterPath).Do()
 	if err != nil {
 		return Cluster{}, err
@@ -126,6 +127,7 @@ func buildResourceLimiter(cluster *gke_api_beta.Cluster) *cloudprovider.Resource
 }
 
 func (m *autoscalingGkeClientV1beta1) DeleteNodePool(toBeRemoved string) error {
+	registerRequest("node_pools", "delete")
 	deleteOp, err := m.gkeBetaService.Projects.Locations.Clusters.NodePools.Delete(
 		fmt.Sprintf(m.nodePoolPath, toBeRemoved)).Do()
 	if err != nil {
@@ -200,6 +202,7 @@ func (m *autoscalingGkeClientV1beta1) CreateNodePool(mig *GkeMig) error {
 			Autoscaling:      &autoscaling,
 		},
 	}
+	registerRequest("node_pools", "create")
 	createOp, err := m.gkeBetaService.Projects.Locations.Clusters.NodePools.Create(
 		m.clusterPath, &createRequest).Do()
 	if err != nil {
@@ -211,6 +214,7 @@ func (m *autoscalingGkeClientV1beta1) CreateNodePool(mig *GkeMig) error {
 func (m *autoscalingGkeClientV1beta1) waitForGkeOp(op *gke_api_beta.Operation) error {
 	for start := time.Now(); time.Since(start) < m.operationWaitTimeout; time.Sleep(m.operationPollInterval) {
 		glog.V(4).Infof("Waiting for operation %s %s", op.TargetLink, op.Name)
+		registerRequest("operations", "get")
 		if op, err := m.gkeBetaService.Projects.Locations.Operations.Get(
 			fmt.Sprintf(m.operationPath, op.Name)).Do(); err == nil {
 			glog.V(4).Infof("Operation %s %s status: %s", op.TargetLink, op.Name, op.Status)

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
@@ -436,7 +436,8 @@ func BuildGKE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if err != nil {
 		glog.Fatalf("Failed to create GKE cloud provider: %v", err)
 	}
-	// Register GKE API usage metrics.
+	// Register GKE & GCE API usage metrics.
 	registerMetrics()
+	gce.RegisterMetrics()
 	return provider
 }

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
@@ -436,5 +436,7 @@ func BuildGKE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if err != nil {
 		glog.Fatalf("Failed to create GKE cloud provider: %v", err)
 	}
+	// Register GKE API usage metrics.
+	registerMetrics()
 	return provider
 }

--- a/cluster-autoscaler/cloudprovider/gke/gke_metrics.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_metrics.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gke
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	caNamespace = "cluster_autoscaler"
+)
+
+var (
+	/**** Metrics related to GKE API usage ****/
+	requestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: caNamespace,
+			Name:      "gke_request_count",
+			Help:      "Counter of GKE API requests for each verb and API resource.",
+		}, []string{"resource", "verb"},
+	)
+)
+
+// registerMetrics registers all GKE metrics.
+func registerMetrics() {
+	prometheus.MustRegister(requestCounter)
+}
+
+// registerRequest registers request to GKE API.
+func registerRequest(resource string, verb string) {
+	requestCounter.WithLabelValues(resource, verb).Add(1.0)
+}


### PR DESCRIPTION
Request counter for now (split by resource & verb).

```
# TYPE cluster_autoscaler_gce_request_count counter
cluster_autoscaler_gce_request_count{resource="instance_group_managers",verb="get"} 35
cluster_autoscaler_gce_request_count{resource="instance_group_managers",verb="list_managed_instances"} 18
cluster_autoscaler_gce_request_count{resource="instance_templates",verb="get"} 1
cluster_autoscaler_gce_request_count{resource="machine_types",verb="get"} 1
cluster_autoscaler_gce_request_count{resource="machine_types",verb="list"} 1
# HELP cluster_autoscaler_gke_request_count Counter of GKE API requests for each verb and API resource.
# TYPE cluster_autoscaler_gke_request_count counter
cluster_autoscaler_gke_request_count{resource="clusters",verb="get"} 3
```