### PR TITLE
Remove namespace from hamster example.

### DIFF
--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -16,7 +16,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: hamster
-  namespace: default
 spec:
   replicas: 2
   template:
@@ -33,4 +32,3 @@ spec:
             memory: 50Mi
         command: ["/bin/sh"]
         args: ["-c", "while true; do timeout 0.5s yes >/dev/null; sleep 0.5s; done"]
-


### PR DESCRIPTION
Very minor change, but in order to ensure that the vpa ends up in the same namespace as the deployment, the default namespace needs to be removed here. This fixes any issues with the current context have a default namespace that is not named "default".