### PR TITLE
Ability to pause the autoscaler based on a tag in the AutoScaling Group

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -230,3 +230,8 @@ func BuildAlicloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 	}
 	return cloudProvider
 }
+
+func (ali *aliCloudProvider) Paused() bool {
+	// Support to be added later
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -133,7 +133,7 @@ func testProvider(t *testing.T, m *AwsManager) *awsCloudProvider {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	provider, err := BuildAwsCloudProvider(m, resourceLimiter)
+	provider, err := BuildAwsCloudProvider(m, resourceLimiter, "")
 	assert.NoError(t, err)
 	return provider.(*awsCloudProvider)
 }
@@ -143,7 +143,7 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	_, err := BuildAwsCloudProvider(testAwsManager, resourceLimiter)
+	_, err := BuildAwsCloudProvider(testAwsManager, resourceLimiter, "")
 	assert.NoError(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -440,3 +440,15 @@ func extractTaintsFromAsg(tags []*autoscaling.TagDescription) []apiv1.Taint {
 	}
 	return taints
 }
+
+// Paused will return true if any asg has the pause tag
+func (m *AwsManager) Paused(pauseTag string) bool {
+	for _, asg := range m.getAsgs() {
+		for _, tag := range asg.Tags {
+			if *tag.Key == pauseTag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -170,3 +170,9 @@ func BuildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscov
 	}
 	return provider
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (azure *AzureCloudProvider) Paused() bool {
+	// Support to be added later
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -368,3 +368,9 @@ func (asg *Asg) Delete() error {
 func (asg *Asg) Autoprovisioned() bool {
 	return false
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (baiducloud *baiducloudCloudProvider) Paused() bool {
+	// Support to be added later
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -68,6 +68,9 @@ type CloudProvider interface {
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 	Refresh() error
+
+	// Based on the value returned by this function, we can decided to pause the autoscaling activity
+	Paused() bool
 }
 
 // ErrNotImplemented is returned if a method is not implemented.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -361,3 +361,9 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	RegisterMetrics()
 	return provider
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (gce *GceCloudProvider) Paused() bool {
+	// Support to be added later
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -346,3 +346,8 @@ func BuildKubemark(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 	}
 	return provider
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (kubemark *KubemarkCloudProvider) Paused() bool {
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -207,3 +207,9 @@ func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 
 	return provider
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (mcp *magnumCloudProvider) Paused() bool {
+	// Support to be added later
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
+++ b/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
@@ -231,3 +231,8 @@ func (_m *CloudProvider) Refresh() error {
 
 	return r0
 }
+
+// Paused should return true, if autoscaling needs to be paused
+func (_m *CloudProvider) Paused() bool {
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -248,6 +248,11 @@ func (tcp *TestCloudProvider) Refresh() error {
 	return nil
 }
 
+// Paused should return true, if autoscaling needs to be paused
+func (tcp *TestCloudProvider) Paused() bool {
+	return false
+}
+
 // TestNodeGroup is a node group used by TestCloudProvider.
 type TestNodeGroup struct {
 	sync.Mutex

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -133,4 +133,6 @@ type AutoscalingOptions struct {
 	// Setting it to false employs a more lenient filtering approach that does not try to pack the pods on the nodes.
 	// Pods with nominatedNodeName set are always filtered out.
 	FilterOutSchedulablePodsUsesPacking bool
+	// Pause any scaling activities if this tag is present (AWS only)
+	PauseTag string
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -149,6 +149,12 @@ func (a *StaticAutoscaler) cleanUpIfRequired() {
 
 // RunOnce iterates over node groups and scales them up/down if necessary
 func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError {
+
+	if a.AutoscalingContext.CloudProvider.Paused() {
+		klog.V(4).Info("Paused tag present. Nothing to do")
+		return nil
+	}
+
 	a.cleanUpIfRequired()
 	a.processorCallbacks.reset()
 


### PR DESCRIPTION
# Description

I created this issue earlier https://github.com/kubernetes/autoscaler/issues/1976 and this is my attempt at solving it for AWS cloud provider.

This adds a feature to pause node autoscaler based on a tag in the autoscaling group (AWS) and have the ability to pass in the tag when node autoscaler starts.

E.G --pause-tags=pause-node-autoscaler

In this example, then we should be able to add the tag `pause-node-autoscaler` to the ASG and have autoscaler pause any autoscaling activities.

## Backgroud

The reason I believe we need this feature is, when we cycle instances in an ASG (for deploying a new AMI for an example), Cluster Autoscaler interferes with that operation and terminates/launch instances during the update process. So we'd like to pause Cluster Autoscaler by adding a tag to the ASG and remove this tag when the update is complete.