### PR TITLE
Use separate client for events

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -93,16 +93,16 @@ func NewAutoscalingContext(options config.AutoscalingOptions, predicateChecker *
 }
 
 // NewAutoscalingKubeClients builds AutoscalingKubeClients out of basic client.
-func NewAutoscalingKubeClients(opts config.AutoscalingOptions, kubeClient kube_client.Interface) *AutoscalingKubeClients {
+func NewAutoscalingKubeClients(opts config.AutoscalingOptions, kubeClient, eventsKubeClient kube_client.Interface) *AutoscalingKubeClients {
 	listerRegistryStopChannel := make(chan struct{})
 	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(kubeClient, listerRegistryStopChannel)
-	kubeEventRecorder := kube_util.CreateEventRecorder(kubeClient)
+	kubeEventRecorder := kube_util.CreateEventRecorder(eventsKubeClient)
 	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap)
 	if err != nil {
 		klog.Error("Failed to initialize status configmap, unable to write status events")
 		// Get a dummy, so we can at least safely call the methods
 		// TODO(maciekpytel): recover from this after successful status configmap update?
-		logRecorder, _ = utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, false)
+		logRecorder, _ = utils.NewStatusMapRecorder(eventsKubeClient, opts.ConfigNamespace, kubeEventRecorder, false)
 	}
 
 	return &AutoscalingKubeClients{

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -38,6 +38,7 @@ import (
 type AutoscalerOptions struct {
 	config.AutoscalingOptions
 	KubeClient             kube_client.Interface
+	EventsKubeClient       kube_client.Interface
 	AutoscalingKubeClients *context.AutoscalingKubeClients
 	CloudProvider          cloudprovider.CloudProvider
 	PredicateChecker       *simulator.PredicateChecker
@@ -78,7 +79,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.Processors = ca_processors.DefaultProcessors()
 	}
 	if opts.AutoscalingKubeClients == nil {
-		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient)
+		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient, opts.EventsKubeClient)
 	}
 	if opts.PredicateChecker == nil {
 		predicateCheckerStopChannel := make(chan struct{})

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -265,6 +265,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	// Create basic config from flags.
 	autoscalingOptions := createAutoscalingOptions()
 	kubeClient := createKubeClient(getKubeConfig())
+	eventsKubeClient := createKubeClient(getKubeConfig())
 	processors := ca_processors.DefaultProcessors()
 	if autoscalingOptions.CloudProviderName == "gke" {
 		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
@@ -274,6 +275,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions: autoscalingOptions,
 		KubeClient:         kubeClient,
+		EventsKubeClient:   eventsKubeClient,
 		Processors:         processors,
 	}
 


### PR DESCRIPTION
Using separate Kubernetes client for events is recommended practice. Also, throttling is especially painful with bulk scale down of empty nodes.