### PR TITLE
Cluster Autoscaler 1.3: fix ServerAppSecret issues for AKS clusters

### DIFF
--- a/cluster-autoscaler/Godeps/Godeps.json
+++ b/cluster-autoscaler/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/autoscaler/cluster-autoscaler",
-	"GoVersion": "go1.10",
+	"GoVersion": "go1.11",
 	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
@@ -23,43 +23,43 @@
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/version",
-			"Comment": "v14.6.0-1-gbb6ed208",
-			"Rev": "bb6ed208fc21868552a57e5bae21dbe7f6302f66"
+			"Comment": "v14.6.0-1-gb453d8436",
+			"Rev": "b453d8436a3f013cca2f092954626aa6e9119eea"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-ansiterm",
@@ -71,33 +71,33 @@
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/adal",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/to",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/validation",
-			"Comment": "v10.6.2-1-g6cd5ab3",
-			"Rev": "6cd5ab36b2938ba6b45ee6ab87ff09eb04314b34"
+			"Comment": "v10.6.2-1-g327cb53",
+			"Rev": "327cb53e4a983ed5cf1b99a515ec49fc643c5d33"
 		},
 		{
 			"ImportPath": "github.com/JeffAshton/win_pdh",
@@ -140,163 +140,163 @@
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awserr",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/defaults",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/request",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/session",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ec2",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ecr",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elb",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/elbv2",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/kms",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sts",
-			"Comment": "v1.12.7",
-			"Rev": "760741802ad40f49ae9fc4a69ef6706d2527d62e"
+			"Comment": "v1.12.7-2-g04d1f7e7",
+			"Rev": "04d1f7e7bfb2abe632a12dbea2143332633070d0"
 		},
 		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
