### PR TITLE
Add cache for resource IDs of vmss instances

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -22,17 +22,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
-	"k8s.io/klog"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	"k8s.io/klog"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 )
 
 // ScaleSet implements NodeGroup interface.
@@ -46,6 +46,8 @@ type ScaleSet struct {
 	mutex       sync.Mutex
 	lastRefresh time.Time
 	curSize     int64
+	// virtualMachines holds a list of vmss instances (instanceID -> resourceID).
+	virtualMachines map[string]string
 }
 
 // NewScaleSet creates a new NewScaleSet.
@@ -54,10 +56,11 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager) (*ScaleSet, erro
 		azureRef: azureRef{
 			Name: spec.Name,
 		},
-		minSize: spec.MinSize,
-		maxSize: spec.MaxSize,
-		manager: az,
-		curSize: -1,
+		minSize:         spec.MinSize,
+		maxSize:         spec.MaxSize,
+		manager:         az,
+		curSize:         -1,
+		virtualMachines: make(map[string]string),
 	}
 
 	return scaleSet, nil
@@ -188,8 +191,7 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // Note that the list results is not used directly because their resource ID format
 // is not consistent with Get results.
 // TODO(feiskyer): use list results directly after the issue fixed in Azure VMSS API.
-func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, error) {
-	instanceIDs := make([]string, 0)
+func (scaleSet *ScaleSet) GetScaleSetVms() ([]string, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -200,15 +202,22 @@ func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, 
 		return nil, err
 	}
 
+	instanceIDs := make([]string, 0)
 	for _, vm := range result {
 		instanceIDs = append(instanceIDs, *vm.InstanceID)
 	}
 
-	allVMs := make([]compute.VirtualMachineScaleSetVM, 0)
+	allVMs := make([]string, 0)
 	for _, instanceID := range instanceIDs {
+		// Get from cache first.
+		if v, ok := scaleSet.virtualMachines[instanceID]; ok {
+			allVMs = append(allVMs, v)
+			continue
+		}
+
+		// Not in cache, get from Azure API.
 		getCtx, getCancel := getContextWithCancel()
 		defer getCancel()
-
 		vm, err := scaleSet.manager.azClient.virtualMachineScaleSetVMsClient.Get(getCtx, resourceGroup, scaleSet.Name, instanceID)
 		if err != nil {
 			exists, realErr := checkResourceExistsFromError(err)
@@ -223,7 +232,14 @@ func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, 
 			}
 		}
 
-		allVMs = append(allVMs, vm)
+		// The resource ID is empty string, which indicates the instance may be in deleting state.
+		if len(*vm.ID) == 0 {
+			continue
+		}
+
+		// Save into cache.
+		scaleSet.virtualMachines[instanceID] = *vm.ID
+		allVMs = append(allVMs, *vm.ID)
 	}
 
 	return allVMs, nil
@@ -447,6 +463,9 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*schedulercache.NodeInfo, error) {
 
 // Nodes returns a list of all nodes that belong to this node group.
 func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
+	scaleSet.mutex.Lock()
+	defer scaleSet.mutex.Unlock()
+
 	vms, err := scaleSet.GetScaleSetVms()
 	if err != nil {
 		return nil, err
@@ -454,10 +473,7 @@ func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 
 	instances := make([]cloudprovider.Instance, 0, len(vms))
 	for i := range vms {
-		if len(*vms[i].ID) == 0 {
-			continue
-		}
-		name := "azure://" + *vms[i].ID
+		name := "azure://" + vms[i]
 		instances = append(instances, cloudprovider.Instance{Id: name})
 	}
 


### PR DESCRIPTION
This PR adds caches for resource IDs of vmss instances. Those IDs won't change after creation, so it's safe for CA to keep them in memory.

Without this, cluster-autoscaler would be Throttled by Azure API: 

```json
"details": [
    {
      "code": "TooManyRequests",
      "message": "{\"operationGroup\":\"GetVMScaleSetVM30Min\",\"startTime\":\"2018-11-29T20:49:14.3565951+00:00\",\"endTime\":\"2018-11-29T21:04:14.3565951+00:00\",\"allowedRequestCount\":2500,\"measuredRequestCount\":2596}",
      "target": "GetVMScaleSetVM30Min"
    }
  ],
  "innererror": {
    "internalErrorCode": "TooManyRequestsReceived"
  },
  "code": "OperationNotAllowed",
  "message": "The server rejected the request because too many requests have been received for this subscription."
}
```

cc @kkmsft 