### PR TITLE
Add OpenStack cloud provider

### DIFF
--- a/cluster-autoscaler/Godeps/Godeps.json
+++ b/cluster-autoscaler/Godeps/Godeps.json
@@ -1221,6 +1221,10 @@
 			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
 		},
 		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
+			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
+		},
+		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
 			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
 		},
@@ -1289,11 +1293,23 @@
 			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
 		},
 		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources",
+			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks",
+			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
+		},
+		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
 			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
+			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/testhelper",
 			"Rev": "c818fa66e4c88b30db28038fe3f18f2f4a0db9a8"
 		},
 		{

--- a/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
@@ -1,7 +1,7 @@
-// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum
+// +build magnum
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,42 +20,23 @@ package builder
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	aws.ProviderName,
-	azure.ProviderName,
-	gce.ProviderNameGCE,
-	alicloud.ProviderName,
-	baiducloud.ProviderName,
 	magnum.ProviderName,
 }
 
-// DefaultCloudProvider is GCE.
-const DefaultCloudProvider = gce.ProviderNameGCE
+// DefaultCloudProvider for OpenStack-only build is OpenStack.
+const DefaultCloudProvider = magnum.ProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case gce.ProviderNameGCE:
-		return gce.BuildGCE(opts, do, rl)
-	case aws.ProviderName:
-		return aws.BuildAWS(opts, do, rl)
-	case azure.ProviderName:
-		return azure.BuildAzure(opts, do, rl)
-	case alicloud.ProviderName:
-		return alicloud.BuildAlicloud(opts, do, rl)
-	case baiducloud.ProviderName:
-		return baiducloud.BuildBaiducloud(opts, do, rl)
 	case magnum.ProviderName:
 		return magnum.BuildMagnum(opts, do, rl)
 	}
