### PR TITLE
Soft taint when there are no candidates

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -408,7 +408,8 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 				a.clusterStateRegistry.Recalculate()
 			}
 
-			if scaleDownStatus.Result == status.ScaleDownNoNodeDeleted &&
+			if (scaleDownStatus.Result == status.ScaleDownNoNodeDeleted ||
+				scaleDownStatus.Result == status.ScaleDownNoUnneeded) &&
 				a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount != 0 {
 				scaleDown.SoftTaintUnneededNodes(allNodes)
 			}


### PR DESCRIPTION
Quick fix for not applying soft taints when nodes haven't been unneeded for long enough. Long-term, I really think we should reconsider scale down statuses and what they mean (not unneeded for long enough != no unneeded)