### PR TITLE
AWS: Improved balancing

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -19,6 +19,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -90,12 +91,12 @@ func (m *asgCache) parseExplicitAsgs(specs []string) error {
 	return nil
 }
 
-// Register ASG. Returns true if the ASG was registered.
-func (m *asgCache) register(asg *asg) bool {
+// Register ASG. Returns the registered ASG.
+func (m *asgCache) register(asg *asg) *asg {
 	for i := range m.registeredAsgs {
 		if existing := m.registeredAsgs[i]; existing.AwsRef == asg.AwsRef {
 			if reflect.DeepEqual(existing, asg) {
-				return false
+				return existing
 			}
 
 			glog.V(4).Infof("Updating ASG %s", asg.AwsRef.Name)
@@ -117,22 +118,22 @@ func (m *asgCache) register(asg *asg) bool {
 			existing.LaunchTemplateVersion = asg.LaunchTemplateVersion
 			existing.Tags = asg.Tags
 
-			return true
+			return existing
 		}
 	}
 	glog.V(1).Infof("Registering ASG %s", asg.AwsRef.Name)
 	m.registeredAsgs = append(m.registeredAsgs, asg)
-	return true
+	return asg
 }
 
-// Unregister ASG. Returns true if the ASG was unregistered.
-func (m *asgCache) unregister(a *asg) bool {
+// Unregister ASG. Returns the unregistered ASG.
+func (m *asgCache) unregister(a *asg) *asg {
 	updated := make([]*asg, 0, len(m.registeredAsgs))
-	changed := false
+	var changed *asg
 	for _, existing := range m.registeredAsgs {
 		if existing.AwsRef == a.AwsRef {
 			glog.V(1).Infof("Unregistered ASG %s", a.AwsRef.Name)
-			changed = true
+			changed = a
 			continue
 		}
 		updated = append(updated, existing)
@@ -167,6 +168,10 @@ func (m *asgCache) FindForInstance(instance AwsInstanceRef) *asg {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	return m.findForInstance(instance)
+}
+
+func (m *asgCache) findForInstance(instance AwsInstanceRef) *asg {
 	if asg, found := m.instanceToAsg[instance]; found {
 		return asg
 	}
@@ -184,6 +189,72 @@ func (m *asgCache) InstancesByAsg(ref AwsRef) ([]AwsInstanceRef, error) {
 	}
 
 	return nil, fmt.Errorf("Error while looking for instances of ASG: %s", ref)
+}
+
+func (m *asgCache) SetAsgSize(asg *asg, size int) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	params := &autoscaling.SetDesiredCapacityInput{
+		AutoScalingGroupName: aws.String(asg.Name),
+		DesiredCapacity:      aws.Int64(int64(size)),
+		HonorCooldown:        aws.Bool(false),
+	}
+	glog.V(0).Infof("Setting asg %s size to %d", asg.Name, size)
+	_, err := m.service.SetDesiredCapacity(params)
+	if err != nil {
+		return err
+	}
+
+	// Proactively set the ASG size so autoscaler makes better decisions
+	asg.curSize = size
+
+	return nil
+}
+
+// DeleteInstances deletes the given instances. All instances must be controlled by the same ASG.
+func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if len(instances) == 0 {
+		return nil
+	}
+	commonAsg := m.findForInstance(*instances[0])
+	if commonAsg == nil {
+		return fmt.Errorf("can't delete instance %s, which is not part of an ASG", instances[0].Name)
+	}
+
+	for _, instance := range instances {
+		asg := m.findForInstance(*instance)
+
+		if asg != commonAsg {
+			instanceIds := make([]string, len(instances))
+			for i, instance := range instances {
+				instanceIds[i] = instance.Name
+			}
+
+			return fmt.Errorf("can't delete instances %s as they belong to at least two different ASGs (%s and %s)", strings.Join(instanceIds, ","), commonAsg.Name, asg.Name)
+		}
+	}
+
+	for _, instance := range instances {
+		params := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+			InstanceId:                     aws.String(instance.Name),
+			ShouldDecrementDesiredCapacity: aws.Bool(true),
+		}
+		resp, err := m.service.TerminateInstanceInAutoScalingGroup(params)
+		if err != nil {
+			return err
+		}
+
+		// Proactively decrement the size so autoscaler makes better decisions
+		commonAsg.curSize--
+
+		glog.V(4).Infof(*resp.Activity.Description)
+	}
+
+	return nil
 }
 
 // Fetch automatically discovered ASGs. These ASGs should be unregistered if
@@ -261,7 +332,7 @@ func (m *asgCache) regenerate() error {
 		}
 		exists[asg.AwsRef] = true
 
-		m.register(asg)
+		asg = m.register(asg)
 
 		newAsgToInstancesCache[asg.AwsRef] = make([]AwsInstanceRef, len(group.Instances))
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -330,10 +330,18 @@ func TestIncreaseSize(t *testing.T) {
 
 	provider.Refresh()
 
-	err := asgs[0].IncreaseSize(1)
+	initialSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, initialSize)
+
+	err = asgs[0].IncreaseSize(1)
 	assert.NoError(t, err)
 	service.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
 	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+
+	newSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, newSize)
 }
 
 func TestBelongs(t *testing.T) {
@@ -403,6 +411,54 @@ func TestDeleteNodes(t *testing.T) {
 
 	provider.Refresh()
 
+	initialSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, initialSize)
+
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id",
+		},
+	}
+	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	assert.NoError(t, err)
+	service.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 1)
+	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
+
+	newSize, err := asgs[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, newSize)
+}
+
+func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
+	service := &AutoScalingMock{}
+	manager := newTestAwsManagerWithAsgs(t, service, []string{"1:5:test-asg"})
+	provider := testProvider(t, manager)
+	asgs := provider.NodeGroups()
+
+	service.On("TerminateInstanceInAutoScalingGroup", &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String("test-instance-id"),
+		ShouldDecrementDesiredCapacity: aws.Bool(true),
+	}).Return(&autoscaling.TerminateInstanceInAutoScalingGroupOutput{
+		Activity: &autoscaling.Activity{Description: aws.String("Deleted instance")},
+	})
+
+	// Look up the current number of instances...
+	service.On("DescribeAutoScalingGroupsPages",
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice([]string{"test-asg"}),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		},
+		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
+		fn(testNamedDescribeAutoScalingGroupsOutput("test-asg", 2, "test-instance-id", "second-test-instance-id"), false)
+	}).Return(nil)
+
+	provider.Refresh()
+	// Call the manager directly as otherwise the call would be a noop as its within less then 60s
+	manager.forceRefresh()
+
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: "aws:///us-east-1a/test-instance-id",
@@ -410,8 +466,6 @@ func TestDeleteNodes(t *testing.T) {
 	}
 	err := asgs[0].DeleteNodes([]*apiv1.Node{node})
 	assert.NoError(t, err)
