### PR TITLE
GCE CA: use public selfLink URL format.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
@@ -23,21 +23,54 @@ import (
 )
 
 func TestParseUrl(t *testing.T) {
+	// Valid 'www' URL for instanceGroups
 	proj, zone, name, err := parseGceUrl("https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.Nil(t, err)
 	assert.Equal(t, "mwielgus-proj", proj)
 	assert.Equal(t, "us-central1-b", zone)
 	assert.Equal(t, "kubernetes-minion-group", name)
 
+	// Valid 'www' URL for instances
+	proj, zone, name, err = parseGceUrl("https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instances/my-instance-1", "instances")
+	assert.Nil(t, err)
+	assert.Equal(t, "mwielgus-proj", proj)
+	assert.Equal(t, "us-central1-b", zone)
+	assert.Equal(t, "my-instance-1", name)
+
+	// Valid 'content' URL for instanceGroups
 	proj, zone, name, err = parseGceUrl("https://content.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.Nil(t, err)
 	assert.Equal(t, "mwielgus-proj", proj)
 	assert.Equal(t, "us-central1-b", zone)
 	assert.Equal(t, "kubernetes-minion-group", name)
 
-	proj, zone, name, err = parseGceUrl("www.onet.pl", "instanceGroups")
+	// Valid 'content' URL for instances
+	proj, zone, name, err = parseGceUrl("https://content.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-f/instances/my-instance-2", "instanceGroups")
+	assert.Nil(t, err)
+	assert.Equal(t, "mwielgus-proj", proj)
+	assert.Equal(t, "us-central1-f", zone)
+	assert.Equal(t, "my-instance-2", name)
+
+	// Don't validate subdomains; test that we accept anything ending in .googleapis.com
+	proj, zone, name, err = parseGceUrl("https://18adjadj391.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
+	assert.Nil(t, err)
+	assert.Equal(t, "mwielgus-proj", proj)
+	assert.Equal(t, "us-central1-b", zone)
+	assert.Equal(t, "kubernetes-minion-group", name)
+
+	// Invalid TLD
+	_, _, _, err = parseGceUrl("https://www.googleapis.net/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.NotNil(t, err)
 
-	proj, zone, name, err = parseGceUrl("https://content.googleapis.com/compute/vabc/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
+	// Empty 'expectedResource'
+	_, _, _, err = parseGceUrl("googleapis.net/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "")
+	assert.NotNil(t, err)
+
+	// Invalid domain & URL
+	_, _, _, err = parseGceUrl("www.onet.pl", "instanceGroups")
+	assert.NotNil(t, err)
+
+	// Validate the URL suffix
+	_, _, _, err = parseGceUrl("https://content.googleapis.com/compute/vabc/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.NotNil(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/gke_cloud_provider_test.go
@@ -304,7 +304,7 @@ func TestMig(t *testing.T) {
 	mig1 := reflect.ValueOf(nodeGroup).Interface().(*GkeMig)
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	mig1.exist = true
-	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1"))
+	assert.True(t, strings.HasPrefix(mig1.Id(), "https://www.googleapis.com/compute/v1/projects/project1/zones/us-central1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	assert.Equal(t, 0, mig1.MinSize())
 	assert.Equal(t, 1000, mig1.MaxSize())
@@ -474,7 +474,7 @@ func TestNewNodeGroupForGpu(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeGroup)
 	mig1 := reflect.ValueOf(nodeGroup).Interface().(*GkeMig)
-	assert.True(t, strings.HasPrefix(mig1.Id(), "https://content.googleapis.com/compute/v1/projects/project1/zones/us-west1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1-gpu"))
+	assert.True(t, strings.HasPrefix(mig1.Id(), "https://www.googleapis.com/compute/v1/projects/project1/zones/us-west1-b/instanceGroups/"+nodeAutoprovisioningPrefix+"-n1-standard-1-gpu"))
 	assert.Equal(t, true, mig1.Autoprovisioned())
 	assert.Equal(t, 0, mig1.MinSize())
 	assert.Equal(t, 1000, mig1.MaxSize())


### PR DESCRIPTION
- gcloud commands & APIs return "www.googleapis.com", not
"content.googleapis.com" as the selfLink. This documentation & error message
change makes this more obvious.
- Improve checks & tests around valid expectedResource names.

---

Example output that end-users see:

```
➜  gcloud compute instance-groups describe gke-your-first-cluster-1-pool-1-4f8729cc-grp --zone=us-central1-a
creationTimestamp: '2019-01-08T10:05:47.710-08:00'
description: "This instance group is controlled by Instance Group Manager 'gke-your-first-cluster-1-pool-1-4f8729cc-grp'.\
  \ To modify instances in this group, use the Instance Group Manager API: https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers"
fingerprint: 42WmSpB8rSM=
id: '5710522466650642580'
kind: compute#instanceGroup
name: gke-your-first-cluster-1-pool-1-4f8729cc-grp
network: https://www.googleapis.com/compute/v1/projects/silverlock-sandbox/global/networks/default
selfLink: https://www.googleapis.com/compute/v1/projects/silverlock-sandbox/zones/us-central1-a/instanceGroups/gke-your-first-cluster-1-pool-1-4f8729cc-grp
size: 1
subnetwork: https://www.googleapis.com/compute/v1/projects/silverlock-sandbox/regions/us-central1/subnetworks/default
zone: https://www.googleapis.com/compute/v1/projects/silverlock-sandbox/zones/us-central1-a
```