### PR TITLE
Use real-usage sample to estimate memory usage after OOM

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -145,6 +145,6 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
 	if now.Before(container.WindowEnd) {
-		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.MemoryPeak), 1.0, container.WindowEnd)
+		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.WindowEnd)
 	}
 }


### PR DESCRIPTION
Use real-usage sample (exclude previous OOMs) to estimate memory usage after OOM.

This should fix the problem reported by @davidquarles under #1182 - but *not* the initial issue reported by @bskiba there.

Note for a reviewer: I've unexported memoryPeak & oomPeak to decrease chance of invalid usage.