### PR TITLE
hack/verify-all.sh: missing negation

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -61,7 +61,7 @@ do
     echo "Skipping $t"
     continue
   fi
-  if $SILENT ; then
+  if ! $SILENT ; then
     echo -e "Verifying $t"
     if bash "$t" &> /dev/null; then
       echo -e "${color_green}SUCCESS${color_norm}"


### PR DESCRIPTION
A missing negation made that scripts output less stuff if we pass -v (i.e. verbose).