### PR TITLE
VPA - disable errexit in run e2e scripts

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
 set -o nounset
 set -o pipefail
 

--- a/vertical-pod-autoscaler/hack/run-e2e.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
 set -o nounset
 set -o pipefail
 


### PR DESCRIPTION
Since we want to run 2 e2e test scripts we don't want to exit on failure of the first one.