### PR TITLE
Move GPULabel and GPUTypes to cloud provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 .idea/
 *.iml
 
+# VSCode project files
+**/.vscode
+
 # Emacs save files
 *~
 \#*\#

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"os"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -27,12 +29,22 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
-	"os"
 )
 
 const (
 	// ProviderName  is the cloud provider name for alicloud
 	ProviderName = "alicloud"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "aliyun.accelerator/nvidia_name"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 type aliCloudProvider struct {
@@ -88,6 +100,16 @@ func (ali *aliCloudProvider) addAsg(asg *Asg) {
 
 func (ali *aliCloudProvider) Name() string {
 	return ProviderName
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (ali *aliCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (ali *aliCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 func (ali *aliCloudProvider) NodeGroups() []cloudprovider.NodeGroup {

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -35,6 +35,17 @@ import (
 const (
 	// ProviderName is the cloud provider name for AWS
 	ProviderName = "aws"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "k8s.amazonaws.com/accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // awsCloudProvider implements CloudProvider interface.
@@ -61,6 +72,16 @@ func (aws *awsCloudProvider) Cleanup() error {
 // Name returns name of the cloud provider.
 func (aws *awsCloudProvider) Name() string {
 	return ProviderName
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (aws *awsCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (aws *awsCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -32,6 +32,17 @@ import (
 const (
 	// ProviderName is the cloud provider name for Azure
 	ProviderName = "azure"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // AzureCloudProvider provides implementation of CloudProvider interface for Azure.
@@ -59,6 +70,16 @@ func (azure *AzureCloudProvider) Cleanup() error {
 // Name returns name of the cloud provider.
 func (azure *AzureCloudProvider) Name() string {
 	return "azure"
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (azure *AzureCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (azure *AzureCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -35,6 +35,17 @@ import (
 const (
 	// ProviderName is the cloud provider name for baiducloud
 	ProviderName = "baiducloud"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // baiducloudCloudProvider implements CloudProvider interface.
@@ -146,6 +157,16 @@ func (baiducloud *baiducloudCloudProvider) NodeGroups() []cloudprovider.NodeGrou
 		result = append(result, asg)
 	}
 	return result
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (baiducloud *baiducloudCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (baiducloud *baiducloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroupForNode returns the node group for the given node, nil if the node

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -56,6 +56,12 @@ type CloudProvider interface {
 	// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 	GetResourceLimiter() (*ResourceLimiter, error)
 
+	// GPULabel returns the label added to nodes with GPU resource.
+	GPULabel() string
+
+	// GetAvailableGPUTypes return all available GPU types cloud provider supports.
+	GetAvailableGPUTypes() map[string]struct{}
+
 	// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
 	Cleanup() error
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -34,6 +34,17 @@ import (
 const (
 	// ProviderNameGCE is the name of GCE cloud provider.
 	ProviderNameGCE = "gce"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // GceCloudProvider implements CloudProvider interface.
@@ -57,6 +68,16 @@ func (gce *GceCloudProvider) Cleanup() error {
 // Name returns name of the cloud provider.
 func (gce *GceCloudProvider) Name() string {
 	return ProviderNameGCE
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (gce *GceCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (gce *GceCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -43,6 +43,17 @@ import (
 const (
 	// ProviderName is the cloud provider name for kubemark
 	ProviderName = "kubemark"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // KubemarkCloudProvider implements CloudProvider interface for kubemark
@@ -81,6 +92,16 @@ func (kubemark *KubemarkCloudProvider) addNodeGroup(spec string) error {
 // Name returns name of the cloud provider.
 func (kubemark *KubemarkCloudProvider) Name() string {
 	return ProviderName
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (kubemark *KubemarkCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -32,6 +32,17 @@ import (
 const (
 	// ProviderName is the cloud provider name for kubemark
 	ProviderName = "kubemark"
+
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // KubemarkCloudProvider implements CloudProvider interface.
@@ -45,6 +56,16 @@ func BuildKubemarkCloudProvider(kubemarkController interface{}, specs []string, 
 
 // Name returns name of the cloud provider.
 func (kubemark *KubemarkCloudProvider) Name() string { return "" }
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (kubemark *KubemarkCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
+}
 
 // NodeGroups returns all node groups configured for this cloud provider.
 func (kubemark *KubemarkCloudProvider) NodeGroups() []cloudprovider.NodeGroup {

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -33,6 +33,16 @@ import (
 const (
 	// ProviderName is the cloud provider name for Magnum
 	ProviderName = "magnum"
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "cloud.google.com/gke-accelerator"
+)
+
+var (
+	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 )
 
 // magnumCloudProvider implements CloudProvider interface from cluster-autoscaler/cloudprovider module.
@@ -54,6 +64,16 @@ func buildMagnumCloudProvider(magnumManager magnumManager, resourceLimiter *clou
 // Name returns the name of the cloud provider.
 func (os *magnumCloudProvider) Name() string {
 	return ProviderName
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (os *magnumCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (os *magnumCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.

--- a/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
+++ b/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
@@ -41,6 +41,36 @@ func (_m *CloudProvider) Cleanup() error {
 	return r0
 }
 
+// GPULabel provides a mock function with given fields:
+func (_m *CloudProvider) GPULabel() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// GetAvailableGPUTypes provides a mock function with given fields:
+func (_m *CloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	ret := _m.Called()
+
+	var r0 map[string]struct{}
+	if rf, ok := ret.Get(0).(func() map[string]struct{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]struct{})
+		}
+	}
+
+	return r0
+}
+
 // GetAvailableMachineTypes provides a mock function with given fields:
 func (_m *CloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	ret := _m.Called()

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -51,6 +51,7 @@ type TestCloudProvider struct {
 	onNodeGroupDelete func(string) error
 	machineTypes      []string
 	machineTemplates  map[string]*schedulernodeinfo.NodeInfo
+	priceModel        cloudprovider.PricingModel
 	resourceLimiter   *cloudprovider.ResourceLimiter
 }
 
@@ -85,6 +86,20 @@ func NewTestAutoprovisioningCloudProvider(onScaleUp OnScaleUpFunc, onScaleDown O
 // Name returns name of the cloud provider.
 func (tcp *TestCloudProvider) Name() string {
 	return "TestCloudProvider"
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (tcp *TestCloudProvider) GPULabel() string {
+	return "TestGPULabel/accelerator"
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports
+func (tcp *TestCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return map[string]struct{}{
+		"nvidia-tesla-k80":  {},
+		"nvidia-tesla-p100": {},
+		"nvidia-tesla-v100": {},
+	}
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
@@ -126,7 +141,16 @@ func (tcp *TestCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (tcp *TestCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
-	return nil, cloudprovider.ErrNotImplemented
+	if tcp.priceModel == nil {
+		return nil, cloudprovider.ErrNotImplemented
+	}
+
+	return tcp.priceModel, nil
+}
+
+// SetPricingModel set given priceModel to test cloud provider
+func (tcp *TestCloudProvider) SetPricingModel(priceModel cloudprovider.PricingModel) {
+	tcp.priceModel = priceModel
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -67,7 +67,8 @@ func NewAutoscaler(opts AutoscalerOptions) (Autoscaler, errors.AutoscalerError) 
 		opts.AutoscalingOptions,
 		opts.PredicateChecker,
 		opts.AutoscalingKubeClients,
-		opts.Processors, opts.CloudProvider,
+		opts.Processors,
+		opts.CloudProvider,
 		opts.ExpanderStrategy,
 		opts.EstimatorBuilder,
 		opts.Backoff), nil

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -48,6 +48,7 @@ type scaleUpResourcesDelta map[string]int64
 const scaleUpLimitUnknown = math.MaxInt64
 
 func computeScaleUpResourcesLeftLimits(
+	cp cloudprovider.CloudProvider,
 	nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*schedulernodeinfo.NodeInfo,
 	nodesFromNotAutoscaledGroups []*apiv1.Node,
@@ -57,7 +58,7 @@ func computeScaleUpResourcesLeftLimits(
 	var totalGpus map[string]int64
 	var totalGpusErr error
 	if cloudprovider.ContainsGpuResources(resourceLimiter.GetResources()) {
-		totalGpus, totalGpusErr = calculateScaleUpGpusTotal(nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups)
+		totalGpus, totalGpusErr = calculateScaleUpGpusTotal(cp.GPULabel(), nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups)
 	}
 
 	resultScaleUpLimits := make(scaleUpResourcesLimits)
@@ -134,6 +135,7 @@ func calculateScaleUpCoresMemoryTotal(
 }
 
 func calculateScaleUpGpusTotal(
+	GPULabel string,
 	nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*schedulernodeinfo.NodeInfo,
 	nodesFromNotAutoscaledGroups []*apiv1.Node) (map[string]int64, errors.AutoscalerError) {
@@ -149,7 +151,7 @@ func calculateScaleUpGpusTotal(
 			return nil, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for: %s", nodeGroup.Id())
 		}
 		if currentSize > 0 {
-			gpuType, gpuCount, err := gpu.GetNodeTargetGpus(nodeInfo.Node(), nodeGroup)
+			gpuType, gpuCount, err := gpu.GetNodeTargetGpus(GPULabel, nodeInfo.Node(), nodeGroup)
 			if err != nil {
 				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node group %v:", nodeGroup.Id())
 			}
@@ -161,7 +163,7 @@ func calculateScaleUpGpusTotal(
 	}
 
 	for _, node := range nodesFromNotAutoscaledGroups {
-		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(node, nil)
+		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(GPULabel, node, nil)
 		if err != nil {
 			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node gpus count for node %v:", node.Name)
 		}
@@ -178,7 +180,7 @@ func computeBelowMax(total int64, max int64) int64 {
 	return 0
 }
 
-func computeScaleUpResourcesDelta(nodeInfo *schedulernodeinfo.NodeInfo, nodeGroup cloudprovider.NodeGroup, resourceLimiter *cloudprovider.ResourceLimiter) (scaleUpResourcesDelta, errors.AutoscalerError) {
+func computeScaleUpResourcesDelta(cp cloudprovider.CloudProvider, nodeInfo *schedulernodeinfo.NodeInfo, nodeGroup cloudprovider.NodeGroup, resourceLimiter *cloudprovider.ResourceLimiter) (scaleUpResourcesDelta, errors.AutoscalerError) {
 	resultScaleUpDelta := make(scaleUpResourcesDelta)
 
 	nodeCPU, nodeMemory := getNodeInfoCoresAndMemory(nodeInfo)
@@ -186,7 +188,7 @@ func computeScaleUpResourcesDelta(nodeInfo *schedulernodeinfo.NodeInfo, nodeGrou
 	resultScaleUpDelta[cloudprovider.ResourceNameMemory] = nodeMemory
 
 	if cloudprovider.ContainsGpuResources(resourceLimiter.GetResources()) {
-		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(nodeInfo.Node(), nodeGroup)
+		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(cp.GPULabel(), nodeInfo.Node(), nodeGroup)
 		if err != nil {
 			return scaleUpResourcesDelta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node group %v:", nodeGroup.Id())
 		}
@@ -270,6 +272,8 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 	}
 
 	nodeGroups := context.CloudProvider.NodeGroups()
+	gpuLabel := context.CloudProvider.GPULabel()
+	availableGPUTypes := context.CloudProvider.GetAvailableGPUTypes()
 
 	resourceLimiter, errCP := context.CloudProvider.GetResourceLimiter()
 	if errCP != nil {
@@ -278,7 +282,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			errCP)
 	}
 
-	scaleUpResourcesLeft, errLimits := computeScaleUpResourcesLeftLimits(nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups, resourceLimiter)
+	scaleUpResourcesLeft, errLimits := computeScaleUpResourcesLeftLimits(context.CloudProvider, nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups, resourceLimiter)
 	if errLimits != nil {
 		return &status.ScaleUpStatus{Result: status.ScaleUpError}, errLimits.AddPrefix("Could not compute total resources: ")
 	}
@@ -346,7 +350,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			continue
 		}
 
-		scaleUpResourcesDelta, err := computeScaleUpResourcesDelta(nodeInfo, nodeGroup, resourceLimiter)
+		scaleUpResourcesDelta, err := computeScaleUpResourcesDelta(context.CloudProvider, nodeInfo, nodeGroup, resourceLimiter)
 		if err != nil {
 			klog.Errorf("Skipping node group %s; error getting node group resources: %v", nodeGroup.Id(), err)
 			skippedNodeGroups[nodeGroup.Id()] = notReadyReason
@@ -487,7 +491,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		}
 
 		// apply upper limits for CPU and memory
-		newNodes, err = applyScaleUpResourcesLimits(newNodes, scaleUpResourcesLeft, nodeInfo, bestOption.NodeGroup, resourceLimiter)
+		newNodes, err = applyScaleUpResourcesLimits(context.CloudProvider, newNodes, scaleUpResourcesLeft, nodeInfo, bestOption.NodeGroup, resourceLimiter)
 		if err != nil {
 			return &status.ScaleUpStatus{Result: status.ScaleUpError}, err
 		}
@@ -527,7 +531,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		}
 		klog.V(1).Infof("Final scale-up plan: %v", scaleUpInfos)
 		for _, info := range scaleUpInfos {
-			typedErr := executeScaleUp(context, clusterStateRegistry, info, gpu.GetGpuTypeForMetrics(nodeInfo.Node(), nil), now)
+			typedErr := executeScaleUp(context, clusterStateRegistry, info, gpu.GetGpuTypeForMetrics(gpuLabel, availableGPUTypes, nodeInfo.Node(), nil), now)
 			if typedErr != nil {
 				return &status.ScaleUpStatus{Result: status.ScaleUpError}, typedErr
 			}
@@ -703,13 +707,14 @@ func executeScaleUp(context *context.AutoscalingContext, clusterStateRegistry *c
 }
 
 func applyScaleUpResourcesLimits(
+	cp cloudprovider.CloudProvider,
 	newNodes int,
 	scaleUpResourcesLeft scaleUpResourcesLimits,
 	nodeInfo *schedulernodeinfo.NodeInfo,
 	nodeGroup cloudprovider.NodeGroup,
 	resourceLimiter *cloudprovider.ResourceLimiter) (int, errors.AutoscalerError) {
 
-	delta, err := computeScaleUpResourcesDelta(nodeInfo, nodeGroup, resourceLimiter)
+	delta, err := computeScaleUpResourcesDelta(cp, nodeInfo, nodeGroup, resourceLimiter)
 	if err != nil {
 		return 0, err
 	}

--- a/cluster-autoscaler/expander/factory/expander_factory.go
+++ b/cluster-autoscaler/expander/factory/expander_factory.go
@@ -41,11 +41,10 @@ func ExpanderStrategyFromString(expanderFlag string, cloudProvider cloudprovider
 	case expander.LeastWasteExpanderName:
 		return waste.NewStrategy(), nil
 	case expander.PriceBasedExpanderName:
-		pricing, err := cloudProvider.Pricing()
-		if err != nil {
+		if _, err := cloudProvider.Pricing(); err != nil {
 			return nil, err
 		}
-		return price.NewStrategy(pricing,
+		return price.NewStrategy(cloudProvider,
 			price.NewSimplePreferredNodeProvider(autoscalingKubeClients.AllNodeLister()),
 			price.SimpleNodeUnfitness), nil
 	case expander.PriorityBasedExpanderName:

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -27,8 +27,6 @@ import (
 const (
 	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
 	ResourceNvidiaGPU = "nvidia.com/gpu"
-	// GPULabel is the label added to nodes with GPU resource on GKE.
-	GPULabel = "cloud.google.com/gke-accelerator"
 	// DefaultGPUType is the type of GPU used in NAP if the user
 	// don't specify what type of GPU his pod wants.
 	DefaultGPUType = "nvidia-tesla-k80"
@@ -49,21 +47,11 @@ const (
 	MetricsNoGPU = ""
 )
 
-var (
-	// knownGpuTypes lists all known GPU types, to be used in metrics; map for convenient access
-	// TODO(kgolab) obtain this from Cloud Provider
-	knownGpuTypes = map[string]struct{}{
-		"nvidia-tesla-k80":  {},
-		"nvidia-tesla-p100": {},
-		"nvidia-tesla-v100": {},
-	}
-)
-
 // FilterOutNodesWithUnreadyGpus removes nodes that should have GPU, but don't have it in allocatable
 // from ready nodes list and updates their status to unready on all nodes list.
 // This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
 // in GPU missing from their allocatable and capacity.
-func FilterOutNodesWithUnreadyGpus(allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+func FilterOutNodesWithUnreadyGpus(GPULabel string, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
@@ -95,7 +83,7 @@ func FilterOutNodesWithUnreadyGpus(allNodes, readyNodes []*apiv1.Node) ([]*apiv1
 // GetGpuTypeForMetrics returns name of the GPU used on the node or empty string if there's no GPU
 // if the GPU type is unknown, "generic" is returned
 // NOTE: current implementation is GKE/GCE-specific
-func GetGpuTypeForMetrics(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) string {
+func GetGpuTypeForMetrics(GPULabel string, availableGPUTypes map[string]struct{}, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) string {
 	// we use the GKE label if there is one
 	gpuType, labelFound := node.Labels[GPULabel]
 	capacity, capacityFound := node.Status.Capacity[ResourceNvidiaGPU]
@@ -112,7 +100,7 @@ func GetGpuTypeForMetrics(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) s
 
 	// GKE-specific label & capacity are present - consistent state
 	if capacityFound {
-		return validateGpuType(gpuType)
+		return validateGpuType(availableGPUTypes, gpuType)
 	}
 
 	// GKE-specific label present but no capacity (yet?) - check the node template
@@ -135,8 +123,8 @@ func GetGpuTypeForMetrics(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) s
 	return MetricsUnexpectedLabelGPU
 }
 
-func validateGpuType(gpu string) string {
-	if _, found := knownGpuTypes[gpu]; found {
+func validateGpuType(availableGPUTypes map[string]struct{}, gpu string) string {
+	if _, found := availableGPUTypes[gpu]; found {
 		return gpu
 	}
 	return MetricsUnknownGPU
@@ -162,7 +150,7 @@ func getUnreadyNodeCopy(node *apiv1.Node) *apiv1.Node {
 // NodeHasGpu returns true if a given node has GPU hardware.
 // The result will be true if there is hardware capability. It doesn't matter
 // if the drivers are installed and GPU is ready to use.
-func NodeHasGpu(node *apiv1.Node) bool {
+func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 	_, hasGpuLabel := node.Labels[GPULabel]
 	gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[ResourceNvidiaGPU]
 	return hasGpuLabel || (hasGpuAllocatable && !gpuAllocatable.IsZero())
@@ -183,7 +171,7 @@ func PodRequestsGpu(pod *apiv1.Pod) bool {
 
 // GetNodeTargetGpus returns the number of gpus on a given node. This includes gpus which are not yet
 // ready to use and visible in kubernetes.
-func GetNodeTargetGpus(node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuType string, gpuCount int64, error errors.AutoscalerError) {
+func GetNodeTargetGpus(GPULabel string, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuType string, gpuCount int64, error errors.AutoscalerError) {
 	gpuLabel, found := node.Labels[GPULabel]
 	if !found {
 		return "", 0, nil

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	GPULabel = "TestGPULabel/accelerator"
+)
+
 func TestFilterOutNodesWithUnreadyGpus(t *testing.T) {
 	start := time.Now()
 	later := start.Add(10 * time.Minute)
@@ -129,7 +133,7 @@ func TestFilterOutNodesWithUnreadyGpus(t *testing.T) {
 		nodeNoGpuUnready,
 	}
 
-	newAllNodes, newReadyNodes := FilterOutNodesWithUnreadyGpus(initialAllNodes, initialReadyNodes)
+	newAllNodes, newReadyNodes := FilterOutNodesWithUnreadyGpus(GPULabel, initialAllNodes, initialReadyNodes)
 
 	foundInReady := make(map[string]bool)
 	for _, node := range newReadyNodes {
@@ -167,7 +171,7 @@ func TestNodeHasGpu(t *testing.T) {
 	}
 	nodeGpuReady.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
 	nodeGpuReady.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
-	assert.True(t, NodeHasGpu(nodeGpuReady))
+	assert.True(t, NodeHasGpu(GPULabel, nodeGpuReady))
 
 	nodeGpuUnready := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -179,7 +183,7 @@ func TestNodeHasGpu(t *testing.T) {
 			Allocatable: apiv1.ResourceList{},
 		},
 	}
-	assert.True(t, NodeHasGpu(nodeGpuUnready))
+	assert.True(t, NodeHasGpu(GPULabel, nodeGpuUnready))
 
 	nodeNoGpu := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +195,7 @@ func TestNodeHasGpu(t *testing.T) {
 			Allocatable: apiv1.ResourceList{},
 		},
 	}
-	assert.False(t, NodeHasGpu(nodeNoGpu))
+	assert.False(t, NodeHasGpu(GPULabel, nodeNoGpu))
 }
 
 func TestPodRequestsGpu(t *testing.T) {


### PR DESCRIPTION
This PR is to address #1135 

1. Add GPULabel() and GetAvailableGPUTypes() in cloudprodiver interface 
2. Caller will pass GPULabel to methods in gpu.go which original relies on GPULabel
3. Pass cloud.CloudProvider to methods in scale_up.go and scale_down.go that don't use GPULabel directly. 

Please don't merge this PR until I confirm with all cloud provider owners and check if they're ok about labels and supported GPU types. 