@@ -330,103 +330,103 @@
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/containers/v1",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/tasks/v1",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/version/v1",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/types",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/types/task",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/containers",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/dialer",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/errdefs",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/namespaces",
-			"Comment": "v1.0.2",
-			"Rev": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+			"Comment": "v1.0.2-1-g4ff32e4e",
+			"Rev": "4ff32e4e131a8995cb6f619942090a20cf62f9fd"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/libcni",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/invoke",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/020",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/current",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/version",
-			"Comment": "v0.6.0",
-			"Rev": "a7885cb6f8ab03fba07852ded351e4f5e7a112bf"
+			"Comment": "v0.6.0-1-gc55d42d",
+			"Rev": "c55d42d7b54eea39d9db23eb4be8d3ff7c52e205"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",
-			"Comment": "v3.2.13",
-			"Rev": "95a726a27e09030f9ccbd9982a1508f5a6d25ada"
+			"Comment": "v3.2.13-1-g1bc3b1731",
+			"Rev": "1bc3b173198f6818fd5fa8c3857cfb3473823a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
-			"Comment": "v3.2.13",
-			"Rev": "95a726a27e09030f9ccbd9982a1508f5a6d25ada"
+			"Comment": "v3.2.13-1-g1bc3b1731",
+			"Rev": "1bc3b173198f6818fd5fa8c3857cfb3473823a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/srv",
-			"Comment": "v3.2.13",
-			"Rev": "95a726a27e09030f9ccbd9982a1508f5a6d25ada"
+			"Comment": "v3.2.13-1-g1bc3b1731",
+			"Rev": "1bc3b173198f6818fd5fa8c3857cfb3473823a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/types",
-			"Comment": "v3.2.13",
-			"Rev": "95a726a27e09030f9ccbd9982a1508f5a6d25ada"
+			"Comment": "v3.2.13-1-g1bc3b1731",
+			"Rev": "1bc3b173198f6818fd5fa8c3857cfb3473823a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/version",
-			"Comment": "v3.2.13",
-			"Rev": "95a726a27e09030f9ccbd9982a1508f5a6d25ada"
+			"Comment": "v3.2.13-1-g1bc3b1731",
+			"Rev": "1bc3b173198f6818fd5fa8c3857cfb3473823a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",
@@ -454,13 +454,13 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/rkt/api/v1alpha",
-			"Comment": "v1.25.0",
-			"Rev": "ec37f3cb649bfb72408906e7cbf330e4aeda1075"
+			"Comment": "v1.25.0-1-g684bc5a3",
+			"Rev": "684bc5a3b1d5f813716b1e02b08364e4ffde2671"
 		},
 		{
 			"ImportPath": "github.com/cyphar/filepath-securejoin",
-			"Comment": "v0.2.1-1-gae69057",
-			"Rev": "ae69057f2299fb9e5ba2df738607e6a505b74ab6"
+			"Comment": "v0.2.1-2-gb1d242c",
+			"Rev": "b1d242ca25c7b8d319c37255c534e8d94f0c3602"
 		},
 		{
 			"ImportPath": "github.com/d2g/dhcp4",
@@ -482,163 +482,163 @@
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/digestset",
-			"Comment": "v2.6.0-rc.1-209-gedc3ab29",
-			"Rev": "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
+			"Comment": "v2.6.0-rc.1-210-g3eeffed7",
+			"Rev": "3eeffed7f7d48c411380ddabe4a65851caf7a8c7"
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/reference",
-			"Comment": "v2.6.0-rc.1-209-gedc3ab29",
-			"Rev": "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
+			"Comment": "v2.6.0-rc.1-210-g3eeffed7",
+			"Rev": "3eeffed7f7d48c411380ddabe4a65851caf7a8c7"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/blkiodev",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/container",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/events",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/filters",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/image",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/mount",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/network",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/registry",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/strslice",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/swarm",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/swarm/runtime",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/time",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/versions",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/volume",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/client",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/jsonlog",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/jsonmessage",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/longpath",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/mount",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/parsers",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/parsers/operatingsystem",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/stdcopy",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/sysinfo",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/system",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term/windows",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/tlsconfig",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
-			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7403-ga352a0f7e",
+			"Rev": "a352a0f7e422b18c4a746f8f648cbe8c3944edb4"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
@@ -662,8 +662,8 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipvs",
-			"Comment": "v0.8.0-dev.2-910-gba46b928",
-			"Rev": "ba46b928444931e6865d8618dc03622cac79aa6f"
+			"Comment": "v0.8.0-dev.2-911-g218c638d",
+			"Rev": "218c638de1a491d47ec533ecee66b2d673e0cd93"
 		},
 		{
 			"ImportPath": "github.com/docker/libtrust",
@@ -818,213 +818,213 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.1-1-gdb68f376",
+			"Rev": "db68f3764483340e8884a1f63309c1edc15375d0"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",
@@ -1232,31 +1232,31 @@
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/client",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/client/volume",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/spec",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/pkg/parser",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/pkg/units",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/volume",
-			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
+			"Rev": "531f64ca3bc3ee5bfef8b7093773f9cd85640f03"
 		},
 		{
 			"ImportPath": "github.com/lpabon/godbc",
@@ -1344,83 +1344,83 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/apparmor",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups/fs",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/configs",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/configs/validate",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/criurpc",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/intelrdt",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/keys",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/mount",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/seccomp",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/stacktrace",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/system",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/user",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/utils",
-			"Comment": "v1.0.0-rc5-46-g871ba2e5",
-			"Rev": "871ba2e58e24314d1fab4517a80410191ba5ad01"
+			"Comment": "v1.0.0-rc5-47-geec8e4f4",
+			"Rev": "eec8e4f4b3b0cabca4c3249d1e495e6e243245f8"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
@@ -1500,8 +1500,8 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher/client",
-			"Comment": "v0.1.0-196-g09693a8",
-			"Rev": "09693a8743ba5ee58c58c1b1e8a4abd17af00d45"
+			"Comment": "v0.1.0-197-gd45c695",
+			"Rev": "d45c69530155b5e5fd79635107d89cb206508c2f"
 		},
 		{
 			"ImportPath": "github.com/renstrom/dedent",
@@ -1510,7 +1510,7 @@
 		},
 		{
 			"ImportPath": "github.com/rubiojr/go-vhd/vhd",
-			"Rev": "0bfd3b39853cdde5762efda92289f14b0ac0491b"
+			"Rev": "9ffa105fce03da87bf02e87f321f76e1cd6f751c"
 		},
 		{
 			"ImportPath": "github.com/satori/go.uuid",
@@ -1574,13 +1574,13 @@
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",
-			"Comment": "v1.2.1-14-gc679ae2",
-			"Rev": "c679ae2cc0cb27ec3293fea7e254e47386f05d69"
+			"Comment": "v1.2.1-15-g2591ae6",
+			"Rev": "2591ae6fa2ac21e79887f66701c0edb6de4f3936"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/mock",
-			"Comment": "v1.2.1-14-gc679ae2",
-			"Rev": "c679ae2cc0cb27ec3293fea7e254e47386f05d69"
+			"Comment": "v1.2.1-15-g2591ae6",
+			"Rev": "2591ae6fa2ac21e79887f66701c0edb6de4f3936"
 		},
 		{
 			"ImportPath": "github.com/syndtr/gocapability/capability",
@@ -1604,118 +1604,118 @@
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/find",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/list",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup/methods",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/lookup/types",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/nfc",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/object",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/methods",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/types",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/property",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/session",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/sts",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/sts/internal",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/task",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/debug",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/methods",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/mo",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/progress",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/soap",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/types",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/xml",
-			"Comment": "v0.17.1-46-ge70dd44",
-			"Rev": "e70dd44f80baf671099254d675eb278529038234"
+			"Comment": "v0.17.1-48-gcd0802c",
+			"Rev": "cd0802cef689cb25748bfd0b899829bb0854dac5"
 		},
 		{
 			"ImportPath": "github.com/vmware/photon-controller-go-sdk/SSPI",
@@ -1775,7 +1775,7 @@
 		},
 		{
 			"ImportPath": "golang.org/x/exp/inotify",
-			"Rev": "292a51b8d262487dab23a588950e8052d63d9113"
+			"Rev": "c3a3f1a5a0efafc1ea77d65a08acc6b63169e4e7"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",
@@ -1927,39 +1927,39 @@
 		},
 		{
 			"ImportPath": "google.golang.org/api/compute/v0.alpha",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/compute/v0.beta",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/compute/v1",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/container/v1",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/container/v1beta1",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/gensupport",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/googleapi",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/googleapi/internal/uritemplates",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/api/tpu/v1",
-			"Rev": "546068db2599be50f81c52b1aa5bc4b8f40f4701"
+			"Rev": "c143ef153993fa4295815fbe4d1269e27bc8c8ff"
 		},
 		{
 			"ImportPath": "google.golang.org/genproto/googleapis/rpc/status",
@@ -2106,1231 +2106,1231 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admission/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "98b82614c2120175546ca53faf6b90106de0253c"
+			"Rev": "f10d1307da0b468517e0ebac8369e1f83750e80b"
 		},
 		{
 			"ImportPath": "k8s.io/apiextensions-apiserver/pkg/features",
-			"Rev": "eba0fb19668017f64ab4e64855b3385c5248ac59"
+			"Rev": "5dbd7a528bbd271213f8005a6ce8029d181612f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation/path",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/duration",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/proxy",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/uuid",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "70ab26cf4bab12e8f6639d9a25955dbd8dfa66c8"
+			"Rev": "3d75f5f70425fa7da327d51804d3b834e65de7d9"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1beta1",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticator",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/group",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/union",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/x509",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/user",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizer",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/metrics",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/request",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/features",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/rest",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/healthz",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/httplog",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/mux",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/util",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/names",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flag",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flushwriter",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/logs",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/webhook",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/wsstream",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Rev": "aa8bd8a2ac2a41add9cfebccf8e34dc0505ab0e2"
+			"Rev": "c7e747b549538944f7b0413fa1f697a6e5df9977"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/dynamic",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta2",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v2beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v2alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/events",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/events/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/internalinterfaces",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/events/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/events/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta2",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v2beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v2alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/certificates/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/core/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/events/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/extensions/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/networking/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/policy/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/scheduling/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/scheduling/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/settings/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/exec",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/restmapper",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsint",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsv1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsv1beta2",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/autoscalingv1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/extensionsint",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/extensionsv1beta1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/testing",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/third_party/forked/golang/template",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/leaderelection",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/leaderelection/resourcelock",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/pager",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/record",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/reference",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/remotecommand",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport/spdy",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/buffer",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/certificate",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/certificate/csr",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/connrotation",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/exec",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/jsonpath",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/retry",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
-			"Rev": "11400414f83b2041c77f981a43c63905241ab04f"
+			"Rev": "ea431ce125cdfa61e012f93986add569797ce22a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
@@ -3354,2113 +3354,2113 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-proxy/app",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app/options",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/events",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/legacyscheme",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/pod",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/ref",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/resource",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/service",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/testapi",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/pod",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/resource",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/service",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/v1beta2",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/helper",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/helper/qos",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/pods",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/v1/helper",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/v1/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/events",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/events/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/events/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/install",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/v1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/capabilities",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/chaosclient",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/scheme",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/events/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/admissionregistration",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/apps",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/apps/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/autoscaling",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/autoscaling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/batch",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/batch/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/certificates",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/certificates/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/extensions",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/extensions/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/internalinterfaces",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/networking",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/networking/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/policy",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/policy/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/scheduling",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/scheduling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/settings",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/settings/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/storage",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/storage/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/admissionregistration/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/apps/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/autoscaling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/batch/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/certificates/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/core/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/extensions/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/networking/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/policy/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/scheduling/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/settings/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/storage/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/azure/auth",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/filter",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/photon",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/deployment/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/events",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/expand/cache",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/persistentvolume",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/aws",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/azure",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/gcp",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/rancher",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/secrets",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/features",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/fieldpath",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/apps",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/genericclioptions",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/scheme",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/hash",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/slice",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/cri",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/scheme",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cadvisor",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/certificate",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/checkpoint",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/checkpointmanager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/config",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/configmap",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/container",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/container/testing",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/cm",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/network",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/network/kubenet",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/network/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/remote",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/envvars",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/events",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/eviction",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/eviction/api",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/images",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint/store",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/status",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/files",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/panic",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kuberuntime",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/leaky",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/lifecycle",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/logs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/metrics/collectors",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/mountpod",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/dns",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pleg",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pod",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/preemption",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober/results",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/remote",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/secret",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/portforward",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/remotecommand",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/stats",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/streaming",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/stats",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/status",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/sysctl",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/token",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/types",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/cache",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/format",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/ioutils",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/manager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/example_plugin_apis/v1beta1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/example_plugin_apis/v1beta2",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/queue",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/sliceutils",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/store",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/cache",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/populator",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/winstats",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubemark",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/master/ports",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/printers",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/printers/internalversion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/exec",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/http",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/tcp",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/scheme",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/v1alpha1",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/config",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/healthcheck",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/iptables",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/ipvs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/userspace",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/winkernel",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/winuserspace",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/quota",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithm",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithm/predicates",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithmprovider",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/api",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/api/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/cache",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/core",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/factory",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/metrics",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/scheduler/volumebinder",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/apparmor",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/sysctl",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/securitycontext",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/serviceaccount",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/async",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/bandwidth",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/config",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/configz",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/conntrack",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/dbus",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ebtables",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/env",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/file",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/filesystem",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/flag",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/flock",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/goroutinemap",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/hash",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/io",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ipconfig",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ipset",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/iptables",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ipvs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/keymutex",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/labels",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/mount",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/net",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/net/sets",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/netsh",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/node",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/nsenter",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/oom",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/parsers",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/pod",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/pointer",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/procfs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/removeall",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/resizefs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/resourcecontainer",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/rlimit",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/selinux",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/slice",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/strings",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/sysctl",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/tail",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/taints",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/version",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version/verflag",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/aws_ebs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/azure_dd",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/azure_file",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/cephfs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/cinder",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/configmap",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/csi",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/csi/labelmanager",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/downwardapi",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/empty_dir",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/fc",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/flexvolume",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/flocker",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/gce_pd",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/git_repo",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/glusterfs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/host_path",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/iscsi",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/local",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/nfs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/photon_pd",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/portworx",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/projected",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/quobyte",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/rbd",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/scaleio",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/secret",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/storageos",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/fs",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/operationexecutor",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/recyclerclient",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/types",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/volumepathhandler",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/validation",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/vsphere_volume",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/windows/service",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/utils",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/golang/expansion",
-			"Comment": "v1.12.0-alpha.0-1034-geac9c4ff57",
-			"Rev": "eac9c4ff5711158eaca899a58d1293e39cbd040e"
+			"Comment": "v1.12.0-alpha.0-1035-ge3f78f3555",
+			"Rev": "e3f78f35555cb024f4b475911d42bb160fb521c8"
 		},
 		{
 			"ImportPath": "k8s.io/utils/clock",

--- a/cluster-autoscaler/_override/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
+++ b/cluster-autoscaler/_override/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
@@ -76,7 +76,6 @@ func (client ManagedClustersClient) CreateOrUpdate(ctx context.Context, resource
 					{Target: "parameters.ManagedClusterProperties.AadProfile", Name: validation.Null, Rule: false,
 						Chain: []validation.Constraint{{Target: "parameters.ManagedClusterProperties.AadProfile.ClientAppID", Name: validation.Null, Rule: true, Chain: nil},
 							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppID", Name: validation.Null, Rule: true, Chain: nil},
-							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppSecret", Name: validation.Null, Rule: true, Chain: nil},
 						}},
 				}}}}}); err != nil {
 		return result, validation.NewError("containerservice.ManagedClustersClient", "CreateOrUpdate", err.Error())
@@ -607,5 +606,79 @@ func (client ManagedClustersClient) listByResourceGroupNextResults(lastResults M
 // ListByResourceGroupComplete enumerates all values, automatically crossing page boundaries as required.
 func (client ManagedClustersClient) ListByResourceGroupComplete(ctx context.Context, resourceGroupName string) (result ManagedClusterListResultIterator, err error) {
 	result.page, err = client.ListByResourceGroup(ctx, resourceGroupName)
+	return
+}
+
+// UpdateTags updates a managed cluster with the specified tags.
+// Parameters:
+// resourceGroupName - the name of the resource group.
+// resourceName - the name of the managed cluster resource.
+// parameters - parameters supplied to the Update Managed Cluster Tags operation.
+func (client ManagedClustersClient) UpdateTags(ctx context.Context, resourceGroupName string, resourceName string, parameters TagsObject) (result ManagedClustersUpdateTagsFuture, err error) {
+	req, err := client.UpdateTagsPreparer(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersClient", "UpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.UpdateTagsSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersClient", "UpdateTags", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateTagsPreparer prepares the UpdateTags request.
+func (client ManagedClustersClient) UpdateTagsPreparer(ctx context.Context, resourceGroupName string, resourceName string, parameters TagsObject) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2018-03-31"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// UpdateTagsSender sends the UpdateTags request. The method will close the
+// http.Response Body if it receives an error.
+func (client ManagedClustersClient) UpdateTagsSender(req *http.Request) (future ManagedClustersUpdateTagsFuture, err error) {
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// UpdateTagsResponder handles the response to the UpdateTags request. The method always
+// closes the http.Response Body.
+func (client ManagedClustersClient) UpdateTagsResponder(resp *http.Response) (result ManagedCluster, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
 	return
 }

--- a/cluster-autoscaler/_override/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/models.go
+++ b/cluster-autoscaler/_override/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/models.go
@@ -1301,6 +1301,35 @@ func (future *ManagedClustersDeleteFuture) Result(client ManagedClustersClient) 
 	return
 }
 
+// ManagedClustersUpdateTagsFuture an abstraction for monitoring and retrieving the results of a long-running
+// operation.
+type ManagedClustersUpdateTagsFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *ManagedClustersUpdateTagsFuture) Result(client ManagedClustersClient) (mc ManagedCluster, err error) {
+	var done bool
+	done, err = future.Done(client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersUpdateTagsFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("containerservice.ManagedClustersUpdateTagsFuture")
+		return
+	}
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if mc.Response.Response, err = future.GetResult(sender); err == nil && mc.Response.Response.StatusCode != http.StatusNoContent {
+		mc, err = client.UpdateTagsResponder(mc.Response.Response)
+		if err != nil {
+			err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersUpdateTagsFuture", "Result", mc.Response.Response, "Failure responding to request")
+		}
+	}
+	return
+}
+
 // ManagedClusterUpgradeProfile the list of available upgrades for compute pools.
 type ManagedClusterUpgradeProfile struct {
 	autorest.Response `json:"-"`
@@ -1707,6 +1736,21 @@ type SSHConfiguration struct {
 type SSHPublicKey struct {
 	// KeyData - Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.
 	KeyData *string `json:"keyData,omitempty"`
+}
+
+// TagsObject tags object for patch operations.
+type TagsObject struct {
+	// Tags - Resource tags.
+	Tags map[string]*string `json:"tags"`
+}
+
+// MarshalJSON is the custom marshaler for TagsObject.
+func (toVar TagsObject) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if toVar.Tags != nil {
+		objectMap["tags"] = toVar.Tags
+	}
+	return json.Marshal(objectMap)
 }
 
 // VMDiagnostics profile for diagnostics on the container service VMs.

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -210,7 +210,7 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 	_, err = as.manager.azClient.deploymentsClient.CreateOrUpdate(ctx, as.manager.config.ResourceGroup, newDeploymentName, newDeployment)
-	glog.V(3).Infof("Waiting for deploymentsClient.CreateOrUpdate(%s, %s, %s)", as.manager.config.ResourceGroup, newDeploymentName, newDeployment)
+	glog.V(3).Infof("Waiting for deploymentsClient.CreateOrUpdate(%s, %s)", as.manager.config.ResourceGroup, newDeploymentName)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -119,9 +119,9 @@ func (az *azVirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGrou
 }
 
 func (az *azVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error) {
-	glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q,%q): start", resourceGroupName)
+	glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q): start", resourceGroupName)
 	defer func() {
-		glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q,%q): end", resourceGroupName)
+		glog.V(10).Infof("azVirtualMachineScaleSetsClient.List(%q): end", resourceGroupName)
 	}()
 
 	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
@@ -142,9 +142,9 @@ func (az *azVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGro
 }
 
 func (az *azVirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error) {
-	glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%q): start", resourceGroupName, vmScaleSetName, vmInstanceIDs)
+	glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%v): start", resourceGroupName, vmScaleSetName, vmInstanceIDs)
 	defer func() {
-		glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%q): end", resourceGroupName, vmScaleSetName, vmInstanceIDs)
+		glog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstances(%q,%q,%v): end", resourceGroupName, vmScaleSetName, vmInstanceIDs)
 	}()
 
 	future, err := az.client.DeleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)

