### PR TITLE
Add listers for more controllers

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -22,8 +22,8 @@ import (
 	"math"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
@@ -244,7 +244,7 @@ var (
 // false if it didn't and error if an error occurred. Assumes that all nodes in the cluster are
 // ready and in sync with instance groups.
 func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.AutoscalingProcessors, clusterStateRegistry *clusterstate.ClusterStateRegistry, unschedulablePods []*apiv1.Pod,
-	nodes []*apiv1.Node, daemonSets []*extensionsv1.DaemonSet) (*status.ScaleUpStatus, errors.AutoscalerError) {
+	nodes []*apiv1.Node, daemonSets []*appsv1.DaemonSet) (*status.ScaleUpStatus, errors.AutoscalerError) {
 	// From now on we only care about unschedulable pods that were marked after the newest
 	// node became available for the scheduler.
 	if len(unschedulablePods) == 0 {

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -33,8 +33,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	kube_record "k8s.io/client-go/tools/record"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -436,7 +436,7 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig) {
 
 	processors := ca_processors.TestProcessors()
 
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, extraPods, nodes, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, extraPods, nodes, []*appsv1.DaemonSet{})
 	processors.ScaleUpStatusProcessor.Process(&context, scaleUpStatus)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
@@ -533,7 +533,7 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 
 	processors := ca_processors.TestProcessors()
 
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*appsv1.DaemonSet{})
 	assert.NoError(t, err)
 	// A node is already coming - no need for scale up.
 	assert.False(t, scaleUpStatus.WasSuccessful())
@@ -588,7 +588,7 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	p4 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3, p4}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3, p4}, []*apiv1.Node{n1, n2}, []*appsv1.DaemonSet{})
 
 	assert.NoError(t, err)
 	// Two nodes needed but one node is already coming, so it should increase by one.
@@ -641,7 +641,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	processors := ca_processors.TestProcessors()
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1, n2}, []*appsv1.DaemonSet{})
 
 	assert.NoError(t, err)
 	// Node group is unhealthy.
@@ -685,7 +685,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	p3 := BuildTestPod("p-new", 500, 0)
 
 	processors := ca_processors.TestProcessors()
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p3}, []*apiv1.Node{n1}, []*appsv1.DaemonSet{})
 	processors.ScaleUpStatusProcessor.Process(&context, scaleUpStatus)
 
 	assert.NoError(t, err)
@@ -764,7 +764,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	}
 
 	processors := ca_processors.TestProcessors()
-	scaleUpStatus, typedErr := ScaleUp(&context, processors, clusterState, pods, nodes, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, typedErr := ScaleUp(&context, processors, clusterState, pods, nodes, []*appsv1.DaemonSet{})
 
 	assert.NoError(t, typedErr)
 	assert.True(t, scaleUpStatus.WasSuccessful())
@@ -818,7 +818,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	processors.NodeGroupListProcessor = &mockAutoprovisioningNodeGroupListProcessor{t}
 	processors.NodeGroupManager = &mockAutoprovisioningNodeGroupManager{t}
 
-	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*extensionsv1.DaemonSet{})
+	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p1}, []*apiv1.Node{}, []*appsv1.DaemonSet{})
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, "autoprovisioned-T1", getStringFromChan(createdGroups))

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -19,6 +19,8 @@ package core
 import (
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
@@ -28,15 +30,13 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
 
-	apiv1 "k8s.io/api/core/v1"
-
-	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/klog"
 )
 
