### PR TITLE
Correct VPA Readme anchor links

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -2,16 +2,16 @@
 
 ## Contents
 - [Intro](#intro)
-- [Installation](#intallation)
+- [Installation](#installation)
   - [Prerequisites](#prerequisites)
   - [Install command](#install-command)
   - [Quick start](#quick-start)
   - [Test your installation](#test-your-installation)
   - [Example VPA configuration](#example-vpa-configuration)
   - [Troubleshooting](#troubleshooting)
-  - [Components of VPA](#component-of-vpa)
+  - [Components of VPA](#components-of-vpa)
   - [Tear down](#tear-down)
-- [Known limitations](#known-limitation)
+- [Known limitations](#known-limitations)
   - [Limitations of beta version](#limitations-of-beta-version)
 
 # Intro

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -13,6 +13,7 @@
   - [Tear down](#tear-down)
 - [Known limitations](#known-limitations)
   - [Limitations of beta version](#limitations-of-beta-version)
+- [Related Links](#related-links)
 
 # Intro
 


### PR DESCRIPTION
Fixes a number of broken anchor links with the VPA Readme and adds one to final section (`Related Links`)