### PR TITLE
Ignoring upcoming nodes from unhealthy nodegroups.

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -285,6 +285,10 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 
 	upcomingNodes := make([]*schedulercache.NodeInfo, 0)
 	for nodeGroup, numberOfNodes := range clusterStateRegistry.GetUpcomingNodes() {
+		if !clusterStateRegistry.IsNodeGroupHealthy(nodeGroup) {
+			klog.Warningf("Node group %s has %d upcoming nodes but is unhealthy. Ignoring those nodes.", nodeGroup, numberOfNodes)
+			continue
+		}
 		nodeTemplate, found := nodeInfos[nodeGroup]
 		if !found {
 			return &status.ScaleUpStatus{Result: status.ScaleUpError}, errors.NewAutoscalerError(


### PR DESCRIPTION
This is a fix for https://github.com/kubernetes/autoscaler/issues/1133

I set the base branch as the 1.13 release branch. Please let me know if that is not the way to go.

If a nodegroup is in an Unhealthy state but has upcoming nodes, it is still considered to be ready to serve a pod that cannot be scheduled.
This means that other nodegroups that might be able to host the pod will not be expanded.

This happens for instance on AWS when you have an ASG with spot instances and the your price is either too high or the market does not have any spot instances available. The autoscaling group will be marked as `Unhealthy` and yet have upcoming nodes that will (maybe) never come. Other autoscaling groups will not get the chance to be expanded.