### PR TITLE
Updated aws instance types actual for 2019.02.10

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -27,6 +27,42 @@ type instanceType struct {
 
 // InstanceTypes is a map of ec2 resources
 var InstanceTypes = map[string]*instanceType{
+	"a1": {
+		InstanceType: "a1",
+		VCPU:         16,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"a1.2xlarge": {
+		InstanceType: "a1.2xlarge",
+		VCPU:         8,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"a1.4xlarge": {
+		InstanceType: "a1.4xlarge",
+		VCPU:         16,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"a1.large": {
+		InstanceType: "a1.large",
+		VCPU:         2,
+		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"a1.medium": {
+		InstanceType: "a1.medium",
+		VCPU:         1,
+		MemoryMb:     2048,
+		GPU:          0,
+	},
+	"a1.xlarge": {
+		InstanceType: "a1.xlarge",
+		VCPU:         4,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
 	"c1.medium": {
 		InstanceType: "c1.medium",
 		VCPU:         2,
@@ -193,6 +229,48 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "c5d.xlarge",
 		VCPU:         4,
 		MemoryMb:     8192,
+		GPU:          0,
+	},
+	"c5n": {
+		InstanceType: "c5n",
+		VCPU:         72,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"c5n.18xlarge": {
+		InstanceType: "c5n.18xlarge",
+		VCPU:         72,
+		MemoryMb:     196608,
+		GPU:          0,
+	},
+	"c5n.2xlarge": {
+		InstanceType: "c5n.2xlarge",
+		VCPU:         8,
+		MemoryMb:     21504,
+		GPU:          0,
+	},
+	"c5n.4xlarge": {
+		InstanceType: "c5n.4xlarge",
+		VCPU:         16,
+		MemoryMb:     43008,
+		GPU:          0,
+	},
+	"c5n.9xlarge": {
+		InstanceType: "c5n.9xlarge",
+		VCPU:         36,
+		MemoryMb:     98304,
+		GPU:          0,
+	},
+	"c5n.large": {
+		InstanceType: "c5n.large",
+		VCPU:         2,
+		MemoryMb:     5376,
+		GPU:          0,
+	},
+	"c5n.xlarge": {
+		InstanceType: "c5n.xlarge",
+		VCPU:         4,
+		MemoryMb:     10752,
 		GPU:          0,
 	},
 	"cc2.8xlarge": {
@@ -704,6 +782,18 @@ var InstanceTypes = map[string]*instanceType{
 		VCPU:         32,
 		MemoryMb:     249856,
 		GPU:          4,
+	},
+	"p3dn": {
+		InstanceType: "p3dn",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          8,
+	},
+	"p3dn.24xlarge": {
+		InstanceType: "p3dn.24xlarge",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          8,
 	},
 	"r3": {
 		InstanceType: "r3",


### PR DESCRIPTION
Sync instance type for aws via `make generate`