### PR TITLE
Typo fixed: "Merics" -> "Metrics"

### DIFF
--- a/hack/scripts/ca_metrics_parser.py
+++ b/hack/scripts/ca_metrics_parser.py
@@ -73,7 +73,7 @@ def parse_metrics_file(metrics_file):
   '''
   Return interesting metrics for all Cluster Autoscaler functions.
 
-  Merics are stored in a map keyed by function name and are expressed in 
+  Metrics are stored in a map keyed by function name and are expressed in 
   seconds. They include
   * sum of all samples
   * count of sumples


### PR DESCRIPTION
Fixs typo in line 76.