### PR TITLE
cloudprovider/azure: fix formatting directive

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -141,6 +141,11 @@ func (m *azureRef) GetKey() string {
 	return m.Name
 }
 
+// String is represented by calling GetKey()
+func (m *azureRef) String() string {
+	return m.GetKey()
+}
+
 // BuildAzure builds Azure cloud provider, manager etc.
 func BuildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -279,7 +279,7 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef) error {
 		return nil
 	}
 
-	klog.V(3).Infof("Deleting vmss instances %q", instances)
+	klog.V(3).Infof("Deleting vmss instances %v", instances)
 
 	commonAsg, err := scaleSet.manager.GetAsgForInstance(instances[0])
 	if err != nil {


### PR DESCRIPTION
Switch formatting directive to `%v` when logging `instances`. This
allows `go test ./...` to work in `autoscaler/cluster-autoscaler`.

Without this running the tests currently fail with:

```console
cloudprovider/azure/azure_scale_set.go:282:2: Infof format %q has arg instances of wrong type []*k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.azureRef
FAIL	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure [build failed]
```

As this is trying to print `[]*azureRef` I added a `String()` method
to `azureRef` which returns `Name`. Without that it will print pointer
values which is unlikely to be useful as a default.