### PR TITLE
Added memory saver mode for VPA recommender

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -46,6 +46,11 @@ type ClusterState struct {
 	labelSetMap labelSetMap
 }
 
+// StateMapSize is the number of pods being tracked by the VPA
+func (cluster *ClusterState) StateMapSize() int {
+	return len(cluster.aggregateStateMap)
+}
+
 // AggregateStateKey determines the set of containers for which the usage samples
 // are kept aggregated in the model.
 type AggregateStateKey interface {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -42,6 +42,7 @@ const (
 var (
 	checkpointsWriteTimeout = flag.Duration("checkpoints-timeout", time.Minute, `Timeout for writing checkpoints since the start of the recommender's main loop`)
 	minCheckpointsPerRun    = flag.Int("min-checkpoints", 10, "Minimum number of checkpoints to write per recommender's main loop")
+	memorySaver             = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
 // Recommender recommend resources for certain containers, based on utilization periodically got from metrics api.
@@ -192,6 +193,7 @@ func (r *recommender) RunOnce() {
 
 	r.GarbageCollect()
 	timer.ObserveStep("GarbageCollect")
+	klog.V(3).Infof("ClusterState is tracking %d aggregated container states", r.clusterState.StateMapSize())
 }
 
 // RecommenderFactory makes instances of Recommender.
@@ -232,7 +234,7 @@ func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, us
 	clusterState := model.NewClusterState()
 	return RecommenderFactory{
 		ClusterState:           clusterState,
-		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState),
+		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState, *memorySaver),
 		CheckpointWriter:       checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1beta2()),
 		VpaClient:              vpa_clientset.NewForConfigOrDie(config).AutoscalingV1beta2(),
 		PodResourceRecommender: logic.CreatePodResourceRecommender(),

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
@@ -62,6 +62,14 @@ var (
 
 	functionLatency = metrics.CreateExecutionTimeMetric(metricsNamespace,
 		"Time spent in various parts of VPA Recommender main loop.")
+
+	aggregateContainerStatesCount = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "aggregate_container_states_count",
+			Help:      "Number of aggregate container states being tracked by the recommender",
+		},
+	)
 )
 
 type objectCounterKey struct {
@@ -77,9 +85,7 @@ type ObjectCounter struct {
 
 // Register initializes all metrics for VPA Recommender
 func Register() {
-	prometheus.MustRegister(vpaObjectCount)
-	prometheus.MustRegister(recommendationLatency)
-	prometheus.MustRegister(functionLatency)
+	prometheus.MustRegister(vpaObjectCount, recommendationLatency, functionLatency, aggregateContainerStatesCount)
 }
 
 // NewExecutionTimer provides a timer for Recommender's RunOnce execution
@@ -90,6 +96,11 @@ func NewExecutionTimer() *metrics.ExecutionTimer {
 // ObserveRecommendationLatency observes the time it took for the first recommendation to appear
 func ObserveRecommendationLatency(created time.Time) {
 	recommendationLatency.Observe(time.Now().Sub(created).Seconds())
+}
+
+// RecordAggregateContainerStatesCount records the number of containers being tracked by the recommender
+func RecordAggregateContainerStatesCount(statesCount int) {
+	aggregateContainerStatesCount.Set(float64(statesCount))
 }
 
 // NewObjectCounter creates a new helper to split VPA objects into buckets


### PR DESCRIPTION
This PR adds a flag which indicates that the VPA recommender will onlty track pods and containers which have an associated VPA. Fixes #1548 

