### PR TITLE
Correct flag for node group auto-discovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -26,7 +26,7 @@ A minimum IAM policy would look like:
 }
 ```
 
-If you'd like to auto-discover node groups by specifying the `--node-group-auto-discover` flag, a `DescribeTags` permission is also required:
+If you'd like to auto-discover node groups by specifying the `--node-group-auto-discovery` flag, a `DescribeTags` permission is also required:
 
 ```json
 {


### PR DESCRIPTION
This fixes the `--node-group-auto-discovery` flag in the aws README.