### PR TITLE
Migrate to go1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 
 matrix:
   include:
-    - go: 1.8
+    - go: "1.10"
 
 install:
   - mkdir -p $HOME/gopath/src/k8s.io

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -237,7 +237,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node, no
 				}
 			}
 			if !foundPlace {
-				return fmt.Errorf("failed to find place for %s", podKey)
+				return fmt.Errorf("failed to find place for %s", podKey(pod))
 			}
 		}
 

--- a/hack/install-verify-tools.sh
+++ b/hack/install-verify-tools.sh
@@ -21,10 +21,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 GO_VERSION=($(go version))
 
-# golint only works for golang 1.5+
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
-  go get -u github.com/golang/lint/golint
-fi
+go get -u github.com/golang/lint/golint
 
 go get -u github.com/tools/godep
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -22,13 +22,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4|go1.5|go1.6|go1.7|go1.8') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping gofmt."
-  exit 1
-fi
-
 cd "${KUBE_ROOT}"
 
 find_files() {

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -20,13 +20,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-GO_VERSION=($(go version))
-# golint only works for golang 1.5+
-if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
-  echo "GOLINT requires go 1.5+. Skipping"
-  exit
-fi
-
 cd "${KUBE_ROOT}"
 
 GOLINT=${GOLINT:-"golint"}

--- a/vertical-pod-autoscaler/updater/recommender/caching_recommender.go
+++ b/vertical-pod-autoscaler/updater/recommender/caching_recommender.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"crypto/sha1"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/updater/apimock"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
@@ -63,7 +64,7 @@ func (c *cachingRecommenderImpl) Get(spec *apiv1.PodSpec) (*apimock.Recommendati
 	}
 	response, err := c.api.GetRecommendation(spec)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching recommendation", err)
+		return nil, fmt.Errorf("error fetching recommendation: %v", err)
 	}
 	if response != nil && cacheKey != nil {
 		c.cache.Set(cacheKey, response)


### PR DESCRIPTION
Go 1.8 is no longer supported and travis is not able to run presubmit with it.