### PR TITLE
Set AWS_REGION so tests don't wait for SDK timeout #1449

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -80,6 +80,13 @@ func getRegion(cfg ...*aws.Config) string {
 }
 
 // createAwsManagerInternal allows for a customer autoScalingWrapper to be passed in by tests
+//
+// #1449 If running tests outside of AWS without AWS_REGION among environment
+// variables, avoid a 5+ second EC2 Metadata lookup timeout in getRegion by
+// setting and resetting AWS_REGION before calling createAWSManagerInternal:
+//
+//	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
+//	os.Setenv("AWS_REGION", "fanghorn")
 func createAWSManagerInternal(
 	configReader io.Reader,
 	discoveryOpts cloudprovider.NodeGroupDiscoveryOptions,

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -33,16 +33,19 @@ import (
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
+// resetAWSRegion resets AWS_REGION environment variable key to its pre-test
+// value, but only if it was originally present among environment variables.
+func resetAWSRegion(value string, present bool) {
+	os.Unsetenv("AWS_REGION")
+	if present {
+		os.Setenv("AWS_REGION", value)
+	}
+}
+
 // TestGetRegion ensures correct source supplies AWS Region.
 func TestGetRegion(t *testing.T) {
 	key := "AWS_REGION"
-	originalRegion, originalPresent := os.LookupEnv(key)
-	defer func(region string, present bool) {
-		os.Unsetenv(key)
-		if present {
-			os.Setenv(key, region)
-		}
-	}(originalRegion, originalPresent)
+	defer resetAWSRegion(os.LookupEnv(key))
 	// Ensure environment variable retains precedence.
 	expected1 := "the-shire-1"
 	os.Setenv(key, expected1)
@@ -188,6 +191,9 @@ func TestFetchExplicitAsgs(t *testing.T) {
 			fmt.Sprintf("%d:%d:%s", min, max-1, groupname),
 		},
 	}
+	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
+	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
+	os.Setenv("AWS_REGION", "fanghorn")
 	// fetchExplicitASGs is called at manager creation time.
 	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s}, nil)
 	assert.NoError(t, err)
@@ -214,6 +220,9 @@ func TestBuildInstanceType(t *testing.T) {
 		},
 	})
 
+	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
+	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
+	os.Setenv("AWS_REGION", "fanghorn")
 	m, err := createAWSManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, nil, &ec2Wrapper{s})
 	assert.NoError(t, err)
 
@@ -276,6 +285,9 @@ func TestGetASGTemplate(t *testing.T) {
 				},
 			})
 
+			// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
+			defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
+			os.Setenv("AWS_REGION", "fanghorn")
 			m, err := createAWSManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, nil, &ec2Wrapper{s})
 			assert.NoError(t, err)
 
@@ -350,6 +362,9 @@ func TestFetchAutoAsgs(t *testing.T) {
 		NodeGroupAutoDiscoverySpecs: []string{fmt.Sprintf("asg:tag=%s", strings.Join(tags, ","))},
 	}
 
+	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
+	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
+	os.Setenv("AWS_REGION", "fanghorn")
 	// fetchAutoASGs is called at manager creation time, via forceRefresh
 	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s})
 	assert.NoError(t, err)


### PR DESCRIPTION
This patch sets and then resets the `AWS_REGION` environment variable in
tests that call `createAWSManagerInternal`, which calls `getRegion`.

`getRegion` introduced `AWS_REGION` lookup at runtime, but tests that
don't (a) run inside AWS or (b) set `AWS_REGION` environment variable
encountered AWS SDK's EC2 Metadata lookup timeout. Tests that indirectly
invoked `getRegion`, e.g., via `createAWSManagerInternal`, saw at least
a 5-second timeout per invocation, ballooning test times.