### PR TITLE
Some configurable parameters

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -41,6 +42,7 @@ var (
 		tlsPrivateKey: flag.String("tls-private-key", "/etc/tls-certs/serverKey.pem", "Path to server certificate key PEM file."),
 	}
 
+	port      = flag.Int("port", 8000, "The port to listen on.")
 	address   = flag.String("address", ":8944", "The address to expose Prometheus metrics.")
 	namespace = os.Getenv("NAMESPACE")
 )
@@ -72,7 +74,7 @@ func main() {
 	})
 	clientset := getClient()
 	server := &http.Server{
-		Addr:      ":8000",
+		Addr:      fmt.Sprintf(":%d", *port),
 		TLSConfig: configTLS(clientset, certs.serverCert, certs.serverKey),
 	}
 	go selfRegistration(clientset, certs.caCert, &namespace)

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -188,7 +188,7 @@ func (p *prometheusHistoryProvider) readLastLabels(res map[model.PodID]*PodHisto
 func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
 	res := make(map[model.PodID]*PodHistory)
 	podSelector := fmt.Sprintf("job=\"%s\", %s=~\".+\", %s!=\"POD\", %s!=\"\"",
-		p.config.CadvisorMetricsJobName, p.config.PodNameLabel,
+		p.config.CadvisorMetricsJobName, p.config.CtrPodNameLabel,
 		p.config.CtrNameLabel, p.config.CtrNameLabel)
 	err := p.readResourceHistory(res, fmt.Sprintf("container_cpu_usage_seconds_total{%s}[%s]", podSelector, p.config.HistoryLength), model.ResourceCPU)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
-// Prometheus history provider configuration, allow to select which metrics
+// PrometheusHistoryProviderConfig allow to select which metrics
 // should be queried to get real resource utilization.
 type PrometheusHistoryProviderConfig struct {
 	Address                                            string

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -60,8 +60,6 @@ type prometheusHistoryProvider struct {
 	config           PrometheusHistoryProviderConfig
 }
 
-var singletonHistoryProvider *prometheusHistoryProvider
-
 // NewPrometheusHistoryProvider contructs a history provider that gets data from Prometheus.
 func NewPrometheusHistoryProvider(config PrometheusHistoryProviderConfig) HistoryProvider {
 	return &prometheusHistoryProvider{

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -35,10 +35,20 @@ var (
 	checkpointsGCInterval  = flag.Duration("checkpoints-gc-interval", 10*time.Minute, `How often orphaned checkpoints should be garbage collected`)
 	prometheusAddress      = flag.String("prometheus-address", "", `Where to reach for Prometheus metrics`)
 	prometheusJobName      = flag.String("prometheus-cadvisor-job-name", "kubernetes-cadvisor", `Name of the prometheus job name which scrapes the cAdvisor metrics`)
-	storage                = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	address                = flag.String("address", ":8942", "The address to expose Prometheus metrics.")
 	kubeApiQps             = flag.Float64("kube-api-qps", 5.0, `QPS limit when making requests to Kubernetes apiserver`)
 	kubeApiBurst           = flag.Float64("kube-api-burst", 10.0, `QPS burst limit when making requests to Kubernetes apiserver`)
+
+	storage = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
+	// prometheus history provider configs
+	historyLength       = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
+	podLabelPrefix      = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
+	podLabelsMetricName = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
+	podNamespaceLabel   = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for container names`)
+	podNameLabel        = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for container names`)
+	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
+	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
+	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 )
 
 func main() {
@@ -56,7 +66,19 @@ func main() {
 	if useCheckpoints {
 		recommender.GetClusterStateFeeder().InitFromCheckpoints()
 	} else {
-		recommender.GetClusterStateFeeder().InitFromHistoryProvider(history.NewPrometheusHistoryProvider(*prometheusAddress, *prometheusJobName))
+		config := history.PrometheusHistoryProviderConfig{
+			Address:                *prometheusAddress,
+			HistoryLength:          *historyLength,
+			PodLabelPrefix:         *podLabelPrefix,
+			PodLabelsMetricName:    *podLabelsMetricName,
+			PodNamespaceLabel:      *podNamespaceLabel,
+			PodNameLabel:           *podNameLabel,
+			CtrNamespaceLabel:      *ctrNamespaceLabel,
+			CtrPodNameLabel:        *ctrPodNameLabel,
+			CtrNameLabel:           *ctrNameLabel,
+			CadvisorMetricsJobName: *prometheusJobName,
+		}
+		recommender.GetClusterStateFeeder().InitFromHistoryProvider(history.NewPrometheusHistoryProvider(config))
 	}
 
 	ticker := time.Tick(*metricsFetcherInterval)


### PR DESCRIPTION
To use VPA on AWS EKS I needed to change the port for the admission controller webhook, so I would propose to have a flag for it.

For the recommender to be able to get historical metrics from prometheus I need to tune the metrics and labels to query prometheus properly, so I would add a bunch of flags for that.

This PR is just to share the ideas.