--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -122,7 +122,7 @@ func (agentPool *ContainerServiceAgentPool) getAKSNodeCount() (count int, err er
 		agentPool.resourceGroup,
 		agentPool.clusterName)
 	if err != nil {
-		glog.Error("Failed to get AKS cluster (name:%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to get AKS cluster (name:%q): %v", agentPool.clusterName, err)
 		return -1, err
 	}
 
@@ -147,7 +147,7 @@ func (agentPool *ContainerServiceAgentPool) getACSNodeCount() (count int, err er
 		agentPool.resourceGroup,
 		agentPool.clusterName)
 	if err != nil {
-		glog.Error("Failed to get ACS cluster (name:%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to get ACS cluster (name:%q): %v", agentPool.clusterName, err)
 		return -1, err
 	}
 
@@ -172,7 +172,7 @@ func (agentPool *ContainerServiceAgentPool) setAKSNodeCount(count int) error {
 		agentPool.resourceGroup,
 		agentPool.clusterName)
 	if err != nil {
-		glog.Error("Failed to get AKS cluster (name:%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to get AKS cluster (name:%q): %v", agentPool.clusterName, err)
 		return err
 	}
 
@@ -190,7 +190,7 @@ func (agentPool *ContainerServiceAgentPool) setAKSNodeCount(count int) error {
 	future, err := aksClient.CreateOrUpdate(updateCtx, agentPool.resourceGroup,
 		agentPool.clusterName, managedCluster)
 	if err != nil {
-		glog.Error("Failed to update AKS cluster (%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to update AKS cluster (%q): %v", agentPool.clusterName, err)
 		return err
 	}
 	return future.WaitForCompletion(updateCtx, aksClient.Client)
@@ -205,7 +205,7 @@ func (agentPool *ContainerServiceAgentPool) setACSNodeCount(count int) error {
 		agentPool.resourceGroup,
 		agentPool.clusterName)
 	if err != nil {
-		glog.Error("Failed to get ACS cluster (name:%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to get ACS cluster (name:%q): %v", agentPool.clusterName, err)
 		return err
 	}
 
@@ -223,7 +223,7 @@ func (agentPool *ContainerServiceAgentPool) setACSNodeCount(count int) error {
 	future, err := acsClient.CreateOrUpdate(updateCtx, agentPool.resourceGroup,
 		agentPool.clusterName, acsCluster)
 	if err != nil {
-		glog.Error("Failed to update ACS cluster (%q): %v", agentPool.clusterName, err)
+		glog.Errorf("Failed to update ACS cluster (%q): %v", agentPool.clusterName, err)
 		return err
 	}
 	return future.WaitForCompletion(updateCtx, acsClient.Client)
@@ -297,7 +297,7 @@ func (agentPool *ContainerServiceAgentPool) TargetSize() (int, error) {
 //a delete is performed from a scale down.
 func (agentPool *ContainerServiceAgentPool) SetSize(targetSize int) error {
 	if targetSize > agentPool.MaxSize() || targetSize < agentPool.MinSize() {
-		glog.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MaxSize)
+		glog.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MinSize())
 		return fmt.Errorf("Target size %d requested outside Max: %d, Min: %d", targetSize, agentPool.MaxSize(), agentPool.MinSize())
 	}
 

--- a/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
+++ b/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/managedclusters.go
@@ -76,7 +76,6 @@ func (client ManagedClustersClient) CreateOrUpdate(ctx context.Context, resource
 					{Target: "parameters.ManagedClusterProperties.AadProfile", Name: validation.Null, Rule: false,
 						Chain: []validation.Constraint{{Target: "parameters.ManagedClusterProperties.AadProfile.ClientAppID", Name: validation.Null, Rule: true, Chain: nil},
 							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppID", Name: validation.Null, Rule: true, Chain: nil},
-							{Target: "parameters.ManagedClusterProperties.AadProfile.ServerAppSecret", Name: validation.Null, Rule: true, Chain: nil},
 						}},
 				}}}}}); err != nil {
 		return result, validation.NewError("containerservice.ManagedClustersClient", "CreateOrUpdate", err.Error())
@@ -607,5 +606,79 @@ func (client ManagedClustersClient) listByResourceGroupNextResults(lastResults M
 // ListByResourceGroupComplete enumerates all values, automatically crossing page boundaries as required.
 func (client ManagedClustersClient) ListByResourceGroupComplete(ctx context.Context, resourceGroupName string) (result ManagedClusterListResultIterator, err error) {
 	result.page, err = client.ListByResourceGroup(ctx, resourceGroupName)
+	return
+}
+
+// UpdateTags updates a managed cluster with the specified tags.
+// Parameters:
+// resourceGroupName - the name of the resource group.
+// resourceName - the name of the managed cluster resource.
+// parameters - parameters supplied to the Update Managed Cluster Tags operation.
+func (client ManagedClustersClient) UpdateTags(ctx context.Context, resourceGroupName string, resourceName string, parameters TagsObject) (result ManagedClustersUpdateTagsFuture, err error) {
+	req, err := client.UpdateTagsPreparer(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersClient", "UpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.UpdateTagsSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersClient", "UpdateTags", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateTagsPreparer prepares the UpdateTags request.
+func (client ManagedClustersClient) UpdateTagsPreparer(ctx context.Context, resourceGroupName string, resourceName string, parameters TagsObject) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2018-03-31"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// UpdateTagsSender sends the UpdateTags request. The method will close the
+// http.Response Body if it receives an error.
+func (client ManagedClustersClient) UpdateTagsSender(req *http.Request) (future ManagedClustersUpdateTagsFuture, err error) {
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// UpdateTagsResponder handles the response to the UpdateTags request. The method always
+// closes the http.Response Body.
+func (client ManagedClustersClient) UpdateTagsResponder(resp *http.Response) (result ManagedCluster, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
 	return
 }

--- a/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/models.go
+++ b/cluster-autoscaler/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice/models.go
@@ -1301,6 +1301,35 @@ func (future *ManagedClustersDeleteFuture) Result(client ManagedClustersClient) 
 	return
 }
 
+// ManagedClustersUpdateTagsFuture an abstraction for monitoring and retrieving the results of a long-running
+// operation.
+type ManagedClustersUpdateTagsFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *ManagedClustersUpdateTagsFuture) Result(client ManagedClustersClient) (mc ManagedCluster, err error) {
+	var done bool
+	done, err = future.Done(client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersUpdateTagsFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("containerservice.ManagedClustersUpdateTagsFuture")
+		return
+	}
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if mc.Response.Response, err = future.GetResult(sender); err == nil && mc.Response.Response.StatusCode != http.StatusNoContent {
+		mc, err = client.UpdateTagsResponder(mc.Response.Response)
+		if err != nil {
+			err = autorest.NewErrorWithError(err, "containerservice.ManagedClustersUpdateTagsFuture", "Result", mc.Response.Response, "Failure responding to request")
+		}
+	}
+	return
+}
+
 // ManagedClusterUpgradeProfile the list of available upgrades for compute pools.
 type ManagedClusterUpgradeProfile struct {
 	autorest.Response `json:"-"`
@@ -1707,6 +1736,21 @@ type SSHConfiguration struct {
 type SSHPublicKey struct {
 	// KeyData - Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.
 	KeyData *string `json:"keyData,omitempty"`
+}
+
+// TagsObject tags object for patch operations.
+type TagsObject struct {
+	// Tags - Resource tags.
+	Tags map[string]*string `json:"tags"`
+}
+
+// MarshalJSON is the custom marshaler for TagsObject.
+func (toVar TagsObject) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if toVar.Tags != nil {
+		objectMap["tags"] = toVar.Tags
+	}
+	return json.Marshal(objectMap)
 }
 
 // VMDiagnostics profile for diagnostics on the container service VMs.


### PR DESCRIPTION
Without this change, CA would report following errors when using on AKS clusters:

```
containerservice.Managed
ClustersClient#CreateOrUpdate: Invalid input: autorest/validation: validation failed: parameter=parameters.ManagedCluste
rProperties.AadProfile.ServerAppSecret constraint=Null value=(*string)(nil) details: value can not be null; required parameter`
```

Fixes #1369 #1105 #1304
