### PR TITLE
Ignore starting nodes in node group health

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -323,7 +323,7 @@ func (csr *ClusterStateRegistry) IsNodeGroupHealthy(nodeGroupName string) bool {
 	unjustifiedUnready := 0
 	// Too few nodes, something is missing. Below the expected node count.
 	if readiness.Ready < acceptable.MinNodes {
-		unjustifiedUnready += acceptable.MinNodes - readiness.Ready
+		unjustifiedUnready += acceptable.MinNodes - readiness.Ready - readiness.NotStarted
 	}
 	// TODO: verify against max nodes as well.
 


### PR DESCRIPTION
When a user (or test) manually creates new nodes, or if Cluster Autoscaler restarts and loses track of scale-ups it requested, it may consider a node group unhealthy because of upcoming nodes. This is inconsistent with how cluster state is computed and with how scale-up expansion options are calculated, and most likely not what we want to do.