### PR TITLE
Doc: scheduler.alpha.kubernetes.io/critical-pod annotations are deprecated. Use priorityClassName instead.

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -122,8 +122,8 @@ default deployment strategy on GCP.
 It is possible to run a customized deployment of Cluster Autoscaler on worker nodes, but extra care needs
 to be taken to ensure that Cluster Autoscaler remains up and running. Users can put it into kube-system
 namespace (Cluster Autoscaler doesn't scale down node with non-mirrored kube-system pods running
-on them) and add `scheduler.alpha.kubernetes.io/critical-pod` annotation (so that the rescheduler,
-if enabled, will kill other pods to make space for it to run).
+on them) and set a `priorityClassName: system-cluster-critical` property on your pod spec
+(so that the rescheduler, if enabled, will kill other pods to make space for it to run).
 
 Supported cloud providers:
 * GCE https://kubernetes.io/docs/concepts/cluster-administration/cluster-management/

--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -123,7 +123,7 @@ It is possible to run a customized deployment of Cluster Autoscaler on worker no
 to be taken to ensure that Cluster Autoscaler remains up and running. Users can put it into kube-system
 namespace (Cluster Autoscaler doesn't scale down node with non-mirrored kube-system pods running
 on them) and set a `priorityClassName: system-cluster-critical` property on your pod spec
-(so that the rescheduler, if enabled, will kill other pods to make space for it to run).
+(to prevent your pod from being evicted).
 
 Supported cloud providers:
 * GCE https://kubernetes.io/docs/concepts/cluster-administration/cluster-management/

--- a/cluster-autoscaler/cloudprovider/alicloud/README.md
+++ b/cluster-autoscaler/cloudprovider/alicloud/README.md
@@ -86,9 +86,8 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: admin
       containers:
         - image: registry.cn-hangzhou.aliyuncs.com/acs/autoscaler:v1.3.1.2
@@ -153,9 +152,8 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: admin
       containers:
         - image: registry.cn-hangzhou.aliyuncs.com/acs/autoscaler:v1.3.1.2

--- a/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
@@ -129,9 +129,8 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: admin
       containers:
         - image: registry.cn-hangzhou.aliyuncs.com/acs/autoscaler:v1.3.1


### PR DESCRIPTION
Hi guys,

Thanks for this awesome work!
I noticed in the documentation the use of the `scheduler.alpha.kubernetes.io/critical-pod` annotation that has been deprecated as of version 1.13 and will be removed in 1.14.

So this PR changes the doc to use `priorityClassName: system-cluster-critical`.

Let me know  if I need to change some wording.

Thanks for your help,
Joseph