### PR TITLE
 Fix windows name parsing for Azure VMAS nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -38,7 +38,7 @@ Pre-requirements:
 - Get the scale set name which is used for nodes scaling.
 - Encode each data with base64.
 
-Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-vmss.yaml](cluster-autoscaler-vmss.yaml), including
+Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.yaml), including
 
 - ClientID: `<base64-encoded-client-id>`
 - ClientSecret: `<base64-encoded-client-secret>`
@@ -64,19 +64,19 @@ or multiple node groups:
 Then deploy cluster-autoscaler by running
 
 ```sh
-kubectl create -f cluster-autoscaler-vmss.yaml
+kubectl create -f examples/cluster-autoscaler-vmss.yaml
 ```
 
 To run a CA pod in master node - CA deployment should tolerate the master `taint` and `nodeSelector` should be used to schedule the pods in master node.
 
 ```sh
-kubectl create -f cluster-autoscaler-vmss-master.yaml
+kubectl create -f examples/cluster-autoscaler-vmss-master.yaml
 ```
 
-To run a CA pod with Azure managed service identity (MSI), use [cluster-autoscaler-vmss-msi.yaml](cluster-autoscaler-vmss-msi.yaml) instead:
+To run a CA pod with Azure managed service identity (MSI), use [cluster-autoscaler-vmss-msi.yaml](examples/cluster-autoscaler-vmss-msi.yaml) instead:
 
 ```sh
-kubectl create -f cluster-autoscaler-vmss-msi.yaml
+kubectl create -f examples/cluster-autoscaler-vmss-msi.yaml
 ```
 
 ### Standard deployment
@@ -88,7 +88,7 @@ Pre-requirements:
 - Get a node pool name for nodes scaling from acs-engine deployment manifests
 - Encode each data with base64.
 
-Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-standard-master.yaml](cluster-autoscaler-standard-master.yaml), including
+Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-standard-master.yaml](examples/cluster-autoscaler-standard-master.yaml), including
 
 - ClientID: `<base64-encoded-client-id>`
 - ClientSecret: `<base64-encoded-client-secret>`
@@ -124,10 +124,10 @@ Then deploy cluster-autoscaler by running
 kubectl create -f cluster-autoscaler-standard-master.yaml
 ```
 
-To run a CA pod with Azure managed service identity (MSI), use [cluster-autoscaler-standard-msi.yaml](cluster-autoscaler-standard-msi.yaml) instead:
+To run a CA pod with Azure managed service identity (MSI), use [cluster-autoscaler-standard-msi.yaml](examples/cluster-autoscaler-standard-msi.yaml) instead:
 
 ```sh
-kubectl create -f cluster-autoscaler-standard-msi.yaml
+kubectl create -f examples/cluster-autoscaler-standard-msi.yaml
 ```
 
 **WARNING**: Cluster autoscaler depends on user provided deployment parameters to provision new nodes. It should be redeployed with new parameters after upgrading Kubernetes cluster (e.g. upgraded by `acs-engine upgrade` command), or else new nodes will be provisioned with old version.
@@ -152,7 +152,7 @@ Pre-requirements:
 
 - Encode each data with base64.
 
-Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-containerservice](cluster-autoscaler-containerservice.yaml), including
+Fill the values of cluster-autoscaler-azure secret in [cluster-autoscaler-containerservice](examples/cluster-autoscaler-containerservice.yaml), including
 
 - ClientID: `<base64-encoded-client-id>`
 - ClientSecret: `<base64-encoded-client-secret>`
@@ -181,7 +181,7 @@ QUNTCg==
 Then deploy cluster-autoscaler by running
 
 ```sh
