### PR TITLE
VPA: add YAML start of a document marks

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-beta-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-beta-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Some workflows assume concatenated YAML to be as valid & applicable as a bunch of separate YAML files.

This commit make make it safe & valid to merge all VPA files in deploy/ prior to execution.

Fixes syntax error resulting from merging VPA files without explicit initial start-of-a-document marks:

`error: error validating "vpa.yaml": error validating data: ValidationError(ServiceAccount): unknown field "spec" in io.k8s.api.core.v1.ServiceAccount; if you choose to ignore these errors, turn validation off with --validate=false`