### PR TITLE
Pass on-event oomInfo without creating a new goroutine.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -91,10 +91,7 @@ func parseEvictionEvent(event *apiv1.Event) []OomInfo {
 func (o *Observer) OnEvent(event *apiv1.Event) {
 	glog.V(1).Infof("OOM Observer processing event: %+v", event)
 	for _, oomInfo := range parseEvictionEvent(event) {
-		info := oomInfo
-		go func() {
-			o.ObservedOomsChannel <- info
-		}()
+		o.ObservedOomsChannel <- oomInfo
 	}
 }
 


### PR DESCRIPTION
Can be seen as a continuation of #1335 - now using buffered channel in OnEvent too.