### PR TITLE
Fix garbage collection for empty aggregate container states.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -198,6 +198,13 @@ func TestAggregateContainerStateLoadFromCheckpoint(t *testing.T) {
 func TestAggregateContainerStateIsExpired(t *testing.T) {
 	cs := NewAggregateContainerState()
 	cs.LastSampleStart = testTimestamp
+	cs.TotalSamplesCount = 1
 	assert.False(t, cs.isExpired(testTimestamp.Add(7*24*time.Hour)))
 	assert.True(t, cs.isExpired(testTimestamp.Add(8*24*time.Hour)))
+
+	csEmpty := NewAggregateContainerState()
+	csEmpty.TotalSamplesCount = 0
+	csEmpty.CreationTime = testTimestamp
+	assert.False(t, csEmpty.isExpired(testTimestamp.Add(7*24*time.Hour)))
+	assert.True(t, csEmpty.isExpired(testTimestamp.Add(8*24*time.Hour)))
 }


### PR DESCRIPTION
Fixes the issue that we never removed aggregate container states for pods that lived too short too get any samples (common with short-lived cronjobs).
Adds garbage collection of old empty containers. Also removes aggregate container states that are empty and inactive - there are no live pods that can contribute metric samples.

/assign @jbartosik 

FYI @kgolab @schylek 