### PR TITLE
Azure: update docs to ensure aks/aks-engine autoscaler users provide the resource group name correctly

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -156,7 +156,7 @@ Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-contai
 
 - ClientID: `<base64-encoded-client-id>`
 - ClientSecret: `<base64-encoded-client-secret>`
-- ResourceGroup: `<base64-encoded-resource-group>` (Note: Please use lower case)
+- ResourceGroup: `<base64-encoded-resource-group>` (Note: ResourceGroup is case-sensitive)
 - SubscriptionID: `<base64-encode-subscription-id>`
 - TenantID: `<base64-encoded-tenant-id>`
 - ClusterName: `<base64-encoded-clustername>`


### PR DESCRIPTION
Amending docs as per the thread in #884 . For Cluster-Autoscaler to work, we need to ensure that resource groups match by case when provided in the secret.