+
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/magnum/README.md
+++ b/cluster-autoscaler/cloudprovider/magnum/README.md
@@ -1,0 +1,47 @@
+# Cluster Autoscaler for OpenStack Magnum
+The cluster autoscaler for Magnum scales worker nodes within any
+specified nodegroup. It will run as a `Deployment` in your cluster.
+This README will go over some of the necessary steps required to get
+the cluster autoscaler up and running.
+
+## Permissions and credentials
+
+The autoscaler needs a `ServiceAccount` with permissions for Kubernetes and
+requires credentials for interacting with OpenStack.
+
+An example `ServiceAccount` is given in [examples/cluster-autoscaler-svcaccount.yaml](examples/cluster-autoscaler-svcaccount.yaml).
+
+The credentials for authenticating with OpenStack are stored in a secret and
+mounted as a file inside the container. [examples/cluster-autoscaler-secret](examples/cluster-autoscaler-secret.yaml)
+can be modified with the contents of your cloud-config. This file can be obtained from your master node,
+in `/etc/kubernetes` (may be named `kube_openstack_config` instead of `cloud-config`).
+
+## Autoscaler deployment
+
+The deployment in `examples/cluster-autoscaler-deployment.yaml` can be used,
+but the arguments passed to the autoscaler will need to be changed
+to match your cluster.
+
+| Argument         | Usage                                                                                                                                      |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| --cluster-name   | The name of your Kubernetes cluster. If there are multiple clusters sharing the same name then the cluster IDs should be used instead.     |
+| --cloud-provider | Can be omitted if the autoscaler is built with `BUILD_TAGS=magnum`.                                                                        |
+| --nodes          | Of the form `min:max:NodeGroupName`. Node groups are not yet implemented in Magnum so only a single node group is currently supported.     |
+
+## Notes
+
+Magnum does not yet support multiple node groups within a single cluster, but this
+is currently in development. Once node groups are available for Magnum, support
+for autoscaling clusters using nodegroups will be made available by adding another
+implementation of the [Magnum manager interface](./magnum_manager.go). 
+
+The autoscaler will not remove nodes which have non-default kube-system pods.
+This prevents the node that the autoscaler is running on from being scaled down.
+If you are deploying the autoscaler into a cluster which already has more than one node,
+it is best to deploy it onto any node which already has non-default kube-system pods,
+to minimise the number of nodes which cannot be removed when scaling.
+
+Or, if you are using a Magnum version which supports scheduling on the master node, then
+the example deployment file
+[examples/cluster-autoscaler-deployment-master.yaml](examples/cluster-autoscaler-deployment-master.yaml)
+can be used.

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-master.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-master.yaml
@@ -1,0 +1,49 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      namespace: kube-system
+      labels:
+        app: cluster-autoscaler
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 1001
+      tolerations:
+        - key: CriticalAddonsOnly
+          value: "True"
+          effect: NoSchedule
+        - key: dedicated
+          value: "master"
+          effect: NoSchedule
+      serviceAccountName: cluster-autoscaler-account
+      containers:
+        - name: cluster-autoscaler
+          image: thartland/magnum-autoscaler:v1.0
+          imagePullPolicy: Always
+          command:
+            - ./cluster-autoscaler
+            - --alsologtostderr
+            - --cluster-name=scaler-01
+            - --cloud-config=/config/cloud-config
+            - --cloud-provider=magnum
+            - --nodes=1:10:DefaultNodeGroup
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: cluster-autoscaler-cloud-config

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
@@ -1,0 +1,38 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      namespace: kube-system
+      labels:
+        app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler-account
+      containers:
+        - name: cluster-autoscaler
+          image: thartland/magnum-autoscaler:v1.0
+          imagePullPolicy: Always
+          command:
+            - ./cluster-autoscaler
+            - --alsologtostderr
+            - --cluster-name=scaler-01
+            - --cloud-config=/config/cloud-config
+            - --cloud-provider=magnum
+            - --nodes=1:10:DefaultNodeGroup
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: cluster-autoscaler-cloud-config

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-secret.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-autoscaler-cloud-config
+  namespace: kube-system
+type: Opaque
+stringData:
+  cloud-config: |-
+    [Global]
+    auth-url=http://192.128.1.15:5000/v3
+    user-id=9a377d66afcf4b83848e7e1ae3178f33
+    password=FVJ2zbkewGnhZrzymI
+    trust-id=adbbbcd022bd4a3ea8b1703d4aa37ebc
+    region=RegionOne

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
@@ -1,0 +1,63 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-role
+rules:
+  - apiGroups: [""]
+    resources: ["events","endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get","update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch","list","get","update"]
+  - apiGroups: [""]
+    resources: ["pods","services","replicationcontrollers","persistentvolumeclaims","persistentvolumes"]
+    verbs: ["watch","list","get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["watch","list","get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch","list"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets","replicasets","statefulsets"]
+    verbs: ["watch","list","get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["watch","list","get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status"]
+    verbs: ["delete","get","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-role
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler-account
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler-account
+  namespace: kube-system

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"io"
+	"os"
+	"sync"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/klog"
+)
+
+const (
+	// ProviderName is the cloud provider name for Magnum
+	ProviderName = "magnum"
+)
+
+// magnumCloudProvider implements CloudProvider interface from cluster-autoscaler/cloudprovider module.
+type magnumCloudProvider struct {
+	magnumManager   *magnumManager
+	resourceLimiter *cloudprovider.ResourceLimiter
+	nodeGroups      []magnumNodeGroup
+}
+
+func buildMagnumCloudProvider(magnumManager magnumManager, resourceLimiter *cloudprovider.ResourceLimiter) (cloudprovider.CloudProvider, error) {
+	os := &magnumCloudProvider{
+		magnumManager:   &magnumManager,
+		resourceLimiter: resourceLimiter,
+		nodeGroups:      []magnumNodeGroup{},
+	}
+	return os, nil
+}
+
+// Name returns the name of the cloud provider.
+func (os *magnumCloudProvider) Name() string {
+	return ProviderName
+}
+
+// NodeGroups returns all node groups managed by this cloud provider.
+func (os *magnumCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+	groups := make([]cloudprovider.NodeGroup, len(os.nodeGroups))
+	for i, group := range os.nodeGroups {
+		groups[i] = &group
+	}
+	return groups
+}
+
+// AddNodeGroup appends a node group to the list of node groups managed by this cloud provider.
+func (os *magnumCloudProvider) AddNodeGroup(group magnumNodeGroup) {
+	os.nodeGroups = append(os.nodeGroups, group)
+}
+
+// NodeGroupForNode returns the node group that a given node belongs to.
+//
+// Since only a single node group is currently supported, the first node group is always returned.
+func (os *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	// TODO: wait for magnum nodegroup support
+	return &(os.nodeGroups[0]), nil
+}
+
+// Pricing is not implemented.
+func (os *magnumCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetAvailableMachineTypes is not implemented.
+func (os *magnumCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+	return []string{}, nil
+}
+
+// NewNodeGroup is not implemented.
+func (os *magnumCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetResourceLimiter returns resource constraints for the cloud provider
+func (os *magnumCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return os.resourceLimiter, nil
+}
+
+// GetInstanceID gets the instance ID for the specified node.
+func (os *magnumCloudProvider) GetInstanceID(node *apiv1.Node) string {
+	return node.Spec.ProviderID
+}
+
+// Refresh is called before every autoscaler main loop.
+//
+// Currently only prints debug information.
+func (os *magnumCloudProvider) Refresh() error {
+	for _, nodegroup := range os.nodeGroups {
+		klog.V(3).Info(nodegroup.Debug())
+	}
+	return nil
+}
+
+// Cleanup currently does nothing.
+func (os *magnumCloudProvider) Cleanup() error {
+	return nil
+}
+
+// BuildMagnum is called by the autoscaler to build a magnum cloud provider.
+//
+// The magnumManager is created here, and the node groups are created
+// based on the specs provided via the command line parameters.
+func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	var config io.ReadCloser
+
+	// Should be loaded with --cloud-config /etc/kubernetes/kube_openstack_config from master node
+	if opts.CloudConfig != "" {
+		var err error
+		config, err = os.Open(opts.CloudConfig)
+		if err != nil {
+			klog.Fatalf("Couldn't open cloud provider configuration %s: %#v", opts.CloudConfig, err)
+		}
+		defer config.Close()
+	}
+
+	manager, err := createMagnumManager(config, do, opts)
+	if err != nil {
+		klog.Fatalf("Failed to create magnum manager: %v", err)
+	}
+
+	provider, err := buildMagnumCloudProvider(manager, rl)
+	if err != nil {
+		klog.Fatalf("Failed to create magnum cloud provider: %v", err)
+	}
+
+	// TODO: When magnum node group support is available then 0 NodeGroupSpecs will be a valid input.
+	if len(do.NodeGroupSpecs) == 0 {
+		klog.Fatalf("Must specify at least one node group with --nodes=<min>:<max>:<name>,...")
+	}
+
+	// TODO: Temporary, only makes sense to have one nodegroup until magnum nodegroups are implemented
+	// Node groups will be available in k8s_fedora_atomic_v2 driver https://review.openstack.org/#/c/629274/
+	if len(do.NodeGroupSpecs) > 1 {
+		klog.Fatalf("Magnum autoscaler only supports a single nodegroup for now")
+	}
+
+	clusterUpdateLock := sync.Mutex{}
+
+	for _, nodegroupSpec := range do.NodeGroupSpecs {
+		spec, err := dynamic.SpecFromString(nodegroupSpec, scaleToZeroSupported)
+		if err != nil {
+			klog.Fatalf("Could not parse node group spec %s: %v", nodegroupSpec, err)
+		}
+
+		ng := magnumNodeGroup{
+			magnumManager:       manager,
+			id:                  spec.Name,
+			clusterUpdateMutex:  &clusterUpdateLock,
+			minSize:             spec.MinSize,
+			maxSize:             spec.MaxSize,
+			targetSize:          new(int),
+			waitTimeStep:        waitForStatusTimeStep,
+			deleteBatchingDelay: deleteNodesBatchingDelay,
+		}
+		*ng.targetSize, err = ng.magnumManager.nodeGroupSize(ng.id)
+		if err != nil {
+			klog.Fatalf("Could not set current nodes in node group: %v", err)
+		}
+		provider.(*magnumCloudProvider).AddNodeGroup(ng)
+	}
+
+	return provider
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+const (
+	defaultManager = "heat"
+)
+
+// magnumManager is an interface for the basic interactions with the cluster.
+type magnumManager interface {
+	nodeGroupSize(nodegroup string) (int, error)
+	updateNodeCount(nodegroup string, nodes int) error
+	getNodes(nodegroup string) ([]string, error)
+	deleteNodes(nodegroup string, nodes []NodeRef, updatedNodeCount int) error
+	getClusterStatus() (string, error)
+	canUpdate() (bool, string, error)
+	templateNodeInfo(nodegroup string) (*schedulernodeinfo.NodeInfo, error)
+}
+
+// createMagnumManager creates the desired implementation of magnumManager.
+// Currently reads the environment variable OSMANAGER to find which to create,
+// and falls back to a default if the variable is not found.
+func createMagnumManager(configReader io.Reader, discoverOpts cloudprovider.NodeGroupDiscoveryOptions, opts config.AutoscalingOptions) (magnumManager, error) {
+	// For now get manager from env var, can consider adding flag later
+	manager, ok := os.LookupEnv("OSMANAGER")
+	if !ok {
+		manager = defaultManager
+	}
+
+	switch manager {
+	case "heat":
+		return createMagnumManagerHeat(configReader, discoverOpts, opts)
+	}
+
+	return nil, fmt.Errorf("magnum manager does not exist: %s", manager)
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+	"gopkg.in/gcfg.v1"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog"
+	provider_os "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+const (
+	stackStatusUpdateInProgress = "UPDATE_IN_PROGRESS"
+	stackStatusUpdateComplete   = "UPDATE_COMPLETE"
+)
+
+// statusesPreventingUpdate is a set of statuses that would prevent
+// the cluster from successfully scaling.
+//
+// TODO: If it becomes possible to update even in UPDATE_FAILED state then it can be removed here
+// https://storyboard.openstack.org/#!/story/2005056
+var statusesPreventingUpdate = sets.NewString(
+	clusterStatusUpdateInProgress,
+	clusterStatusUpdateFailed,
+)
+
+// magnumManagerHeat implements the magnumManager interface.
+//
+// Most interactions with the cluster are done directly with magnum,
+// but scaling down requires an intermediate step using heat to
+// delete the specific nodes that the autoscaler has picked for removal.
+type magnumManagerHeat struct {
+	clusterClient *gophercloud.ServiceClient
+	heatClient    *gophercloud.ServiceClient
+	clusterName   string
+
+	stackName string
+	stackID   string
+
+	kubeMinionsStackName string
+	kubeMinionsStackID   string
+
+	waitTimeStep time.Duration
+}
+
+// createMagnumManagerHeat sets up cluster and stack clients and returns
+// an magnumManagerHeat.
+func createMagnumManagerHeat(configReader io.Reader, discoverOpts cloudprovider.NodeGroupDiscoveryOptions, opts config.AutoscalingOptions) (*magnumManagerHeat, error) {
+	var cfg provider_os.Config
+	if configReader != nil {
+		if err := gcfg.ReadInto(&cfg, configReader); err != nil {
+			klog.Errorf("Couldn't read config: %v", err)
+			return nil, err
+		}
+	}
+
+	if opts.ClusterName == "" {
+		klog.Fatalf("The cluster-name parameter must be set")
+	}
+
+	authOpts := toAuthOptsExt(cfg)
+
+	provider, err := openstack.NewClient(cfg.Global.AuthURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not authenticate client: %v", err)
+	}
+
+	if cfg.Global.CAFile != "" {
+		roots, err := certutil.NewPool(cfg.Global.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		config := &tls.Config{}
+		config.RootCAs = roots
+		provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
+
+	}
+
+	err = openstack.AuthenticateV3(provider, authOpts, gophercloud.EndpointOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("could not authenticate: %v", err)
+	}
+
+	clusterClient, err := openstack.NewContainerInfraV1(provider, gophercloud.EndpointOpts{Type: "container-infra", Name: "magnum", Region: cfg.Global.Region})
+	if err != nil {
+		return nil, fmt.Errorf("could not create container-infra client: %v", err)
+	}
+
+	heatClient, err := openstack.NewOrchestrationV1(provider, gophercloud.EndpointOpts{Type: "orchestration", Name: "heat", Region: cfg.Global.Region})
+	if err != nil {
+		return nil, fmt.Errorf("could not create orchestration client: %v", err)
+	}
+
+	manager := magnumManagerHeat{
+		clusterClient: clusterClient,
+		clusterName:   opts.ClusterName,
+		heatClient:    heatClient,
+		waitTimeStep:  waitForStatusTimeStep,
+	}
+
+	// Check that the cluster exists, and get the ID of its heat stack
+	cluster, err := clusters.Get(manager.clusterClient, manager.clusterName).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("unable to access cluster (%s): %v", manager.clusterName, err)
+	}
+	manager.stackID = cluster.StackID
+
+	// Need both the stack name and ID to use in GET requests for the stack, so get name and store that on the manager
+	manager.stackName, err = manager.getStackName(manager.stackID)
+	if err != nil {
+		return nil, fmt.Errorf("could not store stack name on manager: %v", err)
+	}
+
+	// Need to be able top access the nested stack which has a mapping between minion indices and IP/ID of the node.
+	// The cluster stack has an ID for this nested stack but we need the name as well.
+	manager.kubeMinionsStackName, manager.kubeMinionsStackID, err = manager.getKubeMinionsStack(manager.stackName, manager.stackID)
+	if err != nil {
+		return nil, fmt.Errorf("could not store kube minions stack name/ID on manager: %v", err)
+	}
+
+	return &manager, nil
+}
+
+// nodeGroupSize gets the current cluster size as reported by magnum.
+// The nodegroup argument is ignored as this implementation of magnumManager
+// assumes that only a single node group exists.
+func (osm *magnumManagerHeat) nodeGroupSize(nodegroup string) (int, error) {
+	cluster, err := clusters.Get(osm.clusterClient, osm.clusterName).Extract()
+	if err != nil {
+		return 0, fmt.Errorf("could not get cluster: %v", err)
+	}
+	return cluster.NodeCount, nil
+}
+
+// updateNodeCount replaces the cluster node_count in magnum.
+func (osm *magnumManagerHeat) updateNodeCount(nodegroup string, nodes int) error {
+	updateOpts := []clusters.UpdateOptsBuilder{
+		UpdateOptsInt{Op: clusters.ReplaceOp, Path: "/node_count", Value: nodes},
+	}
+	_, err := clusters.Update(osm.clusterClient, osm.clusterName, updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("could not update cluster: %v", err)
+	}
+	return nil
+}
+
+// getNodes should return ProviderIDs for all nodes in the node group,
+// used to find any nodes which are unregistered in kubernetes.
+// This can not be done with heat currently but a change has been merged upstream
+// that will allow this.
+func (osm *magnumManagerHeat) getNodes(nodegroup string) ([]string, error) {
+	// TODO: get node ProviderIDs by getting nova instance IDs from heat
+	// Waiting for https://review.openstack.org/#/c/639053/ to be able to get
+	// nova instance IDs from the kube_minions stack resource.
+	// This works fine being empty for now anyway.
+	return []string{}, nil
+}
+
+// deleteNodes deletes nodes by passing a comma separated list of names or IPs
+// of minions to remove to heat, and simultaneously sets the new number of minions on the stack.
+// The magnum node_count is then set to the new value (does not cause any more nodes to be removed).
+//
+// TODO: The two step process is required until https://storyboard.openstack.org/#!/story/2005052
+// is complete, which will allow resizing with specific nodes to be deleted as a single Magnum operation.
+func (osm *magnumManagerHeat) deleteNodes(nodegroup string, nodes []NodeRef, updatedNodeCount int) error {
+	stackIndices, err := osm.findStackIndices(nodes)
+	if err != nil {
+		return fmt.Errorf("could not find stack indices for nodes to be deleted: %v", err)
+	}
+	minionsToRemove := strings.Join(stackIndices, ",")
+
+	updateOpts := stacks.UpdateOpts{
+		Parameters: map[string]interface{}{
+			"minions_to_remove": minionsToRemove,
+			"number_of_minions": updatedNodeCount,
+		},
+	}
+
+	updateResult := stacks.UpdatePatch(osm.heatClient, osm.stackName, osm.stackID, updateOpts)
+	err = updateResult.ExtractErr()
+	if err != nil {
+		return fmt.Errorf("stack patch failed: %v", err)
+	}
+
+	// Wait for the stack to do its thing before updating the cluster node_count
+	err = osm.waitForStackStatus(stackStatusUpdateInProgress, waitForUpdateStatusTimeout)
+	if err != nil {
+		return fmt.Errorf("error waiting for stack %s status: %v", stackStatusUpdateInProgress, err)
+	}
+	err = osm.waitForStackStatus(stackStatusUpdateComplete, waitForCompleteStatusTimout)
+	if err != nil {
+		return fmt.Errorf("error waiting for stack %s status: %v", stackStatusUpdateComplete, err)
+	}
+
+	err = osm.updateNodeCount(nodegroup, updatedNodeCount)
+	if err != nil {
+		return fmt.Errorf("could not set new cluster size: %v", err)
+	}
+	return nil
+}
+
+// getClusterStatus returns the current status of the magnum cluster.
+func (osm *magnumManagerHeat) getClusterStatus() (string, error) {
+	cluster, err := clusters.Get(osm.clusterClient, osm.clusterName).Extract()
+	if err != nil {
+		return "", fmt.Errorf("could not get cluster: %v", err)
+	}
+	return cluster.Status, nil
+}
+
+// canUpdate checks if the cluster status is present in a set of statuses that
+// prevent the cluster from being updated.
+// Returns if updating is possible and the status for convenience.
+func (osm *magnumManagerHeat) canUpdate() (bool, string, error) {
+	clusterStatus, err := osm.getClusterStatus()
+	if err != nil {
+		return false, "", fmt.Errorf("could not get cluster status: %v", err)
+	}
+	return !statusesPreventingUpdate.Has(clusterStatus), clusterStatus, nil
+}
+
+// getStackStatus returns the current status of the heat stack used by the magnum cluster.
+func (osm *magnumManagerHeat) getStackStatus() (string, error) {
+	stack, err := stacks.Get(osm.heatClient, osm.stackName, osm.stackID).Extract()
+	if err != nil {
+		return "", fmt.Errorf("could not get stack from heat: %v", err)
+	}
+	return stack.Status, nil
+}
+
+// templateNodeInfo returns a NodeInfo with a node template based on the VM flavor
+// that is used to created minions in a given node group.
+func (osm *magnumManagerHeat) templateNodeInfo(nodegroup string) (*schedulernodeinfo.NodeInfo, error) {
+	// TODO: create a node template by getting the minion flavor from the heat stack.
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// waitForStackStatus checks periodically to see if the heat stack has entered a given status.
+// Returns when the status is observed or the timeout is reached.
+func (osm *magnumManagerHeat) waitForStackStatus(status string, timeout time.Duration) error {
+	klog.V(2).Infof("Waiting for stack %s status", status)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(osm.waitTimeStep) {
+		currentStatus, err := osm.getStackStatus()
+		if err != nil {
+			return fmt.Errorf("error waiting for stack status: %v", err)
+		}
+		if currentStatus == status {
+			klog.V(0).Infof("Waited for stack %s status", status)
+			return nil
+		}
+	}
+	return fmt.Errorf("timeout (%v) waiting for stack status %s", timeout, status)
+}
+
+// getStackName finds the name of a stack matching a given ID.
+func (osm *magnumManagerHeat) getStackName(stackID string) (string, error) {
+	stack, err := stacks.Find(osm.heatClient, stackID).Extract()
+	if err != nil {
+		return "", fmt.Errorf("could not find stack with ID %s: %v", osm.stackID, err)
+	}
+	klog.V(0).Infof("For stack ID %s, stack name is %s", osm.stackID, stack.Name)
+	return stack.Name, nil
+}
+
+// getKubeMinionsStack finds the nested kube_minions stack belonging to the main cluster stack,
+// and returns its name and ID.
+func (osm *magnumManagerHeat) getKubeMinionsStack(stackName, stackID string) (name string, ID string, err error) {
+	minionsResource, err := stackresources.Get(osm.heatClient, stackName, stackID, "kube_minions").Extract()
+	if err != nil {
+		return "", "", fmt.Errorf("could not get kube_minions stack resource: %v", err)
+	}
+
+	stack, err := stacks.Find(osm.heatClient, minionsResource.PhysicalID).Extract()
+	if err != nil {
+		return "", "", fmt.Errorf("could not find stack matching resource ID in heat: %v", err)
+	}
+
+	klog.V(0).Infof("Found nested kube_minions stack: name %s, ID %s", stack.Name, minionsResource.PhysicalID)
+
+	return stack.Name, minionsResource.PhysicalID, nil
+}
+
+// findStackIndices finds the stack indices of a set of nodes.
+//
+// The heat stack stores a mapping between minion indices and their stack IDs.
+// The stack IDs are equal to a property of the minions, this could be IP or could be machine ID.
+// i.e {'0': '188.185.64.117'}
+// or  {'0': 'f12070fef4144bef82812aff177b83c1'}
+// Deleting minions in heat can be done with either the index of the minion or the ID associated with it,
+// but since the ID could be one of several things it is useful to be able to resolve back to indices.
+func (osm *magnumManagerHeat) findStackIndices(nodeRefs []NodeRef) ([]string, error) {
+	stack, err := stacks.Get(osm.heatClient, osm.kubeMinionsStackName, osm.kubeMinionsStackID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("could not get kube_minions nested stack from heat: %v", err)
+	}
+
+	var IDToIndex = make(map[string]string)
+	for _, output := range stack.Outputs {
+		if output["output_key"] == "refs_map" {
+			minionsMapInterface := output["output_value"].(map[string]interface{})
+			for index, ID := range minionsMapInterface {
+				IDToIndex[ID.(string)] = index
+			}
+		}
+	}
+
+	var indices []string
+
+	notFound := 0
+	for _, ref := range nodeRefs {
+		if index, found := stackIndexFromID(IDToIndex, ref); found {
+			klog.V(0).Infof("Resolved node %s to stack index %s", ref.Name, index)
+			indices = append(indices, index)
+		} else {
+			klog.V(0).Infof("Could not resolve node %+v to a stack index", ref)
+			notFound += 1
+		}
+	}
+
+	if notFound > 0 {
+		return nil, fmt.Errorf("%d nodes could not be resolved to stack indices", notFound)
+	}
+
+	return indices, nil
+}
+
+// stackIndexFromID finds the index of a given node from the heat kube_minions output map,
+// which is provided by findStackIndices (inverted).
+// The boolean return value specifies if the index was found or not.
+func stackIndexFromID(IDToIndex map[string]string, nodeRef NodeRef) (string, bool) {
+	if index, found := IDToIndex[nodeRef.MachineID]; found {
+		return index, found
+	}
+	for _, IP := range nodeRef.IPs {
+		if index, found := IDToIndex[IP]; found {
+			return index, found
+		}
+	}
+	return "", false
+}
+
+// UpdateOptsInt has a value of type int rather than string.
+//
+// A Magnum API running with python2 accepts a string for
+// replacing node_count, but with python3 only an integer type
+// is accepted.
+//
+// TODO: Can remove when this is provided by gophercloud
+// https://github.com/gophercloud/gophercloud/issues/1458
+type UpdateOptsInt struct {
+	Op    clusters.UpdateOp `json:"op" required:"true"`
+	Path  string            `json:"path" required:"true"`
+	Value int               `json:"value,omitempty"`
+}
+
+// ToClustersUpdateMap assembles a request body based on the contents of
+// UpdateOpts.
+func (opts UpdateOptsInt) ToClustersUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
@@ -1,0 +1,829 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/stretchr/testify/assert"
+)
+
+var clusterUUID = "732851e1-f792-4194-b966-4cbfa5f30093"
+var clusterNodeCount = 5
+var clusterStatus = clusterStatusUpdateComplete
+var clusterStackID = "2e35472f-d3c1-40b1-93fe-a421db19cc89"
+
+var clusterGetResponseSuccess = fmt.Sprintf(`
+{
+    "create_timeout":60,
+    "links":[
+        {
+            "href":"http://10.100.101.102:9511/v1/clusters/732851e1-f792-4194-b966-4cbfa5f30093",
+            "rel":"self"
+        },
+        {
+            "href":"http://10.100.101.102:9511/clusters/732851e1-f792-4194-b966-4cbfa5f30093",
+            "rel":"bookmark"
+        }
+    ],
+    "labels":{
+    },
+    "updated_at":"2019-02-07T14:07:33+00:00",
+    "keypair":"test-key",
+    "master_flavor_id":"m2.medium",
+    "user_id":"tester",
+    "uuid":"%s",
+    "api_address":"https://172.24.4.6:6443",
+    "master_addresses":[
+        "172.24.4.6"
+    ],
+    "node_count":%d,
+    "project_id":"d656bd69-82a2-4efe-bbee-abd0b0a83252",
+    "status":"%s",
+    "docker_volume_size":null,
+    "master_count":1,
+    "node_addresses":[
+        "172.24.4.10"
+    ],
+    "status_reason":"Stack UPDATE completed successfully",
+    "coe_version":"v1.9.3",
+    "cluster_template_id":"af067ca7-d0a2-43ee-9529-40e538072d86",
+    "name":"cluster-01",
+    "stack_id":"%s",
+    "created_at":"2019-02-01T13:13:48+00:00",
+    "discovery_url":"https://discovery.etcd.io/efa82529a12040a19deec2e7addd3183",
+    "flavor_id":"m2.medium",
+    "container_version":"1.12.6"
+}`, clusterUUID, clusterNodeCount, clusterStatus, clusterStackID)
+
+var badClusterUUID = "fa9887b8-e8d8-46d1-a82f-3c28618f8db1"
+
+var clusterGetResponseFail = fmt.Sprintf(`
+{
+    "errors":[
+        {
+            "status":404,
+            "code":"client",
+            "links":[
+
+            ],
+            "title":"Cluster %s could not be found",
+            "detail":"Cluster %s could not be found.",
+            "request_id":""
+        }
+    ]
+}`, badClusterUUID, badClusterUUID)
+
+var stackName = "cluster-01-aftjnjwdczjr"
+var stackID = "2e35472f-d3c1-40b1-93fe-a421db19cc89"
+var stackStatus = "UPDATE_COMPLETE"
+
+var badStackID = "708389ff-10fa-4008-9e0f-a3d5f979e88c"
+
+var stackGetResponse = `
+{
+    "stack":{
+        "parent":null,
+        "disable_rollback":true,
+        "description":"This template will boot a Kubernetes cluster with one or more minions.\n",
+        "parameters":{
+            "OS::stack_id":"2e35472f-d3c1-40b1-93fe-a421db19cc89",
+            "OS::project_id":"d656bd69-82a2-4efe-bbee-abd0b0a83252",
+            "OS::stack_name":"cluster-01-aftjnjwdczjr"
+        },
+        "deletion_time":null,
+        "stack_name":"%s",
+        "stack_user_project_id":"0aa1d684229d4b5985b090e5b2c651d6",
+        "stack_status_reason":"Stack UPDATE completed successfully",
+        "creation_time":"2019-02-01T13:13:55Z",
+        "links":[
+            {
+                "href":"https://10.100.101.102:8004/v1/d656bd69-82a2-4efe-bbee-abd0b0a83252/stacks/cluster-01-aftjnjwdczjr/2e35472f-d3c1-40b1-93fe-a421db19cc89",
+                "rel":"self"
+            }
+        ],
+        "capabilities":[
+
+        ],
+        "notification_topics":[
+
+        ],
+        "tags":null,
+        "timeout_mins":60,
+        "stack_status":"%s",
+        "stack_owner":null,
+        "updated_time":"2019-02-07T14:06:29Z",
+        "id":"%s",
+        "outputs":[
+        ]
+    }
+}`
+
+var stackGetResponseSuccess = fmt.Sprintf(stackGetResponse, stackName, stackStatus, stackID)
+
+var stackGetResponseNotFound = fmt.Sprintf(`
+{
+    "explanation":"The resource could not be found.",
+    "code":404,
+    "error":{
+        "message":"The Stack (%s) could not be found.",
+        "traceback":null,
+        "type":"EntityNotFound"
+    },
+    "title":"Not Found"
+}`, badStackID)
+
+var deleteNodeRefs = []NodeRef{
+	{Name: stackName + "-minion-1", MachineID: "3ae2e15807bd48ccbb26f9bb5f2996d6", ProviderID: "openstack:///3ae2e15807bd48ccbb26f9bb5f2996d6", IPs: []string{"10.0.0.52"}},
+}
+var patchResponseSuccess = `{"uuid": "732851e1-f792-4194-b966-4cbfa5f30093"}`
+
+var stackUpdateResponseFail = fmt.Sprintf(`
+{
+    "errors":[
+        {
+            "status":404,
+            "code":"client",
+            "links":[
+
+            ],
+            "title":"Cluster %s could not be found",
+            "detail":"Cluster %s could not be found.",
+            "request_id":""
+        }
+    ]
+}`, badClusterUUID, badClusterUUID)
+
+var stackBadPatchResponse = `
+{
+    "explanation":"The server could not comply with the request since it is either malformed or otherwise incorrect.",
+    "code":400,
+    "error":{
+        "message":"Property error: : resources.kube_minions.properties.count: : -1 is out of range (min: 0, max: None)",
+        "traceback":null,
+        "type":"StackValidationFailed"
+    },
+    "title":"Bad Request"
+}`
+
+var kubeMinionsStackID = "be32904e-021b-4069-a670-67bbf4650dca"
+var kubeMinionsStackName = fmt.Sprintf("%s-kube_minions-aidbol4lxwlf", stackName)
+
+var stackresourceGetKubeMinionsResponse = fmt.Sprintf(`
+{
+    "resource":{
+        "resource_name":"kube_minions",
+        "description":"",
+        "logical_resource_id":"kube_minions",
+        "creation_time":"2019-02-21T10:59:33Z",
+        "resource_status_reason":"state changed",
+        "updated_time":"2019-02-22T15:33:30Z",
+        "required_by":[
+
+        ],
+        "resource_status":"UPDATE_COMPLETE",
+        "physical_resource_id":"%s",
+        "attributes":{
+            "attributes":null,
+            "refs":null,
+            "refs_map":null,
+            "removed_rsrc_list":[
+
+            ]
+        },
+        "resource_type":"OS::Heat::ResourceGroup"
+    }
+}`, kubeMinionsStackID)
+
+var stackresourceGetKubeMinionsNotFound = fmt.Sprintf(`
+{
+    "explanation":"The resource could not be found.",
+    "code":404,
+    "error":{
+        "message":"The Stack (%s) could not be found.",
+        "traceback":null,
+        "type":"EntityNotFound"
+    },
+    "title":"Not Found"
+}`, badStackID)
+
+var stackGetKubeMinionsStackResponse = fmt.Sprintf(`
+{
+    "stack":{
+        "parent":"afa343f6-17f5-4cb6-82ea-779a7142f014",
+        "disable_rollback":true,
+        "description":"No description",
+        "parameters":{
+            "OS::project_id":"d656bd69-82a2-4efe-bbee-abd0b0a83252",
+            "OS::stack_id":"%s",
+            "OS::stack_name":"%s"
+        },
+        "deletion_time":null,
+        "stack_name":"%s",
+        "stack_user_project_id":"bc47c8c25c084b22914e0491bd9c5fab",
+        "stack_status_reason":"Stack UPDATE completed successfully",
+        "creation_time":"2019-02-21T11:06:28Z",
+        "links":[
+
+        ],
+        "capabilities":[
+
+        ],
+        "notification_topics":[
+
+        ],
+        "tags":null,
+        "timeout_mins":60,
+        "stack_status":"UPDATE_COMPLETE",
+        "stack_owner":null,
+        "updated_time":"2019-02-22T15:33:30Z",
+        "id":"be32904e-021b-4069-a670-67bbf4650dca",
+        "outputs":[
+            {
+                "output_value":{
+                    "0":"ffbc651da661462d94352e01f3020688",
+                    "1":"3ae2e15807bd48ccbb26f9bb5f2996d6"
+                },
+                "output_key":"refs_map",
+                "description":"No description given"
+            }
+        ],
+        "template_description":"No description"
+    }
+}`, kubeMinionsStackID, kubeMinionsStackName, kubeMinionsStackName)
+
+func createTestServiceClient() *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "cbc36478b0bd8e67e89469c7749d4127"},
+		Endpoint:       th.Endpoint() + "v1/",
+	}
+}
+
+func createTestMagnumManagerHeat(client *gophercloud.ServiceClient) *magnumManagerHeat {
+	return &magnumManagerHeat{
+		clusterClient: client,
+		heatClient:    client,
+		waitTimeStep:  100 * time.Millisecond,
+	}
+}
+
+func createManagerGetClusterSuccess() *magnumManagerHeat {
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, clusterGetResponseSuccess)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+
+	return osm
+}
+
+func createManagerGetClusterFail() *magnumManagerHeat {
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		fmt.Fprint(w, clusterGetResponseFail)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = badClusterUUID
+
+	return osm
+}
+
+func TestNodeGroupSizeSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterSuccess()
+
+	nodeCount, err := osm.nodeGroupSize("default")
+	assert.NoError(t, err)
+	assert.Equal(t, clusterNodeCount, nodeCount)
+}
+
+func TestNodeGroupSizeFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterFail()
+
+	_, err := osm.nodeGroupSize("default")
+	assert.Error(t, err)
+	assert.Equal(t, "could not get cluster: Resource not found", err.Error())
+}
+
+func TestGetClusterStatusSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterSuccess()
+
+	gotStatus, err := osm.getClusterStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, clusterStatus, gotStatus)
+}
+
+func TestGetClusterStatusFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterFail()
+
+	_, err := osm.getClusterStatus()
+	assert.Error(t, err)
+	assert.Equal(t, "could not get cluster: Resource not found", err.Error())
+}
+
+func TestCanUpdateSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterSuccess()
+
+	can, status, err := osm.canUpdate()
+	assert.NoError(t, err)
+	assert.Equal(t, true, can)
+	assert.Equal(t, clusterStatus, status)
+}
+
+func TestCanUpdateFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	osm := createManagerGetClusterFail()
+
+	_, _, err := osm.canUpdate()
+	assert.Error(t, err)
+	assert.Equal(t, "could not get cluster status: could not get cluster: Resource not found", err.Error())
+}
+
+func TestGetStackNameSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateComplete, stackID)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+
+	gotStackName, err := osm.getStackName(osm.stackID)
+	assert.NoError(t, err)
+	assert.Equal(t, stackName, gotStackName)
+}
+
+func TestGetStackNameNotFound(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		fmt.Fprint(w, stackGetResponseNotFound)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = badStackID
+
+	_, err := osm.getStackName(osm.stackID)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("could not find stack with ID %s: Resource not found", badStackID), err.Error())
+}
+
+func TestGetStackStatusSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, stackGetResponseSuccess)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	status, err := osm.getStackStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, stackStatus, status)
+}
+
+func TestGetStackStatusFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		fmt.Fprint(w, stackGetResponseNotFound)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = badStackID
+	osm.stackName = stackName
+
+	_, err := osm.getStackStatus()
+	assert.Error(t, err)
+	assert.Equal(t, "could not get stack from heat: Resource not found", err.Error())
+}
+
+func TestUpdateNodeCountSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprint(w, patchResponseSuccess)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+
+	err := osm.updateNodeCount("default", 2)
+	assert.NoError(t, err)
+}
+
+func TestUpdateNodeCountFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/clusters/"+badClusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		fmt.Fprint(w, stackUpdateResponseFail)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = badClusterUUID
+
+	err := osm.updateNodeCount("default", 2)
+	assert.Error(t, err)
+	assert.Equal(t, "could not update cluster: Resource not found", err.Error())
+}
+
+func TestDeleteNodesSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	GETRequestCount := 0
+
+	// Handle stack PATCH, then two stack GETS (for checking UPDATE_IN_PROGRESS -> UPDATE_COMPLETE)
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if r.Method == http.MethodGet {
+			GETRequestCount += 1
+			if GETRequestCount == 1 {
+				// findStackIndices
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, stackGetKubeMinionsStackResponse)
+			} else if GETRequestCount == 2 {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateInProgress, stackID)
+			} else if GETRequestCount == 3 {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateComplete, stackID)
+			}
+		}
+	})
+
+	// Handle cluster node_count PATCH
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, patchResponseSuccess)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	err := osm.deleteNodes("default", deleteNodeRefs, 1)
+	assert.NoError(t, err)
+}
+
+func TestDeleteNodesStackPatchFail(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	GETRequestCount := 0
+
+	// Handle bad stack PATCH, then two stack GETS (for checking UPDATE_IN_PROGRESS -> UPDATE_COMPLETE)
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, stackBadPatchResponse)
+			return
+		}
+		if r.Method == http.MethodGet {
+			GETRequestCount += 1
+			if GETRequestCount == 1 {
+				// findStackIndices
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, stackGetKubeMinionsStackResponse)
+			} else if GETRequestCount == 2 {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateInProgress, stackID)
+			} else if GETRequestCount == 3 {
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateComplete, stackID)
+			}
+		}
+	})
+
+	// Handle cluster node_count PATCH
+	th.Mux.HandleFunc("/v1/clusters/"+clusterUUID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	err := osm.deleteNodes("default", deleteNodeRefs, -1)
+	assert.Error(t, err)
+
+	expectedErrString := fmt.Sprintf("stack patch failed: Bad request with: [PATCH %s/v1/stacks/%s/%s], error message: %s",
+		th.Server.URL, stackName, stackID, stackBadPatchResponse)
+
+	assert.Equal(t, expectedErrString, err.Error())
+}
+
+func TestFindStackIndicesMissing(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, stackGetKubeMinionsStackResponse)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	nodes := []NodeRef{
+		{Name: fmt.Sprintf("%s-minion-0", stackName), MachineID: "ffbc651da661462d94352e01f3020688"},
+		{Name: fmt.Sprintf("%s-minion-1", stackName)},
+	}
+
+	_, err := osm.findStackIndices(nodes)
+	assert.Error(t, err)
+	assert.Equal(t, "1 nodes could not be resolved to stack indices", err.Error())
+}
+
+func TestWaitForStackStatusSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	GETRequestCount := 0
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		if GETRequestCount == 0 {
+			GETRequestCount += 1
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateInProgress, stackID)
+		} else {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, stackGetResponseSuccess)
+		}
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	assert.NoError(t, err)
+}
+
+func TestWaitForStackStatusTimeout(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, stackGetResponse, stackName, stackStatusUpdateInProgress, stackID)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	assert.Error(t, err)
+	assert.Equal(t, "timeout (200ms) waiting for stack status UPDATE_COMPLETE", err.Error())
+}
+
+func TestWaitForStackStatusError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, stackGetResponseNotFound)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	assert.Error(t, err)
+	assert.Equal(t, "error waiting for stack status: could not get stack from heat: Resource not found", err.Error())
+}
+
+func TestGetKubeMinionsStackSuccess(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/"+stackName+"/"+stackID+"/resources/kube_minions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, stackresourceGetKubeMinionsResponse)
+	})
+
+	th.Mux.HandleFunc("/v1/stacks/"+kubeMinionsStackID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, stackGetKubeMinionsStackResponse)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = stackID
+	osm.stackName = stackName
+
+	name, ID, err := osm.getKubeMinionsStack(osm.stackName, osm.stackID)
+	assert.NoError(t, err)
+	assert.Equal(t, kubeMinionsStackName, name)
+	assert.Equal(t, kubeMinionsStackID, ID)
+}
+
+func TestGetKubeMinionsStackNotFound(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/v1/stacks/"+stackName+"/"+badStackID+"/resources/kube_minions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, stackresourceGetKubeMinionsNotFound)
+	})
+
+	sc := createTestServiceClient()
+
+	osm := createTestMagnumManagerHeat(sc)
+	osm.clusterName = clusterUUID
+	osm.stackID = badStackID
+	osm.stackName = stackName
+
+	_, _, err := osm.getKubeMinionsStack(osm.stackName, osm.stackID)
+	assert.Error(t, err)
+	assert.Equal(t, "could not get kube_minions stack resource: Resource not found", err.Error())
+
+}
+
+func TestStackIndexFromID(t *testing.T) {
+	minion0IP := []string{"10.0.0.52"}
+	minion0ID := "a390ca6ab24846af8ddd854a52fd5281"
+	minion0 := NodeRef{MachineID: minion0ID, IPs: minion0IP}
+
+	minion1IP := []string{"10.0.0.59"}
+	minion1ID := "5bc76eeb2b2e4625a1a559560aa90e5a"
+	minion1 := NodeRef{MachineID: minion1ID, IPs: minion1IP}
+
+	minion2IP := []string{"10.0.0.70"}
+	minion2ID := "86db2aa4666948cfa2b828eb93cf3fd1"
+	minion2 := NodeRef{MachineID: minion2ID, IPs: minion2IP}
+
+	mappingWithIPs := map[string]string{
+		minion0IP[0]: "0",
+		minion1IP[0]: "1",
+	}
+
+	mappingWithIDs := map[string]string{
+		minion0ID: "0",
+		minion1ID: "1",
+	}
+
+	emptyMapping := map[string]string{}
+
+	tests := []struct {
+		name          string
+		mapping       map[string]string
+		nodeRef       NodeRef
+		expectedIndex string
+		expectedFound bool
+	}{
+		{"UUIDs 0", mappingWithIDs, minion0, "0", true},
+		{"UUIDs 1", mappingWithIDs, minion1, "1", true},
+		{"UUIDs 2", mappingWithIDs, minion2, "", false},
+
+		{"IPs 0", mappingWithIPs, minion0, "0", true},
+		{"IPs 1", mappingWithIPs, minion1, "1", true},
+		{"IPs 2", mappingWithIPs, minion2, "", false},
+
+		{"empty 0", emptyMapping, minion0, "", false},
+		{"empty 1", emptyMapping, minion1, "", false},
+		{"empty 2", emptyMapping, minion2, "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index, found := stackIndexFromID(test.mapping, test.nodeRef)
+			assert.Equal(t, test.expectedIndex, index, "failed to find index with mapping %+v and NodeRef %+v", test.mapping, test.nodeRef)
+			assert.Equal(t, test.expectedFound, found, "failed to find / not find with mapping %+v and NodeRef %+v", test.mapping, test.nodeRef)
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/klog"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// magnumNodeGroup implements NodeGroup interface from cluster-autoscaler/cloudprovider.
+//
+// Represents a homogeneous collection of nodes within a cluster,
+// which can be dynamically resized between a minimum and maximum
+// number of nodes.
+type magnumNodeGroup struct {
+	magnumManager magnumManager
+	id            string
+
+	clusterUpdateMutex *sync.Mutex
+
+	minSize int
+	maxSize int
+	// Stored as a pointer so that when autoscaler copies the nodegroup it can still update the target size
+	targetSize *int
+
+	nodesToDelete      []*apiv1.Node
+	nodesToDeleteMutex sync.Mutex
+
+	waitTimeStep        time.Duration
+	deleteBatchingDelay time.Duration
+
+	// Used so that only one DeleteNodes goroutine has to get the node group size at the start of the deletion
+	deleteNodesCachedSize   int
+	deleteNodesCachedSizeAt time.Time
+}
+
+// waitForClusterStatus checks periodically to see if the cluster has entered a given status.
+// Returns when the status is observed or the timeout is reached.
+func (ng *magnumNodeGroup) waitForClusterStatus(status string, timeout time.Duration) error {
+	klog.V(2).Infof("Waiting for cluster %s status", status)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(ng.waitTimeStep) {
+		clusterStatus, err := ng.magnumManager.getClusterStatus()
+		if err != nil {
+			return fmt.Errorf("error waiting for %s status: %v", status, err)
+		}
+		if clusterStatus == status {
+			klog.V(0).Infof("Waited for cluster %s status", status)
+			return nil
+		}
+	}
+	return fmt.Errorf("timeout (%v) waiting for %s status", timeout, status)
+}
+
+// IncreaseSize increases the number of nodes by replacing the cluster's node_count.
+//
+// Takes precautions so that the cluster is not modified while in an UPDATE_IN_PROGRESS state.
+// Blocks until the cluster has reached UPDATE_COMPLETE.
+func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
+	ng.clusterUpdateMutex.Lock()
+	defer ng.clusterUpdateMutex.Unlock()
+
+	if delta <= 0 {
+		return fmt.Errorf("size increase must be positive")
+	}
+
+	size, err := ng.magnumManager.nodeGroupSize(ng.id)
+	if err != nil {
+		return fmt.Errorf("could not check current nodegroup size: %v", err)
+	}
+	if size+delta > ng.MaxSize() {
+		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize())
+	}
+
+	updatePossible, currentStatus, err := ng.magnumManager.canUpdate()
+	if err != nil {
+		return fmt.Errorf("can not increase node count: %v", err)
+	}
+	if !updatePossible {
+		return fmt.Errorf("can not add nodes, cluster is in %s status", currentStatus)
+	}
+	klog.V(0).Infof("Increasing size by %d, %d->%d", delta, *ng.targetSize, *ng.targetSize+delta)
+	*ng.targetSize += delta
+
+	err = ng.magnumManager.updateNodeCount(ng.id, *ng.targetSize)
+	if err != nil {
+		return fmt.Errorf("could not increase cluster size: %v", err)
+	}
+
+	// Block until cluster has gone into update status and then completed
+	err = ng.waitForClusterStatus(clusterStatusUpdateInProgress, waitForUpdateStatusTimeout)
+	if err != nil {
+		return fmt.Errorf("wait for cluster status failed: %v", err)
+	}
+	err = ng.waitForClusterStatus(clusterStatusUpdateComplete, waitForCompleteStatusTimout)
+	if err != nil {
+		return fmt.Errorf("wait for cluster status failed: %v", err)
+	}
+	return nil
+}
+
+// deleteNodes deletes a set of nodes chosen by the autoscaler.
+//
+// The process of deletion depends on the implementation of magnumManager,
+// but this function handles what should be common between all implementations:
+//   - simultaneous but separate calls from the autoscaler are batched together
+//   - does not allow scaling while the cluster is already in an UPDATE_IN_PROGRESS state
+//   - after scaling down, blocks until the cluster has reached UPDATE_COMPLETE
+func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+
+	// Batch simultaneous deletes on individual nodes
+	ng.nodesToDeleteMutex.Lock()
+
+	// First get the node group size and store the value, so that any other parallel delete calls can use it
+	// without having to make the get request for the cluster themselves.
+	// cachedSize keeps a local copy for this goroutine, so that ng.deleteNodesCachedSize is used
+	// only within the ng.nodesToDeleteMutex.
+	var cachedSize int
+	var err error
+	if time.Since(ng.deleteNodesCachedSizeAt) > time.Second*10 {
+		cachedSize, err = ng.magnumManager.nodeGroupSize(ng.id)
+		if err != nil {
+			ng.nodesToDeleteMutex.Unlock()
+			return fmt.Errorf("could not get current node count: %v", err)
+		}
+		ng.deleteNodesCachedSize = cachedSize
+		ng.deleteNodesCachedSizeAt = time.Now()
+	} else {
+		cachedSize = ng.deleteNodesCachedSize
+	}
+
+	// Check that these nodes would not make the batch delete more nodes than the minimum would allow
+	if cachedSize-len(ng.nodesToDelete)-len(nodes) < ng.MinSize() {
+		ng.nodesToDeleteMutex.Unlock()
+		return fmt.Errorf("deleting nodes would take nodegroup below minimum size")
+	}
+	// otherwise, add the nodes to the batch and release the lock
+	ng.nodesToDelete = append(ng.nodesToDelete, nodes...)
+	ng.nodesToDeleteMutex.Unlock()
+
+	// The first of the parallel delete calls to obtain this lock will be the one to actually perform the deletion
+	ng.clusterUpdateMutex.Lock()
+	defer ng.clusterUpdateMutex.Unlock()
+
+	ng.nodesToDeleteMutex.Lock()
+	if len(ng.nodesToDelete) == 0 {
+		// Deletion was handled by another goroutine
+		ng.nodesToDeleteMutex.Unlock()
+		return nil
+	}
+	ng.nodesToDeleteMutex.Unlock()
+
+	// This goroutine has the clusterUpdateMutex, so will be the one
+	// to actually delete the nodes. While this goroutine waits, others
+	// will add their nodes to nodesToDelete and block at acquiring
+	// the clusterUpdateMutex lock. One they get it, the deletion will
+	// already be done and they will return above at the check
+	// for len(ng.nodesToDelete) == 0.
+	time.Sleep(ng.deleteBatchingDelay)
+
+	ng.nodesToDeleteMutex.Lock()
+	nodes = make([]*apiv1.Node, len(ng.nodesToDelete))
+	copy(nodes, ng.nodesToDelete)
+	ng.nodesToDelete = nil
+	ng.nodesToDeleteMutex.Unlock()
+
+	var nodeNames []string
+	for _, node := range nodes {
+		nodeNames = append(nodeNames, node.Name)
+	}
+	klog.V(1).Infof("Deleting nodes: %v", nodeNames)
+
+	updatePossible, currentStatus, err := ng.magnumManager.canUpdate()
+	if err != nil {
+		return fmt.Errorf("could not check if cluster is ready to delete nodes: %v", err)
+	}
+	if !updatePossible {
+		return fmt.Errorf("can not delete nodes, cluster is in %s status", currentStatus)
+	}
+
+	// Double check that the total number of batched nodes for deletion will not take the node group below its minimum size
+	if cachedSize-len(nodes) < ng.MinSize() {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", cachedSize-len(nodes), ng.MinSize())
+	}
+
+	var nodeRefs []NodeRef
+	for _, node := range nodes {
+
+		// Find node IPs, can be multiple (IPv4 and IPv6)
+		var IPs []string
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == apiv1.NodeInternalIP {
+				IPs = append(IPs, addr.Address)
+			}
+		}
+		nodeRefs = append(nodeRefs, NodeRef{
+			Name:       node.Name,
+			MachineID:  node.Status.NodeInfo.MachineID,
+			ProviderID: node.Spec.ProviderID,
+			IPs:        IPs,
+		})
+	}
+
+	err = ng.magnumManager.deleteNodes(ng.id, nodeRefs, cachedSize-len(nodes))
+	if err != nil {
+		return fmt.Errorf("manager error deleting nodes: %v", err)
+	}
+
+	// Block until cluster has gone into update status and then completed
+	err = ng.waitForClusterStatus(clusterStatusUpdateInProgress, waitForUpdateStatusTimeout)
+	if err != nil {
+		return fmt.Errorf("wait for cluster status failed: %v", err)
+	}
+	err = ng.waitForClusterStatus(clusterStatusUpdateComplete, waitForCompleteStatusTimout)
+	if err != nil {
+		return fmt.Errorf("wait for cluster status failed: %v", err)
+	}
+
+	// Check the new node group size and store that as the new target
+	newSize, err := ng.magnumManager.nodeGroupSize(ng.id)
+	if err != nil {
+		// Set to the expected size as a fallback
+		*ng.targetSize = cachedSize - len(nodes)
+		return fmt.Errorf("could not check new cluster size after scale down: %v", err)
+	}
+	*ng.targetSize = newSize
+
+	return nil
+}
+
+// DecreaseTargetSize decreases the cluster node_count in magnum.
+func (ng *magnumNodeGroup) DecreaseTargetSize(delta int) error {
+	if delta >= 0 {
+		return fmt.Errorf("size decrease must be negative")
+	}
+	klog.V(0).Infof("Decreasing target size by %d, %d->%d", delta, *ng.targetSize, *ng.targetSize+delta)
+	*ng.targetSize += delta
+	return ng.magnumManager.updateNodeCount(ng.id, *ng.targetSize)
+}
+
+// Id returns the node group ID
+func (ng *magnumNodeGroup) Id() string {
+	return ng.id
+}
+
+// Debug returns a string formatted with the node group's min, max and target sizes.
+func (ng *magnumNodeGroup) Debug() string {
+	return fmt.Sprintf("%s min=%d max=%d target=%d", ng.id, ng.minSize, ng.maxSize, *ng.targetSize)
+}
+
+// Nodes returns a list of nodes that belong to this node group.
+func (ng *magnumNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	nodes, err := ng.magnumManager.getNodes(ng.id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get nodes: %v", err)
+	}
+	var instances []cloudprovider.Instance
+	for _, node := range nodes {
+		instances = append(instances, cloudprovider.Instance{Id: node})
+	}
+	return instances, nil
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (ng *magnumNodeGroup) TemplateNodeInfo() (*schedulernodeinfo.NodeInfo, error) {
+	return ng.magnumManager.templateNodeInfo(ng.id)
+}
+
+// Exist returns if this node group exists.
+// Currently always returns true.
+func (ng *magnumNodeGroup) Exist() bool {
+	return true
+}
+
+// Create creates the node group on the cloud provider side.
+func (ng *magnumNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
+}
+
+// Delete deletes the node group on the cloud provider side.
+func (ng *magnumNodeGroup) Delete() error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// Autoprovisioned returns if the nodegroup is autoprovisioned.
+func (ng *magnumNodeGroup) Autoprovisioned() bool {
+	return false
+}
+
+// MaxSize returns the maximum allowed size of the node group.
+func (ng *magnumNodeGroup) MaxSize() int {
+	return ng.maxSize
+}
+
+// MinSize returns the minimum allowed size of the node group.
+func (ng *magnumNodeGroup) MinSize() int {
+	return ng.minSize
+}
+
+// TargetSize returns the target size of the node group.
+func (ng *magnumNodeGroup) TargetSize() (int, error) {
+	return *ng.targetSize, nil
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+type magnumManagerMock struct {
+	mock.Mock
+}
+
+func (m *magnumManagerMock) nodeGroupSize(nodegroup string) (int, error) {
+	args := m.Called(nodegroup)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *magnumManagerMock) updateNodeCount(nodegroup string, nodes int) error {
+	args := m.Called(nodegroup, nodes)
+	return args.Error(0)
+}
+
+func (m *magnumManagerMock) getNodes(nodegroup string) ([]string, error) {
+	args := m.Called(nodegroup)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *magnumManagerMock) deleteNodes(nodegroup string, nodes []NodeRef, updatedNodeCount int) error {
+	args := m.Called(nodegroup, nodes, updatedNodeCount)
+	return args.Error(0)
+}
+
+func (m *magnumManagerMock) getClusterStatus() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *magnumManagerMock) canUpdate() (bool, string, error) {
+	args := m.Called()
+	return args.Bool(0), args.String(1), args.Error(2)
+}
+
+func (m *magnumManagerMock) templateNodeInfo(nodegroup string) (*schedulernodeinfo.NodeInfo, error) {
+	return &schedulernodeinfo.NodeInfo{}, nil
+}
+
+func createTestNodeGroup(manager magnumManager) *magnumNodeGroup {
+	current := 1
+	ng := magnumNodeGroup{
+		magnumManager:       manager,
+		id:                  "TestNodeGroup",
+		clusterUpdateMutex:  &sync.Mutex{},
+		minSize:             1,
+		maxSize:             10,
+		targetSize:          &current,
+		waitTimeStep:        100 * time.Millisecond,
+		deleteBatchingDelay: 250 * time.Millisecond,
+	}
+	return &ng
+}
+
+func TestWaitForClusterStatus(t *testing.T) {
+	manager := &magnumManagerMock{}
+	ng := createTestNodeGroup(manager)
+
+	// Test all working normally
+	t.Run("success", func(t *testing.T) {
+		manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+		err := ng.waitForClusterStatus(clusterStatusUpdateComplete, 200*time.Millisecond)
+		assert.NoError(t, err)
+	})
+
+	// Test timeout
+	t.Run("timeout", func(t *testing.T) {
+		manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Times(2)
+		err := ng.waitForClusterStatus(clusterStatusUpdateComplete, 200*time.Millisecond)
+		assert.Error(t, err)
+		assert.Equal(t, "timeout (200ms) waiting for UPDATE_COMPLETE status", err.Error())
+	})
+
+	// Test error returned from manager
+	t.Run("manager error", func(t *testing.T) {
+		manager.On("getClusterStatus").Return("", errors.New("manager error")).Once()
+		err := ng.waitForClusterStatus(clusterStatusUpdateComplete, 200*time.Millisecond)
+		assert.Error(t, err)
+		assert.Equal(t, "error waiting for UPDATE_COMPLETE status: manager error", err.Error())
+	})
+}
+
+func TestIncreaseSize(t *testing.T) {
+	manager := &magnumManagerMock{}
+	ng := createTestNodeGroup(manager)
+
+	// Test all working normally
+	t.Run("success", func(t *testing.T) {
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(1, nil).Once()
+		manager.On("canUpdate").Return(true, "", nil).Once()
+		manager.On("updateNodeCount", "TestNodeGroup", 2).Return(nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+		err := ng.IncreaseSize(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, *ng.targetSize, "target size not updated")
+	})
+
+	// Test negative increase
+	t.Run("negative increase", func(t *testing.T) {
+		err := ng.IncreaseSize(-1)
+		assert.Error(t, err)
+		assert.Equal(t, "size increase must be positive", err.Error())
+	})
+
+	// Test zero increase
+	t.Run("zero increase", func(t *testing.T) {
+		err := ng.IncreaseSize(0)
+		assert.Error(t, err)
+		assert.Equal(t, "size increase must be positive", err.Error())
+	})
+
+	// Test current total nodes fails
+	t.Run("node group size fails", func(t *testing.T) {
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(0, errors.New("manager error")).Once()
+		err := ng.IncreaseSize(1)
+		assert.Error(t, err)
+		assert.Equal(t, "could not check current nodegroup size: manager error", err.Error())
+	})
+
+	// Test increase too large
+	t.Run("increase too large", func(t *testing.T) {
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(1, nil).Once()
+		err := ng.IncreaseSize(10)
+		assert.Error(t, err)
+		assert.Equal(t, "size increase too large, desired:11 max:10", err.Error())
+	})
+
+	// Test cluster status prevents update
+	t.Run("status prevents update", func(t *testing.T) {
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(1, nil).Once()
+		manager.On("canUpdate").Return(false, clusterStatusUpdateInProgress, nil).Once()
+		err := ng.IncreaseSize(1)
+		assert.Error(t, err)
+		assert.Equal(t, "can not add nodes, cluster is in UPDATE_IN_PROGRESS status", err.Error())
+	})
+
+	// Test cluster status check fails
+	t.Run("status check fails", func(t *testing.T) {
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(1, nil).Once()
+		manager.On("canUpdate").Return(false, "", errors.New("manager error")).Once()
+		err := ng.IncreaseSize(1)
+		assert.Error(t, err)
+		assert.Equal(t, "can not increase node count: manager error", err.Error())
+	})
+
+	// Test update node count fails
+	t.Run("update node count fails", func(t *testing.T) {
+		*ng.targetSize = 1
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(1, nil).Once()
+		manager.On("canUpdate").Return(true, "", nil).Once()
+		manager.On("updateNodeCount", "TestNodeGroup", 2).Return(errors.New("manager error")).Once()
+		err := ng.IncreaseSize(1)
+		assert.Error(t, err)
+		assert.Equal(t, "could not increase cluster size: manager error", err.Error())
+	})
+}
+
+var machineIDs []string
+
+var nodesToDelete []*apiv1.Node
+var nodeRefs []NodeRef
+
+func init() {
+	machineIDs = []string{
+		"4d030dc5f2944154aaba43a004f9fccc",
+		"ce120bf512f14497be3c1b07ac9a433a",
+		"7cce782693dd4805bc8e2735d3600433",
+		"8bf92ce193f7401c9a24d1dc2e75dc5d",
+		"1ef6ab6407c3482185fbff428271a6a0",
+	}
+	for i, machineID := range machineIDs {
+		nodeRefs = append(nodeRefs,
+			NodeRef{Name: fmt.Sprintf("cluster-abc-minion-%d", i+1),
+				MachineID:  machineID,
+				ProviderID: fmt.Sprintf("openstack:///%s", machineID),
+				IPs:        []string{fmt.Sprintf("10.0.0.%d", 100+i)},
+			},
+		)
+	}
+
+	for i := 0; i < 5; i++ {
+		node := apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("cluster-abc-minion-%d", i+1),
+			},
+			Status: apiv1.NodeStatus{
+				NodeInfo: apiv1.NodeSystemInfo{
+					MachineID: machineIDs[i],
+				},
+				Addresses: []apiv1.NodeAddress{
+					{Type: apiv1.NodeInternalIP, Address: fmt.Sprintf("10.0.0.%d", 100+i)},
+				},
+			},
+			Spec: apiv1.NodeSpec{
+				ProviderID: fmt.Sprintf("openstack:///%s", machineIDs[i]),
+			},
+		}
+
+		nodesToDelete = append(nodesToDelete, &node)
+	}
+}
+
+func TestDeleteNodes(t *testing.T) {
+	manager := &magnumManagerMock{}
+	ng := createTestNodeGroup(manager)
+	ng.deleteBatchingDelay = 25 * time.Millisecond
+
+	// Test all working normally
+	t.Run("success", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		manager.On("canUpdate").Return(true, clusterStatusUpdateComplete, nil).Once()
+		manager.On("deleteNodes", "TestNodeGroup", nodeRefs, 5).Return(nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(5, nil).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, *ng.targetSize)
+	})
+
+	// Test cluster status check failing
+	t.Run("cluster status check fail", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		manager.On("canUpdate").Return(false, "", errors.New("manager error")).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, "could not check if cluster is ready to delete nodes: manager error", err.Error())
+	})
+
+	// Test cluster status prevents update
+	t.Run("cluster status prevents update", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		manager.On("canUpdate").Return(false, clusterStatusUpdateInProgress, nil).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, fmt.Sprintf("can not delete nodes, cluster is in %s status", clusterStatusUpdateInProgress), err.Error())
+	})
+
+	// Test error returned when checking current cluster size before deleting
+	t.Run("current size check fail", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(0, errors.New("manager error")).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, "could not get current node count: manager error", err.Error())
+	})
+
+	// Test trying to delete more nodes than minimum would allow, when the initial target size is out of sync with the cluster
+	t.Run("delete below min", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.minSize = 8
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, "deleting nodes would take nodegroup below minimum size", err.Error())
+	})
+	ng.minSize = 1
+
+	// Test call to deleteNodes on manager failing
+	t.Run("deleteNodes fails", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		manager.On("canUpdate").Return(true, clusterStatusUpdateComplete, nil).Once()
+		manager.On("deleteNodes", "TestNodeGroup", nodeRefs, 5).Return(errors.New("manager error")).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, "manager error deleting nodes: manager error", err.Error())
+	})
+
+	// Test final call to get new cluster size fails
+	t.Run("get size after delete fails", func(t *testing.T) {
+		*ng.targetSize = 10
+		ng.deleteNodesCachedSizeAt = time.Time{}
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+		manager.On("canUpdate").Return(true, clusterStatusUpdateComplete, nil).Once()
+		manager.On("deleteNodes", "TestNodeGroup", nodeRefs, 5).Return(nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Once()
+		manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+		manager.On("nodeGroupSize", "TestNodeGroup").Return(0, errors.New("manager error")).Once()
+		err := ng.DeleteNodes(nodesToDelete)
+		assert.Error(t, err)
+		assert.Equal(t, "could not check new cluster size after scale down: manager error", err.Error())
+		assert.Equal(t, 5, *ng.targetSize, "targetSize should have been set to expected size 5, it is %d", *ng.targetSize)
+	})
+}
+
+func TestDeleteNodesBatching(t *testing.T) {
+	manager := &magnumManagerMock{}
+	ng := createTestNodeGroup(manager)
+	*ng.targetSize = 10
+
+	// Test all working normally
+	manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+	manager.On("canUpdate").Return(true, "", nil).Once()
+	manager.On("deleteNodes", "TestNodeGroup", nodeRefs, 5).Return(nil).Once()
+	manager.On("nodeGroupSize", "TestNodeGroup").Return(5, nil).Once()
+	manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Once()
+	manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+
+	go func() {
+		time.Sleep(time.Millisecond * 100)
+		err := ng.DeleteNodes(nodesToDelete[3:5])
+		assert.NoError(t, err, "Delete call that should have been batched did not return nil")
+	}()
+
+	err := ng.DeleteNodes(nodesToDelete[0:3])
+	assert.NoError(t, err)
+	assert.Equal(t, 5, *ng.targetSize)
+	manager.AssertExpectations(t)
+}
+
+func TestDeleteNodesBatchBelowMin(t *testing.T) {
+	manager := &magnumManagerMock{}
+	ng := createTestNodeGroup(manager)
+	ng.minSize = 8
+	*ng.targetSize = 10
+
+	// Try to batch 5 nodes for deletion when minSize only allows for two to be deleted
+
+	manager.On("nodeGroupSize", "TestNodeGroup").Return(10, nil).Once()
+	manager.On("canUpdate").Return(true, "", nil).Once()
+	manager.On("deleteNodes", "TestNodeGroup", nodeRefs[0:2], 8).Return(nil).Once()
+	manager.On("nodeGroupSize", "TestNodeGroup").Return(8, nil).Once()
+	manager.On("getClusterStatus").Return(clusterStatusUpdateInProgress, nil).Once()
+	manager.On("getClusterStatus").Return(clusterStatusUpdateComplete, nil).Once()
+
+	for i := 1; i < 5; i++ {
+		go func(i int) {
+			// Wait and preserve order
+			time.Sleep(time.Millisecond*100 + 25*time.Millisecond*time.Duration(i))
+			err := ng.DeleteNodes(nodesToDelete[i : i+1])
+			if i == 1 {
+				// One node should be added to the batch
+				assert.NoError(t, err, "Delete call that should have been batched did not return nil")
+			} else {
+				// The rest should fail
+				assert.Error(t, err)
+				assert.Equal(t, "deleting nodes would take nodegroup below minimum size", err.Error())
+			}
+		}(i)
+	}
+
+	err := ng.DeleteNodes(nodesToDelete[0:1])
+	assert.NoError(t, err)
+	manager.AssertExpectations(t)
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_util.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_util.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package magnum
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
+	provider_os "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+)
+
+const (
+	clusterStatusUpdateInProgress = "UPDATE_IN_PROGRESS"
+	clusterStatusUpdateComplete   = "UPDATE_COMPLETE"
+	clusterStatusUpdateFailed     = "UPDATE_FAILED"
+
+	waitForStatusTimeStep       = 30 * time.Second
+	waitForUpdateStatusTimeout  = 2 * time.Minute
+	waitForCompleteStatusTimout = 10 * time.Minute
+
+	// Could move to property of magnumManager implementations if needed
+	scaleToZeroSupported = false
+
+	// Time that the goroutine that first acquires clusterUpdateMutex
+	// in deleteNodes should wait for other synchronous calls to deleteNodes.
+	deleteNodesBatchingDelay = 2 * time.Second
+)
+
+func toAuthOptsExt(cfg provider_os.Config) trusts.AuthOptsExt {
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: cfg.Global.AuthURL,
+		Username:         cfg.Global.Username,
+		UserID:           cfg.Global.UserID,
+		Password:         cfg.Global.Password,
+		TenantID:         cfg.Global.TenantID,
+		TenantName:       cfg.Global.TenantName,
+		DomainID:         cfg.Global.DomainID,
+		DomainName:       cfg.Global.DomainName,
+
+		// Persistent service, so we need to be able to renew tokens.
+		AllowReauth: true,
+	}
+
+	return trusts.AuthOptsExt{
+		TrustID:            cfg.Global.TrustID,
+		AuthOptionsBuilder: &opts,
+	}
+}
+
+// NodeRef stores the name, machineID and providerID of a node.
+type NodeRef struct {
+	Name       string
+	MachineID  string
+	ProviderID string
+	IPs        []string
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/doc.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/doc.go
@@ -1,0 +1,85 @@
+/*
+Package clusters contains functionality for working with Magnum Cluster resources.
+
+Example to Create a Cluster
+
+	masterCount := 1
+	nodeCount := 1
+	createTimeout := 30
+	opts := clusters.CreateOpts{
+		ClusterTemplateID: "0562d357-8641-4759-8fed-8173f02c9633",
+		CreateTimeout:     &createTimeout,
+		DiscoveryURL:      "",
+		FlavorID:          "m1.small",
+		KeyPair:           "my_keypair",
+		Labels:            map[string]string{},
+		MasterCount:       &masterCount,
+		MasterFlavorID:    "m1.small",
+		Name:              "k8s",
+		NodeCount:         &nodeCount,
+	}
+
+	cluster, err := clusters.Create(serviceClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get a Cluster
+
+	clusterName := "cluster123"
+	cluster, err := clusters.Get(serviceClient, clusterName).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", cluster)
+
+Example to List Clusters
+
+	listOpts := clusters.ListOpts{
+		Limit: 20,
+	}
+
+	allPages, err := clusters.List(serviceClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allClusters, err := clusters.ExtractClusters(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, cluster := range allClusters {
+		fmt.Printf("%+v\n", cluster)
+	}
+
+Example to Update a Cluster
+
+	updateOpts := []clusters.UpdateOptsBuilder{
+		clusters.UpdateOpts{
+			Op:    clusters.ReplaceOp,
+			Path:  "/master_lb_enabled",
+			Value: "True",
+		},
+		clusters.UpdateOpts{
+			Op:    clusters.ReplaceOp,
+			Path:  "/registry_enabled",
+			Value: "True",
+		},
+	}
+	clusterUUID, err := clusters.Update(serviceClient, clusterUUID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", clusterUUID)
+
+Example to Delete a Cluster
+
+	clusterUUID := "dc6d336e3fc4c0a951b5698cd1236ee"
+	err := clusters.Delete(serviceClient, clusterUUID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package clusters

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/requests.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/requests.go
@@ -1,0 +1,159 @@
+package clusters
+
+import (
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder Builder.
+type CreateOptsBuilder interface {
+	ToClusterCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts params
+type CreateOpts struct {
+	ClusterTemplateID string            `json:"cluster_template_id" required:"true"`
+	CreateTimeout     *int              `json:"create_timeout"`
+	DiscoveryURL      string            `json:"discovery_url,omitempty"`
+	DockerVolumeSize  *int              `json:"docker_volume_size,omitempty"`
+	FlavorID          string            `json:"flavor_id,omitempty"`
+	Keypair           string            `json:"keypair,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	MasterCount       *int              `json:"master_count,omitempty"`
+	MasterFlavorID    string            `json:"master_flavor_id,omitempty"`
+	Name              string            `json:"name"`
+	NodeCount         *int              `json:"node_count,omitempty"`
+}
+
+// ToClusterCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToClusterCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create requests the creation of a new cluster.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToClusterCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}
+
+// Get retrieves a specific clusters based on its unique ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}
+
+// Delete deletes the specified cluster ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	r.Header = result.Header
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToClustersListQuery() (string, error)
+}
+
+// ListOpts allows the sorting of paginated collections through
+// the API. SortKey allows you to sort by a particular cluster attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for pagination.
+type ListOpts struct {
+	Marker  string `q:"marker"`
+	Limit   int    `q:"limit"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToClustersListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToClustersListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// clusters. It accepts a ListOptsBuilder, which allows you to sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToClustersListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type UpdateOp string
+
+const (
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+	ReplaceOp UpdateOp = "replace"
+)
+
+type UpdateOpts struct {
+	Op    UpdateOp `json:"op" required:"true"`
+	Path  string   `json:"path" required:"true"`
+	Value string   `json:"value,omitempty"`
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToClustersUpdateMap() (map[string]interface{}, error)
+}
+
+// ToClusterUpdateMap assembles a request body based on the contents of
+// UpdateOpts.
+func (opts UpdateOpts) ToClustersUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update implements cluster updated request.
+func Update(client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+	var o []map[string]interface{}
+	for _, opt := range opts {
+		b, err := opt.ToClustersUpdateMap()
+		if err != nil {
+			r.Err = err
+			return r
+		}
+		o = append(o, b)
+	}
+
+	var result *http.Response
+	result, r.Err = client.Patch(updateURL(client, id), o, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/results.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/results.go
@@ -1,0 +1,114 @@
+package clusters
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response of a Create operations.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult is the result from a Delete operation. Call its Extract or ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a cluster resource.
+func (r commonResult) Extract() (*Cluster, error) {
+	var s *Cluster
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+func (r UpdateResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+type Cluster struct {
+	APIAddress        string             `json:"api_address"`
+	COEVersion        string             `json:"coe_version"`
+	ClusterTemplateID string             `json:"cluster_template_id"`
+	ContainerVersion  string             `json:"container_version"`
+	CreateTimeout     int                `json:"create_timeout"`
+	CreatedAt         time.Time          `json:"created_at"`
+	DiscoveryURL      string             `json:"discovery_url"`
+	DockerVolumeSize  int                `json:"docker_volume_size"`
+	Faults            map[string]string  `json:"faults"`
+	FlavorID          string             `json:"flavor_id"`
+	KeyPair           string             `json:"keypair"`
+	Labels            map[string]string  `json:"labels"`
+	Links             []gophercloud.Link `json:"links"`
+	MasterFlavorID    string             `json:"master_flavor_id"`
+	MasterAddresses   []string           `json:"master_addresses"`
+	MasterCount       int                `json:"master_count"`
+	Name              string             `json:"name"`
+	NodeAddresses     []string           `json:"node_addresses"`
+	NodeCount         int                `json:"node_count"`
+	ProjectID         string             `json:"project_id"`
+	StackID           string             `json:"stack_id"`
+	Status            string             `json:"status"`
+	StatusReason      string             `json:"status_reason"`
+	UUID              string             `json:"uuid"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	UserID            string             `json:"user_id"`
+}
+
+type ClusterPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r ClusterPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, nil
+}
+
+// IsEmpty checks whether a ClusterPage struct is empty.
+func (r ClusterPage) IsEmpty() (bool, error) {
+	is, err := ExtractClusters(r)
+	return len(is) == 0, err
+}
+
+func ExtractClusters(r pagination.Page) ([]Cluster, error) {
+	var s struct {
+		Clusters []Cluster `json:"clusters"`
+	}
+	err := (r.(ClusterPage)).ExtractInto(&s)
+	return s.Clusters, err
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/urls.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters/urls.go
@@ -1,0 +1,35 @@
+package clusters
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+var apiName = "clusters"
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiName)
+}
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiName, id)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("clusters", id)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("clusters")
+}
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/doc.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/doc.go
@@ -1,0 +1,71 @@
+/*
+Package stackresources provides operations for working with stack resources.
+A resource is a template artifact that represents some component of your
+desired architecture (a Cloud Server, a group of scaled Cloud Servers, a load
+balancer, some configuration management system, and so forth).
+
+Example of get resource information in stack
+
+    rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+    if rsrc_result.Err != nil {
+        panic(rsrc_result.Err)
+    }
+    rsrc, err := rsrc_result.Extract()
+    if err != nil {
+        panic(err)
+    }
+
+Example for list stack resources
+
+    all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    all_stack_rsrcs, err := stackresources.ExtractResources(all_stack_rsrc_pages)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println("Resource List:")
+    for _, rsrc := range all_stack_rsrcs {
+        // Get information of a resource in stack
+        rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+        if rsrc_result.Err != nil {
+            panic(rsrc_result.Err)
+        }
+        rsrc, err := rsrc_result.Extract()
+        if err != nil {
+            panic(err)
+        }
+        fmt.Println("Resource Name: ", rsrc.Name, ", Physical ID: ", rsrc.PhysicalID, ", Status: ", rsrc.Status)
+    }
+
+
+Example for get resource type schema
+
+    schema_result := stackresources.Schema(client, "OS::Heat::Stack")
+    if schema_result.Err != nil {
+        panic(schema_result.Err)
+    }
+    schema, err := schema_result.Extract()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("Schema for resource type OS::Heat::Stack")
+    fmt.Println(schema.SupportStatus)
+
+Example for get resource type Template
+
+    tmp_result := stackresources.Template(client, "OS::Heat::Stack")
+    if tmp_result.Err != nil {
+        panic(tmp_result.Err)
+    }
+    tmp, err := tmp_result.Extract()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("Template for resource type OS::Heat::Stack")
+    fmt.Println(string(tmp))
+*/
+package stackresources

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/requests.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/requests.go
@@ -1,0 +1,77 @@
+package stackresources
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Find retrieves stack resources for the given stack name.
+func Find(c *gophercloud.ServiceClient, stackName string) (r FindResult) {
+	_, r.Err = c.Get(findURL(c, stackName), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToStackResourceListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Marker and Limit are used for pagination.
+type ListOpts struct {
+	// Include resources from nest stacks up to Depth levels of recursion.
+	Depth int `q:"nested_depth"`
+}
+
+// ToStackResourceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToStackResourceListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list resources for the given stack.
+func List(client *gophercloud.ServiceClient, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, stackName, stackID)
+	if opts != nil {
+		query, err := opts.ToStackResourceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ResourcePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get retreives data for the given stack resource.
+func Get(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, stackName, stackID, resourceName), &r.Body, nil)
+	return
+}
+
+// Metadata retreives the metadata for the given stack resource.
+func Metadata(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r MetadataResult) {
+	_, r.Err = c.Get(metadataURL(c, stackName, stackID, resourceName), &r.Body, nil)
+	return
+}
+
+// ListTypes makes a request against the API to list resource types.
+func ListTypes(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listTypesURL(client), func(r pagination.PageResult) pagination.Page {
+		return ResourceTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Schema retreives the schema for the given resource type.
+func Schema(c *gophercloud.ServiceClient, resourceType string) (r SchemaResult) {
+	_, r.Err = c.Get(schemaURL(c, resourceType), &r.Body, nil)
+	return
+}
+
+// Template retreives the template representation for the given resource type.
+func Template(c *gophercloud.ServiceClient, resourceType string) (r TemplateResult) {
+	_, r.Err = c.Get(templateURL(c, resourceType), &r.Body, nil)
+	return
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/results.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/results.go
@@ -1,0 +1,206 @@
+package stackresources
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Resource represents a stack resource.
+type Resource struct {
+	Attributes   map[string]interface{} `json:"attributes"`
+	CreationTime time.Time              `json:"-"`
+	Description  string                 `json:"description"`
+	Links        []gophercloud.Link     `json:"links"`
+	LogicalID    string                 `json:"logical_resource_id"`
+	Name         string                 `json:"resource_name"`
+	PhysicalID   string                 `json:"physical_resource_id"`
+	RequiredBy   []interface{}          `json:"required_by"`
+	Status       string                 `json:"resource_status"`
+	StatusReason string                 `json:"resource_status_reason"`
+	Type         string                 `json:"resource_type"`
+	UpdatedTime  time.Time              `json:"-"`
+}
+
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Resource(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// FindResult represents the result of a Find operation.
+type FindResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a slice of Resource objects and is called after a
+// Find operation.
+func (r FindResult) Extract() ([]Resource, error) {
+	var s struct {
+		Resources []Resource `json:"resources"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Resources, err
+}
+
+// ResourcePage abstracts the raw results of making a List() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
+// data provided through the ExtractResources call.
+type ResourcePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a page contains no Server results.
+func (r ResourcePage) IsEmpty() (bool, error) {
+	resources, err := ExtractResources(r)
+	return len(resources) == 0, err
+}
+
+// ExtractResources interprets the results of a single page from a List() call, producing a slice of Resource entities.
+func ExtractResources(r pagination.Page) ([]Resource, error) {
+	var s struct {
+		Resources []Resource `json:"resources"`
+	}
+	err := (r.(ResourcePage)).ExtractInto(&s)
+	return s.Resources, err
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a Resource object and is called after a
+// Get operation.
+func (r GetResult) Extract() (*Resource, error) {
+	var s struct {
+		Resource *Resource `json:"resource"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Resource, err
+}
+
+// MetadataResult represents the result of a Metadata operation.
+type MetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a map object and is called after a
+// Metadata operation.
+func (r MetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Meta map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Meta, err
+}
+
+// ResourceTypePage abstracts the raw results of making a ListTypes() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
+// data provided through the ExtractResourceTypes call.
+type ResourceTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ResourceTypePage contains no resource types.
+func (r ResourceTypePage) IsEmpty() (bool, error) {
+	rts, err := ExtractResourceTypes(r)
+	return len(rts) == 0, err
+}
+
+// ResourceTypes represents the type that holds the result of ExtractResourceTypes.
+// We define methods on this type to sort it before output
+type ResourceTypes []string
+
+func (r ResourceTypes) Len() int {
+	return len(r)
+}
+
+func (r ResourceTypes) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r ResourceTypes) Less(i, j int) bool {
+	return r[i] < r[j]
+}
+
+// ExtractResourceTypes extracts and returns resource types.
+func ExtractResourceTypes(r pagination.Page) (ResourceTypes, error) {
+	var s struct {
+		ResourceTypes ResourceTypes `json:"resource_types"`
+	}
+	err := (r.(ResourceTypePage)).ExtractInto(&s)
+	return s.ResourceTypes, err
+}
+
+// TypeSchema represents a stack resource schema.
+type TypeSchema struct {
+	Attributes    map[string]interface{} `json:"attributes"`
+	Properties    map[string]interface{} `json:"properties"`
+	ResourceType  string                 `json:"resource_type"`
+	SupportStatus map[string]interface{} `json:"support_status"`
+}
+
+// SchemaResult represents the result of a Schema operation.
+type SchemaResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a TypeSchema object and is called after a
+// Schema operation.
+func (r SchemaResult) Extract() (*TypeSchema, error) {
+	var s *TypeSchema
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// TemplateResult represents the result of a Template operation.
+type TemplateResult struct {
+	gophercloud.Result
+}
+
+// Extract returns the template and is called after a
+// Template operation.
+func (r TemplateResult) Extract() ([]byte, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	template, err := json.MarshalIndent(r.Body, "", "  ")
+	return template, err
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/urls.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources/urls.go
@@ -1,0 +1,31 @@
+package stackresources
+
+import "github.com/gophercloud/gophercloud"
+
+func findURL(c *gophercloud.ServiceClient, stackName string) string {
+	return c.ServiceURL("stacks", stackName, "resources")
+}
+
+func listURL(c *gophercloud.ServiceClient, stackName, stackID string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources")
+}
+
+func getURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName, "metadata")
+}
+
+func listTypesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("resource_types")
+}
+
+func schemaURL(c *gophercloud.ServiceClient, typeName string) string {
+	return c.ServiceURL("resource_types", typeName)
+}
+
+func templateURL(c *gophercloud.ServiceClient, typeName string) string {
+	return c.ServiceURL("resource_types", typeName, "template")
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/doc.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/doc.go
@@ -1,0 +1,239 @@
+/*
+Package stacks provides operation for working with Heat stacks. A stack is a
+group of resources (servers, load balancers, databases, and so forth)
+combined to fulfill a useful purpose. Based on a template, Heat orchestration
+engine creates an instantiated set of resources (a stack) to run the
+application framework or component specified (in the template). A stack is a
+running instance of a template. The result of creating a stack is a deployment
+of the application framework or component.
+
+Prepare required import packages
+
+import (
+  "fmt"
+  "github.com/gophercloud/gophercloud"
+  "github.com/gophercloud/gophercloud/openstack"
+  "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+)
+
+Example of Preparing Orchestration client:
+
+    client, err := openstack.NewOrchestrationV1(provider,  gophercloud.EndpointOpts{Region: "RegionOne"})
+
+Example of List Stack:
+    all_stack_pages, err := stacks.List(client, nil).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+    all_stacks, err := stacks.ExtractStacks(all_stack_pages)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, stack := range all_stacks {
+        fmt.Printf("%+v\n", stack)
+    }
+
+
+Example to Create an Stack
+
+    // Create Template
+    t := make(map[string]interface{})
+    f, err := ioutil.ReadFile("template.yaml")
+    if err != nil {
+        panic(err)
+    }
+    err = yaml.Unmarshal(f, t)
+    if err != nil {
+        panic(err)
+    }
+
+    template := &stacks.Template{}
+    template.TE = stacks.TE{
+        Bin: f,
+    }
+    // Create Environment if needed
+    t_env := make(map[string]interface{})
+    f_env, err := ioutil.ReadFile("env.yaml")
+    if err != nil {
+        panic(err)
+    }
+    err = yaml.Unmarshal(f_env, t_env)
+    if err != nil {
+        panic(err)
+    }
+
+    env := &stacks.Environment{}
+    env.TE = stacks.TE{
+        Bin: f_env,
+    }
+
+    // Remember, the priority of parameters you given through
+    // Parameters is higher than the parameters you provided in EnvironmentOpts.
+    params := make(map[string]string)
+    params["number_of_nodes"] = 1
+    tags := []string{"example-stack"}
+    createOpts := &stacks.CreateOpts{
+        // The name of the stack. It must start with an alphabetic character.
+        Name:       "testing_group",
+        // A structure that contains either the template file or url. Call the
+        // associated methods to extract the information relevant to send in a create request.
+        TemplateOpts: template,
+        // A structure that contains details for the environment of the stack.
+        EnvironmentOpts: env,
+        // User-defined parameters to pass to the template.
+        Parameters: params,
+        // A list of tags to assosciate with the Stack
+        Tags: tags,
+    }
+
+    r := stacks.Create(client, createOpts)
+    //dcreated_stack := stacks.CreatedStack()
+    if r.Err != nil {
+        panic(r.Err)
+    }
+    created_stack, err := r.Extract()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Created Stack: %v", created_stack.ID)
+
+Example for Get Stack
+
+    get_result := stacks.Get(client, stackName, created_stack.ID)
+    if get_result.Err != nil {
+        panic(get_result.Err)
+    }
+    stack, err := get_result.Extract()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("Get Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+
+Example for Find Stack
+
+	find_result  := stacks.Find(client, stackIdentity)
+	if find_result.Err != nil {
+		panic(find_result.Err)
+	}
+	stack, err := find_result.Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Find Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+
+Example for Delete Stack
+
+    del_r := stacks.Delete(client, stackName, created_stack.ID)
+    if del_r.Err != nil {
+        panic(del_r.Err)
+    }
+    fmt.Println("Deleted Stack: ", stackName)
+
+Summary of  Behavior Between Stack Update and UpdatePatch Methods :
+
+Function | Test Case | Result
+
+Update()	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+Update()	| Template ONLY | Template updates, raw_template.environment overlay is removed
+Update()	| Parameters ONLY | No update, template is required
+
+UpdatePatch() 	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+UpdatePatch() 	| Template ONLY | Template updates, but raw_template.environment overlay is not removed, existing parameter values will remain
+UpdatePatch() 	| Parameters ONLY | Parameters (raw_template.environment) is updated, excluded values are unchanged
+
+The PUT Update() function will remove parameters from the raw_template.environment overlay
+if they are excluded from the operation, whereas PATCH Update() will never be destructive to the
+raw_template.environment overlay.  It is not possible to expose the raw_template values with a
+patch update once they have been added to the environment overlay with the PATCH verb, but
+newly added values that do not have a corresponding key in the overlay will display the
+raw_template value.
+
+Example to Update a Stack Using the Update (PUT) Method
+
+	t := make(map[string]interface{})
+	f, err := ioutil.ReadFile("template.yaml")
+	if err != nil {
+		panic(err)
+	}
+	err = yaml.Unmarshal(f, t)
+	if err != nil {
+		panic(err)
+	}
+
+	template := stacks.Template{}
+	template.TE = stacks.TE{
+		Bin: f,
+	}
+
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
+
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+		TemplateOpts: &template,
+	}
+
+	res := stacks.Update(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
+
+Example to Update a Stack Using the UpdatePatch (PATCH) Method
+
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
+
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+	}
+
+	res := stacks.UpdatePatch(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
+
+Example YAML Template Containing a Heat::ResourceGroup With Three Nodes
+
+	heat_template_version: 2016-04-08
+
+	parameters:
+		number_of_nodes:
+			type: number
+			default: 3
+			description: the number of nodes
+		node_flavor:
+			type: string
+			default: m1.small
+			description: node flavor
+		node_image:
+			type: string
+			default: centos7.5-latest
+			description: node os image
+		node_network:
+			type: string
+			default: my-node-network
+			description: node network name
+
+	resources:
+		resource_group:
+			type: OS::Heat::ResourceGroup
+			properties:
+			count: { get_param: number_of_nodes }
+			resource_def:
+				type: OS::Nova::Server
+				properties:
+					name: my_nova_server_%index%
+					image: { get_param: node_image }
+					flavor: { get_param: node_flavor }
+					networks:
+						- network: {get_param: node_network}
+*/
+package stacks

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/environment.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/environment.go
@@ -1,0 +1,134 @@
+package stacks
+
+import "strings"
+
+// Environment is a structure that represents stack environments
+type Environment struct {
+	TE
+}
+
+// EnvironmentSections is a map containing allowed sections in a stack environment file
+var EnvironmentSections = map[string]bool{
+	"parameters":         true,
+	"parameter_defaults": true,
+	"resource_registry":  true,
+}
+
+// Validate validates the contents of the Environment
+func (e *Environment) Validate() error {
+	if e.Parsed == nil {
+		if err := e.Parse(); err != nil {
+			return err
+		}
+	}
+	for key := range e.Parsed {
+		if _, ok := EnvironmentSections[key]; !ok {
+			return ErrInvalidEnvironment{Section: key}
+		}
+	}
+	return nil
+}
+
+// Parse environment file to resolve the URL's of the resources. This is done by
+// reading from the `Resource Registry` section, which is why the function is
+// named GetRRFileContents.
+func (e *Environment) getRRFileContents(ignoreIf igFunc) error {
+	// initialize environment if empty
+	if e.Files == nil {
+		e.Files = make(map[string]string)
+	}
+	if e.fileMaps == nil {
+		e.fileMaps = make(map[string]string)
+	}
+
+	// get the resource registry
+	rr := e.Parsed["resource_registry"]
+
+	// search the resource registry for URLs
+	switch rr.(type) {
+	// process further only if the resource registry is a map
+	case map[string]interface{}, map[interface{}]interface{}:
+		rrMap, err := toStringKeys(rr)
+		if err != nil {
+			return err
+		}
+		// the resource registry might contain a base URL for the resource. If
+		// such a field is present, use it. Otherwise, use the default base URL.
+		var baseURL string
+		if val, ok := rrMap["base_url"]; ok {
+			baseURL = val.(string)
+		} else {
+			baseURL = e.baseURL
+		}
+
+		// The contents of the resource may be located in a remote file, which
+		// will be a template. Instantiate a temporary template to manage the
+		// contents.
+		tempTemplate := new(Template)
+		tempTemplate.baseURL = baseURL
+		tempTemplate.client = e.client
+
+		// Fetch the contents of remote resource URL's
+		if err = tempTemplate.getFileContents(rr, ignoreIf, false); err != nil {
+			return err
+		}
+		// check the `resources` section (if it exists) for more URL's. Note that
+		// the previous call to GetFileContents was (deliberately) not recursive
+		// as we want more control over where to look for URL's
+		if val, ok := rrMap["resources"]; ok {
+			switch val.(type) {
+			// process further only if the contents are a map
+			case map[string]interface{}, map[interface{}]interface{}:
+				resourcesMap, err := toStringKeys(val)
+				if err != nil {
+					return err
+				}
+				for _, v := range resourcesMap {
+					switch v.(type) {
+					case map[string]interface{}, map[interface{}]interface{}:
+						resourceMap, err := toStringKeys(v)
+						if err != nil {
+							return err
+						}
+						var resourceBaseURL string
+						// if base_url for the resource type is defined, use it
+						if val, ok := resourceMap["base_url"]; ok {
+							resourceBaseURL = val.(string)
+						} else {
+							resourceBaseURL = baseURL
+						}
+						tempTemplate.baseURL = resourceBaseURL
+						if err := tempTemplate.getFileContents(v, ignoreIf, false); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+		// if the resource registry contained any URL's, store them. This can
+		// then be passed as parameter to api calls to Heat api.
+		e.Files = tempTemplate.Files
+		return nil
+	default:
+		return nil
+	}
+}
+
+// function to choose keys whose values are other environment files
+func ignoreIfEnvironment(key string, value interface{}) bool {
+	// base_url and hooks refer to components which cannot have urls
+	if key == "base_url" || key == "hooks" {
+		return true
+	}
+	// if value is not string, it cannot be a URL
+	valueString, ok := value.(string)
+	if !ok {
+		return true
+	}
+	// if value contains `::`, it must be a reference to another resource type
+	// e.g. OS::Nova::Server : Rackspace::Cloud::Server
+	if strings.Contains(valueString, "::") {
+		return true
+	}
+	return false
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/errors.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/errors.go
@@ -1,0 +1,41 @@
+package stacks
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+type ErrInvalidEnvironment struct {
+	gophercloud.BaseError
+	Section string
+}
+
+func (e ErrInvalidEnvironment) Error() string {
+	return fmt.Sprintf("Environment has wrong section: %s", e.Section)
+}
+
+type ErrInvalidDataFormat struct {
+	gophercloud.BaseError
+}
+
+func (e ErrInvalidDataFormat) Error() string {
+	return fmt.Sprintf("Data in neither json nor yaml format.")
+}
+
+type ErrInvalidTemplateFormatVersion struct {
+	gophercloud.BaseError
+	Version string
+}
+
+func (e ErrInvalidTemplateFormatVersion) Error() string {
+	return fmt.Sprintf("Template format version not found.")
+}
+
+type ErrTemplateRequired struct {
+	gophercloud.BaseError
+}
+
+func (e ErrTemplateRequired) Error() string {
+	return fmt.Sprintf("Template required for this function.")
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/fixtures.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/fixtures.go
@@ -1,0 +1,199 @@
+package stacks
+
+// ValidJSONTemplate is a valid OpenStack Heat template in JSON format
+const ValidJSONTemplate = `
+{
+  "heat_template_version": "2014-10-16",
+  "parameters": {
+    "flavor": {
+      "default": "debian2G",
+      "description": "Flavor for the server to be created",
+      "hidden": true,
+      "type": "string"
+    }
+  },
+  "resources": {
+    "test_server": {
+      "properties": {
+        "flavor": "2 GB General Purpose v1",
+        "image": "Debian 7 (Wheezy) (PVHVM)",
+        "name": "test-server"
+      },
+      "type": "OS::Nova::Server"
+    }
+  }
+}
+`
+
+// ValidYAMLTemplate is a valid OpenStack Heat template in YAML format
+const ValidYAMLTemplate = `
+heat_template_version: 2014-10-16
+parameters:
+  flavor:
+    type: string
+    description: Flavor for the server to be created
+    default: debian2G
+    hidden: true
+resources:
+  test_server:
+    type: "OS::Nova::Server"
+    properties:
+      name: test-server
+      flavor: 2 GB General Purpose v1
+      image: Debian 7 (Wheezy) (PVHVM)
+`
+
+// InvalidTemplateNoVersion is an invalid template as it has no `version` section
+const InvalidTemplateNoVersion = `
+parameters:
+  flavor:
+    type: string
+    description: Flavor for the server to be created
+    default: debian2G
+    hidden: true
+resources:
+  test_server:
+    type: "OS::Nova::Server"
+    properties:
+      name: test-server
+      flavor: 2 GB General Purpose v1
+      image: Debian 7 (Wheezy) (PVHVM)
+`
+
+// ValidJSONEnvironment is a valid environment for a stack in JSON format
+const ValidJSONEnvironment = `
+{
+	"parameters": {
+		"user_key": "userkey"
+	},
+	"resource_registry": {
+		"My::WP::Server": "file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml",
+		"OS::Quantum*": "OS::Neutron*",
+		"AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml",
+		"OS::Metering::Alarm": "OS::Ceilometer::Alarm",
+		"AWS::RDS::DBInstance": "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml",
+		"resources": {
+			"my_db_server": {
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml"
+			},
+			"my_server": {
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+				"hooks": "pre-create"
+			},
+			"nested_stack": {
+				"nested_resource": {
+					"hooks": "pre-update"
+				},
+				"another_resource": {
+					"hooks": [
+						"pre-create",
+						"pre-update"
+					]
+				}
+			}
+		}
+	}
+}
+`
+
+// ValidYAMLEnvironment is a valid environment for a stack in YAML format
+const ValidYAMLEnvironment = `
+parameters:
+  user_key: userkey
+resource_registry:
+  My::WP::Server: file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml
+  # allow older templates with Quantum in them.
+  "OS::Quantum*": "OS::Neutron*"
+  # Choose your implementation of AWS::CloudWatch::Alarm
+  "AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml"
+  #"AWS::CloudWatch::Alarm": "OS::Heat::CWLiteAlarm"
+  "OS::Metering::Alarm": "OS::Ceilometer::Alarm"
+  "AWS::RDS::DBInstance": "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml"
+  resources:
+    my_db_server:
+      "OS::DBInstance": file:///home/mine/all_my_cool_templates/db.yaml
+    my_server:
+      "OS::DBInstance": file:///home/mine/all_my_cool_templates/db.yaml
+      hooks: pre-create
+    nested_stack:
+      nested_resource:
+        hooks: pre-update
+      another_resource:
+        hooks: [pre-create, pre-update]
+`
+
+// InvalidEnvironment is an invalid environment as it has an extra section called `resources`
+const InvalidEnvironment = `
+parameters:
+	flavor:
+		type: string
+		description: Flavor for the server to be created
+		default: debian2G
+		hidden: true
+resources:
+	test_server:
+		type: "OS::Nova::Server"
+		properties:
+			name: test-server
+			flavor: 2 GB General Purpose v1
+			image: Debian 7 (Wheezy) (PVHVM)
+parameter_defaults:
+	KeyName: heat_key
+`
+
+// ValidJSONEnvironmentParsed is the expected parsed version of ValidJSONEnvironment
+var ValidJSONEnvironmentParsed = map[string]interface{}{
+	"parameters": map[string]interface{}{
+		"user_key": "userkey",
+	},
+	"resource_registry": map[string]interface{}{
+		"My::WP::Server":         "file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml",
+		"OS::Quantum*":           "OS::Neutron*",
+		"AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml",
+		"OS::Metering::Alarm":    "OS::Ceilometer::Alarm",
+		"AWS::RDS::DBInstance":   "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml",
+		"resources": map[string]interface{}{
+			"my_db_server": map[string]interface{}{
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+			},
+			"my_server": map[string]interface{}{
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+				"hooks":          "pre-create",
+			},
+			"nested_stack": map[string]interface{}{
+				"nested_resource": map[string]interface{}{
+					"hooks": "pre-update",
+				},
+				"another_resource": map[string]interface{}{
+					"hooks": []interface{}{
+						"pre-create",
+						"pre-update",
+					},
+				},
+			},
+		},
+	},
+}
+
+// ValidJSONTemplateParsed is the expected parsed version of ValidJSONTemplate
+var ValidJSONTemplateParsed = map[string]interface{}{
+	"heat_template_version": "2014-10-16",
+	"parameters": map[string]interface{}{
+		"flavor": map[string]interface{}{
+			"default":     "debian2G",
+			"description": "Flavor for the server to be created",
+			"hidden":      true,
+			"type":        "string",
+		},
+	},
+	"resources": map[string]interface{}{
+		"test_server": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"flavor": "2 GB General Purpose v1",
+				"image":  "Debian 7 (Wheezy) (PVHVM)",
+				"name":   "test-server",
+			},
+			"type": "OS::Nova::Server",
+		},
+	},
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/requests.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/requests.go
@@ -1,0 +1,482 @@
+package stacks
+
+import (
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type CreateOptsBuilder interface {
+	ToStackCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A list of tags to assosciate with the Stack
+	Tags []string `json:"-"`
+}
+
+// ToStackCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOpts) ToStackCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	if opts.Tags != nil {
+		b["tags"] = strings.Join(opts.Tags, ",")
+	}
+
+	return b, nil
+}
+
+// Create accepts a CreateOpts struct and creates a new stack using the values
+// provided.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToStackCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// AdoptOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Adopt function in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type AdoptOptsBuilder interface {
+	ToStackAdoptMap() (map[string]interface{}, error)
+}
+
+// AdoptOpts is the common options struct used in this package's Adopt
+// operation.
+type AdoptOpts struct {
+	// Existing resources data represented as a string to add to the
+	// new stack. Data returned by Abandon could be provided as AdoptsStackData.
+	AdoptStackData string `json:"adopt_stack_data" required:"true"`
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	//TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// ToStackAdoptMap casts a CreateOpts struct to a map.
+func (opts AdoptOpts) ToStackAdoptMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	return b, nil
+}
+
+// Adopt accepts an AdoptOpts struct and creates a new stack using the resources
+// from another stack.
+func Adopt(c *gophercloud.ServiceClient, opts AdoptOptsBuilder) (r AdoptResult) {
+	b, err := opts.ToStackAdoptMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(adoptURL(c), b, &r.Body, nil)
+	return
+}
+
+// SortDir is a type for specifying in which direction to sort a list of stacks.
+type SortDir string
+
+// SortKey is a type for specifying by which key to sort a list of stacks.
+type SortKey string
+
+var (
+	// SortAsc is used to sort a list of stacks in ascending order.
+	SortAsc SortDir = "asc"
+	// SortDesc is used to sort a list of stacks in descending order.
+	SortDesc SortDir = "desc"
+	// SortName is used to sort a list of stacks by name.
+	SortName SortKey = "name"
+	// SortStatus is used to sort a list of stacks by status.
+	SortStatus SortKey = "status"
+	// SortCreatedAt is used to sort a list of stacks by date created.
+	SortCreatedAt SortKey = "created_at"
+	// SortUpdatedAt is used to sort a list of stacks by date updated.
+	SortUpdatedAt SortKey = "updated_at"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToStackListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network attributes you want to see returned. SortKey allows you to sort
+// by a particular network attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Status  string  `q:"status"`
+	Name    string  `q:"name"`
+	Marker  string  `q:"marker"`
+	Limit   int     `q:"limit"`
+	SortKey SortKey `q:"sort_keys"`
+	SortDir SortDir `q:"sort_dir"`
+}
+
+// ToStackListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToStackListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// stacks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToStackListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return StackPage{pagination.SinglePageBase(r)}
+	}
+	return pagination.NewPager(c, url, createPage)
+}
+
+// Get retreives a stack based on the stack name and stack ID.
+func Get(c *gophercloud.ServiceClient, stackName, stackID string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, stackName, stackID), &r.Body, nil)
+	return
+}
+
+// Find retrieves a stack based on the stack name or stack ID.
+func Find(c *gophercloud.ServiceClient, stackIdentity string) (r GetResult) {
+	_, r.Err = c.Get(findURL(c, stackIdentity), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Update operation in this package.
+type UpdateOptsBuilder interface {
+	ToStackUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdatePatchOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the UpdatePatch operation in this package
+type UpdatePatchOptsBuilder interface {
+	ToStackUpdatePatchMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the common options struct used in this package's Update
+// and UpdatePatch operations.
+type UpdateOpts struct {
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A list of tags to associate with the Stack
+	Tags []string `json:"-"`
+}
+
+// ToStackUpdateMap validates that a template was supplied and calls
+// the toStackUpdateMap private function.
+func (opts UpdateOpts) ToStackUpdateMap() (map[string]interface{}, error) {
+	if opts.TemplateOpts == nil {
+		return nil, ErrTemplateRequired{}
+	}
+	return toStackUpdateMap(opts)
+}
+
+// ToStackUpdatePatchMap calls the private function toStackUpdateMap
+// directly.
+func (opts UpdateOpts) ToStackUpdatePatchMap() (map[string]interface{}, error) {
+	return toStackUpdateMap(opts)
+}
+
+// ToStackUpdateMap casts a CreateOpts struct to a map.
+func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	files := make(map[string]string)
+
+	if opts.TemplateOpts != nil {
+		if err := opts.TemplateOpts.Parse(); err != nil {
+			return nil, err
+		}
+
+		if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+			return nil, err
+		}
+		opts.TemplateOpts.fixFileRefs()
+		b["template"] = string(opts.TemplateOpts.Bin)
+
+		for k, v := range opts.TemplateOpts.Files {
+			files[k] = v
+		}
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	if opts.Tags != nil {
+		b["tags"] = strings.Join(opts.Tags, ",")
+	}
+
+	return b, nil
+}
+
+// Update accepts an UpdateOpts struct and updates an existing stack using the
+//  http PUT verb with the values provided. opts.TemplateOpts is required.
+func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToStackUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, stackName, stackID), b, nil, nil)
+	return
+}
+
+// Update accepts an UpdateOpts struct and updates an existing stack using the
+//  http PATCH verb with the values provided. opts.TemplateOpts is not required.
+func UpdatePatch(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToStackUpdatePatchMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(updateURL(c, stackName, stackID), b, nil, nil)
+	return
+}
+
+// Delete deletes a stack based on the stack name and stack ID.
+func Delete(c *gophercloud.ServiceClient, stackName, stackID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, stackName, stackID), nil)
+	return
+}
+
+// PreviewOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Preview operation in this package.
+type PreviewOptsBuilder interface {
+	ToStackPreviewMap() (map[string]interface{}, error)
+}
+
+// PreviewOpts contains the common options struct used in this package's Preview
+// operation.
+type PreviewOpts struct {
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// ToStackPreviewMap casts a PreviewOpts struct to a map.
+func (opts PreviewOpts) ToStackPreviewMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	return b, nil
+}
+
+// Preview accepts a PreviewOptsBuilder interface and creates a preview of a stack using the values
+// provided.
+func Preview(c *gophercloud.ServiceClient, opts PreviewOptsBuilder) (r PreviewResult) {
+	b, err := opts.ToStackPreviewMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(previewURL(c), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Abandon deletes the stack with the provided stackName and stackID, but leaves its
+// resources intact, and returns data describing the stack and its resources.
+func Abandon(c *gophercloud.ServiceClient, stackName, stackID string) (r AbandonResult) {
+	_, r.Err = c.Delete(abandonURL(c, stackName, stackID), &gophercloud.RequestOpts{
+		JSONResponse: &r.Body,
+		OkCodes:      []int{200},
+	})
+	return
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/results.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/results.go
@@ -1,0 +1,301 @@
+package stacks
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreatedStack represents the object extracted from a Create operation.
+type CreatedStack struct {
+	ID    string             `json:"id"`
+	Links []gophercloud.Link `json:"links"`
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a CreatedStack object and is called after a
+// Create operation.
+func (r CreateResult) Extract() (*CreatedStack, error) {
+	var s struct {
+		CreatedStack *CreatedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.CreatedStack, err
+}
+
+// AdoptResult represents the result of an Adopt operation. AdoptResult has the
+// same form as CreateResult.
+type AdoptResult struct {
+	CreateResult
+}
+
+// StackPage is a pagination.Pager that is returned from a call to the List function.
+type StackPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Stacks.
+func (r StackPage) IsEmpty() (bool, error) {
+	stacks, err := ExtractStacks(r)
+	return len(stacks) == 0, err
+}
+
+// ListedStack represents an element in the slice extracted from a List operation.
+type ListedStack struct {
+	CreationTime time.Time          `json:"-"`
+	Description  string             `json:"description"`
+	ID           string             `json:"id"`
+	Links        []gophercloud.Link `json:"links"`
+	Name         string             `json:"stack_name"`
+	Status       string             `json:"stack_status"`
+	StatusReason string             `json:"stack_status_reason"`
+	Tags         []string           `json:"tags"`
+	UpdatedTime  time.Time          `json:"-"`
+}
+
+func (r *ListedStack) UnmarshalJSON(b []byte) error {
+	type tmp ListedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = ListedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// ExtractStacks extracts and returns a slice of ListedStack. It is used while iterating
+// over a stacks.List call.
+func ExtractStacks(r pagination.Page) ([]ListedStack, error) {
+	var s struct {
+		ListedStacks []ListedStack `json:"stacks"`
+	}
+	err := (r.(StackPage)).ExtractInto(&s)
+	return s.ListedStacks, err
+}
+
+// RetrievedStack represents the object extracted from a Get operation.
+type RetrievedStack struct {
+	Capabilities        []interface{}            `json:"capabilities"`
+	CreationTime        time.Time                `json:"-"`
+	Description         string                   `json:"description"`
+	DisableRollback     bool                     `json:"disable_rollback"`
+	ID                  string                   `json:"id"`
+	Links               []gophercloud.Link       `json:"links"`
+	NotificationTopics  []interface{}            `json:"notification_topics"`
+	Outputs             []map[string]interface{} `json:"outputs"`
+	Parameters          map[string]string        `json:"parameters"`
+	Name                string                   `json:"stack_name"`
+	Status              string                   `json:"stack_status"`
+	StatusReason        string                   `json:"stack_status_reason"`
+	Tags                []string                 `json:"tags"`
+	TemplateDescription string                   `json:"template_description"`
+	Timeout             int                      `json:"timeout_mins"`
+	UpdatedTime         time.Time                `json:"-"`
+}
+
+func (r *RetrievedStack) UnmarshalJSON(b []byte) error {
+	type tmp RetrievedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = RetrievedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a RetrievedStack object and is called after a
+// Get operation.
+func (r GetResult) Extract() (*RetrievedStack, error) {
+	var s struct {
+		Stack *RetrievedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stack, err
+}
+
+// UpdateResult represents the result of a Update operation.
+type UpdateResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// PreviewedStack represents the result of a Preview operation.
+type PreviewedStack struct {
+	Capabilities        []interface{}      `json:"capabilities"`
+	CreationTime        time.Time          `json:"-"`
+	Description         string             `json:"description"`
+	DisableRollback     bool               `json:"disable_rollback"`
+	ID                  string             `json:"id"`
+	Links               []gophercloud.Link `json:"links"`
+	Name                string             `json:"stack_name"`
+	NotificationTopics  []interface{}      `json:"notification_topics"`
+	Parameters          map[string]string  `json:"parameters"`
+	Resources           []interface{}      `json:"resources"`
+	TemplateDescription string             `json:"template_description"`
+	Timeout             int                `json:"timeout_mins"`
+	UpdatedTime         time.Time          `json:"-"`
+}
+
+func (r *PreviewedStack) UnmarshalJSON(b []byte) error {
+	type tmp PreviewedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = PreviewedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// PreviewResult represents the result of a Preview operation.
+type PreviewResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a PreviewedStack object and is called after a
+// Preview operation.
+func (r PreviewResult) Extract() (*PreviewedStack, error) {
+	var s struct {
+		PreviewedStack *PreviewedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.PreviewedStack, err
+}
+
+// AbandonedStack represents the result of an Abandon operation.
+type AbandonedStack struct {
+	Status             string                 `json:"status"`
+	Name               string                 `json:"name"`
+	Template           map[string]interface{} `json:"template"`
+	Action             string                 `json:"action"`
+	ID                 string                 `json:"id"`
+	Resources          map[string]interface{} `json:"resources"`
+	Files              map[string]string      `json:"files"`
+	StackUserProjectID string                 `json:"stack_user_project_id"`
+	ProjectID          string                 `json:"project_id"`
+	Environment        map[string]interface{} `json:"environment"`
+}
+
+// AbandonResult represents the result of an Abandon operation.
+type AbandonResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to an AbandonedStack object and is called after an
+// Abandon operation.
+func (r AbandonResult) Extract() (*AbandonedStack, error) {
+	var s *AbandonedStack
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// String converts an AbandonResult to a string. This is useful to when passing
+// the result of an Abandon operation to an AdoptOpts AdoptStackData field.
+func (r AbandonResult) String() (string, error) {
+	out, err := json.Marshal(r)
+	return string(out), err
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/template.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/template.go
@@ -1,0 +1,141 @@
+package stacks
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// Template is a structure that represents OpenStack Heat templates
+type Template struct {
+	TE
+}
+
+// TemplateFormatVersions is a map containing allowed variations of the template format version
+// Note that this contains the permitted variations of the _keys_ not the values.
+var TemplateFormatVersions = map[string]bool{
+	"HeatTemplateFormatVersion": true,
+	"heat_template_version":     true,
+	"AWSTemplateFormatVersion":  true,
+}
+
+// Validate validates the contents of the Template
+func (t *Template) Validate() error {
+	if t.Parsed == nil {
+		if err := t.Parse(); err != nil {
+			return err
+		}
+	}
+	var invalid string
+	for key := range t.Parsed {
+		if _, ok := TemplateFormatVersions[key]; ok {
+			return nil
+		}
+		invalid = key
+	}
+	return ErrInvalidTemplateFormatVersion{Version: invalid}
+}
+
+// GetFileContents recursively parses a template to search for urls. These urls
+// are assumed to point to other templates (known in OpenStack Heat as child
+// templates). The contents of these urls are fetched and stored in the `Files`
+// parameter of the template structure. This is the only way that a user can
+// use child templates that are located in their filesystem; urls located on the
+// web (e.g. on github or swift) can be fetched directly by Heat engine.
+func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool) error {
+	// initialize template if empty
+	if t.Files == nil {
+		t.Files = make(map[string]string)
+	}
+	if t.fileMaps == nil {
+		t.fileMaps = make(map[string]string)
+	}
+	switch te.(type) {
+	// if te is a map
+	case map[string]interface{}, map[interface{}]interface{}:
+		teMap, err := toStringKeys(te)
+		if err != nil {
+			return err
+		}
+		for k, v := range teMap {
+			value, ok := v.(string)
+			if !ok {
+				// if the value is not a string, recursively parse that value
+				if err := t.getFileContents(v, ignoreIf, recurse); err != nil {
+					return err
+				}
+			} else if !ignoreIf(k, value) {
+				// at this point, the k, v pair has a reference to an external template.
+				// The assumption of heatclient is that value v is a reference
+				// to a file in the users environment
+
+				// create a new child template
+				childTemplate := new(Template)
+
+				// initialize child template
+
+				// get the base location of the child template
+				baseURL, err := gophercloud.NormalizePathURL(t.baseURL, value)
+				if err != nil {
+					return err
+				}
+				childTemplate.baseURL = baseURL
+				childTemplate.client = t.client
+
+				// fetch the contents of the child template
+				if err := childTemplate.Parse(); err != nil {
+					return err
+				}
+
+				// process child template recursively if required. This is
+				// required if the child template itself contains references to
+				// other templates
+				if recurse {
+					if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
+						return err
+					}
+				}
+				// update parent template with current child templates' content.
+				// At this point, the child template has been parsed recursively.
+				t.fileMaps[value] = childTemplate.URL
+				t.Files[childTemplate.URL] = string(childTemplate.Bin)
+
+			}
+		}
+		return nil
+	// if te is a slice, call the function on each element of the slice.
+	case []interface{}:
+		teSlice := te.([]interface{})
+		for i := range teSlice {
+			if err := t.getFileContents(teSlice[i], ignoreIf, recurse); err != nil {
+				return err
+			}
+		}
+	// if te is anything else, return
+	case string, bool, float64, nil, int:
+		return nil
+	default:
+		return gophercloud.ErrUnexpectedType{Actual: fmt.Sprintf("%v", reflect.TypeOf(te))}
+	}
+	return nil
+}
+
+// function to choose keys whose values are other template files
+func ignoreIfTemplate(key string, value interface{}) bool {
+	// key must be either `get_file` or `type` for value to be a URL
+	if key != "get_file" && key != "type" {
+		return true
+	}
+	// value must be a string
+	valueString, ok := value.(string)
+	if !ok {
+		return true
+	}
+	// `.template` and `.yaml` are allowed suffixes for template URLs when referred to by `type`
+	if key == "type" && !(strings.HasSuffix(valueString, ".template") || strings.HasSuffix(valueString, ".yaml")) {
+		return true
+	}
+	return false
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/urls.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/urls.go
@@ -1,0 +1,39 @@
+package stacks
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("stacks")
+}
+
+func adoptURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, name, id string) string {
+	return c.ServiceURL("stacks", name, id)
+}
+
+func findURL(c *gophercloud.ServiceClient, identity string) string {
+	return c.ServiceURL("stacks", identity)
+}
+
+func updateURL(c *gophercloud.ServiceClient, name, id string) string {
+	return getURL(c, name, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, name, id string) string {
+	return getURL(c, name, id)
+}
+
+func previewURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("stacks", "preview")
+}
+
+func abandonURL(c *gophercloud.ServiceClient, name, id string) string {
+	return c.ServiceURL("stacks", name, id, "abandon")
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/utils.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/utils.go
@@ -1,0 +1,160 @@
+package stacks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// Client is an interface that expects a Get method similar to http.Get. This
+// is needed for unit testing, since we can mock an http client. Thus, the
+// client will usually be an http.Client EXCEPT in unit tests.
+type Client interface {
+	Get(string) (*http.Response, error)
+}
+
+// TE is a base structure for both Template and Environment
+type TE struct {
+	// Bin stores the contents of the template or environment.
+	Bin []byte
+	// URL stores the URL of the template. This is allowed to be a 'file://'
+	// for local files.
+	URL string
+	// Parsed contains a parsed version of Bin. Since there are 2 different
+	// fields referring to the same value, you must be careful when accessing
+	// this filed.
+	Parsed map[string]interface{}
+	// Files contains a mapping between the urls in templates to their contents.
+	Files map[string]string
+	// fileMaps is a map used internally when determining Files.
+	fileMaps map[string]string
+	// baseURL represents the location of the template or environment file.
+	baseURL string
+	// client is an interface which allows TE to fetch contents from URLS
+	client Client
+}
+
+// Fetch fetches the contents of a TE from its URL. Once a TE structure has a
+// URL, call the fetch method to fetch the contents.
+func (t *TE) Fetch() error {
+	// if the baseURL is not provided, use the current directors as the base URL
+	if t.baseURL == "" {
+		u, err := getBasePath()
+		if err != nil {
+			return err
+		}
+		t.baseURL = u
+	}
+
+	// if the contents are already present, do nothing.
+	if t.Bin != nil {
+		return nil
+	}
+
+	// get a fqdn from the URL using the baseURL of the TE. For local files,
+	// the URL's will have the `file` scheme.
+	u, err := gophercloud.NormalizePathURL(t.baseURL, t.URL)
+	if err != nil {
+		return err
+	}
+	t.URL = u
+
+	// get an HTTP client if none present
+	if t.client == nil {
+		t.client = getHTTPClient()
+	}
+
+	// use the client to fetch the contents of the TE
+	resp, err := t.client.Get(t.URL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	t.Bin = body
+	return nil
+}
+
+// get the basepath of the TE
+func getBasePath() (string, error) {
+	basePath, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	u, err := gophercloud.NormalizePathURL("", basePath)
+	if err != nil {
+		return "", err
+	}
+	return u, nil
+}
+
+// get a an HTTP client to retrieve URL's. This client allows the use of `file`
+// scheme since we may need to fetch files from users filesystem
+func getHTTPClient() Client {
+	transport := &http.Transport{}
+	transport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	return &http.Client{Transport: transport}
+}
+
+// Parse will parse the contents and then validate. The contents MUST be either JSON or YAML.
+func (t *TE) Parse() error {
+	if err := t.Fetch(); err != nil {
+		return err
+	}
+	if jerr := json.Unmarshal(t.Bin, &t.Parsed); jerr != nil {
+		if yerr := yaml.Unmarshal(t.Bin, &t.Parsed); yerr != nil {
+			return ErrInvalidDataFormat{}
+		}
+	}
+	return t.Validate()
+}
+
+// Validate validates the contents of TE
+func (t *TE) Validate() error {
+	return nil
+}
+
+// igfunc is a parameter used by GetFileContents and GetRRFileContents to check
+// for valid URL's.
+type igFunc func(string, interface{}) bool
+
+// convert map[interface{}]interface{} to map[string]interface{}
+func toStringKeys(m interface{}) (map[string]interface{}, error) {
+	switch m.(type) {
+	case map[string]interface{}, map[interface{}]interface{}:
+		typedMap := make(map[string]interface{})
+		if _, ok := m.(map[interface{}]interface{}); ok {
+			for k, v := range m.(map[interface{}]interface{}) {
+				typedMap[k.(string)] = v
+			}
+		} else {
+			typedMap = m.(map[string]interface{})
+		}
+		return typedMap, nil
+	default:
+		return nil, gophercloud.ErrUnexpectedType{Expected: "map[string]interface{}/map[interface{}]interface{}", Actual: fmt.Sprintf("%v", reflect.TypeOf(m))}
+	}
+}
+
+// fix the reference to files by replacing relative URL's by absolute
+// URL's
+func (t *TE) fixFileRefs() {
+	tStr := string(t.Bin)
+	if t.fileMaps == nil {
+		return
+	}
+	for k, v := range t.fileMaps {
+		tStr = strings.Replace(tStr, k, v, -1)
+	}
+	t.Bin = []byte(tStr)
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/convenience.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/convenience.go
@@ -1,0 +1,348 @@
+package testhelper
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	logBodyFmt = "\033[1;31m%s %s\033[0m"
+	greenCode  = "\033[0m\033[1;32m"
+	yellowCode = "\033[0m\033[1;33m"
+	resetCode  = "\033[0m\033[1;31m"
+)
+
+func prefix(depth int) string {
+	_, file, line, _ := runtime.Caller(depth)
+	return fmt.Sprintf("Failure in %s, line %d:", filepath.Base(file), line)
+}
+
+func green(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", greenCode, str, resetCode)
+}
+
+func yellow(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", yellowCode, str, resetCode)
+}
+
+func logFatal(t *testing.T, str string) {
+	t.Fatalf(logBodyFmt, prefix(3), str)
+}
+
+func logError(t *testing.T, str string) {
+	t.Errorf(logBodyFmt, prefix(3), str)
+}
+
+type diffLogger func([]string, interface{}, interface{})
+
+type visit struct {
+	a1  uintptr
+	a2  uintptr
+	typ reflect.Type
+}
+
+// Recursively visits the structures of "expected" and "actual". The diffLogger function will be
+// invoked with each different value encountered, including the reference path that was followed
+// to get there.
+func deepDiffEqual(expected, actual reflect.Value, visited map[visit]bool, path []string, logDifference diffLogger) {
+	defer func() {
+		// Fall back to the regular reflect.DeepEquals function.
+		if r := recover(); r != nil {
+			var e, a interface{}
+			if expected.IsValid() {
+				e = expected.Interface()
+			}
+			if actual.IsValid() {
+				a = actual.Interface()
+			}
+
+			if !reflect.DeepEqual(e, a) {
+				logDifference(path, e, a)
+			}
+		}
+	}()
+
+	if !expected.IsValid() && actual.IsValid() {
+		logDifference(path, nil, actual.Interface())
+		return
+	}
+	if expected.IsValid() && !actual.IsValid() {
+		logDifference(path, expected.Interface(), nil)
+		return
+	}
+	if !expected.IsValid() && !actual.IsValid() {
+		return
+	}
+
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if expected.CanAddr() && actual.CanAddr() && hard(expected.Kind()) {
+		addr1 := expected.UnsafeAddr()
+		addr2 := actual.UnsafeAddr()
+
+		if addr1 > addr2 {
+			addr1, addr2 = addr2, addr1
+		}
+
+		if addr1 == addr2 {
+			// References are identical. We can short-circuit
+			return
+		}
+
+		typ := expected.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			// Already visited.
+			return
+		}
+
+		// Remember this visit for later.
+		visited[v] = true
+	}
+
+	switch expected.Kind() {
+	case reflect.Array:
+		for i := 0; i < expected.Len(); i++ {
+			hop := append(path, fmt.Sprintf("[%d]", i))
+			deepDiffEqual(expected.Index(i), actual.Index(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Slice:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		if expected.Len() == actual.Len() && expected.Pointer() == actual.Pointer() {
+			return
+		}
+		for i := 0; i < expected.Len(); i++ {
+			hop := append(path, fmt.Sprintf("[%d]", i))
+			deepDiffEqual(expected.Index(i), actual.Index(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Interface:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		deepDiffEqual(expected.Elem(), actual.Elem(), visited, path, logDifference)
+		return
+	case reflect.Ptr:
+		deepDiffEqual(expected.Elem(), actual.Elem(), visited, path, logDifference)
+		return
+	case reflect.Struct:
+		for i, n := 0, expected.NumField(); i < n; i++ {
+			field := expected.Type().Field(i)
+			hop := append(path, "."+field.Name)
+			deepDiffEqual(expected.Field(i), actual.Field(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Map:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		if expected.Len() == actual.Len() && expected.Pointer() == actual.Pointer() {
+			return
+		}
+
+		var keys []reflect.Value
+		if expected.Len() >= actual.Len() {
+			keys = expected.MapKeys()
+		} else {
+			keys = actual.MapKeys()
+		}
+
+		for _, k := range keys {
+			expectedValue := expected.MapIndex(k)
+			actualValue := actual.MapIndex(k)
+
+			if !expectedValue.IsValid() {
+				logDifference(path, nil, actual.Interface())
+				return
+			}
+			if !actualValue.IsValid() {
+				logDifference(path, expected.Interface(), nil)
+				return
+			}
+
+			hop := append(path, fmt.Sprintf("[%v]", k))
+			deepDiffEqual(expectedValue, actualValue, visited, hop, logDifference)
+		}
+		return
+	case reflect.Func:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+		}
+		return
+	default:
+		if expected.Interface() != actual.Interface() {
+			logDifference(path, expected.Interface(), actual.Interface())
+		}
+	}
+}
+
+func deepDiff(expected, actual interface{}, logDifference diffLogger) {
+	if expected == nil || actual == nil {
+		logDifference([]string{}, expected, actual)
+		return
+	}
+
+	expectedValue := reflect.ValueOf(expected)
+	actualValue := reflect.ValueOf(actual)
+
+	if expectedValue.Type() != actualValue.Type() {
+		logDifference([]string{}, expected, actual)
+		return
+	}
+	deepDiffEqual(expectedValue, actualValue, map[visit]bool{}, []string{}, logDifference)
+}
+
+// AssertEquals compares two arbitrary values and performs a comparison. If the
+// comparison fails, a fatal error is raised that will fail the test
+func AssertEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		logFatal(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// CheckEquals is similar to AssertEquals, except with a non-fatal error
+func CheckEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		logError(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// AssertDeepEquals - like Equals - performs a comparison - but on more complex
+// structures that requires deeper inspection
+func AssertDeepEquals(t *testing.T, expected, actual interface{}) {
+	pre := prefix(2)
+
+	differed := false
+	deepDiff(expected, actual, func(path []string, expected, actual interface{}) {
+		differed = true
+		t.Errorf("\033[1;31m%sat %s expected %s, but got %s\033[0m",
+			pre,
+			strings.Join(path, ""),
+			green(expected),
+			yellow(actual))
+	})
+	if differed {
+		logFatal(t, "The structures were different.")
+	}
+}
+
+// CheckDeepEquals is similar to AssertDeepEquals, except with a non-fatal error
+func CheckDeepEquals(t *testing.T, expected, actual interface{}) {
+	pre := prefix(2)
+
+	deepDiff(expected, actual, func(path []string, expected, actual interface{}) {
+		t.Errorf("\033[1;31m%s at %s expected %s, but got %s\033[0m",
+			pre,
+			strings.Join(path, ""),
+			green(expected),
+			yellow(actual))
+	})
+}
+
+func isByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) bool {
+	return bytes.Equal(expectedBytes, actualBytes)
+}
+
+// AssertByteArrayEquals a convenience function for checking whether two byte arrays are equal
+func AssertByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
+	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+		logFatal(t, "The bytes differed.")
+	}
+}
+
+// CheckByteArrayEquals a convenience function for silent checking whether two byte arrays are equal
+func CheckByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
+	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+		logError(t, "The bytes differed.")
+	}
+}
+
+// isJSONEquals is a utility function that implements JSON comparison for AssertJSONEquals and
+// CheckJSONEquals.
+func isJSONEquals(t *testing.T, expectedJSON string, actual interface{}) bool {
+	var parsedExpected, parsedActual interface{}
+	err := json.Unmarshal([]byte(expectedJSON), &parsedExpected)
+	if err != nil {
+		t.Errorf("Unable to parse expected value as JSON: %v", err)
+		return false
+	}
+
+	jsonActual, err := json.Marshal(actual)
+	AssertNoErr(t, err)
+	err = json.Unmarshal(jsonActual, &parsedActual)
+	AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(parsedExpected, parsedActual) {
+		prettyExpected, err := json.MarshalIndent(parsedExpected, "", "  ")
+		if err != nil {
+			t.Logf("Unable to pretty-print expected JSON: %v\n%s", err, expectedJSON)
+		} else {
+			// We can't use green() here because %#v prints prettyExpected as a byte array literal, which
+			// is... unhelpful. Converting it to a string first leaves "\n" uninterpreted for some reason.
+			t.Logf("Expected JSON:\n%s%s%s", greenCode, prettyExpected, resetCode)
+		}
+
+		prettyActual, err := json.MarshalIndent(actual, "", "  ")
+		if err != nil {
+			t.Logf("Unable to pretty-print actual JSON: %v\n%#v", err, actual)
+		} else {
+			// We can't use yellow() for the same reason.
+			t.Logf("Actual JSON:\n%s%s%s", yellowCode, prettyActual, resetCode)
+		}
+
+		return false
+	}
+	return true
+}
+
+// AssertJSONEquals serializes a value as JSON, parses an expected string as JSON, and ensures that
+// both are consistent. If they aren't, the expected and actual structures are pretty-printed and
+// shown for comparison.
+//
+// This is useful for comparing structures that are built as nested map[string]interface{} values,
+// which are a pain to construct as literals.
+func AssertJSONEquals(t *testing.T, expectedJSON string, actual interface{}) {
+	if !isJSONEquals(t, expectedJSON, actual) {
+		logFatal(t, "The generated JSON structure differed.")
+	}
+}
+
+// CheckJSONEquals is similar to AssertJSONEquals, but nonfatal.
+func CheckJSONEquals(t *testing.T, expectedJSON string, actual interface{}) {
+	if !isJSONEquals(t, expectedJSON, actual) {
+		logError(t, "The generated JSON structure differed.")
+	}
+}
+
+// AssertNoErr is a convenience function for checking whether an error value is
+// an actual error
+func AssertNoErr(t *testing.T, e error) {
+	if e != nil {
+		logFatal(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
+	}
+}
+
+// CheckNoErr is similar to AssertNoErr, except with a non-fatal error
+func CheckNoErr(t *testing.T, e error) {
+	if e != nil {
+		logError(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
+	}
+}

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/doc.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/doc.go
@@ -1,0 +1,4 @@
+/*
+Package testhelper container methods that are useful for writing unit tests.
+*/
+package testhelper

--- a/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/http_responses.go
+++ b/cluster-autoscaler/vendor/github.com/gophercloud/gophercloud/testhelper/http_responses.go
@@ -1,0 +1,91 @@
+package testhelper
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+var (
+	// Mux is a multiplexer that can be used to register handlers.
+	Mux *http.ServeMux
+
+	// Server is an in-memory HTTP server for testing.
+	Server *httptest.Server
+)
+
+// SetupHTTP prepares the Mux and Server.
+func SetupHTTP() {
+	Mux = http.NewServeMux()
+	Server = httptest.NewServer(Mux)
+}
+
+// TeardownHTTP releases HTTP-related resources.
+func TeardownHTTP() {
+	Server.Close()
+}
+
+// Endpoint returns a fake endpoint that will actually target the Mux.
+func Endpoint() string {
+	return Server.URL + "/"
+}
+
+// TestFormValues ensures that all the URL parameters given to the http.Request are the same as values.
+func TestFormValues(t *testing.T, r *http.Request, values map[string]string) {
+	want := url.Values{}
+	for k, v := range values {
+		want.Add(k, v)
+	}
+
+	r.ParseForm()
+	if !reflect.DeepEqual(want, r.Form) {
+		t.Errorf("Request parameters = %v, want %v", r.Form, want)
+	}
+}
+
+// TestMethod checks that the Request has the expected method (e.g. GET, POST).
+func TestMethod(t *testing.T, r *http.Request, expected string) {
+	if expected != r.Method {
+		t.Errorf("Request method = %v, expected %v", r.Method, expected)
+	}
+}
+
+// TestHeader checks that the header on the http.Request matches the expected value.
+func TestHeader(t *testing.T, r *http.Request, header string, expected string) {
+	if actual := r.Header.Get(header); expected != actual {
+		t.Errorf("Header %s = %s, expected %s", header, actual, expected)
+	}
+}
+
+// TestBody verifies that the request body matches an expected body.
+func TestBody(t *testing.T, r *http.Request, expected string) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Unable to read body: %v", err)
+	}
+	str := string(b)
+	if expected != str {
+		t.Errorf("Body = %s, expected %s", str, expected)
+	}
+}
+
+// TestJSONRequest verifies that the JSON payload of a request matches an expected structure, without asserting things about
+// whitespace or ordering.
+func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Unable to read request body: %v", err)
+	}
+
+	var actualJSON interface{}
+	err = json.Unmarshal(b, &actualJSON)
+	if err != nil {
+		t.Errorf("Unable to parse request body as JSON: %v", err)
+	}
+
+	CheckJSONEquals(t, expected, actualJSON)
+}


### PR DESCRIPTION
This pull request adds a cloud provider for OpenStack. This requires a more up to date version of gophercloud. The specific newer commit of gophercloud is chosen because the commit following it [changes a function signature](https://github.com/gophercloud/gophercloud/commit/7bd760e8eb1d7c94108db464cc992df1620278d1#diff-18ac4c04e89cf251c4c250ccfa91b7f8R84), and this leads to [problems with k8s.io/kubernetes itself](https://gist.github.com/tghartland/e564a2e57b09e7008a82b4ad18b5c4da).

As of right now this autoscaler only supports OpenStack clusters using Magnum and Heat, but this is done through an interface OpenstackManager. I will be adding another implementation of this interface to support Magnum clusters with proper nodegroups when that is available, but this could also be extended to support any other kind of OpenStack cluster. There is only the Magnum/Heat manager now but it is already set up to support more via changing an environment variable.

All nodegroups managed by the OpenstackCloudProvider interact with openstack through a single instance of the manager.

Since Magnum does not yet have nodegroups, only a single nodegroup is currently allowed and this represents the entire cluster.