### PR TITLE
Consider GPU utilization in scaling down

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -34,9 +34,12 @@ type GpuLimits struct {
 type AutoscalingOptions struct {
 	// MaxEmptyBulkDelete is a number of empty nodes that can be removed at the same time.
 	MaxEmptyBulkDelete int
-	// ScaleDownUtilizationThreshold sets threshold for nodes to be considered for scale down.
+	// ScaleDownUtilizationThreshold sets threshold for nodes to be considered for scale down if cpu or memory utilization is over threshold.
 	// Well-utilized nodes are not touched.
 	ScaleDownUtilizationThreshold float64
+	// ScaleDownGpuUtilizationThreshold sets threshold for gpu nodes to be considered for scale down if gpu utilization is over threshold.
+	// Well-utilized nodes are not touched.
+	ScaleDownGpuUtilizationThreshold float64
 	// ScaleDownUnneededTime sets the duration CA expects a node to be unneeded/eligible for removal
 	// before scaling down the node.
 	ScaleDownUnneededTime time.Duration

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -93,7 +93,10 @@ var (
 	scaleDownUnreadyTime = flag.Duration("scale-down-unready-time", 20*time.Minute,
 		"How long an unready node should be unneeded before it is eligible for scale down")
 	scaleDownUtilizationThreshold = flag.Float64("scale-down-utilization-threshold", 0.5,
-		"Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down")
+		"Sum of cpu or memory of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down")
+	scaleDownGpuUtilizationThreshold = flag.Float64("scale-down-gpu-utilization-threshold", 0.5,
+		"Sum of gpu requests of all pods running on the node divided by node's allocatable resource, below which a node can be considered for scale down."+
+			"Utilization calculation only cares about gpu resource for accelerator node. cpu and memory utilization will be ignored.")
 	scaleDownNonEmptyCandidatesCount = flag.Int("scale-down-non-empty-candidates-count", 30,
 		"Maximum number of non empty nodes considered in one iteration as candidates for scale down with drain."+
 			"Lower value means better CA responsiveness but possible slower scale down latency."+
@@ -210,6 +213,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownUnneededTime:               *scaleDownUnneededTime,
 		ScaleDownUnreadyTime:                *scaleDownUnreadyTime,
 		ScaleDownUtilizationThreshold:       *scaleDownUtilizationThreshold,
+		ScaleDownGpuUtilizationThreshold:    *scaleDownGpuUtilizationThreshold,
 		ScaleDownNonEmptyCandidatesCount:    *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:        *scaleDownCandidatesPoolRatio,
 		ScaleDownCandidatesPoolMinCount:     *scaleDownCandidatesPoolMinCount,

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -39,9 +39,10 @@ import (
 func BuildTestPod(name string, cpu int64, mem int64) *apiv1.Pod {
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      name,
-			SelfLink:  fmt.Sprintf("/api/v1/namespaces/default/pods/%s", name),
+			Namespace:   "default",
+			Name:        name,
+			SelfLink:    fmt.Sprintf("/api/v1/namespaces/default/pods/%s", name),
+			Annotations: map[string]string{},
 		},
 		Spec: apiv1.PodSpec{
 			Containers: []apiv1.Container{
@@ -128,7 +129,17 @@ func AddGpusToNode(node *apiv1.Node, gpusCount int64) {
 		})
 	node.Status.Capacity[resourceNvidiaGPU] = *resource.NewQuantity(gpusCount, resource.DecimalSI)
 	node.Status.Allocatable[resourceNvidiaGPU] = *resource.NewQuantity(gpusCount, resource.DecimalSI)
+	AddGpuLabelToNode(node)
+}
+
+// AddGpuLabelToNode adds GPULabel to give node. This is used to mock intermediate result that GPU on node is not ready
+func AddGpuLabelToNode(node *apiv1.Node) {
 	node.Labels[gpuLabel] = defaultGPUType
+}
+
+// GetGPULabel return GPULabel on the node. This is only used in unit tests.
+func GetGPULabel() string {
+	return gpuLabel
 }
 
 // SetNodeReadyState sets node ready state to either ConditionTrue or ConditionFalse.


### PR DESCRIPTION
Address #1367 

1. Consider GPU resource in utilization calculation. 
2. Add separate flag for GPU Utilization Threshold. 
3. Add UTs and also cover the case that annotate GPU pods to prevent eviction. (Training use case)