### PR TITLE
Regenerate the ec2 instance types using latest metadata

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -27,6 +27,42 @@ type instanceType struct {
 
 // InstanceTypes is a map of ec2 resources
 var InstanceTypes = map[string]*instanceType{
+	"a1": {
+		InstanceType: "a1",
+		VCPU:         16,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"a1.2xlarge": {
+		InstanceType: "a1.2xlarge",
+		VCPU:         8,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"a1.4xlarge": {
+		InstanceType: "a1.4xlarge",
+		VCPU:         16,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"a1.large": {
+		InstanceType: "a1.large",
+		VCPU:         2,
+		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"a1.medium": {
+		InstanceType: "a1.medium",
+		VCPU:         1,
+		MemoryMb:     2048,
+		GPU:          0,
+	},
+	"a1.xlarge": {
+		InstanceType: "a1.xlarge",
+		VCPU:         4,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
 	"c1.medium": {
 		InstanceType: "c1.medium",
 		VCPU:         2,
@@ -195,6 +231,48 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     8192,
 		GPU:          0,
 	},
+	"c5n": {
+		InstanceType: "c5n",
+		VCPU:         72,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"c5n.18xlarge": {
+		InstanceType: "c5n.18xlarge",
+		VCPU:         72,
+		MemoryMb:     196608,
+		GPU:          0,
+	},
+	"c5n.2xlarge": {
+		InstanceType: "c5n.2xlarge",
+		VCPU:         8,
+		MemoryMb:     21504,
+		GPU:          0,
+	},
+	"c5n.4xlarge": {
+		InstanceType: "c5n.4xlarge",
+		VCPU:         16,
+		MemoryMb:     43008,
+		GPU:          0,
+	},
+	"c5n.9xlarge": {
+		InstanceType: "c5n.9xlarge",
+		VCPU:         36,
+		MemoryMb:     98304,
+		GPU:          0,
+	},
+	"c5n.large": {
+		InstanceType: "c5n.large",
+		VCPU:         2,
+		MemoryMb:     5376,
+		GPU:          0,
+	},
+	"c5n.xlarge": {
+		InstanceType: "c5n.xlarge",
+		VCPU:         4,
+		MemoryMb:     10752,
+		GPU:          0,
+	},
 	"cc2.8xlarge": {
 		InstanceType: "cc2.8xlarge",
 		VCPU:         32,
@@ -307,7 +385,7 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "g3s.xlarge",
 		VCPU:         4,
 		MemoryMb:     31232,
-		GPU:          0,
+		GPU:          1,
 	},
 	"h1": {
 		InstanceType: "h1",
@@ -573,6 +651,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     8192,
 		GPU:          0,
 	},
+	"m5.metal": {
+		InstanceType: "m5.metal",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
 	"m5.xlarge": {
 		InstanceType: "m5.xlarge",
 		VCPU:         4,
@@ -651,6 +735,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     8192,
 		GPU:          0,
 	},
+	"m5d.metal": {
+		InstanceType: "m5d.metal",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
 	"m5d.xlarge": {
 		InstanceType: "m5d.xlarge",
 		VCPU:         4,
@@ -704,6 +794,18 @@ var InstanceTypes = map[string]*instanceType{
 		VCPU:         32,
 		MemoryMb:     249856,
 		GPU:          4,
+	},
+	"p3dn": {
+		InstanceType: "p3dn",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          8,
+	},
+	"p3dn.24xlarge": {
+		InstanceType: "p3dn.24xlarge",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          8,
 	},
 	"r3": {
 		InstanceType: "r3",
@@ -819,6 +921,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     16384,
 		GPU:          0,
 	},
+	"r5.metal": {
+		InstanceType: "r5.metal",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          0,
+	},
 	"r5.xlarge": {
 		InstanceType: "r5.xlarge",
 		VCPU:         4,
@@ -895,6 +1003,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "r5d.large",
 		VCPU:         2,
 		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"r5d.metal": {
+		InstanceType: "r5d.metal",
+		VCPU:         96,
+		MemoryMb:     786432,
 		GPU:          0,
 	},
 	"r5d.xlarge": {
@@ -1105,6 +1219,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "z1d.large",
 		VCPU:         2,
 		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"z1d.metal": {
+		InstanceType: "z1d.metal",
+		VCPU:         48,
+		MemoryMb:     393216,
 		GPU:          0,
 	},
 	"z1d.xlarge": {


### PR DESCRIPTION
Originally I found that the g3s.xlarge instance type was not reporting a GPU so after much back and forth I finally got AWS to add it to the metadata endpoint.

The changes were generated by running `gen.go`, it looks to have fixed up the g3s.xlarge instance but also added a bunch of new instance types, if I ran it wrong let me know.