### PR TITLE
VPA - Introduce VpaTargetSelectorFetcher

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"fmt"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/client-go/discovery"
+	cacheddiscovery "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/dynamic"
+	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/scale"
+
+	"github.com/golang/glog"
+)
+
+// VpaTargetSelectorFetcher gets a labelSelector used to gather Pods controlled by the given VPA.
+type VpaTargetSelectorFetcher interface {
+	// Fetch returns a labelSelector used to gather Pods controlled by the given VPA.
+	// If error is nil, the returned labelSelector is not nil.
+	Fetch(vpa *vpa_types.VerticalPodAutoscaler) (labels.Selector, error)
+}
+
+// NewVpaTargetSelectorFetcher returns new instance of VpaTargetSelectorFetcher
+func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Interface) VpaTargetSelectorFetcher {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		glog.Fatalf("Could not create discoveryClient: %v", err)
+	}
+	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
+	restClient := kubeClient.CoreV1().RESTClient()
+	cachedDiscoveryClient := cacheddiscovery.NewMemCacheClient(discoveryClient)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	go wait.Until(func() {
+		mapper.Reset()
+	}, 5*time.Minute, make(chan struct{}))
+
+	scaleNamespacer := scale.New(restClient, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
+	return &vpaTargetSelectorFetcher{
+		scaleNamespacer: scaleNamespacer,
+		mapper:          mapper,
+	}
+}
+
+// vpaTargetSelectorFetcher implements VpaTargetSelectorFetcher interface
+// by querying API server for the controller pointed by VPA's targetRef
+type vpaTargetSelectorFetcher struct {
+	scaleNamespacer scale.ScalesGetter
+	mapper          apimeta.RESTMapper
+}
+
+func (f *vpaTargetSelectorFetcher) Fetch(vpa *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
+	if vpa.Spec.TargetRef == nil {
+		return nil, fmt.Errorf("targetRef not defined")
+	}
+	groupVersion, err := schema.ParseGroupVersion(vpa.Spec.TargetRef.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+	groupKind := schema.GroupKind{
+		Group: groupVersion.Group,
+		Kind:  vpa.Spec.TargetRef.Kind,
+	}
+	selector, err := f.getLabelSelectorFromResource(groupKind, vpa.Namespace, vpa.Spec.TargetRef.Name)
+	if err != nil {
+		return nil, err
+	}
+	if selector != nil {
+		return selector, nil
+	}
+	// TODO: handle DaemonSet too
+	return nil, fmt.Errorf("Unhandled targetRef %s / %s / %s",
+		vpa.Spec.TargetRef.APIVersion, vpa.Spec.TargetRef.Kind, vpa.Spec.TargetRef.Name)
+}
+
+func (f *vpaTargetSelectorFetcher) getLabelSelectorFromResource(
+	groupKind schema.GroupKind, namespace, name string,
+) (labels.Selector, error) {
+	mappings, err := f.mapper.RESTMappings(groupKind)
+	if err != nil {
+		return nil, err
+	}
+	for _, mapping := range mappings {
+		groupResource := mapping.Resource.GroupResource()
+		scale, err := f.scaleNamespacer.Scales(namespace).Get(groupResource, name)
+		if err == nil {
+			selector, err := labels.Parse(scale.Status.Selector)
+			if err != nil {
+				return nil, err
+			}
+			return selector, nil
+		}
+	}
+
+	// nothing found but that's still OK, maybe our target ref does not support it
+	return nil, nil
+}

--- a/vertical-pod-autoscaler/pkg/target/mock/fetcher_mock.go
+++ b/vertical-pod-autoscaler/pkg/target/mock/fetcher_mock.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocktarget
+
+import (
+	gomock "github.com/golang/mock/gomock"
+	labels "k8s.io/apimachinery/pkg/labels"
+	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+)
+
+// MockVpaTargetSelectorFetcher is a mock of VpaTargetSelectorFetcher interface
+type MockVpaTargetSelectorFetcher struct {
+	ctrl     *gomock.Controller
+	recorder *_MockVpaTargetSelectorFetcherRecorder
+}
+
+// Recorder for MockVpaTargetSelectorFetcher (not exported)
+type _MockVpaTargetSelectorFetcherRecorder struct {
+	mock *MockVpaTargetSelectorFetcher
+}
+
+// NewMockVpaTargetSelectorFetcher returns mock instance of a mock of VpaTargetSelectorFetcher
+func NewMockVpaTargetSelectorFetcher(ctrl *gomock.Controller) *MockVpaTargetSelectorFetcher {
+	mock := &MockVpaTargetSelectorFetcher{ctrl: ctrl}
+	mock.recorder = &_MockVpaTargetSelectorFetcherRecorder{mock}
+	return mock
+}
+
+// EXPECT enables configuring expectaions
+func (_m *MockVpaTargetSelectorFetcher) EXPECT() *_MockVpaTargetSelectorFetcherRecorder {
+	return _m.recorder
+}
+
+// Fetch enables configuring expectations on Fetch method
+func (_m *MockVpaTargetSelectorFetcher) Fetch(vpa *v1beta2.VerticalPodAutoscaler) (labels.Selector, error) {
+	ret := _m.ctrl.Call(_m, "Fetch", vpa)
+	ret0, _ := ret[0].(labels.Selector)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVpaTargetSelectorFetcherRecorder) Fetch(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0)
+}

