### PR TITLE
priority expander based on client-go for cluster autoscaler is missing permissions

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
@@ -60,7 +60,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["create"]
+  verbs: ["create","list","watch"]
 - apiGroups: [""]
   resources: ["configmaps"]
   resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-containerservice.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-containerservice.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
@@ -68,7 +68,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/baiducloud/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/baiducloud/examples/cluster-autoscaler-one-asg.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
@@ -42,10 +42,10 @@ rules:
     verbs: ["watch", "list", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create","list","watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["cluster-autoscaler-status"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
     verbs: ["delete", "get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
@MaciekPytel 
Related to: https://github.com/kubernetes/autoscaler/pull/1843
Priority expander needs now wider permissions, so I updated deployment examples.