-kubectl create -f cluster-autoscaler-containerservice.yaml
+kubectl create -f examples/cluster-autoscaler-containerservice.yaml
 ```
 
 ### AKS deployment

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -70,15 +70,17 @@ const (
 	k8sLinuxVMAgentClusterIDIndex  = 2
 	k8sLinuxVMAgentIndexArrayIndex = 3
 
-	k8sWindowsVMNamingFormat               = "^([a-fA-F0-9]{5})([0-9a-zA-Z]{3})([a-zA-Z0-9]{4,6})$"
+	k8sWindowsOldVMNamingFormat            = "^([a-fA-F0-9]{5})([0-9a-zA-Z]{3})([9])([a-zA-Z0-9]{3,5})$"
+	k8sWindowsVMNamingFormat               = "^([a-fA-F0-9]{4})([0-9a-zA-Z]{3})([0-9]{3,8})$"
 	k8sWindowsVMAgentPoolPrefixIndex       = 1
 	k8sWindowsVMAgentOrchestratorNameIndex = 2
 	k8sWindowsVMAgentPoolInfoIndex         = 3
 )
 
 var (
-	vmnameLinuxRegexp   = regexp.MustCompile(k8sLinuxVMNamingFormat)
-	vmnameWindowsRegexp = regexp.MustCompile(k8sWindowsVMNamingFormat)
+	vmnameLinuxRegexp      = regexp.MustCompile(k8sLinuxVMNamingFormat)
+	vmnameWindowsRegexp    = regexp.MustCompile(k8sWindowsVMNamingFormat)
+	oldvmnameWindowsRegexp = regexp.MustCompile(k8sWindowsOldVMNamingFormat)
 )
 
 //AzUtil consists of utility functions which utilizes clients to different services.
@@ -439,28 +441,33 @@ func k8sLinuxVMNameParts(vmName string) (poolIdentifier, nameSuffix string, agen
 	return vmNameParts[k8sLinuxVMAgentPoolNameIndex], vmNameParts[k8sLinuxVMAgentClusterIDIndex], vmNum, nil
 }
 
-// windowsVMNameParts returns parts of Windows VM name e.g: 50621k8s9000
-func windowsVMNameParts(vmName string) (poolPrefix string, acsStr string, poolIndex int, agentIndex int, err error) {
-	vmNameParts := vmnameWindowsRegexp.FindStringSubmatch(vmName)
-	if len(vmNameParts) != 4 {
-		return "", "", -1, -1, fmt.Errorf("resource name was missing from identifier")
+// windowsVMNameParts returns parts of Windows VM name
+func windowsVMNameParts(vmName string) (poolPrefix string, orch string, poolIndex int, agentIndex int, err error) {
+	var poolInfo string
+	vmNameParts := oldvmnameWindowsRegexp.FindStringSubmatch(vmName)
+	if len(vmNameParts) != 5 {
+		vmNameParts = vmnameWindowsRegexp.FindStringSubmatch(vmName)
+		if len(vmNameParts) != 4 {
+			return "", "", -1, -1, fmt.Errorf("resource name was missing from identifier")
+		}
+		poolInfo = vmNameParts[3]
+	} else {
+		poolInfo = vmNameParts[4]
 	}
 
-	poolPrefix = vmNameParts[k8sWindowsVMAgentPoolPrefixIndex]
-	acsStr = vmNameParts[k8sWindowsVMAgentOrchestratorNameIndex]
-	poolInfo := vmNameParts[k8sWindowsVMAgentPoolInfoIndex]
+	poolPrefix = vmNameParts[1]
+	orch = vmNameParts[2]
 
-	poolIndex, err = strconv.Atoi(poolInfo[:3])
+	poolIndex, err = strconv.Atoi(poolInfo[:2])
 	if err != nil {
-		return "", "", -1, -1, fmt.Errorf("Error parsing VM Name: %v", err)
+		return "", "", -1, -1, fmt.Errorf("error parsing VM Name: %v", err)
 	}
-
-	agentIndex, err = strconv.Atoi(poolInfo[3:])
+	agentIndex, err = strconv.Atoi(poolInfo[2:])
 	if err != nil {
-		return "", "", -1, -1, fmt.Errorf("Error parsing VM Name: %v", err)
+		return "", "", -1, -1, fmt.Errorf("error parsing VM Name: %v", err)
 	}
 
-	return poolPrefix, acsStr, poolIndex, agentIndex, nil
+	return poolPrefix, orch, poolIndex, agentIndex, nil
 }
 
 // GetVMNameIndex return the index of VM in the node pools.

--- a/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
@@ -71,26 +71,33 @@ func TestK8sLinuxVMNameParts(t *testing.T) {
 }
 
 func TestWindowsVMNameParts(t *testing.T) {
-	expectedPoolPrefix := "38988"
-	expectedAcs := "k8s"
-	expectedPoolIndex := 903
-	expectedAgentIndex := 12
+	data := []struct {
+		VMName, expectedPoolPrefix, expectedOrch string
+		expectedPoolIndex, expectedAgentIndex    int
+	}{
+		{"38988k8s90312", "38988", "k8s", 3, 12},
+		{"4506k8s010", "4506", "k8s", 1, 0},
+		{"2314k8s03000001", "2314", "k8s", 3, 1},
+		{"2314k8s0310", "2314", "k8s", 3, 10},
+	}
 
-	poolPrefix, acs, poolIndex, agentIndex, err := windowsVMNameParts("38988k8s90312")
-	if poolPrefix != expectedPoolPrefix {
-		t.Fatalf("incorrect poolPrefix. expected=%s actual=%s", expectedPoolPrefix, poolPrefix)
-	}
-	if acs != expectedAcs {
-		t.Fatalf("incorrect acs string. expected=%s actual=%s", expectedAcs, acs)
-	}
-	if poolIndex != expectedPoolIndex {
-		t.Fatalf("incorrect poolIndex. expected=%d actual=%d", expectedPoolIndex, poolIndex)
-	}
-	if agentIndex != expectedAgentIndex {
-		t.Fatalf("incorrect agentIndex. expected=%d actual=%d", expectedAgentIndex, agentIndex)
-	}
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	for _, d := range data {
+		poolPrefix, orch, poolIndex, agentIndex, err := windowsVMNameParts(d.VMName)
+		if poolPrefix != d.expectedPoolPrefix {
+			t.Fatalf("incorrect poolPrefix. expected=%s actual=%s", d.expectedPoolPrefix, poolPrefix)
+		}
+		if orch != d.expectedOrch {
+			t.Fatalf("incorrect acs string. expected=%s actual=%s", d.expectedOrch, orch)
+		}
+		if poolIndex != d.expectedPoolIndex {
+			t.Fatalf("incorrect poolIndex. expected=%d actual=%d", d.expectedPoolIndex, poolIndex)
+		}
+		if agentIndex != d.expectedAgentIndex {
+			t.Fatalf("incorrect agentIndex. expected=%d actual=%d", d.expectedAgentIndex, agentIndex)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-containerservice.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-containerservice.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -107,10 +107,14 @@ subjects:
 ---
 apiVersion: v1
 data:
+  ClientID: <base64-encoded-client-id>
+  ClientSecret: <base64-encoded-client-secret>
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
-  Deployment: <base64-encoded-azure-initial-deploy-name>
-  VMType: c3RhbmRhcmQ=
+  TenantID: <base64-encoded-tenant-id>
+  VMType: QUtTCg==
+  ClusterName: <base64-encoded-clustername>
+  NodeResourceGroup: <base64-encoded-node-resource-group>
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -133,24 +137,25 @@ spec:
       labels:
         app: cluster-autoscaler
     spec:
-      hostNetwork: true
       serviceAccountName: cluster-autoscaler
-      tolerations:
-      - effect: NoSchedule
-        operator: "Equal"
-        value: "true"
-        key: node-role.kubernetes.io/master
-      nodeSelector:
-        kubernetes.io/role: master
       containers:
-      - command:
+      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:agentpool1
-        - --nodes=1:10:agentpool2
+        - --nodes=3:10:nodepool1
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -162,51 +167,34 @@ spec:
             secretKeyRef:
               key: ResourceGroup
               name: cluster-autoscaler-azure
-        - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
-          value: "true"
+        - name: ARM_TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              key: TenantID
+              name: cluster-autoscaler-azure
+        - name: ARM_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: ClientID
+              name: cluster-autoscaler-azure
+        - name: ARM_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: ClientSecret
+              name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-        - name: ARM_DEPLOYMENT
+        - name: AZURE_CLUSTER_NAME
           valueFrom:
             secretKeyRef:
-              key: Deployment
+              key: ClusterName
               name: cluster-autoscaler-azure
-        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
-        resources:
-          limits:
-            cpu: 100m
-            memory: 300Mi
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-certificates.crt
-          name: ssl-certs
-          readOnly: true
-        - mountPath: /var/lib/azure/
-          name: deploy-parameters
-          readOnly: true
-        - mountPath: /var/lib/waagent/
-          name: waagent
-          readOnly: true
-      dnsPolicy: ClusterFirst
+        - name: AZURE_NODE_RESOURCE_GROUP
+          valueFrom:
+            secretKeyRef:
+              key: NodeResourceGroup
+              name: cluster-autoscaler-azure
       restartPolicy: Always
-      volumes:
-      - hostPath:
-          path: /etc/ssl/certs/ca-certificates.crt
-          type: ""
-        name: ssl-certs
-      - name: deploy-parameters
-        secret:
-          secretName: cluster-autoscaler-azure-deploy-parameters
-          items:
-          - key: deploy-parameters
-            path: azuredeploy.parameters.json
-      - hostPath:
-          path: /var/lib/waagent/
-        name: waagent

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -107,9 +107,13 @@ subjects:
 ---
 apiVersion: v1
 data:
+  ClientID: <base64-encoded-client-id>
+  ClientSecret: <base64-encoded-client-secret>
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
-  VMType: dm1zcw==
+  TenantID: <base64-encoded-tenant-id>
+  Deployment: <base64-encoded-azure-initial-deploy-name>
+  VMType: c3RhbmRhcmQ=
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -132,7 +136,6 @@ spec:
       labels:
         app: cluster-autoscaler
     spec:
-      hostNetwork: true
       serviceAccountName: cluster-autoscaler
       tolerations:
       - effect: NoSchedule
@@ -142,17 +145,14 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
-        command:
+      - command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:vmss1
-        - --nodes=1:10:vmss2
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -164,13 +164,34 @@ spec:
             secretKeyRef:
               key: ResourceGroup
               name: cluster-autoscaler-azure
-        - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
-          value: "true"
+        - name: ARM_TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              key: TenantID
+              name: cluster-autoscaler-azure
+        - name: ARM_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: ClientID
+              name: cluster-autoscaler-azure
+        - name: ARM_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: ClientSecret
+              name: cluster-autoscaler-azure
         - name: ARM_VM_TYPE
           valueFrom:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
+        - name: ARM_DEPLOYMENT
+          valueFrom:
+            secretKeyRef:
+              key: Deployment
+              name: cluster-autoscaler-azure
+        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
         resources:
           limits:
             cpu: 100m
@@ -182,15 +203,19 @@ spec:
         - mountPath: /etc/ssl/certs/ca-certificates.crt
           name: ssl-certs
           readOnly: true
-        - mountPath: /var/lib/waagent/
-          name: waagent
+        - mountPath: /var/lib/azure/
+          name: deploy-parameters
           readOnly: true
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
       - hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
           type: ""
         name: ssl-certs
-      - hostPath:
-          path: /var/lib/waagent/
-        name: waagent
+      - name: deploy-parameters
+        secret:
+          secretName: cluster-autoscaler-azure-deploy-parameters
+          items:
+          - key: deploy-parameters
+            path: azuredeploy.parameters.json

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -107,14 +107,10 @@ subjects:
 ---
 apiVersion: v1
 data:
-  ClientID: <base64-encoded-client-id>
-  ClientSecret: <base64-encoded-client-secret>
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
-  TenantID: <base64-encoded-tenant-id>
-  VMType: QUtTCg==
-  ClusterName: <base64-encoded-clustername>
-  NodeResourceGroup: <base64-encoded-node-resource-group>
+  Deployment: <base64-encoded-azure-initial-deploy-name>
+  VMType: c3RhbmRhcmQ=
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -137,25 +133,24 @@ spec:
       labels:
         app: cluster-autoscaler
     spec:
+      hostNetwork: true
       serviceAccountName: cluster-autoscaler
+      tolerations:
+      - effect: NoSchedule
+        operator: "Equal"
+        value: "true"
+        key: node-role.kubernetes.io/master
+      nodeSelector:
+        kubernetes.io/role: master
       containers:
-      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
-        resources:
-          limits:
-            cpu: 100m
-            memory: 300Mi
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        command:
+      - command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=3:10:nodepool1
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -167,34 +162,51 @@ spec:
             secretKeyRef:
               key: ResourceGroup
               name: cluster-autoscaler-azure
-        - name: ARM_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: TenantID
-              name: cluster-autoscaler-azure
-        - name: ARM_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: ClientID
-              name: cluster-autoscaler-azure
-        - name: ARM_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: ClientSecret
-              name: cluster-autoscaler-azure
+        - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
+          value: "true"
         - name: ARM_VM_TYPE
           valueFrom:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-        - name: AZURE_CLUSTER_NAME
+        - name: ARM_DEPLOYMENT
           valueFrom:
             secretKeyRef:
-              key: ClusterName
+              key: Deployment
               name: cluster-autoscaler-azure
-        - name: AZURE_NODE_RESOURCE_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: NodeResourceGroup
-              name: cluster-autoscaler-azure
+        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-certificates.crt
+          name: ssl-certs
+          readOnly: true
+        - mountPath: /var/lib/azure/
+          name: deploy-parameters
+          readOnly: true
+        - mountPath: /var/lib/waagent/
+          name: waagent
+          readOnly: true
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
+      volumes:
+      - hostPath:
+          path: /etc/ssl/certs/ca-certificates.crt
+          type: ""
+        name: ssl-certs
+      - name: deploy-parameters
+        secret:
+          secretName: cluster-autoscaler-azure-deploy-parameters
+          items:
+          - key: deploy-parameters
+            path: azuredeploy.parameters.json
+      - hostPath:
+          path: /var/lib/waagent/
+        name: waagent

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -112,7 +112,8 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  VMType: dm1zcw==
+  Deployment: <base64-encoded-azure-initial-deploy-name>
+  VMType: c3RhbmRhcmQ=
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -137,24 +138,14 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
-        resources:
-          limits:
-            cpu: 100m
-            memory: 300Mi
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        command:
+      - command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:vmss1
-        - --nodes=1:10:vmss2
+        - --nodes=1:10:agentpool1
+        - --nodes=1:10:agentpool2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -186,13 +177,38 @@ spec:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
+        - name: ARM_DEPLOYMENT
+          valueFrom:
+            secretKeyRef:
+              key: Deployment
+              name: cluster-autoscaler-azure
+        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
         volumeMounts:
         - mountPath: /etc/ssl/certs/ca-certificates.crt
           name: ssl-certs
           readOnly: true
+        - mountPath: /var/lib/azure/
+          name: deploy-parameters
+          readOnly: true
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
       - hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
           type: ""
         name: ssl-certs
+      - name: deploy-parameters
+        secret:
+          secretName: cluster-autoscaler-azure-deploy-parameters
+          items:
+          - key: deploy-parameters
+            path: azuredeploy.parameters.json

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -112,8 +112,7 @@ data:
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
   TenantID: <base64-encoded-tenant-id>
-  Deployment: <base64-encoded-azure-initial-deploy-name>
-  VMType: c3RhbmRhcmQ=
+  VMType: dm1zcw==
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -137,15 +136,25 @@ spec:
         app: cluster-autoscaler
     spec:
       serviceAccountName: cluster-autoscaler
+      tolerations:
+      - effect: NoSchedule
+        operator: "Equal"
+        value: "true"
+        key: node-role.kubernetes.io/master
+      nodeSelector:
+        kubernetes.io/role: master
       containers:
-      - command:
+      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
+        command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:agentpool1
-        - --nodes=1:10:agentpool2
+        - --nodes=1:10:vmss1
+        - --nodes=1:10:vmss2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -177,14 +186,6 @@ spec:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-        - name: ARM_DEPLOYMENT
-          valueFrom:
-            secretKeyRef:
-              key: Deployment
-              name: cluster-autoscaler-azure
-        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
         resources:
           limits:
             cpu: 100m
@@ -196,19 +197,9 @@ spec:
         - mountPath: /etc/ssl/certs/ca-certificates.crt
           name: ssl-certs
           readOnly: true
-        - mountPath: /var/lib/azure/
-          name: deploy-parameters
-          readOnly: true
-      dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
       - hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
           type: ""
         name: ssl-certs
-      - name: deploy-parameters
-        secret:
-          secretName: cluster-autoscaler-azure-deploy-parameters
-          items:
-          - key: deploy-parameters
-            path: azuredeploy.parameters.json

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -107,13 +107,9 @@ subjects:
 ---
 apiVersion: v1
 data:
-  ClientID: <base64-encoded-client-id>
-  ClientSecret: <base64-encoded-client-secret>
   ResourceGroup: <base64-encoded-resource-group>
   SubscriptionID: <base64-encode-subscription-id>
-  TenantID: <base64-encoded-tenant-id>
-  Deployment: <base64-encoded-azure-initial-deploy-name>
-  VMType: c3RhbmRhcmQ=
+  VMType: dm1zcw==
 kind: Secret
 metadata:
   name: cluster-autoscaler-azure
@@ -136,6 +132,7 @@ spec:
       labels:
         app: cluster-autoscaler
     spec:
+      hostNetwork: true
       serviceAccountName: cluster-autoscaler
       tolerations:
       - effect: NoSchedule
@@ -145,14 +142,17 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-      - command:
+      - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        imagePullPolicy: Always
+        name: cluster-autoscaler
+        command:
         - ./cluster-autoscaler
         - --v=3
         - --logtostderr=true
         - --cloud-provider=azure
         - --skip-nodes-with-local-storage=false
-        - --nodes=1:10:agentpool1
-        - --nodes=1:10:agentpool2
+        - --nodes=1:10:vmss1
+        - --nodes=1:10:vmss2
         env:
         - name: ARM_SUBSCRIPTION_ID
           valueFrom:
@@ -164,34 +164,13 @@ spec:
             secretKeyRef:
               key: ResourceGroup
               name: cluster-autoscaler-azure
-        - name: ARM_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: TenantID
-              name: cluster-autoscaler-azure
-        - name: ARM_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: ClientID
-              name: cluster-autoscaler-azure
-        - name: ARM_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: ClientSecret
-              name: cluster-autoscaler-azure
+        - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
+          value: "true"
         - name: ARM_VM_TYPE
           valueFrom:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-        - name: ARM_DEPLOYMENT
-          valueFrom:
-            secretKeyRef:
-              key: Deployment
-              name: cluster-autoscaler-azure
-        image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
-        imagePullPolicy: Always
-        name: cluster-autoscaler
         resources:
           limits:
             cpu: 100m
@@ -203,19 +182,15 @@ spec:
         - mountPath: /etc/ssl/certs/ca-certificates.crt
           name: ssl-certs
           readOnly: true
-        - mountPath: /var/lib/azure/
-          name: deploy-parameters
+        - mountPath: /var/lib/waagent/
+          name: waagent
           readOnly: true
-      dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
       - hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
           type: ""
         name: ssl-certs
-      - name: deploy-parameters
-        secret:
-          secretName: cluster-autoscaler-azure-deploy-parameters
-          items:
-          - key: deploy-parameters
-            path: azuredeploy.parameters.json
+      - hostPath:
+          path: /var/lib/waagent/
+        name: waagent

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicasets"]
+  resources: ["statefulsets", "replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
@@ -136,17 +136,17 @@ spec:
         app: cluster-autoscaler
     spec:
       serviceAccountName: cluster-autoscaler
-      tolerations:
-      - effect: NoSchedule
-        operator: "Equal"
-        value: "true"
-        key: node-role.kubernetes.io/master
-      nodeSelector:
-        kubernetes.io/role: master
       containers:
       - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
         imagePullPolicy: Always
         name: cluster-autoscaler
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
         command:
         - ./cluster-autoscaler
         - --v=3
@@ -186,13 +186,6 @@ spec:
             secretKeyRef:
               key: VMType
               name: cluster-autoscaler-azure
-        resources:
-          limits:
-            cpu: 100m
-            memory: 300Mi
-          requests:
-            cpu: 100m
-            memory: 300Mi
         volumeMounts:
         - mountPath: /etc/ssl/certs/ca-certificates.crt
           name: ssl-certs


### PR DESCRIPTION
The PR fixes windows name parsing for Azure VMAS nodes. It also moves yaml to examples and add missing daemonsets.

Fixes #1593