### PR TITLE
Fix formatted log messages

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -18,6 +18,7 @@ package alicloud
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -180,7 +181,7 @@ func (asg *Asg) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 
 	node, err := asg.manager.buildNodeFromTemplate(asg, template)
 	if err != nil {
-		glog.Errorf("failed to build instanceType:%s from template in ASG:%s,because of %s", template.InstanceType, asg.Id(), err.Error())
+		glog.Errorf("failed to build instanceType:%v from template in ASG:%s,because of %s", template.InstanceType, asg.Id(), err.Error())
 		return nil, err
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -210,7 +210,7 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 	_, err = as.manager.azClient.deploymentsClient.CreateOrUpdate(ctx, as.manager.config.ResourceGroup, newDeploymentName, newDeployment)
-	glog.V(3).Infof("Waiting for deploymentsClient.CreateOrUpdate(%s, %s, %s)", as.manager.config.ResourceGroup, newDeploymentName, newDeployment)
+	glog.V(3).Infof("Waiting for deploymentsClient.CreateOrUpdate(%s, %s, %v)", as.manager.config.ResourceGroup, newDeploymentName, newDeployment)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -119,9 +119,9 @@ func (az *azVirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGrou
 }
 
 func (az *azVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error) {
-	glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q,%q): start", resourceGroupName)
+	glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q): start", resourceGroupName)
 	defer func() {
-		glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q,%q): end", resourceGroupName)
+		glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q): end", resourceGroupName)
 	}()
 
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
@@ -142,9 +142,9 @@ func (az *azVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGro
 }
 
 func (az *azVirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error) {
-	glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%q): start", resourceGroupName, vmScaleSetName, vmInstanceIDs)
+	glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%v): start", resourceGroupName, vmScaleSetName, vmInstanceIDs)
 	defer func() {
-		glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%q): end", resourceGroupName, vmScaleSetName, vmInstanceIDs)
+		glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%v): end", resourceGroupName, vmScaleSetName, vmInstanceIDs)
 	}()
 
 	future, err := az.client.DeleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)

--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -297,7 +297,7 @@ func (agentPool *ContainerServiceAgentPool) TargetSize() (int, error) {
 //a delete is performed from a scale down.
 func (agentPool *ContainerServiceAgentPool) SetSize(targetSize int) error {
 	if targetSize > agentPool.MaxSize() || targetSize < agentPool.MinSize() {
-		glog.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MaxSize)
+		glog.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MaxSize())
 		return fmt.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MinSize())
 	}
 

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -456,7 +456,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			if err == nil {
 				nodeInfos[createNodeGroupResult.MainCreatedNodeGroup.Id()] = mainCreatedNodeInfo
 			} else {
-				glog.Warning("Cannot build node info for newly created main node group %v; balancing similar node groups may not work; err=%v", createNodeGroupResult.MainCreatedNodeGroup.Id(), err)
+				glog.Warningf("Cannot build node info for newly created main node group %v; balancing similar node groups may not work; err=%v", createNodeGroupResult.MainCreatedNodeGroup.Id(), err)
 				// Use node info based on expansion candidate but upadte Id which likely changed when node group was created.
 				nodeInfos[bestOption.NodeGroup.Id()] = nodeInfos[oldId]
 			}
@@ -469,7 +469,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 				nodeInfo, err := GetNodeInfoFromTemplate(nodeGroup, daemonSets, context.PredicateChecker)
 
 				if err != nil {
-					glog.Warning("Cannot build node info for newly created extra node group %v; balancing similar node groups will not work; err=%v", nodeGroup.Id(), err)
+					glog.Warningf("Cannot build node info for newly created extra node group %v; balancing similar node groups will not work; err=%v", nodeGroup.Id(), err)
 					continue
 				}
 				nodeInfos[nodeGroup.Id()] = nodeInfo


### PR DESCRIPTION
Go 1.11.1 complains about malformatted log messages:

```
# k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure
cloudprovider/azure/azure_agent_pool.go:213: Verbose.Infof format %s has arg newDeployment of wrong type k8s.io/autoscaler/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources.Deployment
cloudprovider/azure/azure_client.go:122: Verbose.Infof format %q reads arg #2, but call has 1 arg
cloudprovider/azure/azure_client.go:124: Verbose.Infof format %q reads arg #2, but call has 1 arg
cloudprovider/azure/azure_client.go:145: Verbose.Infof format %q has arg vmInstanceIDs of wrong type k8s.io/autoscaler/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute.VirtualMachineScaleSetVMInstanceRequiredIDs
cloudprovider/azure/azure_client.go:147: Verbose.Infof format %q has arg vmInstanceIDs of wrong type k8s.io/autoscaler/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute.VirtualMachineScaleSetVMInstanceRequiredIDs
cloudprovider/azure/azure_container_service_pool.go:300: Errorf format %d arg agentPool.MaxSize is a func value, not called
# k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud
cloudprovider/alicloud/alicloud_auto_scaling_group.go:183: Errorf format %s has arg template.InstanceType of wrong type *alicloud.instanceType
```