### PR TITLE
NodeGroup.Nodes() return Instance struct instead instance name

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -159,8 +159,16 @@ func (asg *Asg) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (asg *Asg) Nodes() ([]string, error) {
-	return asg.manager.GetAsgNodes(asg)
+func (asg *Asg) Nodes() ([]cloudprovider.Instance, error) {
+	instanceNames, err := asg.manager.GetAsgNodes(asg)
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]cloudprovider.Instance, 0, len(instanceNames))
+	for _, instanceName := range instanceNames {
+		instances = append(instances, cloudprovider.Instance{Id: instanceName})
+	}
+	return instances, nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -282,18 +282,18 @@ func (ng *AwsNodeGroup) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (ng *AwsNodeGroup) Nodes() ([]string, error) {
+func (ng *AwsNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	asgNodes, err := ng.awsManager.GetAsgNodes(ng.asg.AwsRef)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make([]string, len(asgNodes))
+	instances := make([]cloudprovider.Instance, len(asgNodes))
 
 	for i, asgNode := range asgNodes {
-		nodes[i] = asgNode.ProviderID
+		instances[i] = cloudprovider.Instance{Id: asgNode.ProviderID}
 	}
-	return nodes, nil
+	return instances, nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -239,7 +239,7 @@ func TestNodeGroupForNode(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, nodes, []string{"aws:///us-east-1a/test-instance-id"})
+	assert.Equal(t, []cloudprovider.Instance{{Id: "aws:///us-east-1a/test-instance-id"}}, nodes)
 	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	// test node in cluster that is not in a group managed by cluster autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -380,13 +380,13 @@ func (as *AgentPool) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (as *AgentPool) Nodes() ([]string, error) {
+func (as *AgentPool) Nodes() ([]cloudprovider.Instance, error) {
 	instances, err := as.GetVirtualMachines()
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make([]string, 0, len(instances))
+	nodes := make([]cloudprovider.Instance, 0, len(instances))
 	for _, instance := range instances {
 		if len(*instance.ID) == 0 {
 			continue
@@ -394,7 +394,7 @@ func (as *AgentPool) Nodes() ([]string, error) {
 
 		// To keep consistent with providerID from kubernetes cloud provider, do not convert ID to lower case.
 		name := "azure://" + *instance.ID
-		nodes = append(nodes, name)
+		nodes = append(nodes, cloudprovider.Instance{Id: name})
 	}
 
 	return nodes, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -171,7 +171,7 @@ func (m *asgCache) regenerate() error {
 		}
 
 		for _, instance := range instances {
-			ref := azureRef{Name: instance}
+			ref := azureRef{Name: instance.Id}
 			newCache[ref] = nsg
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -445,8 +445,16 @@ func (agentPool *ContainerServiceAgentPool) Debug() string {
 }
 
 //Nodes returns the list of nodes in the agentPool.
-func (agentPool *ContainerServiceAgentPool) Nodes() ([]string, error) {
-	return agentPool.GetNodes()
+func (agentPool *ContainerServiceAgentPool) Nodes() ([]cloudprovider.Instance, error) {
+	instanceNames, err := agentPool.GetNodes()
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]cloudprovider.Instance, 0, len(instanceNames))
+	for _, instanceName := range instanceNames {
+		instances = append(instances, cloudprovider.Instance{Id: instanceName})
+	}
+	return instances, nil
 }
 
 //TemplateNodeInfo is not implemented.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -446,20 +446,20 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (scaleSet *ScaleSet) Nodes() ([]string, error) {
+func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 	vms, err := scaleSet.GetScaleSetVms()
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]string, 0, len(vms))
+	instances := make([]cloudprovider.Instance, 0, len(vms))
 	for i := range vms {
 		if len(*vms[i].ID) == 0 {
 			continue
 		}
 		name := "azure://" + *vms[i].ID
-		result = append(result, name)
+		instances = append(instances, cloudprovider.Instance{Id: name})
 	}
 
-	return result, nil
+	return instances, nil
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -273,8 +273,17 @@ func (mig *gceMig) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (mig *gceMig) Nodes() ([]string, error) {
-	return mig.gceManager.GetMigNodes(mig)
+func (mig *gceMig) Nodes() ([]cloudprovider.Instance, error) {
+	instanceNames, err := mig.gceManager.GetMigNodes(mig)
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]cloudprovider.Instance, 0, len(instanceNames))
+	for _, instanceName := range instanceNames {
+		instances = append(instances, cloudprovider.Instance{Id: instanceName})
+	}
+	return instances, nil
+
 }
 
 // Exist checks if the node group really exists on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -365,8 +365,8 @@ func TestMig(t *testing.T) {
 			"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nil).Once()
 	nodes, err := mig1.Nodes()
 	assert.NoError(t, err)
-	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g", nodes[0])
-	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1", nodes[1])
+	assert.Equal(t, cloudprovider.Instance{Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g"}, nodes[0])
+	assert.Equal(t, cloudprovider.Instance{Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nodes[1])
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test TemplateNodeInfo.

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider.go
@@ -365,8 +365,16 @@ func (mig *GkeMig) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (mig *GkeMig) Nodes() ([]string, error) {
-	return mig.gkeManager.GetMigNodes(mig)
+func (mig *GkeMig) Nodes() ([]cloudprovider.Instance, error) {
+	instanceNames, err := mig.gkeManager.GetMigNodes(mig)
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]cloudprovider.Instance, 0, len(instanceNames))
+	for _, instanceName := range instanceNames {
+		instances = append(instances, cloudprovider.Instance{Id: instanceName})
+	}
+	return instances, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
@@ -421,8 +421,8 @@ func TestMig(t *testing.T) {
 			"gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nil).Once()
 	nodes, err := mig1.Nodes()
 	assert.NoError(t, err)
-	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g", nodes[0])
-	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1", nodes[1])
+	assert.Equal(t, cloudprovider.Instance{Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g"}, nodes[0])
+	assert.Equal(t, cloudprovider.Instance{Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"}, nodes[1])
 	mock.AssertExpectationsForObjects(t, gkeManagerMock)
 
 	// Test Create.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -169,16 +169,16 @@ func (nodeGroup *NodeGroup) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (nodeGroup *NodeGroup) Nodes() ([]string, error) {
-	ids := make([]string, 0)
+func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	instances := make([]cloudprovider.Instance, 0)
 	nodes, err := nodeGroup.kubemarkController.GetNodeNamesForNodeGroup(nodeGroup.Name)
 	if err != nil {
-		return ids, err
+		return instances, err
 	}
 	for _, node := range nodes {
-		ids = append(ids, ":////"+node)
+		instances = append(instances, cloudprovider.Instance{Id: ":////" + node})
 	}
-	return ids, nil
+	return instances, nil
 }
 
 // DeleteNodes deletes the specified nodes from the node group.

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -344,17 +344,17 @@ func (tng *TestNodeGroup) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (tng *TestNodeGroup) Nodes() ([]string, error) {
+func (tng *TestNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	tng.Lock()
 	defer tng.Unlock()
 
-	result := make([]string, 0)
+	instances := make([]cloudprovider.Instance, 0)
 	for node, nodegroup := range tng.cloudProvider.nodes {
 		if nodegroup == tng.id {
-			result = append(result, node)
+			instances = append(instances, cloudprovider.Instance{Id: node})
 		}
 	}
-	return result, nil
+	return instances, nil
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -887,14 +887,14 @@ func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProvider cloudprovider.C
 			return []UnregisteredNode{}, err
 		}
 		for _, node := range nodes {
-			if !registered.Has(node) {
+			if !registered.Has(node.Id) {
 				notRegistered = append(notRegistered, UnregisteredNode{
 					Node: &apiv1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: node,
+							Name: node.Id,
 						},
 						Spec: apiv1.NodeSpec{
-							ProviderID: node,
+							ProviderID: node.Id,
 						},
 					},
 					UnregisteredSince: time,

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -42,7 +42,9 @@ func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
 func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
 func (f *FakeNodeGroup) Id() string                         { return f.id }
 func (f *FakeNodeGroup) Debug() string                      { return f.id }
-func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{}, nil }
+func (f *FakeNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	return []cloudprovider.Instance{}, nil
+}
 func (f *FakeNodeGroup) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }


### PR DESCRIPTION
This is preparatory work for handling resource related
(stockout/quota-exceeded) error conditions in CA.