### PR TITLE
Rename vpa-target-reader ClusterRoleBinding name

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -185,7 +185,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-vpa-target-reader-binding
+  name: system:vpa-target-reader-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This looks like unintended effect of renaming VPA ClusterRole `scale-reader` to `vpa-target-reader` in 0bc25d5.

Repetitive `vpa-vpa-` while being technically correct and in accordance with naming convention in a surrounding blocks just looks wrong.