### PR TITLE
fix(expander): avoid panic when random expander

### DIFF
--- a/cluster-autoscaler/expander/mostpods/mostpods_test.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods_test.go
@@ -21,25 +21,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
+
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 )
 
 func TestMostPods(t *testing.T) {
-	eo0 := expander.Option{Debug: "EO0"}
 	e := NewStrategy()
 
+	eo0 := expander.Option{Debug: "EO0"}
 	ret := e.BestOption([]expander.Option{eo0}, nil)
 	assert.Equal(t, *ret, eo0)
 
 	eo1 := expander.Option{Debug: "EO1", Pods: []*apiv1.Pod{nil}}
-
 	ret = e.BestOption([]expander.Option{eo0, eo1}, nil)
 	assert.Equal(t, *ret, eo1)
 
 	eo1b := expander.Option{Debug: "EO1b", Pods: []*apiv1.Pod{nil}}
-
 	ret = e.BestOption([]expander.Option{eo0, eo1, eo1b}, nil)
 	assert.NotEqual(t, *ret, eo0)
-
 	assert.True(t, assert.ObjectsAreEqual(*ret, eo1) || assert.ObjectsAreEqual(*ret, eo1b))
 }

--- a/cluster-autoscaler/expander/random/random.go
+++ b/cluster-autoscaler/expander/random/random.go
@@ -33,6 +33,10 @@ func NewStrategy() expander.Strategy {
 
 // RandomExpansion Selects from the expansion options at random
 func (r *random) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	if len(expansionOptions) <= 0 {
+		return nil
+	}
+
 	pos := rand.Int31n(int32(len(expansionOptions)))
 	return &expansionOptions[pos]
 }

--- a/cluster-autoscaler/expander/random/random_test.go
+++ b/cluster-autoscaler/expander/random/random_test.go
@@ -19,21 +19,22 @@ package random
 import (
 	"testing"
 
-	"k8s.io/autoscaler/cluster-autoscaler/expander"
-
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
 )
 
 func TestRandomExpander(t *testing.T) {
-	eo1a := expander.Option{Debug: "EO1a"}
 	e := NewStrategy()
 
+	eo1a := expander.Option{Debug: "EO1a"}
 	ret := e.BestOption([]expander.Option{eo1a}, nil)
 	assert.Equal(t, *ret, eo1a)
 
 	eo1b := expander.Option{Debug: "EO1b"}
-
 	ret = e.BestOption([]expander.Option{eo1a, eo1b}, nil)
-
 	assert.True(t, assert.ObjectsAreEqual(*ret, eo1a) || assert.ObjectsAreEqual(*ret, eo1b))
+
+	ret = e.BestOption([]expander.Option{}, nil)
+	assert.Nil(t, ret)
 }


### PR DESCRIPTION
when the random-expander is used, if the options length is zero there will be a panic cause. this pr try to fix it.