### PR TITLE
Add cache to getInstanceTypeByLCName for avoid aws rate limit

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -36,9 +36,14 @@ type autoScaling interface {
 // autoScalingWrapper provides several utility methods over the auto-scaling service provided by AWS SDK
 type autoScalingWrapper struct {
 	autoScaling
+	launchConfigurationInstanceTypeCache map[string]string
 }
 
 func (m autoScalingWrapper) getInstanceTypeByLCName(name string) (string, error) {
+	if instanceType, found := m.launchConfigurationInstanceTypeCache[name]; found {
+		return instanceType, nil
+	}
+
 	params := &autoscaling.DescribeLaunchConfigurationsInput{
 		LaunchConfigurationNames: []*string{aws.String(name)},
 		MaxRecords:               aws.Int64(1),
@@ -52,7 +57,9 @@ func (m autoScalingWrapper) getInstanceTypeByLCName(name string) (string, error)
 		return "", fmt.Errorf("unable to get first LaunchConfiguration for %s", name)
 	}
 
-	return *launchConfigurations.LaunchConfigurations[0].InstanceType, nil
+	instanceType := *launchConfigurations.LaunchConfigurations[0].InstanceType
+	m.launchConfigurationInstanceTypeCache[name] = instanceType
+	return instanceType, nil
 }
 
 func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*autoscaling.Group, error) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -66,7 +66,7 @@ func (e *EC2Mock) DescribeLaunchTemplateVersions(i *ec2.DescribeLaunchTemplateVe
 	return args.Get(0).(*ec2.DescribeLaunchTemplateVersionsOutput), nil
 }
 
-var testService = autoScalingWrapper{&AutoScalingMock{}}
+var testService = autoScalingWrapper{&AutoScalingMock{}, map[string]string{}}
 
 var testAwsManager = &AwsManager{
 	asgCache: &asgCache{
@@ -80,7 +80,7 @@ var testAwsManager = &AwsManager{
 }
 
 func newTestAwsManagerWithService(service autoScaling, autoDiscoverySpecs []cloudprovider.ASGAutoDiscoveryConfig) *AwsManager {
-	wrapper := autoScalingWrapper{service}
+	wrapper := autoScalingWrapper{service, map[string]string{}}
 	return &AwsManager{
 		autoScalingService: wrapper,
 		asgCache: &asgCache{

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -186,7 +186,7 @@ func createAWSManagerInternal(
 			WithEndpointResolver(getResolver(awsSdkProvider.cfg)))
 
 		if autoScalingService == nil {
-			autoScalingService = &autoScalingWrapper{autoscaling.New(sess)}
+			autoScalingService = &autoScalingWrapper{autoscaling.New(sess), map[string]string{}}
 		}
 
 		if ec2Service == nil {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -226,7 +226,7 @@ func TestFetchExplicitAsgs(t *testing.T) {
 	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
 	os.Setenv("AWS_REGION", "fanghorn")
 	// fetchExplicitASGs is called at manager creation time.
-	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s}, nil)
+	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s, map[string]string{}}, nil)
 	assert.NoError(t, err)
 
 	asgs := m.asgCache.Get()
@@ -397,7 +397,7 @@ func TestFetchAutoAsgs(t *testing.T) {
 	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
 	os.Setenv("AWS_REGION", "fanghorn")
 	// fetchAutoASGs is called at manager creation time, via forceRefresh
-	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s}, nil)
+	m, err := createAWSManagerInternal(nil, do, &autoScalingWrapper{s, map[string]string{}}, nil)
 	assert.NoError(t, err)
 
 	asgs := m.asgCache.Get()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cache to `getInstanceTypeByLCName`.

**Special notes for your reviewer**:
If you have a launch configuration that can't bootstrap a valid Kubernetes node (in our case, a bug on user-data), the cluster-autoscaler try to execute a lot of `DescribeLaunchConfigurations` making the Auto Scaling Group and Launch Configurations aws console unresponsive due  to rate limit. 

Launch configuration is immutable, so add a cache by LC name seems safe.