@@ -289,7 +289,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		scaleUpStatus.Result = status.ScaleUpInCooldown
 		klog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
 	} else {
-		daemonsets, err := a.ListerRegistry.DaemonSetLister().List()
+		daemonsets, err := a.ListerRegistry.DaemonSetLister().List(labels.Everything())
 		if err != nil {
 			klog.Errorf("Failed to get daemonset list")
 			scaleUpStatus.Result = status.ScaleUpError

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -168,7 +168,8 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	}
 	context := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, provider)
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
-		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
+		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
+		nil, nil, nil, nil)
 	context.ListerRegistry = listerRegistry
 
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
@@ -347,7 +348,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	}
 	context := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, provider)
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
-		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
+		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
+		nil, nil, nil, nil)
 	context.ListerRegistry = listerRegistry
 
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
@@ -473,7 +475,8 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	}
 	context := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, provider)
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
-		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
+		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
+		nil, nil, nil, nil)
 	context.ListerRegistry = listerRegistry
 
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
@@ -605,7 +608,8 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	}
 	context := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, provider)
 	listerRegistry := kube_util.NewListerRegistry(allNodeListerMock, readyNodeListerMock, scheduledPodMock,
-		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock)
+		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
+		nil, nil, nil, nil)
 	context.ListerRegistry = listerRegistry
 
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{

--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -37,8 +37,8 @@ import (
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	scheduler_util "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	kube_client "k8s.io/client-go/kubernetes"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
@@ -219,7 +219,7 @@ func CheckPodsSchedulableOnNode(context *context.AutoscalingContext, pods []*api
 //
 // TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
 func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.CloudProvider, kubeClient kube_client.Interface,
-	daemonsets []*extensionsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) (map[string]*schedulercache.NodeInfo, errors.AutoscalerError) {
+	daemonsets []*appsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) (map[string]*schedulercache.NodeInfo, errors.AutoscalerError) {
 	result := make(map[string]*schedulercache.NodeInfo)
 
 	// processNode returns information whether the nodeTemplate was generated and if there was an error.
@@ -301,7 +301,7 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.Clou
 }
 
 // GetNodeInfoFromTemplate returns NodeInfo object built base on TemplateNodeInfo returned by NodeGroup.TemplateNodeInfo().
-func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*extensionsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) (*schedulercache.NodeInfo, errors.AutoscalerError) {
+func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*appsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) (*schedulercache.NodeInfo, errors.AutoscalerError) {
 	id := nodeGroup.Id()
 	baseNodeInfo, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {

--- a/cluster-autoscaler/core/utils_test.go
+++ b/cluster-autoscaler/core/utils_test.go
@@ -31,8 +31,8 @@ import (
 	scheduler_util "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -345,7 +345,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 	predicateChecker := simulator.NewTestPredicateChecker()
 
 	res, err := GetNodeInfosForGroups([]*apiv1.Node{n1, n2, n3, n4}, provider1, fakeClient,
-		[]*extensionsv1.DaemonSet{}, predicateChecker)
+		[]*appsv1.DaemonSet{}, predicateChecker)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(res))
 	_, found := res["n1"]
@@ -359,7 +359,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 
 	// Test for a nodegroup without nodes and TemplateNodeInfo not implemented by cloud proivder
 	res, err = GetNodeInfosForGroups([]*apiv1.Node{}, provider2, fakeClient,
-		[]*extensionsv1.DaemonSet{}, predicateChecker)
+		[]*appsv1.DaemonSet{}, predicateChecker)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(res))
 }

--- a/cluster-autoscaler/utils/daemonset/daemonset.go
+++ b/cluster-autoscaler/utils/daemonset/daemonset.go
@@ -22,13 +22,13 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
 // GetDaemonSetPodsForNode returns daemonset nodes for the given pod.
