### PR TITLE
Return read bytes while reading certs

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/certs.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs.go
@@ -43,7 +43,7 @@ func readFile(filePath string) []byte {
 		return nil
 	}
 	klog.Infof("Successfully read %d bytes from %v", count, filePath)
-	return res
+	return res[:count]
 }
 
 func initCerts(config certsConfig) certsContainer {


### PR DESCRIPTION
I've deployed vertical-pod-autoscaler:0.5.0 with custom certificates. After that, logs of the vpa-admission-controller show the following error: `tls: bad certificate`. The provided fix helped me to address that issue.