### PR TITLE
Fix vmss scaling issues when node's providerIDs are in different cases

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/0"
+	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourcegroups/test-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0"
 )
 
 // VirtualMachineScaleSetsClientMock mocks for VirtualMachineScaleSetsClient.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -33,10 +33,9 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager:         manager,
-		minSize:         1,
-		maxSize:         5,
-		virtualMachines: make(map[string]string),
+		manager: manager,
+		minSize: 1,
+		maxSize: 5,
 	}
 }
 
@@ -92,7 +91,7 @@ func TestBelongs(t *testing.T) {
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
-			ProviderID: "azure:///subscriptions/test-subscrition-id/resourceGroups/invalid-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/0",
+			ProviderID: "azure:///subscriptions/test-subscrition-id/resourcegroups/invalid-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0",
 		},
 	}
 	_, err := scaleSet.Belongs(invalidNode)
@@ -183,10 +182,6 @@ func TestScaleSetNodes(t *testing.T) {
 	ss, ok := group.(*ScaleSet)
 	assert.True(t, ok)
 	assert.NotNil(t, ss)
-	assert.Equal(t, ss.virtualMachines, map[string]string{
-		"0": fakeVirtualMachineScaleSetVMID,
-	})
-
 	instances, err := group.Nodes()
 	assert.NoError(t, err)
 	assert.Equal(t, len(instances), 1)

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -142,6 +142,14 @@ type NodeGroup interface {
 	Autoprovisioned() bool
 }
 
+// NodeGroupExtended represents the extended node group interfaces.
+type NodeGroupExtended interface {
+	// NodesLowered returns a list of all nodes (Id in lowered cases) that belong to this node group.
+	// It is required that Instance objects returned by this method have Id field set.
+	// Other fields are optional.
+	NodesLowered() ([]Instance, error)
+}
+
 // Instance represents a cloud-provider node. The node does not necessarily map to k8s node
 // i.e it does not have to be registered in k8s cluster despite being returned by NodeGroup.Nodes()
 // method. Also it is sane to have Instance object for nodes which are being created or deleted.

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -277,11 +277,11 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 		return err
 	}
 
-	cloudProviderNodeInstances, err := getCloudProviderNodeInstances(csr.cloudProvider)
+	cloudProviderNodeInstances, extended, err := getCloudProviderNodeInstances(csr.cloudProvider)
 	if err != nil {
 		return err
 	}
-	notRegistered := getNotRegisteredNodes(nodes, cloudProviderNodeInstances, currentTime)
+	notRegistered := getNotRegisteredNodes(nodes, cloudProviderNodeInstances, currentTime, extended)
 
 	csr.Lock()
 	defer csr.Unlock()
@@ -919,23 +919,39 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() map[string]int {
 
 // getCloudProviderNodeInstances returns map keyed on node group id where value is list of node instances
 // as returned by NodeGroup.Nodes().
-func getCloudProviderNodeInstances(cloudProvider cloudprovider.CloudProvider) (map[string][]cloudprovider.Instance, error) {
+// Extended is also returned as true if the node group supports NodeGroupExtended interface.
+func getCloudProviderNodeInstances(provider cloudprovider.CloudProvider) (map[string][]cloudprovider.Instance, bool, error) {
+	var nodeGroupInstances []cloudprovider.Instance
+	var extended bool
+	var err error
+
 	allInstances := make(map[string][]cloudprovider.Instance)
-	for _, nodeGroup := range cloudProvider.NodeGroups() {
-		nodeGroupInstances, err := nodeGroup.Nodes()
+	for _, nodeGroup := range provider.NodeGroups() {
+		// Invoke NodesLowered() if the node group has implemented NodeGroupExtended interface.
+		if nodeGroupExtended, ok := nodeGroup.(cloudprovider.NodeGroupExtended); ok {
+			extended = true
+			nodeGroupInstances, err = nodeGroupExtended.NodesLowered()
+		} else { // Or else, invoke Nodes().
+			nodeGroupInstances, err = nodeGroup.Nodes()
+		}
 		if err != nil {
-			return nil, err
+			return nil, extended, err
 		}
 		allInstances[nodeGroup.Id()] = nodeGroupInstances
 	}
-	return allInstances, nil
+	return allInstances, extended, nil
 }
 
 // Calculates which of the existing cloud provider nodes are not registered in Kubernetes.
-func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances map[string][]cloudprovider.Instance, time time.Time) []UnregisteredNode {
+func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances map[string][]cloudprovider.Instance, time time.Time, extended bool) []UnregisteredNode {
 	registered := sets.NewString()
 	for _, node := range allNodes {
-		registered.Insert(node.Spec.ProviderID)
+		providerID := node.Spec.ProviderID
+		if extended {
+			// if extended is set, node's providerID should be converted to lower cases.
+			providerID = strings.ToLower(providerID)
+		}
+		registered.Insert(providerID)
 	}
 	notRegistered := make([]UnregisteredNode, 0)
 	for _, instances := range cloudProviderNodeInstances {


### PR DESCRIPTION
Fix VMSS scaling issues when node's providerIDs are in different cases.

For VMSS node's providerIDs, they may be in different cases depending user's PUT requests to the resources. This would cause autoscaler to delete all newly provisioned nodes. And more seriously, CA would scale up/down again and again.

This PR adds a workaround for this issue, so that different cased providerIDs are processed as same node.

Cross refer https://github.com/kubernetes/kubernetes/issues/71994.

/assign @aleksandra-malinowska @losipiuk 

cc @andyzhangx @ritazh 