### PR TITLE
Add version field to spec

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
@@ -12,6 +12,7 @@ spec:
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
+  version: v1beta1
   versions:
   - name: v1beta1
     served: true
@@ -50,6 +51,7 @@ spec:
     kind: VerticalPodAutoscalerCheckpoint
     shortNames:
     - vpacheckpoint
+  version: v1beta1
   versions:
   - name: v1beta1
     served: true


### PR DESCRIPTION
According to [this document](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#overview) we should also set `version` field.
Without doing this, it is impossible to deploy VPA on Kubernetes 1.10.

Before:
```
./hack/vpa-up.sh
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "verticalpodautoscalers.autoscaling.k8s.io" is invalid: spec.version: Required value
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "verticalpodautoscalercheckpoints.autoscaling.k8s.io" is invalid: spec.version: Required value
clusterrole.rbac.authorization.k8s.io/system:metrics-reader created
clusterrole.rbac.authorization.k8s.io/system:vpa-actor created
clusterrole.rbac.authorization.k8s.io/system:vpa-checkpoint-actor created
clusterrole.rbac.authorization.k8s.io/system:evictioner created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-reader created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-actor created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-checkpoint-actor created
clusterrole.rbac.authorization.k8s.io/system:vpa-target-reader created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-vpa-target-reader-binding created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-evictionter-binding created
serviceaccount/vpa-admission-controller created
clusterrole.rbac.authorization.k8s.io/system:admission-controller created
clusterrolebinding.rbac.authorization.k8s.io/system:admission-controller created
serviceaccount/vpa-updater created
deployment.extensions/vpa-updater created
serviceaccount/vpa-recommender created
deployment.extensions/vpa-recommender created
Generating certs for the VPA Admission Controller in /tmp/vpa-certs.
Generating RSA private key, 2048 bit long modulus
................................+++++
............................................................................+++++
e is 65537 (0x10001)
Generating RSA private key, 2048 bit long modulus
.............................+++++
........................+++++
e is 65537 (0x10001)
Signature ok
subject=/CN=vpa-webhook.kube-system.svc
Getting CA Private Key
Uploading certs to the cluster.
secret/vpa-tls-certs created
Deleting /tmp/vpa-certs.
deployment.extensions/vpa-admission-controller created
service/vpa-webhook created
```

After:
```
./hack/vpa-up.sh
customresourcedefinition.apiextensions.k8s.io/verticalpodautoscalers.autoscaling.k8s.io created
customresourcedefinition.apiextensions.k8s.io/verticalpodautoscalercheckpoints.autoscaling.k8s.io created
clusterrole.rbac.authorization.k8s.io/system:metrics-reader created
clusterrole.rbac.authorization.k8s.io/system:vpa-actor created
clusterrole.rbac.authorization.k8s.io/system:vpa-checkpoint-actor created
clusterrole.rbac.authorization.k8s.io/system:evictioner created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-reader created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-actor created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-checkpoint-actor created
clusterrole.rbac.authorization.k8s.io/system:vpa-target-reader created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-vpa-target-reader-binding created
clusterrolebinding.rbac.authorization.k8s.io/system:vpa-evictionter-binding created
serviceaccount/vpa-admission-controller created
clusterrole.rbac.authorization.k8s.io/system:admission-controller created
clusterrolebinding.rbac.authorization.k8s.io/system:admission-controller created
serviceaccount/vpa-updater created
deployment.extensions/vpa-updater created
serviceaccount/vpa-recommender created
deployment.extensions/vpa-recommender created
Generating certs for the VPA Admission Controller in /tmp/vpa-certs.
Generating RSA private key, 2048 bit long modulus
..............................................................................................................................................+++++
.........................................................................................+++++
e is 65537 (0x10001)
Generating RSA private key, 2048 bit long modulus
..........................................................................................................+++++
............................+++++
e is 65537 (0x10001)
Signature ok
subject=/CN=vpa-webhook.kube-system.svc
Getting CA Private Key
Uploading certs to the cluster.
secret/vpa-tls-certs created
Deleting /tmp/vpa-certs.
deployment.extensions/vpa-admission-controller created
service/vpa-webhook created
```