### PR TITLE
Replace the deprecated function calls of go-autorest

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -105,7 +105,7 @@ func (az *azVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, r
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 
@@ -152,7 +152,7 @@ func (az *azVirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, 
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 
@@ -242,7 +242,7 @@ func (az *azVirtualMachinesClient) Delete(ctx context.Context, resourceGroupName
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 
@@ -296,7 +296,7 @@ func (az *azInterfacesClient) Delete(ctx context.Context, resourceGroupName stri
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 
@@ -345,7 +345,7 @@ func (az *azDeploymentsClient) CreateOrUpdate(ctx context.Context, resourceGroup
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 
@@ -376,7 +376,7 @@ func (az *azDisksClient) Delete(ctx context.Context, resourceGroupName string, d
 		return future.Response(), err
 	}
 
-	err = future.WaitForCompletion(ctx, az.client.Client)
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_container_service_pool.go
@@ -193,7 +193,7 @@ func (agentPool *ContainerServiceAgentPool) setAKSNodeCount(count int) error {
 		klog.Errorf("Failed to update AKS cluster (%q): %v", agentPool.clusterName, err)
 		return err
 	}
-	return future.WaitForCompletion(updateCtx, aksClient.Client)
+	return future.WaitForCompletionRef(updateCtx, aksClient.Client)
 }
 
 // setACSNodeCount sets node count for ACS agent pool.
@@ -226,7 +226,7 @@ func (agentPool *ContainerServiceAgentPool) setACSNodeCount(count int) error {
 		klog.Errorf("Failed to update ACS cluster (%q): %v", agentPool.clusterName, err)
 		return err
 	}
-	return future.WaitForCompletion(updateCtx, acsClient.Client)
+	return future.WaitForCompletionRef(updateCtx, acsClient.Client)
 }
 
 //GetNodeCount returns the count of nodes from the managed agent pool profile


### PR DESCRIPTION
As per the Azure GO SDK docs `WaitForCompletion` is deprecated. This should be safe since `WaitForCompletion` calls `WaitForCompletionRef` anyway