### PR TITLE
Fix some typos

### DIFF
--- a/cluster-autoscaler/processors/nodegroups/nodegroup_list_processor.go
+++ b/cluster-autoscaler/processors/nodegroups/nodegroup_list_processor.go
@@ -40,7 +40,7 @@ func NewDefaultNodeGroupListProcessor() NodeGroupListProcessor {
 	return &NoOpNodeGroupListProcessor{}
 }
 
-// Process processes lists of unschedulable and sheduled pods before scaling of the cluster.
+// Process processes lists of unschedulable and scheduled pods before scaling of the cluster.
 func (p *NoOpNodeGroupListProcessor) Process(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup, nodeInfos map[string]*schedulercache.NodeInfo,
 	unschedulablePods []*apiv1.Pod) ([]cloudprovider.NodeGroup, map[string]*schedulercache.NodeInfo, error) {
 	return nodeGroups, nodeInfos, nil

--- a/cluster-autoscaler/processors/pods/pod_list_processor.go
+++ b/cluster-autoscaler/processors/pods/pod_list_processor.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 )
 
-// PodListProcessor processes lists of unschedulable and sheduled pods before scaling of the cluster.
+// PodListProcessor processes lists of unschedulable and scheduled pods before scaling of the cluster.
 type PodListProcessor interface {
 	Process(context *context.AutoscalingContext, unschedulablePods []*apiv1.Pod, allScheduled []*apiv1.Pod, nodes []*apiv1.Node) ([]*apiv1.Pod, []*apiv1.Pod, error)
 	CleanUp()
@@ -36,7 +36,7 @@ func NewDefaultPodListProcessor() PodListProcessor {
 	return &NoOpPodListProcessor{}
 }
 
-// Process processes lists of unschedulable and sheduled pods before scaling of the cluster.
+// Process processes lists of unschedulable and scheduled pods before scaling of the cluster.
 func (p *NoOpPodListProcessor) Process(context *context.AutoscalingContext, unschedulablePods []*apiv1.Pod, allScheduled []*apiv1.Pod, nodes []*apiv1.Node) ([]*apiv1.Pod, []*apiv1.Pod, error) {
 	return unschedulablePods, allScheduled, nil
 }


### PR DESCRIPTION
Fix some typos: "sheduled" -> "scheduled" in nodegroup_list_processor.go and pod_list_processor.go.