### PR TITLE
Remove identity from Azure VMSS scale request as it is not allowed to be set

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -149,6 +149,7 @@ func (scaleSet *ScaleSet) SetScaleSetSize(size int64) error {
 	}
 
 	op.Sku.Capacity = &size
+	op.Identity = nil
 	op.VirtualMachineScaleSetProperties.ProvisioningState = nil
 	updateCtx, updateCancel := getContextWithCancel()
 	defer updateCancel()


### PR DESCRIPTION
Resolve #1592 by omitting the Identities property from the VirtualMachineScaleSet object when sending the scale request. If set, Azure will return 400 BadRequest.