### PR TITLE
Fix aws flaking Unit Tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -18,6 +18,9 @@ package aws
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -170,21 +173,21 @@ func TestFetchExplicitAsgs(t *testing.T) {
 	validateAsg(t, asgs[0].config, groupname, min, max)
 }
 
-/* Disabled due to flakiness. See https://github.com/kubernetes/autoscaler/issues/608
 func TestFetchAutoAsgs(t *testing.T) {
 	min, max := 1, 10
 	groupname, tags := "coolasg", []string{"tag", "anothertag"}
 
 	s := &AutoScalingMock{}
 	// Lookup groups associated with tags
-	s.On("DescribeTagsPages",
-		&autoscaling.DescribeTagsInput{
-			Filters: []*autoscaling.Filter{
-				{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[0]})},
-				{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[1]})},
-			},
-			MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
+	expectedTagsInput := &autoscaling.DescribeTagsInput{
+		Filters: []*autoscaling.Filter{
+			{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[0]})},
+			{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[1]})},
 		},
+		MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
+	}
+	// Use MatchedBy pattern to avoid list order issue https://github.com/kubernetes/autoscaler/issues/1346
+	s.On("DescribeTagsPages", mock.MatchedBy(tagsMatcher(expectedTagsInput)),
 		mock.AnythingOfType("func(*autoscaling.DescribeTagsOutput, bool) bool"),
 	).Run(func(args mock.Arguments) {
 		fn := args.Get(1).(func(*autoscaling.DescribeTagsOutput, bool) bool)
@@ -226,14 +229,7 @@ func TestFetchAutoAsgs(t *testing.T) {
 	validateAsg(t, asgs[0].config, groupname, min, max)
 
 	// Simulate the previously discovered ASG disappearing
-	s.On("DescribeTagsPages",
-		&autoscaling.DescribeTagsInput{
-			Filters: []*autoscaling.Filter{
-				{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[0]})},
-				{Name: aws.String("key"), Values: aws.StringSlice([]string{tags[1]})},
-			},
-			MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
-		},
+	s.On("DescribeTagsPages", mock.MatchedBy(tagsMatcher(expectedTagsInput)),
 		mock.AnythingOfType("func(*autoscaling.DescribeTagsOutput, bool) bool"),
 	).Run(func(args mock.Arguments) {
 		fn := args.Get(1).(func(*autoscaling.DescribeTagsOutput, bool) bool)
@@ -244,4 +240,22 @@ func TestFetchAutoAsgs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, m.asgCache.get())
 }
-*/
+
+func tagsMatcher(expected *autoscaling.DescribeTagsInput) func(*autoscaling.DescribeTagsInput) bool {
+	return func(actual *autoscaling.DescribeTagsInput) bool {
+		expectedTags := flatTagSlice(expected.Filters)
+		actualTags := flatTagSlice(actual.Filters)
+
+		return *expected.MaxRecords == *actual.MaxRecords && reflect.DeepEqual(expectedTags, actualTags)
+	}
+}
+
+func flatTagSlice(filters []*autoscaling.Filter) []string {
+	tags := []string{}
+	for _, filter := range filters {
+		tags = append(tags, aws.StringValueSlice(filter.Values)...)
+	}
+	// Sort slice for compare
+	sort.Strings(tags)
+	return tags
+}


### PR DESCRIPTION
Looks like  this Unit Test blocks several tasks. I notice someone comment this test and I think we can use `MatchedBy` to customize comparison logic.

This will resolve #1346 and other dependent issues for 1.2

~~I run hack/verify-gofmt.sh and found several files are not formatted and then run `gofmt -s -w ${filename}` Not sure if that's needed. if not, I will remove second commit~~
