### PR TITLE
Delete support for v1beta1 API w/o deleting the API itself.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -17,7 +17,6 @@ limitations under the License.
 package input
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -50,10 +49,6 @@ import (
 
 const (
 	defaultResyncPeriod time.Duration = 10 * time.Minute
-)
-
-var (
-	beta1APIDeprecated = flag.Bool("beta1-api-deprecated", true, `If v1beta1 API objects should be marked as deprecated.`)
 )
 
 // ClusterStateFeeder can update state of ClusterState object.
@@ -432,7 +427,7 @@ func (feeder *clusterStateFeeder) getSelector(vpa *vpa_types.VerticalPodAutoscal
 	if selector != nil {
 		if legacySelector != nil {
 			return labels.Nothing(), []condition{
-				{conditionType: vpa_types.ConfigUnsupported, delete: false, message: "Both targetRef and label selector defined. Please reomve label selector"},
+				{conditionType: vpa_types.ConfigUnsupported, delete: false, message: "Both targetRef and label selector defined. Please remove label selector"},
 				{conditionType: vpa_types.ConfigDeprecated, delete: true},
 			}
 		}
@@ -442,13 +437,10 @@ func (feeder *clusterStateFeeder) getSelector(vpa *vpa_types.VerticalPodAutoscal
 		}
 	}
 	if legacySelector != nil {
-		if *beta1APIDeprecated {
-			return legacySelector, []condition{
-				{conditionType: vpa_types.ConfigUnsupported, delete: true},
-				{conditionType: vpa_types.ConfigDeprecated, delete: false, message: "Deprecated label selector defined, please migrate to targetRef"},
-			}
+		return labels.Nothing(), []condition{
+			{conditionType: vpa_types.ConfigUnsupported, delete: false, message: "Label selector is no longer supported, please migrate to targetRef"},
+			{conditionType: vpa_types.ConfigDeprecated, delete: true},
 		}
-		return legacySelector, []condition{}
 	}
 	msg := "Cannot read targetRef"
 	if fetchErr != nil {


### PR DESCRIPTION
This makes v1beta1 objects handled via ConfigUnsupported condition, sample status of an v1beta1 object after the change:
```
status:
  conditions:
  - lastTransitionTime: 2019-03-12T13:13:01Z
    message: Label selector is no longer supported, please migrate to targetRef
    status: "True"
    type: ConfigUnsupported
  - lastTransitionTime: 2019-03-12T13:13:01Z
    status: "False"
    type: RecommendationProvided
  recommendation: {}
```

**NOTE:** This change is not flag-guarded since it didn't make sense to reuse `beta1-api-deprecated` flag and I didn't wanted to introduce another one. Please let me know if you want this otherwise.

PS. I haven't touched validation in this PR so one can still create v1beta1 objects. This will be part of a separate PR.