### PR TITLE
CPVPA workstream: Create ScalingPolicy duck-type interface

### DIFF
--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/duck_types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/duck_types.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ScalingPolicy defines the common interface for scaling policies
+type ScalingPolicy interface {
+	GetNamespace() string
+	GetName() string
+	GetCreationTimestamp() meta.Time
+
+	GetSelector() *meta.LabelSelector
+
+	GetRecommendation() *RecommendedPodResources
+
+	// GetContainerResourcePolicy returns the ContainerResourcePolicy for a given policy
+	// and container name. It returns nil if there is no policy specified for the container.
+	GetContainerResourcePolicy(name string) *ContainerResourcePolicy
+}
+
+func (v *VerticalPodAutoscaler) GetSelector() *meta.LabelSelector {
+	return v.Spec.Selector
+}
+
+func (v *VerticalPodAutoscaler) GetRecommendation() *RecommendedPodResources {
+	return v.Status.Recommendation
+}
+
+func (v *VerticalPodAutoscaler) GetContainerResourcePolicy(containerName string) *ContainerResourcePolicy {
+	var defaultPolicy *ContainerResourcePolicy
+	if v != nil && v.Spec.ResourcePolicy != nil {
+		containerPolicies := v.Spec.ResourcePolicy.ContainerPolicies
+		for i := range containerPolicies {
+			if containerPolicies[i].ContainerName == containerName {
+				return &containerPolicies[i]
+			}
+			if containerPolicies[i].ContainerName == DefaultContainerResourcePolicy {
+				defaultPolicy = &containerPolicies[i]
+			}
+		}
+	}
+	return defaultPolicy
+}
+
+// GetContainerResourcePolicy returns the ContainerResourcePolicy for a given policy
+// and container name. It returns nil if there is no policy specified for the container.
+func GetContainerResourcePolicy(containerName string, policy ScalingPolicy) *ContainerResourcePolicy {
+	var defaultPolicy *ContainerResourcePolicy
+	if policy != nil {
+		return policy.GetContainerResourcePolicy(containerName)
+	}
+	return defaultPolicy
+}

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/duck_types_test.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/duck_types_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetContainerResourcePolicy(t *testing.T) {
+	containerPolicy1 := ContainerResourcePolicy{
+		ContainerName: "container1",
+		MinAllowed: core.ResourceList{
+			core.ResourceCPU: *resource.NewScaledQuantity(10, 1),
+		},
+	}
+	containerPolicy2 := ContainerResourcePolicy{
+		ContainerName: "container2",
+		MaxAllowed: core.ResourceList{
+			core.ResourceMemory: *resource.NewScaledQuantity(100, 1),
+		},
+	}
+	policy := VerticalPodAutoscaler{
+		Spec: VerticalPodAutoscalerSpec{
+			ResourcePolicy: &PodResourcePolicy{
+				ContainerPolicies: []ContainerResourcePolicy{
+					containerPolicy1, containerPolicy2,
+				},
+			},
+		},
+	}
+	assert.Equal(t, &containerPolicy1, GetContainerResourcePolicy("container1", &policy))
+	assert.Equal(t, &containerPolicy2, GetContainerResourcePolicy("container2", &policy))
+	assert.Nil(t, GetContainerResourcePolicy("container3", &policy))
+
+	// Add the wildcard ("*") policy.
+	defaultPolicy := ContainerResourcePolicy{
+		ContainerName: "*",
+		MinAllowed: core.ResourceList{
+			core.ResourceCPU: *resource.NewScaledQuantity(20, 1),
+		},
+	}
+	policy = VerticalPodAutoscaler{
+		Spec: VerticalPodAutoscalerSpec{
+			ResourcePolicy: &PodResourcePolicy{
+				ContainerPolicies: []ContainerResourcePolicy{
+					containerPolicy1, defaultPolicy, containerPolicy2,
+				},
+			},
+		},
+	}
+	assert.Equal(t, &containerPolicy1, GetContainerResourcePolicy("container1", &policy))
+	assert.Equal(t, &containerPolicy2, GetContainerResourcePolicy("container2", &policy))
+	assert.Equal(t, &defaultPolicy, GetContainerResourcePolicy("container3", &policy))
+}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -227,7 +227,7 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	}
 	vpa.Conditions = conditionsMap
 	vpa.Recommendation = currentRecommendation
