### PR TITLE
Do not run as root by default in Docker

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -22,4 +22,7 @@ RUN clean-install ca-certificates tzdata
 ADD cluster-autoscaler cluster-autoscaler
 ADD run.sh run.sh
 
+RUN useradd -ms /bin/bash cluster-autoscaler
+USER cluster-autoscaler
+
 CMD ./run.sh

--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -17,4 +17,7 @@ MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 
 ADD admission-controller admission-controller
 
+RUN useradd -ms /bin/bash admission-controller
+USER admission-controller
+
 ENTRYPOINT ./admission-controller --v=4 --stderrthreshold=info

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -17,4 +17,7 @@ MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
 
 ADD recommender recommender
 
+RUN useradd -ms /bin/bash recommender
+USER recommender
+
 ENTRYPOINT ./recommender --v=4 --stderrthreshold=info --prometheus-address=http://prometheus.monitoring.svc

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -18,4 +18,7 @@ MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 ADD updater updater
 
+RUN useradd -ms /bin/bash updater
+USER updater
+
 ENTRYPOINT ./updater --v=4 --stderrthreshold=info


### PR DESCRIPTION
Fixes #1972
Not sure if you prefer `nobody` or something else, just let me know.