### PR TITLE
Don't load CA key.

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/certs.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs.go
@@ -24,7 +24,7 @@ import (
 )
 
 type certsContainer struct {
-	caKey, caCert, serverKey, serverCert []byte
+	caCert, serverKey, serverCert []byte
 }
 
 func readFile(filePath string) []byte {
@@ -45,7 +45,6 @@ func readFile(filePath string) []byte {
 
 func initCerts(certsDir string) certsContainer {
 	res := certsContainer{}
-	res.caKey = readFile(path.Join(certsDir, "caKey.pem"))
 	res.caCert = readFile(path.Join(certsDir, "caCert.pem"))
 	res.serverKey = readFile(path.Join(certsDir, "serverKey.pem"))
 	res.serverCert = readFile(path.Join(certsDir, "serverCert.pem"))


### PR DESCRIPTION
We don't use it for anything.

Cherrypick 057743565cf88bfe58af2d4f284cf81a789c49f1 tovpa-release-0.3 branch