-	vpa.ResourcePolicy = apiObject.Spec.ResourcePolicy
+	vpa.ScalingPolicy = apiObject.DeepCopy()
 	if apiObject.Spec.UpdatePolicy != nil {
 		vpa.UpdateMode = apiObject.Spec.UpdatePolicy.UpdateMode
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -80,8 +80,8 @@ type Vpa struct {
 	// All container aggregations that contribute to this VPA.
 	// TODO: Garbage collect old AggregateContainerStates.
 	aggregateContainerStates aggregateContainerStatesMap
-	// Pod Resource Policy provided in the VPA API object. Can be nil.
-	ResourcePolicy *vpa_types.PodResourcePolicy
+	// Scaling policy as defined by the VPA API object. Can be nil.
+	ScalingPolicy vpa_types.ScalingPolicy
 	// Initial checkpoints of AggregateContainerStates for containers.
 	// The key is container name.
 	ContainersInitialAggregateState ContainerNameToAggregateStateMap

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -98,7 +98,7 @@ func (r *recommender) UpdateVPAs() {
 		}
 		resources := r.podResourceRecommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
 		had := vpa.HasRecommendation()
-		vpa.Recommendation = getCappedRecommendation(vpa.ID, resources, observedVpa.Spec.ResourcePolicy)
+		vpa.Recommendation = getCappedRecommendation(vpa.ID, resources, observedVpa)
 		// Set RecommendationProvided if recommendation not empty.
 		if len(vpa.Recommendation.ContainerRecommendations) > 0 {
 			vpa.Conditions.Set(vpa_types.RecommendationProvided, true, "", "")
@@ -122,7 +122,7 @@ func (r *recommender) UpdateVPAs() {
 // and if necessary, capping the Target, LowerBound and UpperBound according
 // to the ResourcePolicy.
 func getCappedRecommendation(vpaID model.VpaID, resources logic.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+	policy vpa_types.ScalingPolicy) *vpa_types.RecommendedPodResources {
 	containerResources := make([]vpa_types.RecommendedContainerResources, 0, len(resources))
 	for containerName, res := range resources {
 		containerResources = append(containerResources, vpa_types.RecommendedContainerResources{

--- a/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
@@ -19,7 +19,6 @@ package routines
 import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	api_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 // GetContainerNameToAggregateStateMap returns ContainerNameToAggregateStateMap for pods.
@@ -28,7 +27,7 @@ func GetContainerNameToAggregateStateMap(vpa *model.Vpa) model.ContainerNameToAg
 	filteredContainerNameToAggregateStateMap := make(model.ContainerNameToAggregateStateMap)
 
 	for containerName, aggregatedContainerState := range containerNameToAggregateStateMap {
-		containerResourcePolicy := api_utils.GetContainerResourcePolicy(containerName, vpa.ResourcePolicy)
+		containerResourcePolicy := vpa_types.GetContainerResourcePolicy(containerName, vpa.ScalingPolicy)
 		autoscalingDisabled := containerResourcePolicy != nil && containerResourcePolicy.Mode != nil &&
 			*containerResourcePolicy.Mode == vpa_types.ContainerScalingModeOff
 		if !autoscalingDisabled && aggregatedContainerState.TotalSamplesCount > 0 {

--- a/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
@@ -25,7 +25,7 @@ import (
 type PodEvictionAdmission interface {
 	// LoopInit initializes PodEvictionAdmission for next Updater loop with the live pods and
 	// pods currently controlled by VPA in this cluster.
-	LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod)
+	LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[vpa_types.ScalingPolicy][]*apiv1.Pod)
 	// Admit returns true if PodEvictionAdmission decides that pod can be evicted with given recommendation.
 	Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool
 	// CleanUp cleans up any state that PodEvictionAdmission may keep. Called
@@ -47,7 +47,7 @@ type sequentialPodEvictionAdmission struct {
 	admissions []PodEvictionAdmission
 }
 
-func (a *sequentialPodEvictionAdmission) LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod) {
+func (a *sequentialPodEvictionAdmission) LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[vpa_types.ScalingPolicy][]*apiv1.Pod) {
 	for _, admission := range a.admissions {
 		admission.LoopInit(allLivePods, vpaControlledPods)
 	}
@@ -71,7 +71,7 @@ func (a *sequentialPodEvictionAdmission) CleanUp() {
 
 type noopPodEvictionAdmission struct{}
 
-func (n *noopPodEvictionAdmission) LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod) {
+func (n *noopPodEvictionAdmission) LoopInit(allLivePods []*apiv1.Pod, vpaControlledPods map[vpa_types.ScalingPolicy][]*apiv1.Pod) {
 }
 func (n *noopPodEvictionAdmission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return true

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 func TestSortPriority(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get()
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
@@ -55,7 +55,7 @@ func TestSortPriority(t *testing.T) {
 }
 
 func TestSortPriorityMultiResource(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "60M")).Get()
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.BuildTestContainer(containerName, "3", "90M")).Get()
@@ -98,7 +98,7 @@ func TestSortPriorityMultiContainers(t *testing.T) {
 	recommendation.ContainerRecommendations = append(recommendation.ContainerRecommendations, container2rec)
 
 	timestampNow := pod1.Status.StartTime.Time.Add(time.Hour * 24)
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 	calculator.AddPod(pod1, recommendation, timestampNow)
 	calculator.AddPod(pod2, recommendation, timestampNow)
 
@@ -114,7 +114,7 @@ func TestSortPriorityMultiContainers(t *testing.T) {
 }
 
 func TestSortPriorityResourcesDecrease(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.BuildTestContainer(containerName, "7", "")).Get()
@@ -136,7 +136,7 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 }
 
 func TestUpdateNotRequired(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
 
@@ -150,7 +150,7 @@ func TestUpdateNotRequired(t *testing.T) {
 }
 
 func TestUpdateRequiredOnMilliQuantities(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "10m", "")).Get()
 
@@ -170,7 +170,7 @@ func TestUseProcessor(t *testing.T) {
 	recommendationProcessor.On("Apply").Return(processedRecommendation, nil)
 
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, nil, recommendationProcessor)
+		nil, nil, recommendationProcessor)
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "10M")).Get()
 
@@ -188,7 +188,7 @@ func TestUseProcessor(t *testing.T) {
 // 2. diverging from the target by more than MinChangePriority.
 func TestUpdateLonglivedPods(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
+		nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
 
 	pods := []*apiv1.Pod{
 		test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
@@ -216,7 +216,7 @@ func TestUpdateLonglivedPods(t *testing.T) {
 // range for at least one container.
 func TestUpdateShortlivedPods(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
+		nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
 
 	pods := []*apiv1.Pod{
 		test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
@@ -241,7 +241,7 @@ func TestUpdateShortlivedPods(t *testing.T) {
 
 func TestUpdatePodWithQuickOOM(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
+		nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
 
 	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
 
@@ -273,7 +273,7 @@ func TestUpdatePodWithQuickOOM(t *testing.T) {
 
 func TestDontUpdatePodWithOOMAfterLongRun(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
+		nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
 
 	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
 
@@ -305,7 +305,7 @@ func TestDontUpdatePodWithOOMAfterLongRun(t *testing.T) {
 
 func TestDontUpdatePodWithOOMOnlyOnOneContainer(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
-		nil, nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
+		nil, &UpdateConfig{MinChangePriority: 0.5}, &test.FakeRecommendationProcessor{})
 
 	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
 
@@ -337,21 +337,21 @@ func TestDontUpdatePodWithOOMOnlyOnOneContainer(t *testing.T) {
 }
 
 func TestNoPods(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*apiv1.Pod{}, result)
 }
 
 type pod1Admission struct{}
 
-func (p *pod1Admission) LoopInit([]*apiv1.Pod, map[*vpa_types.VerticalPodAutoscaler][]*apiv1.Pod) {}
+func (p *pod1Admission) LoopInit([]*apiv1.Pod, map[vpa_types.ScalingPolicy][]*apiv1.Pod) {}
 func (p *pod1Admission) Admit(pod *apiv1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return pod.Name == "POD1"
 }
 func (p *pod1Admission) CleanUp() {}
 
 func TestAdmission(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get()
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
@@ -373,7 +373,7 @@ func TestAdmission(t *testing.T) {
 // Verify getUpdatePriorty does not encounter a NPE when there is no
 // recommendation for a container.
 func TestNoRecommendationForContainer(t *testing.T) {
-	calculator := NewUpdatePriorityCalculator(nil, nil, nil, &test.FakeRecommendationProcessor{})
+	calculator := NewUpdatePriorityCalculator(nil, nil, &test.FakeRecommendationProcessor{})
 	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "5", "10")).Get()
 
 	result := calculator.getUpdatePriority(pod, nil)

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -207,8 +207,7 @@ type RecommendationProcessorMock struct {
 
 // Apply is a mock implementation of RecommendationProcessor.Apply
 func (m *RecommendationProcessorMock) Apply(podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy,
-	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	policy vpa_types.ScalingPolicy,
 	pod *apiv1.Pod) (*vpa_types.RecommendedPodResources, map[string][]string, error) {
 	args := m.Called()
 	var returnArg *vpa_types.RecommendedPodResources
@@ -227,8 +226,7 @@ type FakeRecommendationProcessor struct{}
 
 // Apply is a dummy implementation of RecommendationProcessor.Apply which returns provided podRecommendation
 func (f *FakeRecommendationProcessor) Apply(podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy,
-	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	policy vpa_types.ScalingPolicy,
 	pod *apiv1.Pod) (*vpa_types.RecommendedPodResources, map[string][]string, error) {
 	return podRecommendation, nil, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	vpa_fake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
@@ -152,45 +151,6 @@ func TestGetControllingVPAForPod(t *testing.T) {
 	vpaB := vpaBuilder.WithCreationTimestamp(time.Unix(10, 0)).Get()
 	nonMatchingVPA := vpaBuilder.WithCreationTimestamp(time.Unix(2, 0)).WithSelector("app = other").Get()
 
-	chosen := GetControllingVPAForPod(pod, []*vpa_types.VerticalPodAutoscaler{vpaB, vpaA, nonMatchingVPA})
+	chosen := GetControllingVPAForPod(pod, []vpa_types.ScalingPolicy{vpaB, vpaA, nonMatchingVPA})
 	assert.Equal(t, vpaA, chosen)
-}
-
-func TestGetContainerResourcePolicy(t *testing.T) {
-	containerPolicy1 := vpa_types.ContainerResourcePolicy{
-		ContainerName: "container1",
-		MinAllowed: core.ResourceList{
-			core.ResourceCPU: *resource.NewScaledQuantity(10, 1),
-		},
-	}
-	containerPolicy2 := vpa_types.ContainerResourcePolicy{
-		ContainerName: "container2",
-		MaxAllowed: core.ResourceList{
-			core.ResourceMemory: *resource.NewScaledQuantity(100, 1),
-		},
-	}
-	policy := vpa_types.PodResourcePolicy{
-		ContainerPolicies: []vpa_types.ContainerResourcePolicy{
-			containerPolicy1, containerPolicy2,
-		},
-	}
-	assert.Equal(t, &containerPolicy1, GetContainerResourcePolicy("container1", &policy))
-	assert.Equal(t, &containerPolicy2, GetContainerResourcePolicy("container2", &policy))
-	assert.Nil(t, GetContainerResourcePolicy("container3", &policy))
-
-	// Add the wildcard ("*") policy.
-	defaultPolicy := vpa_types.ContainerResourcePolicy{
-		ContainerName: "*",
-		MinAllowed: core.ResourceList{
-			core.ResourceCPU: *resource.NewScaledQuantity(20, 1),
-		},
-	}
-	policy = vpa_types.PodResourcePolicy{
-		ContainerPolicies: []vpa_types.ContainerResourcePolicy{
-			containerPolicy1, defaultPolicy, containerPolicy2,
-		},
-	}
-	assert.Equal(t, &containerPolicy1, GetContainerResourcePolicy("container1", &policy))
-	assert.Equal(t, &containerPolicy2, GetContainerResourcePolicy("container2", &policy))
-	assert.Equal(t, &defaultPolicy, GetContainerResourcePolicy("container3", &policy))
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -49,8 +49,7 @@ type cappingRecommendationProcessor struct{}
 // Apply returns a recommendation for the given pod, adjusted to obey policy and limits.
 func (c *cappingRecommendationProcessor) Apply(
 	podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy,
-	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	policy vpa_types.ScalingPolicy,
 	pod *apiv1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
 
 	if podRecommendation == nil && policy == nil {
@@ -89,12 +88,12 @@ func (c *cappingRecommendationProcessor) Apply(
 func getCappedRecommendationForContainer(
 	container apiv1.Container,
 	containerRecommendation *vpa_types.RecommendedContainerResources,
-	policy *vpa_types.PodResourcePolicy) (*vpa_types.RecommendedContainerResources, []string, error) {
+	policy vpa_types.ScalingPolicy) (*vpa_types.RecommendedContainerResources, []string, error) {
 	if containerRecommendation == nil {
 		return nil, nil, fmt.Errorf("no recommendation available for container name %v", container.Name)
 	}
 	// containerPolicy can be nil (user does not have to configure it).
-	containerPolicy := GetContainerResourcePolicy(container.Name, policy)
+	containerPolicy := vpa_types.GetContainerResourcePolicy(container.Name, policy)
 
 	cappedRecommendations := containerRecommendation.DeepCopy()
 
@@ -157,13 +156,13 @@ func applyVPAPolicy(recommendation apiv1.ResourceList, policy *vpa_types.Contain
 
 func applyVPAPolicyForContainer(containerName string,
 	containerRecommendation *vpa_types.RecommendedContainerResources,
-	policy *vpa_types.PodResourcePolicy) (*vpa_types.RecommendedContainerResources, error) {
+	policy vpa_types.ScalingPolicy) (*vpa_types.RecommendedContainerResources, error) {
 	if containerRecommendation == nil {
 		return nil, fmt.Errorf("no recommendation available for container name %v", containerName)
 	}
 	cappedRecommendations := containerRecommendation.DeepCopy()
 	// containerPolicy can be nil (user does not have to configure it).
-	containerPolicy := GetContainerResourcePolicy(containerName, policy)
+	containerPolicy := vpa_types.GetContainerResourcePolicy(containerName, policy)
 	if containerPolicy == nil {
 		return cappedRecommendations, nil
 	}
@@ -204,7 +203,7 @@ func maybeCapToMax(recommended resource.Quantity, resourceName apiv1.ResourceNam
 
 // ApplyVPAPolicy returns a recommendation, adjusted to obey policy.
 func ApplyVPAPolicy(podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy) (*vpa_types.RecommendedPodResources, error) {
+	policy vpa_types.ScalingPolicy) (*vpa_types.RecommendedPodResources, error) {
 	if podRecommendation == nil {
 		return nil, nil
 	}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/recommendation_processor.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/recommendation_processor.go
@@ -30,7 +30,6 @@ type RecommendationProcessor interface {
 	// VPA policy and possibly other internal RecommendationProcessor context.
 	// Must return a non-nil pointer to RecommendedPodResources or error.
 	Apply(podRecommendation *vpa_types.RecommendedPodResources,
-		policy *vpa_types.PodResourcePolicy,
-		conditions []vpa_types.VerticalPodAutoscalerCondition,
+		policy vpa_types.ScalingPolicy,
 		pod *v1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error)
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor.go
@@ -32,8 +32,7 @@ type sequentialRecommendationProcessor struct {
 
 // Apply chains calls to underlying RecommendationProcessors in order provided on object construction
 func (p *sequentialRecommendationProcessor) Apply(podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy,
-	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	policy vpa_types.ScalingPolicy,
 	pod *v1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
 	recommendation := podRecommendation
 	accumulatedContainerToAnnotationsMap := ContainerToAnnotationsMap{}
@@ -43,7 +42,7 @@ func (p *sequentialRecommendationProcessor) Apply(podRecommendation *vpa_types.R
 			err                       error
 			containerToAnnotationsMap ContainerToAnnotationsMap
 		)
-		recommendation, containerToAnnotationsMap, err = processor.Apply(recommendation, policy, conditions, pod)
+		recommendation, containerToAnnotationsMap, err = processor.Apply(recommendation, policy, pod)
 
 		for container, newAnnotations := range containerToAnnotationsMap {
 			annotations, found := accumulatedContainerToAnnotationsMap[container]

--- a/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor_test.go
@@ -30,8 +30,7 @@ type fakeProcessor struct {
 }
 
 func (p *fakeProcessor) Apply(podRecommendation *vpa_types.RecommendedPodResources,
-	policy *vpa_types.PodResourcePolicy,
-	conditions []vpa_types.VerticalPodAutoscalerCondition,
+	policy vpa_types.ScalingPolicy,
 	pod *v1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
 	result := podRecommendation.DeepCopy()
 	result.ContainerRecommendations[0].ContainerName += p.message
@@ -49,7 +48,7 @@ func TestSequentialProcessor(t *testing.T) {
 				ContainerName: "",
 			},
 		}}
-	result, annotations, _ := tested.Apply(rec1, nil, nil, nil)
+	result, annotations, _ := tested.Apply(rec1, nil, nil)
 	assert.Equal(t, name1+name2, result.ContainerRecommendations[0].ContainerName)
 	assert.Contains(t, annotations, "trace")
 	assert.Contains(t, annotations["trace"], name1)


### PR DESCRIPTION
As the first step towards support other VPA policies via duck-typing,
we abstract out a ScalingPolicy interface.

The API type directly implements this interface.