### PR TITLE
Move CA version string to own package, for use by cloud providers

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+	"k8s.io/autoscaler/cluster-autoscaler/version"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -342,7 +343,7 @@ func main() {
 	kube_flag.InitFlags()
 	healthCheck := metrics.NewHealthCheck(*maxInactivityTimeFlag, *maxFailingTimeFlag)
 
-	klog.V(1).Infof("Cluster Autoscaler %s", ClusterAutoscalerVersion)
+	klog.V(1).Infof("Cluster Autoscaler %s", version.ClusterAutoscalerVersion)
 
 	go func() {
 		http.Handle("/metrics", prometheus.Handler())

--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package version
 
 // ClusterAutoscalerVersion contains version of CA.
 const ClusterAutoscalerVersion = "1.14.0-beta.2"


### PR DESCRIPTION
Moving the version string into its own package lets it be imported from other packages, which can be useful in the cloud providers.

The second commit in this PR uses the version string to set the user-agent for gophercloud in the magnum cloud provider, to provide more information in request logs. This is a goal of the OpenStack K8s SIG: https://etherpad.openstack.org/p/k8s-sig-ptg-train
```
- Enhancement User agent header patch - gopher cloud
    - append to the user agent the particular project you're working on
    - this is useful for logging and tracing and telemetry
```
The user-agent then looks like
```
cluster/20000bea-83fd-4e21-b6cd-1cd0ea07c157 cluster-autoscaler/1.14.0-beta.2 gophercloud/2.0.0
```
instead of just `gophercloud/2.0.0`.