### PR TITLE
UPSTREAM: <carry>: fix max cluster size calculation on scale up

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -427,7 +427,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 
 		newNodes := bestOption.NodeCount
 
-		if context.MaxNodesTotal > 0 && len(nodes)+newNodes > context.MaxNodesTotal {
+		if context.MaxNodesTotal > 0 && len(nodes)+newNodes+len(upcomingNodes) > context.MaxNodesTotal {
 			klog.V(1).Infof("Capping size to max cluster total size (%d)", context.MaxNodesTotal)
 			newNodes = context.MaxNodesTotal - len(nodes) - len(upcomingNodes)
 			if newNodes < 1 {


### PR DESCRIPTION
When scaling up the calculation for computing the maximum cluster size
does not take into account the number of any upcoming nodes and it is
possible to grow the cluster beyond the cluster
size (--max-nodes-total).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1670695

See also: 5bc77f051cbce1fbe77d99cc6b0670128f330585