### PR TITLE
Fixes for CA Magnum cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -53,89 +53,89 @@ type magnumCloudProvider struct {
 }
 
 func buildMagnumCloudProvider(magnumManager magnumManager, resourceLimiter *cloudprovider.ResourceLimiter) (cloudprovider.CloudProvider, error) {
-	os := &magnumCloudProvider{
+	mcp := &magnumCloudProvider{
 		magnumManager:   &magnumManager,
 		resourceLimiter: resourceLimiter,
 		nodeGroups:      []magnumNodeGroup{},
 	}
-	return os, nil
+	return mcp, nil
 }
 
 // Name returns the name of the cloud provider.
-func (os *magnumCloudProvider) Name() string {
+func (mcp *magnumCloudProvider) Name() string {
 	return ProviderName
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (os *magnumCloudProvider) GPULabel() string {
+func (mcp *magnumCloudProvider) GPULabel() string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (os *magnumCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (mcp *magnumCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 	return availableGPUTypes
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.
-func (os *magnumCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
-	groups := make([]cloudprovider.NodeGroup, len(os.nodeGroups))
-	for i, group := range os.nodeGroups {
+func (mcp *magnumCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+	groups := make([]cloudprovider.NodeGroup, len(mcp.nodeGroups))
+	for i, group := range mcp.nodeGroups {
 		groups[i] = &group
 	}
 	return groups
 }
 
 // AddNodeGroup appends a node group to the list of node groups managed by this cloud provider.
-func (os *magnumCloudProvider) AddNodeGroup(group magnumNodeGroup) {
-	os.nodeGroups = append(os.nodeGroups, group)
+func (mcp *magnumCloudProvider) AddNodeGroup(group magnumNodeGroup) {
+	mcp.nodeGroups = append(mcp.nodeGroups, group)
 }
 
 // NodeGroupForNode returns the node group that a given node belongs to.
 //
 // Since only a single node group is currently supported, the first node group is always returned.
-func (os *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	// TODO: wait for magnum nodegroup support
-	return &(os.nodeGroups[0]), nil
+	return &(mcp.nodeGroups[0]), nil
 }
 
 // Pricing is not implemented.
-func (os *magnumCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (mcp *magnumCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes is not implemented.
-func (os *magnumCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (mcp *magnumCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup is not implemented.
-func (os *magnumCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (mcp *magnumCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns resource constraints for the cloud provider
-func (os *magnumCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
-	return os.resourceLimiter, nil
+func (mcp *magnumCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return mcp.resourceLimiter, nil
 }
 
 // GetInstanceID gets the instance ID for the specified node.
-func (os *magnumCloudProvider) GetInstanceID(node *apiv1.Node) string {
+func (mcp *magnumCloudProvider) GetInstanceID(node *apiv1.Node) string {
 	return node.Spec.ProviderID
 }
 
 // Refresh is called before every autoscaler main loop.
 //
 // Currently only prints debug information.
-func (os *magnumCloudProvider) Refresh() error {
-	for _, nodegroup := range os.nodeGroups {
+func (mcp *magnumCloudProvider) Refresh() error {
+	for _, nodegroup := range mcp.nodeGroups {
 		klog.V(3).Info(nodegroup.Debug())
 	}
 	return nil
 }
 
 // Cleanup currently does nothing.
-func (os *magnumCloudProvider) Cleanup() error {
+func (mcp *magnumCloudProvider) Cleanup() error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -95,6 +95,9 @@ func (mcp *magnumCloudProvider) AddNodeGroup(group magnumNodeGroup) {
 // Since only a single node group is currently supported, the first node group is always returned.
 func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	// TODO: wait for magnum nodegroup support
+	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; found {
+		return nil, nil
+	}
 	return &(mcp.nodeGroups[0]), nil
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
@@ -42,11 +42,11 @@ type magnumManager interface {
 }
 
 // createMagnumManager creates the desired implementation of magnumManager.
-// Currently reads the environment variable OSMANAGER to find which to create,
+// Currently reads the environment variable MAGNUM_MANAGER to find which to create,
 // and falls back to a default if the variable is not found.
 func createMagnumManager(configReader io.Reader, discoverOpts cloudprovider.NodeGroupDiscoveryOptions, opts config.AutoscalingOptions) (magnumManager, error) {
 	// For now get manager from env var, can consider adding flag later
-	manager, ok := os.LookupEnv("OSMANAGER")
+	manager, ok := os.LookupEnv("MAGNUM_MANAGER")
 	if !ok {
 		manager = defaultManager
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat.go
@@ -155,8 +155,8 @@ func createMagnumManagerHeat(configReader io.Reader, discoverOpts cloudprovider.
 // nodeGroupSize gets the current cluster size as reported by magnum.
 // The nodegroup argument is ignored as this implementation of magnumManager
 // assumes that only a single node group exists.
-func (osm *magnumManagerHeat) nodeGroupSize(nodegroup string) (int, error) {
-	cluster, err := clusters.Get(osm.clusterClient, osm.clusterName).Extract()
+func (mgr *magnumManagerHeat) nodeGroupSize(nodegroup string) (int, error) {
+	cluster, err := clusters.Get(mgr.clusterClient, mgr.clusterName).Extract()
 	if err != nil {
 		return 0, fmt.Errorf("could not get cluster: %v", err)
 	}
@@ -164,11 +164,11 @@ func (osm *magnumManagerHeat) nodeGroupSize(nodegroup string) (int, error) {
 }
 
 // updateNodeCount replaces the cluster node_count in magnum.
-func (osm *magnumManagerHeat) updateNodeCount(nodegroup string, nodes int) error {
+func (mgr *magnumManagerHeat) updateNodeCount(nodegroup string, nodes int) error {
 	updateOpts := []clusters.UpdateOptsBuilder{
 		UpdateOptsInt{Op: clusters.ReplaceOp, Path: "/node_count", Value: nodes},
 	}
-	_, err := clusters.Update(osm.clusterClient, osm.clusterName, updateOpts).Extract()
+	_, err := clusters.Update(mgr.clusterClient, mgr.clusterName, updateOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("could not update cluster: %v", err)
 	}
@@ -179,7 +179,7 @@ func (osm *magnumManagerHeat) updateNodeCount(nodegroup string, nodes int) error
 // used to find any nodes which are unregistered in kubernetes.
 // This can not be done with heat currently but a change has been merged upstream
 // that will allow this.
-func (osm *magnumManagerHeat) getNodes(nodegroup string) ([]string, error) {
+func (mgr *magnumManagerHeat) getNodes(nodegroup string) ([]string, error) {
 	// TODO: get node ProviderIDs by getting nova instance IDs from heat
 	// Waiting for https://review.openstack.org/#/c/639053/ to be able to get
 	// nova instance IDs from the kube_minions stack resource.
@@ -193,8 +193,8 @@ func (osm *magnumManagerHeat) getNodes(nodegroup string) ([]string, error) {
 //
 // TODO: The two step process is required until https://storyboard.openstack.org/#!/story/2005052
 // is complete, which will allow resizing with specific nodes to be deleted as a single Magnum operation.
-func (osm *magnumManagerHeat) deleteNodes(nodegroup string, nodes []NodeRef, updatedNodeCount int) error {
-	stackIndices, err := osm.findStackIndices(nodes)
+func (mgr *magnumManagerHeat) deleteNodes(nodegroup string, nodes []NodeRef, updatedNodeCount int) error {
+	stackIndices, err := mgr.findStackIndices(nodes)
 	if err != nil {
 		return fmt.Errorf("could not find stack indices for nodes to be deleted: %v", err)
 	}
@@ -207,23 +207,23 @@ func (osm *magnumManagerHeat) deleteNodes(nodegroup string, nodes []NodeRef, upd
 		},
 	}
 
-	updateResult := stacks.UpdatePatch(osm.heatClient, osm.stackName, osm.stackID, updateOpts)
+	updateResult := stacks.UpdatePatch(mgr.heatClient, mgr.stackName, mgr.stackID, updateOpts)
 	err = updateResult.ExtractErr()
 	if err != nil {
 		return fmt.Errorf("stack patch failed: %v", err)
 	}
 
 	// Wait for the stack to do its thing before updating the cluster node_count
-	err = osm.waitForStackStatus(stackStatusUpdateInProgress, waitForUpdateStatusTimeout)
+	err = mgr.waitForStackStatus(stackStatusUpdateInProgress, waitForUpdateStatusTimeout)
 	if err != nil {
 		return fmt.Errorf("error waiting for stack %s status: %v", stackStatusUpdateInProgress, err)
 	}
-	err = osm.waitForStackStatus(stackStatusUpdateComplete, waitForCompleteStatusTimout)
+	err = mgr.waitForStackStatus(stackStatusUpdateComplete, waitForCompleteStatusTimout)
 	if err != nil {
 		return fmt.Errorf("error waiting for stack %s status: %v", stackStatusUpdateComplete, err)
 	}
 
-	err = osm.updateNodeCount(nodegroup, updatedNodeCount)
+	err = mgr.updateNodeCount(nodegroup, updatedNodeCount)
 	if err != nil {
 		return fmt.Errorf("could not set new cluster size: %v", err)
 	}
@@ -231,8 +231,8 @@ func (osm *magnumManagerHeat) deleteNodes(nodegroup string, nodes []NodeRef, upd
 }
 
 // getClusterStatus returns the current status of the magnum cluster.
-func (osm *magnumManagerHeat) getClusterStatus() (string, error) {
-	cluster, err := clusters.Get(osm.clusterClient, osm.clusterName).Extract()
+func (mgr *magnumManagerHeat) getClusterStatus() (string, error) {
+	cluster, err := clusters.Get(mgr.clusterClient, mgr.clusterName).Extract()
 	if err != nil {
 		return "", fmt.Errorf("could not get cluster: %v", err)
 	}
@@ -242,8 +242,8 @@ func (osm *magnumManagerHeat) getClusterStatus() (string, error) {
 // canUpdate checks if the cluster status is present in a set of statuses that
 // prevent the cluster from being updated.
 // Returns if updating is possible and the status for convenience.
-func (osm *magnumManagerHeat) canUpdate() (bool, string, error) {
-	clusterStatus, err := osm.getClusterStatus()
+func (mgr *magnumManagerHeat) canUpdate() (bool, string, error) {
+	clusterStatus, err := mgr.getClusterStatus()
 	if err != nil {
 		return false, "", fmt.Errorf("could not get cluster status: %v", err)
 	}
@@ -251,8 +251,8 @@ func (osm *magnumManagerHeat) canUpdate() (bool, string, error) {
 }
 
 // getStackStatus returns the current status of the heat stack used by the magnum cluster.
-func (osm *magnumManagerHeat) getStackStatus() (string, error) {
-	stack, err := stacks.Get(osm.heatClient, osm.stackName, osm.stackID).Extract()
+func (mgr *magnumManagerHeat) getStackStatus() (string, error) {
+	stack, err := stacks.Get(mgr.heatClient, mgr.stackName, mgr.stackID).Extract()
 	if err != nil {
 		return "", fmt.Errorf("could not get stack from heat: %v", err)
 	}
@@ -261,17 +261,17 @@ func (osm *magnumManagerHeat) getStackStatus() (string, error) {
 
 // templateNodeInfo returns a NodeInfo with a node template based on the VM flavor
 // that is used to created minions in a given node group.
-func (osm *magnumManagerHeat) templateNodeInfo(nodegroup string) (*schedulernodeinfo.NodeInfo, error) {
+func (mgr *magnumManagerHeat) templateNodeInfo(nodegroup string) (*schedulernodeinfo.NodeInfo, error) {
 	// TODO: create a node template by getting the minion flavor from the heat stack.
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // waitForStackStatus checks periodically to see if the heat stack has entered a given status.
 // Returns when the status is observed or the timeout is reached.
-func (osm *magnumManagerHeat) waitForStackStatus(status string, timeout time.Duration) error {
+func (mgr *magnumManagerHeat) waitForStackStatus(status string, timeout time.Duration) error {
 	klog.V(2).Infof("Waiting for stack %s status", status)
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(osm.waitTimeStep) {
-		currentStatus, err := osm.getStackStatus()
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(mgr.waitTimeStep) {
+		currentStatus, err := mgr.getStackStatus()
 		if err != nil {
 			return fmt.Errorf("error waiting for stack status: %v", err)
 		}
@@ -284,24 +284,24 @@ func (osm *magnumManagerHeat) waitForStackStatus(status string, timeout time.Dur
 }
 
 // getStackName finds the name of a stack matching a given ID.
-func (osm *magnumManagerHeat) getStackName(stackID string) (string, error) {
-	stack, err := stacks.Find(osm.heatClient, stackID).Extract()
+func (mgr *magnumManagerHeat) getStackName(stackID string) (string, error) {
+	stack, err := stacks.Find(mgr.heatClient, stackID).Extract()
 	if err != nil {
-		return "", fmt.Errorf("could not find stack with ID %s: %v", osm.stackID, err)
+		return "", fmt.Errorf("could not find stack with ID %s: %v", mgr.stackID, err)
 	}
-	klog.V(0).Infof("For stack ID %s, stack name is %s", osm.stackID, stack.Name)
+	klog.V(0).Infof("For stack ID %s, stack name is %s", mgr.stackID, stack.Name)
 	return stack.Name, nil
 }
 
 // getKubeMinionsStack finds the nested kube_minions stack belonging to the main cluster stack,
 // and returns its name and ID.
-func (osm *magnumManagerHeat) getKubeMinionsStack(stackName, stackID string) (name string, ID string, err error) {
-	minionsResource, err := stackresources.Get(osm.heatClient, stackName, stackID, "kube_minions").Extract()
+func (mgr *magnumManagerHeat) getKubeMinionsStack(stackName, stackID string) (name string, ID string, err error) {
+	minionsResource, err := stackresources.Get(mgr.heatClient, stackName, stackID, "kube_minions").Extract()
 	if err != nil {
 		return "", "", fmt.Errorf("could not get kube_minions stack resource: %v", err)
 	}
 
-	stack, err := stacks.Find(osm.heatClient, minionsResource.PhysicalID).Extract()
+	stack, err := stacks.Find(mgr.heatClient, minionsResource.PhysicalID).Extract()
 	if err != nil {
 		return "", "", fmt.Errorf("could not find stack matching resource ID in heat: %v", err)
 	}
@@ -319,8 +319,8 @@ func (osm *magnumManagerHeat) getKubeMinionsStack(stackName, stackID string) (na
 // or  {'0': 'f12070fef4144bef82812aff177b83c1'}
 // Deleting minions in heat can be done with either the index of the minion or the ID associated with it,
 // but since the ID could be one of several things it is useful to be able to resolve back to indices.
-func (osm *magnumManagerHeat) findStackIndices(nodeRefs []NodeRef) ([]string, error) {
-	stack, err := stacks.Get(osm.heatClient, osm.kubeMinionsStackName, osm.kubeMinionsStackID).Extract()
+func (mgr *magnumManagerHeat) findStackIndices(nodeRefs []NodeRef) ([]string, error) {
+	stack, err := stacks.Get(mgr.heatClient, mgr.kubeMinionsStackName, mgr.kubeMinionsStackID).Extract()
 	if err != nil {
 		return nil, fmt.Errorf("could not get kube_minions nested stack from heat: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
@@ -296,10 +296,10 @@ func createManagerGetClusterSuccess() *magnumManagerHeat {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
 
-	return osm
+	return manager
 }
 
 func createManagerGetClusterFail() *magnumManagerHeat {
@@ -312,19 +312,19 @@ func createManagerGetClusterFail() *magnumManagerHeat {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = badClusterUUID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = badClusterUUID
 
-	return osm
+	return manager
 }
 
 func TestNodeGroupSizeSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterSuccess()
+	manager := createManagerGetClusterSuccess()
 
-	nodeCount, err := osm.nodeGroupSize("default")
+	nodeCount, err := manager.nodeGroupSize("default")
 	assert.NoError(t, err)
 	assert.Equal(t, clusterNodeCount, nodeCount)
 }
@@ -333,9 +333,9 @@ func TestNodeGroupSizeFail(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterFail()
+	manager := createManagerGetClusterFail()
 
-	_, err := osm.nodeGroupSize("default")
+	_, err := manager.nodeGroupSize("default")
 	assert.Error(t, err)
 	assert.Equal(t, "could not get cluster: Resource not found", err.Error())
 }
@@ -344,9 +344,9 @@ func TestGetClusterStatusSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterSuccess()
+	manager := createManagerGetClusterSuccess()
 
-	gotStatus, err := osm.getClusterStatus()
+	gotStatus, err := manager.getClusterStatus()
 	assert.NoError(t, err)
 	assert.Equal(t, clusterStatus, gotStatus)
 }
@@ -355,9 +355,9 @@ func TestGetClusterStatusFail(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterFail()
+	manager := createManagerGetClusterFail()
 
-	_, err := osm.getClusterStatus()
+	_, err := manager.getClusterStatus()
 	assert.Error(t, err)
 	assert.Equal(t, "could not get cluster: Resource not found", err.Error())
 }
@@ -366,9 +366,9 @@ func TestCanUpdateSuccess(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterSuccess()
+	manager := createManagerGetClusterSuccess()
 
-	can, status, err := osm.canUpdate()
+	can, status, err := manager.canUpdate()
 	assert.NoError(t, err)
 	assert.Equal(t, true, can)
 	assert.Equal(t, clusterStatus, status)
@@ -378,9 +378,9 @@ func TestCanUpdateFail(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	osm := createManagerGetClusterFail()
+	manager := createManagerGetClusterFail()
 
-	_, _, err := osm.canUpdate()
+	_, _, err := manager.canUpdate()
 	assert.Error(t, err)
 	assert.Equal(t, "could not get cluster status: could not get cluster: Resource not found", err.Error())
 }
@@ -398,11 +398,11 @@ func TestGetStackNameSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
 
-	gotStackName, err := osm.getStackName(osm.stackID)
+	gotStackName, err := manager.getStackName(manager.stackID)
 	assert.NoError(t, err)
 	assert.Equal(t, stackName, gotStackName)
 }
@@ -420,11 +420,11 @@ func TestGetStackNameNotFound(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = badStackID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = badStackID
 
-	_, err := osm.getStackName(osm.stackID)
+	_, err := manager.getStackName(manager.stackID)
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("could not find stack with ID %s: Resource not found", badStackID), err.Error())
 }
@@ -442,12 +442,12 @@ func TestGetStackStatusSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	status, err := osm.getStackStatus()
+	status, err := manager.getStackStatus()
 	assert.NoError(t, err)
 	assert.Equal(t, stackStatus, status)
 }
@@ -465,12 +465,12 @@ func TestGetStackStatusFail(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = badStackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = badStackID
+	manager.stackName = stackName
 
-	_, err := osm.getStackStatus()
+	_, err := manager.getStackStatus()
 	assert.Error(t, err)
 	assert.Equal(t, "could not get stack from heat: Resource not found", err.Error())
 }
@@ -488,10 +488,10 @@ func TestUpdateNodeCountSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
 
-	err := osm.updateNodeCount("default", 2)
+	err := manager.updateNodeCount("default", 2)
 	assert.NoError(t, err)
 }
 
@@ -508,10 +508,10 @@ func TestUpdateNodeCountFail(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = badClusterUUID
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = badClusterUUID
 
-	err := osm.updateNodeCount("default", 2)
+	err := manager.updateNodeCount("default", 2)
 	assert.Error(t, err)
 	assert.Equal(t, "could not update cluster: Resource not found", err.Error())
 }
@@ -557,12 +557,12 @@ func TestDeleteNodesSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	err := osm.deleteNodes("default", deleteNodeRefs, 1)
+	err := manager.deleteNodes("default", deleteNodeRefs, 1)
 	assert.NoError(t, err)
 }
 
@@ -607,12 +607,12 @@ func TestDeleteNodesStackPatchFail(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	err := osm.deleteNodes("default", deleteNodeRefs, -1)
+	err := manager.deleteNodes("default", deleteNodeRefs, -1)
 	assert.Error(t, err)
 
 	expectedErrString := fmt.Sprintf("stack patch failed: Bad request with: [PATCH %s/v1/stacks/%s/%s], error message: %s",
@@ -633,17 +633,17 @@ func TestFindStackIndicesMissing(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
 	nodes := []NodeRef{
 		{Name: fmt.Sprintf("%s-minion-0", stackName), MachineID: "ffbc651da661462d94352e01f3020688"},
 		{Name: fmt.Sprintf("%s-minion-1", stackName)},
 	}
 
-	_, err := osm.findStackIndices(nodes)
+	_, err := manager.findStackIndices(nodes)
 	assert.Error(t, err)
 	assert.Equal(t, "1 nodes could not be resolved to stack indices", err.Error())
 }
@@ -669,12 +669,12 @@ func TestWaitForStackStatusSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	err := manager.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
 	assert.NoError(t, err)
 }
 
@@ -690,12 +690,12 @@ func TestWaitForStackStatusTimeout(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	err := manager.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
 	assert.Error(t, err)
 	assert.Equal(t, "timeout (200ms) waiting for stack status UPDATE_COMPLETE", err.Error())
 }
@@ -712,12 +712,12 @@ func TestWaitForStackStatusError(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	err := osm.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
+	err := manager.waitForStackStatus(stackStatusUpdateComplete, 200*time.Millisecond)
 	assert.Error(t, err)
 	assert.Equal(t, "error waiting for stack status: could not get stack from heat: Resource not found", err.Error())
 }
@@ -740,12 +740,12 @@ func TestGetKubeMinionsStackSuccess(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = stackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = stackID
+	manager.stackName = stackName
 
-	name, ID, err := osm.getKubeMinionsStack(osm.stackName, osm.stackID)
+	name, ID, err := manager.getKubeMinionsStack(manager.stackName, manager.stackID)
 	assert.NoError(t, err)
 	assert.Equal(t, kubeMinionsStackName, name)
 	assert.Equal(t, kubeMinionsStackID, ID)
@@ -763,12 +763,12 @@ func TestGetKubeMinionsStackNotFound(t *testing.T) {
 
 	sc := createTestServiceClient()
 
-	osm := createTestMagnumManagerHeat(sc)
-	osm.clusterName = clusterUUID
-	osm.stackID = badStackID
-	osm.stackName = stackName
+	manager := createTestMagnumManagerHeat(sc)
+	manager.clusterName = clusterUUID
+	manager.stackID = badStackID
+	manager.stackName = stackName
 
-	_, _, err := osm.getKubeMinionsStack(osm.stackName, osm.stackID)
+	_, _, err := manager.getKubeMinionsStack(manager.stackName, manager.stackID)
 	assert.Error(t, err)
 	assert.Equal(t, "could not get kube_minions stack resource: Resource not found", err.Error())
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_heat_test.go
@@ -153,7 +153,7 @@ var stackGetResponseNotFound = fmt.Sprintf(`
 }`, badStackID)
 
 var deleteNodeRefs = []NodeRef{
-	{Name: stackName + "-minion-1", MachineID: "3ae2e15807bd48ccbb26f9bb5f2996d6", ProviderID: "openstack:///3ae2e15807bd48ccbb26f9bb5f2996d6", IPs: []string{"10.0.0.52"}},
+	{Name: stackName + "-minion-1", MachineID: "3ae2e15807bd48ccbb26f9bb5f2996d6", ProviderID: "openstack:///3ae2e158-07bd-48cc-bb26-f9bb5f2996d6", IPs: []string{"10.0.0.52"}},
 }
 var patchResponseSuccess = `{"uuid": "732851e1-f792-4194-b966-4cbfa5f30093"}`
 
@@ -260,8 +260,8 @@ var stackGetKubeMinionsStackResponse = fmt.Sprintf(`
         "outputs":[
             {
                 "output_value":{
-                    "0":"ffbc651da661462d94352e01f3020688",
-                    "1":"3ae2e15807bd48ccbb26f9bb5f2996d6"
+                    "0":"ffbc651d-a661-462d-9435-2e01f3020688",
+                    "1":"3ae2e158-07bd-48cc-bb26-f9bb5f2996d6"
                 },
                 "output_key":"refs_map",
                 "description":"No description given"
@@ -778,14 +778,19 @@ func TestStackIndexFromID(t *testing.T) {
 	minion0IP := []string{"10.0.0.52"}
 	minion0ID := "a390ca6ab24846af8ddd854a52fd5281"
 	minion0 := NodeRef{MachineID: minion0ID, IPs: minion0IP}
+	minion0StackID := "a390ca6a-b248-46af-8ddd-854a52fd5281"
 
 	minion1IP := []string{"10.0.0.59"}
 	minion1ID := "5bc76eeb2b2e4625a1a559560aa90e5a"
 	minion1 := NodeRef{MachineID: minion1ID, IPs: minion1IP}
+	minion1StackID := "5bc76eeb-2b2e-4625-a1a5-59560aa90e5a"
 
 	minion2IP := []string{"10.0.0.70"}
 	minion2ID := "86db2aa4666948cfa2b828eb93cf3fd1"
 	minion2 := NodeRef{MachineID: minion2ID, IPs: minion2IP}
+
+	// Empty nodeRef, covers case with MachineID "" and IPs []string{}
+	minion3 := NodeRef{}
 
 	mappingWithIPs := map[string]string{
 		minion0IP[0]: "0",
@@ -793,8 +798,8 @@ func TestStackIndexFromID(t *testing.T) {
 	}
 
 	mappingWithIDs := map[string]string{
-		minion0ID: "0",
-		minion1ID: "1",
+		minion0StackID: "0",
+		minion1StackID: "1",
 	}
 
 	emptyMapping := map[string]string{}
@@ -817,6 +822,8 @@ func TestStackIndexFromID(t *testing.T) {
 		{"empty 0", emptyMapping, minion0, "", false},
 		{"empty 1", emptyMapping, minion1, "", false},
 		{"empty 2", emptyMapping, minion2, "", false},
+
+		{"empty ref", mappingWithIDs, minion3, "", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR has 3 separate commits

* One which renames things that were overlooked when the cloud provider name was changed from openstack to magnum.
* One which excludes the master node from being considered as a part of the nodegroup (fixes #1870)
* One which converts machine UUIDs from a format without dashes which kubernetes stores, to a format with dashes which openstack uses. Needed for looking up minion stack indices when deleting them.

Regarding the second commit, is there a utility function somewhere in the kubernetes codebase for checking if a role exists on a node, or is this the best way to do it?
```go
if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; found {
```