### PR TITLE
Don't panic on unknown aws instance type

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -172,8 +172,13 @@ func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 		glog.Warningf("Found multiple availability zones, using %s\n", az)
 	}
 
+	instanceType, ok := InstanceTypes[instanceTypeName]
+	if !ok {
+		return nil, fmt.Errorf("Unknown instance type %s for %s", instanceTypeName, asg.Name)
+	}
+
 	return &asgTemplate{
-		InstanceType: InstanceTypes[instanceTypeName],
+		InstanceType: instanceType,
 		Region:       region,
 		Zone:         az,
 		Tags:         asg.Tags,


### PR DESCRIPTION
Cluster Autoscaler crashes if there are some AWS ASG that use instances
types and was not updated in the build.
    
Update tests for case when there is unknown instance type and return
error if there is one.

Sample of excepttion:  #483


Covers changes for 1.3 branch only