-func GetDaemonSetPodsForNode(nodeInfo *schedulercache.NodeInfo, daemonsets []*extensionsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) []*apiv1.Pod {
+func GetDaemonSetPodsForNode(nodeInfo *schedulercache.NodeInfo, daemonsets []*appsv1.DaemonSet, predicateChecker *simulator.PredicateChecker) []*apiv1.Pod {
 	result := make([]*apiv1.Pod, 0)
 	for _, ds := range daemonsets {
 		pod := newPod(ds, nodeInfo.Node().Name)
@@ -39,7 +39,7 @@ func GetDaemonSetPodsForNode(nodeInfo *schedulercache.NodeInfo, daemonsets []*ex
 	return result
 }
 
-func newPod(ds *extensionsv1.DaemonSet, nodeName string) *apiv1.Pod {
+func newPod(ds *appsv1.DaemonSet, nodeName string) *apiv1.Pod {
 	newPod := &apiv1.Pod{Spec: ds.Spec.Template.Spec, ObjectMeta: ds.Spec.Template.ObjectMeta}
 	newPod.Namespace = ds.Namespace
 	newPod.Name = fmt.Sprintf("%s-pod-%d", ds.Name, rand.Int63())

--- a/cluster-autoscaler/utils/daemonset/daemonset_test.go
+++ b/cluster-autoscaler/utils/daemonset/daemonset_test.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 
@@ -43,22 +43,22 @@ func TestGetDaemonSetPodsForNode(t *testing.T) {
 	ds2 := newDaemonSet("ds2")
 	ds2.Spec.Template.Spec.NodeSelector = map[string]string{"foo": "bar"}
 
-	pods := GetDaemonSetPodsForNode(nodeInfo, []*extensionsv1.DaemonSet{ds1, ds2}, predicateChecker)
+	pods := GetDaemonSetPodsForNode(nodeInfo, []*appsv1.DaemonSet{ds1, ds2}, predicateChecker)
 
 	assert.Equal(t, 1, len(pods))
 	assert.True(t, strings.HasPrefix(pods[0].Name, "ds1"))
-	assert.Equal(t, 1, len(GetDaemonSetPodsForNode(nodeInfo, []*extensionsv1.DaemonSet{ds1}, predicateChecker)))
-	assert.Equal(t, 0, len(GetDaemonSetPodsForNode(nodeInfo, []*extensionsv1.DaemonSet{ds2}, predicateChecker)))
-	assert.Equal(t, 0, len(GetDaemonSetPodsForNode(nodeInfo, []*extensionsv1.DaemonSet{}, predicateChecker)))
+	assert.Equal(t, 1, len(GetDaemonSetPodsForNode(nodeInfo, []*appsv1.DaemonSet{ds1}, predicateChecker)))
+	assert.Equal(t, 0, len(GetDaemonSetPodsForNode(nodeInfo, []*appsv1.DaemonSet{ds2}, predicateChecker)))
+	assert.Equal(t, 0, len(GetDaemonSetPodsForNode(nodeInfo, []*appsv1.DaemonSet{}, predicateChecker)))
 }
 
-func newDaemonSet(name string) *extensionsv1.DaemonSet {
-	return &extensionsv1.DaemonSet{
+func newDaemonSet(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
 		},
-		Spec: extensionsv1.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "simple-daemon", "type": "production"}},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	policyv1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,7 +29,6 @@ import (
 	v1appslister "k8s.io/client-go/listers/apps/v1"
 	v1batchlister "k8s.io/client-go/listers/batch/v1"
 	v1lister "k8s.io/client-go/listers/core/v1"
-	v1extensionslister "k8s.io/client-go/listers/extensions/v1beta1"
 	v1policylister "k8s.io/client-go/listers/policy/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	podv1 "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -43,7 +41,7 @@ type ListerRegistry interface {
 	ScheduledPodLister() PodLister
 	UnschedulablePodLister() PodLister
 	PodDisruptionBudgetLister() PodDisruptionBudgetLister
-	DaemonSetLister() DaemonSetLister
+	DaemonSetLister() v1appslister.DaemonSetLister
 	ReplicationControllerLister() v1lister.ReplicationControllerLister
 	JobLister() v1batchlister.JobLister
 	ReplicaSetLister() v1appslister.ReplicaSetLister
@@ -56,7 +54,7 @@ type listerRegistryImpl struct {
 	scheduledPodLister          PodLister
 	unschedulablePodLister      PodLister
 	podDisruptionBudgetLister   PodDisruptionBudgetLister
-	daemonSetLister             DaemonSetLister
+	daemonSetLister             v1appslister.DaemonSetLister
 	replicationControllerLister v1lister.ReplicationControllerLister
 	jobLister                   v1batchlister.JobLister
 	replicaSetLister            v1appslister.ReplicaSetLister
@@ -66,7 +64,7 @@ type listerRegistryImpl struct {
 // NewListerRegistry returns a registry providing various listers to list pods or nodes matching conditions
 func NewListerRegistry(allNode NodeLister, readyNode NodeLister, scheduledPod PodLister,
 	unschedulablePod PodLister, podDisruptionBudgetLister PodDisruptionBudgetLister,
-	daemonSetLister DaemonSetLister, replicationControllerLister v1lister.ReplicationControllerLister,
+	daemonSetLister v1appslister.DaemonSetLister, replicationControllerLister v1lister.ReplicationControllerLister,
 	jobLister v1batchlister.JobLister, replicaSetLister v1appslister.ReplicaSetLister,
 	statefulSetLister v1appslister.StatefulSetLister) ListerRegistry {
 	return listerRegistryImpl{
@@ -126,7 +124,7 @@ func (r listerRegistryImpl) PodDisruptionBudgetLister() PodDisruptionBudgetListe
 }
 
 // DaemonSetLister returns the daemonSetLister registered to this registry
-func (r listerRegistryImpl) DaemonSetLister() DaemonSetLister {
+func (r listerRegistryImpl) DaemonSetLister() v1appslister.DaemonSetLister {
 	return r.daemonSetLister
 }
 
@@ -313,31 +311,14 @@ func NewPodDisruptionBudgetLister(kubeClient client.Interface, stopchannel <-cha
 	}
 }
 
-// DaemonSetLister lists daemonsets.
-type DaemonSetLister interface {
-	List() ([]*extensionsv1.DaemonSet, error)
-}
-
-// DaemonSetListerImpl lists all daemonsets.
-type DaemonSetListerImpl struct {
-	daemonSetLister v1extensionslister.DaemonSetLister
-}
-
-// List returns all daemon sets
-func (lister *DaemonSetListerImpl) List() ([]*extensionsv1.DaemonSet, error) {
-	return lister.daemonSetLister.List(labels.Everything())
-}
-
 // NewDaemonSetLister builds a daemonset lister.
-func NewDaemonSetLister(kubeClient client.Interface, stopchannel <-chan struct{}) DaemonSetLister {
-	listWatcher := cache.NewListWatchFromClient(kubeClient.Extensions().RESTClient(), "daemonsets", apiv1.NamespaceAll, fields.Everything())
+func NewDaemonSetLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1appslister.DaemonSetLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.Apps().RESTClient(), "daemonsets", apiv1.NamespaceAll, fields.Everything())
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	lister := v1extensionslister.NewDaemonSetLister(store)
-	reflector := cache.NewReflector(listWatcher, &extensionsv1.DaemonSet{}, store, time.Hour)
+	lister := v1appslister.NewDaemonSetLister(store)
+	reflector := cache.NewReflector(listWatcher, &appsv1.DaemonSet{}, store, time.Hour)
 	go reflector.Run(stopchannel)
-	return &DaemonSetListerImpl{
-		daemonSetLister: lister,
-	}
+	return lister
 }
 
 // NewReplicationControllerLister builds a replicationcontroller lister.

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -19,12 +19,16 @@ package kubernetes
 import (
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	policyv1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	client "k8s.io/client-go/kubernetes"
+	v1appslister "k8s.io/client-go/listers/apps/v1"
+	v1batchlister "k8s.io/client-go/listers/batch/v1"
 	v1lister "k8s.io/client-go/listers/core/v1"
 	v1extensionslister "k8s.io/client-go/listers/extensions/v1beta1"
 	v1policylister "k8s.io/client-go/listers/policy/v1beta1"
@@ -40,28 +44,42 @@ type ListerRegistry interface {
 	UnschedulablePodLister() PodLister
 	PodDisruptionBudgetLister() PodDisruptionBudgetLister
 	DaemonSetLister() DaemonSetLister
+	ReplicationControllerLister() v1lister.ReplicationControllerLister
+	JobLister() v1batchlister.JobLister
+	ReplicaSetLister() v1appslister.ReplicaSetLister
+	StatefulSetLister() v1appslister.StatefulSetLister
 }
 
 type listerRegistryImpl struct {
-	allNodeLister             NodeLister
-	readyNodeLister           NodeLister
-	scheduledPodLister        PodLister
-	unschedulablePodLister    PodLister
-	podDisruptionBudgetLister PodDisruptionBudgetLister
-	daemonSetLister           DaemonSetLister
+	allNodeLister               NodeLister
+	readyNodeLister             NodeLister
+	scheduledPodLister          PodLister
+	unschedulablePodLister      PodLister
+	podDisruptionBudgetLister   PodDisruptionBudgetLister
+	daemonSetLister             DaemonSetLister
+	replicationControllerLister v1lister.ReplicationControllerLister
+	jobLister                   v1batchlister.JobLister
+	replicaSetLister            v1appslister.ReplicaSetLister
+	statefulSetLister           v1appslister.StatefulSetLister
 }
 
 // NewListerRegistry returns a registry providing various listers to list pods or nodes matching conditions
 func NewListerRegistry(allNode NodeLister, readyNode NodeLister, scheduledPod PodLister,
 	unschedulablePod PodLister, podDisruptionBudgetLister PodDisruptionBudgetLister,
-	daemonSetLister DaemonSetLister) ListerRegistry {
+	daemonSetLister DaemonSetLister, replicationControllerLister v1lister.ReplicationControllerLister,
+	jobLister v1batchlister.JobLister, replicaSetLister v1appslister.ReplicaSetLister,
+	statefulSetLister v1appslister.StatefulSetLister) ListerRegistry {
 	return listerRegistryImpl{
-		allNodeLister:             allNode,
-		readyNodeLister:           readyNode,
-		scheduledPodLister:        scheduledPod,
-		unschedulablePodLister:    unschedulablePod,
-		podDisruptionBudgetLister: podDisruptionBudgetLister,
-		daemonSetLister:           daemonSetLister,
+		allNodeLister:               allNode,
+		readyNodeLister:             readyNode,
+		scheduledPodLister:          scheduledPod,
+		unschedulablePodLister:      unschedulablePod,
+		podDisruptionBudgetLister:   podDisruptionBudgetLister,
+		daemonSetLister:             daemonSetLister,
+		replicationControllerLister: replicationControllerLister,
+		jobLister:                   jobLister,
+		replicaSetLister:            replicaSetLister,
+		statefulSetLister:           statefulSetLister,
 	}
 }
 
@@ -73,8 +91,13 @@ func NewListerRegistryWithDefaultListers(kubeClient client.Interface, stopChanne
 	allNodeLister := NewAllNodeLister(kubeClient, stopChannel)
 	podDisruptionBudgetLister := NewPodDisruptionBudgetLister(kubeClient, stopChannel)
 	daemonSetLister := NewDaemonSetLister(kubeClient, stopChannel)
+	replicationControllerLister := NewReplicationControllerLister(kubeClient, stopChannel)
+	jobLister := NewJobLister(kubeClient, stopChannel)
+	replicaSetLister := NewReplicaSetLister(kubeClient, stopChannel)
+	statefulSetLister := NewStatefulSetLister(kubeClient, stopChannel)
 	return NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodLister,
-		unschedulablePodLister, podDisruptionBudgetLister, daemonSetLister)
+		unschedulablePodLister, podDisruptionBudgetLister, daemonSetLister,
+		replicationControllerLister, jobLister, replicaSetLister, statefulSetLister)
 }
 
 // AllNodeLister returns the AllNodeLister registered to this registry
@@ -105,6 +128,26 @@ func (r listerRegistryImpl) PodDisruptionBudgetLister() PodDisruptionBudgetListe
 // DaemonSetLister returns the daemonSetLister registered to this registry
 func (r listerRegistryImpl) DaemonSetLister() DaemonSetLister {
 	return r.daemonSetLister
+}
+
+// ReplicationControllerLister returns the replicationControllerLister registered to this registry
+func (r listerRegistryImpl) ReplicationControllerLister() v1lister.ReplicationControllerLister {
+	return r.replicationControllerLister
+}
+
+// JobLister returns the jobLister registered to this registry
+func (r listerRegistryImpl) JobLister() v1batchlister.JobLister {
+	return r.jobLister
+}
+
+// ReplicaSetLister returns the replicaSetLister registered to this registry
+func (r listerRegistryImpl) ReplicaSetLister() v1appslister.ReplicaSetLister {
+	return r.replicaSetLister
+}
+
+// StatefulSetLister returns the statefulSetLister registered to this registry
+func (r listerRegistryImpl) StatefulSetLister() v1appslister.StatefulSetLister {
+	return r.statefulSetLister
 }
 
 // PodLister lists pods.
@@ -295,4 +338,44 @@ func NewDaemonSetLister(kubeClient client.Interface, stopchannel <-chan struct{}
 	return &DaemonSetListerImpl{
 		daemonSetLister: lister,
 	}
+}
+
+// NewReplicationControllerLister builds a replicationcontroller lister.
+func NewReplicationControllerLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1lister.ReplicationControllerLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "replicationcontrollers", apiv1.NamespaceAll, fields.Everything())
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	lister := v1lister.NewReplicationControllerLister(store)
+	reflector := cache.NewReflector(listWatcher, &apiv1.ReplicationController{}, store, time.Hour)
+	go reflector.Run(stopchannel)
+	return lister
+}
+
+// NewJobLister builds a job lister.
+func NewJobLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1batchlister.JobLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.Batch().RESTClient(), "jobs", apiv1.NamespaceAll, fields.Everything())
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	lister := v1batchlister.NewJobLister(store)
+	reflector := cache.NewReflector(listWatcher, &batchv1.Job{}, store, time.Hour)
+	go reflector.Run(stopchannel)
+	return lister
+}
+
+// NewReplicaSetLister builds a replicaset lister.
+func NewReplicaSetLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1appslister.ReplicaSetLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.Apps().RESTClient(), "replicasets", apiv1.NamespaceAll, fields.Everything())
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	lister := v1appslister.NewReplicaSetLister(store)
+	reflector := cache.NewReflector(listWatcher, &appsv1.ReplicaSet{}, store, time.Hour)
+	go reflector.Run(stopchannel)
+	return lister
+}
+
+// NewStatefulSetLister builds a statefulset lister.
+func NewStatefulSetLister(kubeClient client.Interface, stopchannel <-chan struct{}) v1appslister.StatefulSetLister {
+	listWatcher := cache.NewListWatchFromClient(kubeClient.Apps().RESTClient(), "statefulsets", apiv1.NamespaceAll, fields.Everything())
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	lister := v1appslister.NewStatefulSetLister(store)
+	reflector := cache.NewReflector(listWatcher, &appsv1.StatefulSet{}, store, time.Hour)
+	go reflector.Run(stopchannel)
+	return lister
 }


### PR DESCRIPTION
Currently we call the API many times per loop to get various controllers. Turns out it impacts CA performance quite a bit in large clusters (and it puts an extra load on API server). 

This is preparatory work for migrating those API calls to use watch cache instead.

I decided to use upstream listers directly, rather than wrap them in our own interface. Partly because we will actually need to replace Get() calls which the upstream lister already provides (and our interfaces don't), partly because all we did in our interface was forward the call to upstream interface anyway and using upstream interface feels more consistent with k8s ecosystem.
I've migrated existing daemonSetLister to use upstream interface as well to be consistent with other controllers (and migrated it to use apps/v1.DaemonSet instead of old extensions/v1beta1). I've left other listers as they were, because they actually have custom logic and we won't need Get calls for those. 