### PR TITLE
AliCloud - Add asg configuration's tag to node

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling.go
@@ -101,7 +101,7 @@ type autoScalingWrapper struct {
 	cfg *cloudConfig
 }
 
-func (m autoScalingWrapper) getInstanceTypeByConfiguration(configID string, asgId string) (string, error) {
+func (m autoScalingWrapper) getConfigurationById(configID string, asgId string) (*ess.ScalingConfiguration, error) {
 	params := ess.CreateDescribeScalingConfigurationsRequest()
 	params.ScalingConfigurationId1 = configID
 	params.ScalingGroupId = asgId
@@ -109,19 +109,19 @@ func (m autoScalingWrapper) getInstanceTypeByConfiguration(configID string, asgI
 	resp, err := m.DescribeScalingConfigurations(params)
 	if err != nil {
 		klog.Errorf("failed to get ScalingConfiguration info request for %s,because of %s", configID, err.Error())
-		return "", err
+		return nil, err
 	}
 
 	configurations := resp.ScalingConfigurations.ScalingConfiguration
 
 	if len(configurations) < 1 {
-		return "", fmt.Errorf("unable to get first ScalingConfiguration for %s", configID)
+		return nil, fmt.Errorf("unable to get first ScalingConfiguration for %s", configID)
 	}
 	if len(configurations) > 1 {
 		klog.Warningf("more than one ScalingConfiguration found for config(%q) and ASG(%q)", configID, asgId)
 	}
 
-	return configurations[0].InstanceType, nil
+	return &configurations[0], nil
 }
 
 func (m autoScalingWrapper) getScalingGroupByID(groupID string) (*ess.ScalingGroup, error) {
@@ -232,4 +232,24 @@ func (m autoScalingWrapper) setCapcityInstanceSize(groupId string, capcityInstan
 		return err
 	}
 	return nil
+}
+
+func (m autoScalingWrapper) getInstanceTypeByConfiguration(configID string, asgId string) (string, error) {
+	configuration, err := m.getConfigurationById(configID, asgId)
+
+	if err != nil {
+		return "", err
+	}
+
+	return configuration.InstanceType, nil
+}
+
+func (m autoScalingWrapper) getTagsByConfiguration(configID string, asgId string) (*ess.Tags, error) {
+	configuration, err := m.getConfigurationById(configID, asgId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &configuration.Tags, nil
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alicloud
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,24 @@ func TestBuildGenericLabels(t *testing.T) {
 	nodeName := "virtual-node"
 	labels := buildGenericLabels(template, nodeName)
 	assert.Equal(t, labels[apiv1.LabelInstanceType], template.InstanceType.instanceTypeID)
+}
+
+func TestExtractLabelsFromAsg(t *testing.T) {
+	template := &sgTemplate{
+		InstanceType: &instanceType{
+			instanceTypeID: "gn5-4c-8g",
+			vcpu:           4,
+			memoryInBytes:  8 * 1024 * 1024 * 1024,
+			gpu:            1,
+		},
+		Region: "cn-hangzhou",
+		Zone:   "cn-hangzhou-a",
+		Tags: &ess.Tags{
+			Tag: []ess.Tag{
+				{Key: "k8s.io/cluster-autoscaler/node-template/label/asg1", Value: "true"},
+			},
+		},
+	}
+	labels := extractLabelsFromAsg(template.Tags)
+	assert.Equal(t, labels["asg1"], "true")
 }


### PR DESCRIPTION
This code allows labels of node to be set from cluster-autoscaler based on tags in asg of Alicloud. 
The tag format follows AWS's convention -  k8s.io/cluster-autoscaler/node-template/label/