### PR TITLE
hack/verify-all.sh -v output corrected

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -63,14 +63,14 @@ do
   fi
   if ! $SILENT ; then
     echo -e "Verifying $t"
-    if bash "$t" &> /dev/null; then
+    if bash "$t"; then
       echo -e "${color_green}SUCCESS${color_norm}"
     else
       echo -e "${color_red}FAILED${color_norm}"
       ret=1
     fi
   else
-    bash "$t" || ret=1
+    bash "$t" &> /dev/null || ret=1
   fi
 done
 


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/pull/1365 fixed a missing negation in `hack/verify-all.sh` so we now get proper headers when `-v` is passed, but it forgot to also change whether or not the verifier script output was suppressed or not depending on `-v` -- that setting was correct before https://github.com/kubernetes/autoscaler/pull/1365 and is now wrong (so the PR was sort of a disimprovement). This PR fixes that.

Sorry for the confusion.