--- a/vertical-pod-autoscaler/pkg/target/v1beta1_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/v1beta1_fetcher.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	vpa_types_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	vpa_types_v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	vpa_lister_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+type beta1TargetSelectorFetcher struct {
+	vpaLister vpa_lister_v1beta1.VerticalPodAutoscalerLister
+}
+
+// NewBeta1TargetSelectorFetcher returns new instance of VpaTargetSelectorFetcher that uses selector from deprecated v1beta1
+func NewBeta1TargetSelectorFetcher(config *rest.Config) VpaTargetSelectorFetcher {
+	vpaClient := vpa_clientset.NewForConfigOrDie(config)
+	return &beta1TargetSelectorFetcher{
+		vpaLister: newAllVpasLister(vpaClient, make(chan struct{})),
+	}
+}
+
+func (f *beta1TargetSelectorFetcher) Fetch(vpa *vpa_types_v1beta2.VerticalPodAutoscaler) (labels.Selector, error) {
+	list, err := f.vpaLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list v1beta1 VPAs. Reason: %v", err)
+	}
+
+	for _, beta1vpa := range list {
+		if beta1vpa.Namespace == vpa.Namespace && beta1vpa.Name == vpa.Name && beta1vpa.UID == vpa.UID {
+			if beta1vpa.Spec.Selector == nil {
+				return nil, fmt.Errorf("v1beta1 selector not found")
+			}
+			selector, err := metav1.LabelSelectorAsSelector(beta1vpa.Spec.Selector)
+			if err != nil {
+				// Intentionally ignore error
+				return labels.Nothing(), nil
+			}
+			glog.Infof("Found deprecated label selector for VPA %s/%s", vpa.Namespace, vpa.Name)
+			return selector, nil
+		}
+	}
+
+	return nil, fmt.Errorf("v1beta1 VPA not found")
+}
+
+func newAllVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}) vpa_lister_v1beta1.VerticalPodAutoscalerLister {
+	vpaListWatch := cache.NewListWatchFromClient(vpaClient.AutoscalingV1beta1().RESTClient(), "verticalpodautoscalers", core.NamespaceAll, fields.Everything())
+	indexer, controller := cache.NewIndexerInformer(vpaListWatch,
+		&vpa_types_v1beta1.VerticalPodAutoscaler{},
+		1*time.Hour,
+		&cache.ResourceEventHandlerFuncs{},
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	vpaLister := vpa_lister_v1beta1.NewVerticalPodAutoscalerLister(indexer)
+	go controller.Run(stopChannel)
+	if !cache.WaitForCacheSync(make(chan struct{}), controller.HasSynced) {
+		glog.Fatalf("Failed to sync VPA v1beta1 cache during initialization")
+	} else {
+		glog.Info("Initial VPA v1beta1 synced successfully")
+	}
+	return vpaLister
+}

--- a/vertical-pod-autoscaler/pkg/target/v1beta1_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/v1beta1_fetcher_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	vpa_types_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	vpa_types_v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+// VerticalPodAutoscalerBuilder helps building test instances of VerticalPodAutoscaler.
+type VerticalPodAutoscalerBuilder interface {
+	WithName(vpaName string) VerticalPodAutoscalerBuilder
+	WithNamespace(namespace string) VerticalPodAutoscalerBuilder
+	WithSelector(labelSelector string) VerticalPodAutoscalerBuilder
+	GetV1Beta1() *vpa_types_v1beta1.VerticalPodAutoscaler
+	GetV1Beta2() *vpa_types_v1beta2.VerticalPodAutoscaler
+}
+
+// VerticalPodAutoscaler returns a new VerticalPodAutoscalerBuilder.
+func VerticalPodAutoscaler() VerticalPodAutoscalerBuilder {
+	return &verticalPodAutoscalerBuilder{
+		namespace: "default",
+	}
+}
+
+type verticalPodAutoscalerBuilder struct {
+	vpaName       string
+	namespace     string
+	labelSelector *metav1.LabelSelector
+}
+
+func (b *verticalPodAutoscalerBuilder) WithName(vpaName string) VerticalPodAutoscalerBuilder {
+	c := *b
+	c.vpaName = vpaName
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) WithNamespace(namespace string) VerticalPodAutoscalerBuilder {
+	c := *b
+	c.namespace = namespace
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) WithSelector(labelSelector string) VerticalPodAutoscalerBuilder {
+	c := *b
+	if labelSelector, err := metav1.ParseToLabelSelector(labelSelector); err != nil {
+		panic(err)
+	} else {
+		c.labelSelector = labelSelector
+	}
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) GetV1Beta1() *vpa_types_v1beta1.VerticalPodAutoscaler {
+	return &vpa_types_v1beta1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.vpaName,
+			Namespace: b.namespace,
+		},
+		Spec: vpa_types_v1beta1.VerticalPodAutoscalerSpec{
+			Selector: b.labelSelector,
+		},
+	}
+}
+
+func (b *verticalPodAutoscalerBuilder) GetV1Beta2() *vpa_types_v1beta2.VerticalPodAutoscaler {
+	if b.labelSelector != nil {
+		panic("v1beta2 doesn't support selector")
+	}
+	return &vpa_types_v1beta2.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.vpaName,
+			Namespace: b.namespace,
+		},
+	}
+}
+
+func parseLabelSelector(selector string) labels.Selector {
+	labelSelector, _ := metav1.ParseToLabelSelector(selector)
+	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
+	return parsedSelector
+}
+
+func TestLegacySelector(t *testing.T) {
+
+	type testCase struct {
+		vpa                 *vpa_types_v1beta2.VerticalPodAutoscaler
+		vpaInStore          *vpa_types_v1beta1.VerticalPodAutoscaler
+		expectedSelector    labels.Selector
+		expectedError       bool
+		expectedErrorString string
+	}
+
+	testCases := []testCase{
+		{
+			vpa:                 nil,
+			vpaInStore:          nil,
+			expectedSelector:    nil,
+			expectedError:       true,
+			expectedErrorString: "Failed to list v1beta1 VPAs. Reason: Cannot list",
+		}, {
+			vpa:                 VerticalPodAutoscaler().WithName("a").GetV1Beta2(),
+			vpaInStore:          nil,
+			expectedSelector:    nil,
+			expectedError:       true,
+			expectedErrorString: "Failed to list v1beta1 VPAs. Reason: Cannot list",
+		}, {
+			vpa:                 VerticalPodAutoscaler().WithName("a").GetV1Beta2(),
+			vpaInStore:          VerticalPodAutoscaler().WithName("b").GetV1Beta1(),
+			expectedSelector:    nil,
+			expectedError:       true,
+			expectedErrorString: "v1beta1 VPA not found",
+		}, {
+			vpa:                 VerticalPodAutoscaler().WithName("a").GetV1Beta2(),
+			vpaInStore:          VerticalPodAutoscaler().WithName("a").GetV1Beta1(),
+			expectedSelector:    nil,
+			expectedError:       true,
+			expectedErrorString: "v1beta1 selector not found",
+		}, {
+			vpa:              VerticalPodAutoscaler().WithName("a").GetV1Beta2(),
+			vpaInStore:       VerticalPodAutoscaler().WithName("a").WithSelector("app = t").GetV1Beta1(),
+			expectedSelector: parseLabelSelector("app = t"),
+			expectedError:    false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test case number: %d", i), func(t *testing.T) {
+			vpaLister := &test.VerticalPodAutoscalerListerMock{}
+			if tc.vpaInStore == nil {
+				vpaLister.On("List").Return(nil, fmt.Errorf("Cannot list"))
+			} else {
+				vpaLister.On("List").Return([]*vpa_types_v1beta1.VerticalPodAutoscaler{tc.vpaInStore}, nil)
+			}
+
+			fetcher := beta1TargetSelectorFetcher{
+				vpaLister: vpaLister,
+			}
+
+			selector, err := fetcher.Fetch(tc.vpa)
+
+			if tc.expectedError {
+				assert.Equal(t, fmt.Errorf(tc.expectedErrorString), err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tc.expectedSelector == nil {
+				assert.Nil(t, selector)
+			} else {
+				assert.Equal(t, tc.expectedSelector.String(), selector.String())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Following implementations are provided:
- one for v1beta1 VPAs that fetches label selector
- one for v1beta2 that fetches from targetRef (contributed by kgolab)
- mock