-	service.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 1)
-	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 }
 
 func TestGetResourceLimiter(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -168,55 +168,12 @@ func (m *AwsManager) getAsgs() []*asg {
 
 // SetAsgSize sets ASG size.
 func (m *AwsManager) SetAsgSize(asg *asg, size int) error {
-	params := &autoscaling.SetDesiredCapacityInput{
-		AutoScalingGroupName: aws.String(asg.Name),
-		DesiredCapacity:      aws.Int64(int64(size)),
-		HonorCooldown:        aws.Bool(false),
-	}
-	glog.V(0).Infof("Setting asg %s size to %d", asg.Name, size)
-	_, err := m.autoScalingService.SetDesiredCapacity(params)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.asgCache.SetAsgSize(asg, size)
 }
 
 // DeleteInstances deletes the given instances. All instances must be controlled by the same ASG.
 func (m *AwsManager) DeleteInstances(instances []*AwsInstanceRef) error {
-	if len(instances) == 0 {
-		return nil
-	}
-	commonAsg := m.asgCache.FindForInstance(*instances[0])
-	if commonAsg == nil {
-		return fmt.Errorf("can't delete instance %s, which is not part of an ASG", instances[0].Name)
-	}
-
-	for _, instance := range instances {
-		asg := m.asgCache.FindForInstance(*instance)
-
-		if asg != commonAsg {
-			instanceIds := make([]string, len(instances))
-			for i, instance := range instances {
-				instanceIds[i] = instance.Name
-			}
-
-			return fmt.Errorf("can't delete instances %s as they belong to at least two different ASGs (%s and %s)", strings.Join(instanceIds, ","), commonAsg.Name, asg.Name)
-		}
-	}
-
-	for _, instance := range instances {
-		params := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
-			InstanceId:                     aws.String(instance.Name),
-			ShouldDecrementDesiredCapacity: aws.Bool(true),
-		}
-		resp, err := m.autoScalingService.TerminateInstanceInAutoScalingGroup(params)
-		if err != nil {
-			return err
-		}
-		glog.V(4).Infof(*resp.Activity.Description)
-	}
-
-	return nil
+	return m.asgCache.DeleteInstances(instances)
 }
 
 // GetAsgNodes returns Asg nodes.


### PR DESCRIPTION
Various ClusterAutoscaler components like the BalancingProcessor act based on the current `TargetSize` of a `NodeGroup`. https://github.com/kubernetes/autoscaler/blob/f341d8a68a6aad996964cda5db67e2f254b71c8d/cluster-autoscaler/processors/nodegroupset/balancing_processor.go#L89

As the current AWS implementation only updates `TargetSize` when refreshing the ASG list every minutes (less when being rate-limited), the cached `TargetSize` might quickly mismatch the actual value.

While each ASG change could trigger a cache refresh, I don't think this is optimal as it introduces again further requests.

Instead I decided to pre-calculate the `TargetSize` change for AWS on AutoScalingGroup changes and Node deletion to make better balancing decisions.

Any wrongly pre-calculated `TargetSize` will be auto-corrected on the next successful ASG list refresh.