### PR TITLE
Tainting nodes - update first, refresh on conflict

### DIFF
--- a/cluster-autoscaler/utils/deletetaint/delete_test.go
+++ b/cluster-autoscaler/utils/deletetaint/delete_test.go
@@ -94,6 +94,7 @@ func TestQueryNodes(t *testing.T) {
 
 	val, err := GetToBeDeletedTime(updatedNode)
 	assert.NoError(t, err)
+	assert.NotNil(t, val)
 	assert.True(t, time.Now().Sub(*val) < 10*time.Second)
 }
 
@@ -109,6 +110,7 @@ func TestSoftQueryNodes(t *testing.T) {
 
 	val, err := GetDeletionCandidateTime(updatedNode)
 	assert.NoError(t, err)
+	assert.NotNil(t, val)
 	assert.True(t, time.Now().Sub(*val) < 10*time.Second)
 }
 


### PR DESCRIPTION
Depend on https://github.com/kubernetes/autoscaler/pull/1587