### PR TITLE
Add labels support for Alibaba Cloud Provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling.go
@@ -101,7 +101,7 @@ type autoScalingWrapper struct {
 	cfg *cloudConfig
 }
 
-func (m autoScalingWrapper) getInstanceTypeByConfiguration(configID string, asgId string) (string, error) {
+func (m autoScalingWrapper) getScalingGroupConfigurationByID(configID string, asgId string) (*ess.ScalingConfiguration, error) {
 	params := ess.CreateDescribeScalingConfigurationsRequest()
 	params.ScalingConfigurationId1 = configID
 	params.ScalingGroupId = asgId
@@ -109,19 +109,19 @@ func (m autoScalingWrapper) getInstanceTypeByConfiguration(configID string, asgI
 	resp, err := m.DescribeScalingConfigurations(params)
 	if err != nil {
 		klog.Errorf("failed to get ScalingConfiguration info request for %s,because of %s", configID, err.Error())
-		return "", err
+		return nil, err
 	}
 
 	configurations := resp.ScalingConfigurations.ScalingConfiguration
 
 	if len(configurations) < 1 {
-		return "", fmt.Errorf("unable to get first ScalingConfiguration for %s", configID)
+		return nil, fmt.Errorf("unable to get first ScalingConfiguration for %s", configID)
 	}
 	if len(configurations) > 1 {
 		klog.Warningf("more than one ScalingConfiguration found for config(%q) and ASG(%q)", configID, asgId)
 	}
 
-	return configurations[0].InstanceType, nil
+	return &configurations[0], nil
 }
 
 func (m autoScalingWrapper) getScalingGroupByID(groupID string) (*ess.ScalingGroup, error) {

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_instance_types.go
@@ -63,11 +63,11 @@ func (iw *instanceWrapper) getInstanceTypeById(typeId string) (*instanceType, er
 }
 
 func (iw *instanceWrapper) getInstanceTags(tags ess.Tags) (map[string]string, error) {
-	tags_map := make(map[string]string)
+	tagsMap := make(map[string]string)
 	for _, tag := range tags.Tag {
-		tags_map[tag.Key] = tag.Value
+		tagsMap[tag.Key] = tag.Value
 	}
-	return tags_map, nil
+	return tagsMap, nil
 }
 
 func (iw *instanceWrapper) FindInstanceType(typeId string) *instanceTypeModel {

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_instance_types.go
@@ -19,6 +19,7 @@ package alicloud
 import (
 	"fmt"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ecs"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess"
 	"k8s.io/klog"
 	"time"
 )
@@ -59,6 +60,14 @@ func (iw *instanceWrapper) getInstanceTypeById(typeId string) (*instanceType, er
 		return &instanceTypeModel.instanceType, nil
 	}
 	return nil, fmt.Errorf("failed to find the specific instance type by Id: %s", typeId)
+}
+
+func (iw *instanceWrapper) getInstanceTags(tags ess.Tags) (map[string]string, error) {
+	tags_map := make(map[string]string)
+	for _, tag := range tags.Tag {
+		tags_map[tag.Key] = tag.Value
+	}
+	return tags_map, nil
 }
 
 func (iw *instanceWrapper) FindInstanceType(typeId string) *instanceTypeModel {

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
@@ -38,3 +38,21 @@ func TestBuildGenericLabels(t *testing.T) {
 	labels := buildGenericLabels(template, nodeName)
 	assert.Equal(t, labels[apiv1.LabelInstanceType], template.InstanceType.instanceTypeID)
 }
+
+func TestExtractLabelsFromAsg(t *testing.T) {
+	template := &sgTemplate{
+		InstanceType: &instanceType{
+			instanceTypeID: "gn5-4c-8g",
+			vcpu:           4,
+			memoryInBytes:  8 * 1024 * 1024 * 1024,
+			gpu:            1,
+		},
+		Region: "cn-hangzhou",
+		Zone:   "cn-hangzhou-a",
+		Tags: map[string]string{
+			"workload_type": "cpu",
+		},
+	}
+	labels := template.Tags
+	assert.Equal(t, labels["workload_type"], "cpu")
+}


### PR DESCRIPTION
link to the pr (https://github.com/kubernetes/autoscaler/pull/1719) . @lookstar Hi, If you use autoscaler in Alibaba Cloud Kubernetes,it has supported labels right now. And I am sorry to forget merge these code from internal branch. The difference is we will attach every ess label as node label instead of the value under a specific key. because the other node labels are also plain tag.