### PR TITLE
pass kubeconfig to cloudprovider builder

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gke"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/client-go/rest"
 )
 
 // AvailableCloudProviders supported by the cloud provider builder.
@@ -40,7 +41,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider is GCE.
 const DefaultCloudProvider = gce.ProviderNameGCE
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, kubeConfig *rest.Config) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case gce.ProviderNameGCE:
 		return gce.BuildGCE(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -20,12 +20,13 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/client-go/rest"
 
 	"github.com/golang/glog"
 )
 
 // NewCloudProvider builds a cloud provider from provided parameters.
-func NewCloudProvider(opts config.AutoscalingOptions) cloudprovider.CloudProvider {
+func NewCloudProvider(opts config.AutoscalingOptions, kubeConfig *rest.Config) cloudprovider.CloudProvider {
 	glog.V(1).Infof("Building %s cloud provider.", opts.CloudProviderName)
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{
@@ -42,7 +43,7 @@ func NewCloudProvider(opts config.AutoscalingOptions) cloudprovider.CloudProvide
 		return nil
 	}
 
-	provider := buildCloudProvider(opts, do, rl)
+	provider := buildCloudProvider(opts, do, rl, kubeConfig)
 	if provider != nil {
 		return provider
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -257,7 +257,7 @@ func registerSignalHandlers(autoscaler core.Autoscaler) {
 func buildAutoscaler() (core.Autoscaler, error) {
 	// Create basic config from flags.
 	autoscalingOptions := createAutoscalingOptions()
-	kubeClient := createKubeClient(getKubeConfig())
+	kubeConfig := getKubeConfig()
 	processors := ca_processors.DefaultProcessors()
 	if autoscalingOptions.CloudProviderName == "gke" {
 		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
@@ -266,7 +266,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	}
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions: autoscalingOptions,
-		KubeClient:         kubeClient,
+		KubeConfig:         kubeConfig,
 		Processors:         processors,
 	}
 


### PR DESCRIPTION
We have an internal cloud provider here (which we're planning to publish in a separate PR later) that uses the K8s cluster-api for creating nodes and thus needs to access to the cluster itself (its CloudConfig is just the cluster kubeconfig). As a preparation for that, this PR changes AutoscalerOptions and the cloud provider builder so we pass the kubeconfig down to the `buildCloudProvider` in case any actual cloud provider needs it.