### PR TITLE
Less technical, more verbose PDB reference in FAQ

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -75,7 +75,7 @@ Cluster Autoscaler decreases the size of the cluster when some nodes are consist
 * Pods with restrictive PodDisruptionBudget.
 * Kube-system pods that:
   * are not run on the node by default, *
-  * don't have PDB or their PDB is too restrictive (since CA 0.6).
+  * don't have a [pod disruption budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work) set or their PDB is too restrictive (since CA 0.6).
 * Pods that are not backed by a controller object (so not created by deployment, replica set, job, stateful set etc). *
 * Pods with local storage. *
 * Pods that cannot be moved elsewhere due to various constraints (lack of resources, non-matching node selectors or affinity,


### PR DESCRIPTION
Since it is easy to get to the part referencing PDB through a link from "Troubleshooting" without reading the entire document, reference PDB by full name and link to an explanation of what it is in "What types of pods can prevent CA from removing a node?"