### PR TITLE
Monitor diffs between usage and recommendation.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
+	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 	"k8s.io/client-go/rest"
 	kube_flag "k8s.io/component-base/cli/flag"
@@ -61,6 +62,7 @@ func main() {
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)
 	metrics_recommender.Register()
+	metrics_quality.Register()
 
 	useCheckpoints := *storage != "prometheus"
 	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -19,6 +19,10 @@ package model
 import (
 	"fmt"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
+	"k8s.io/klog"
 )
 
 const (
@@ -83,9 +87,39 @@ func (container *ContainerState) addCPUSample(sample *ContainerUsageSample) bool
 	if !sample.isValid(ResourceCPU) || !sample.MeasureStart.After(container.LastCPUSampleStart) {
 		return false // Discard invalid, duplicate or out-of-order samples.
 	}
+	container.observeRecommendationUsageDiff(sample.Usage, false, corev1.ResourceCPU)
 	container.aggregator.AddSample(sample)
 	container.LastCPUSampleStart = sample.MeasureStart
 	return true
+}
+
+func (container *ContainerState) observeRecommendationUsageDiff(usage ResourceAmount, isOOM bool, resource corev1.ResourceName) {
+	if !container.aggregator.NeedsRecommendation() {
+		return
+	}
+	if container.aggregator.GetLastRecommendation() == nil {
+		metrics_quality.ObserveMissingRecommendation(isOOM, resource)
+		return
+	}
+	recommendation := container.aggregator.GetLastRecommendation()[resource]
+	var recommendationValue float64
+	var usageValue float64
+	if recommendation.IsZero() {
+		metrics_quality.ObserveMissingRecommendation(isOOM, resource)
+		return
+	}
+	switch resource {
+	case corev1.ResourceCPU:
+		recommendationValue = float64(recommendation.MilliValue()) / 1000.0
+		usageValue = CoresFromCPUAmount(usage)
+	case corev1.ResourceMemory:
+		recommendationValue = float64(recommendation.Value())
+		usageValue = BytesFromMemoryAmount(usage)
+	default:
+		klog.Warningf("Unknown resource: %v", resource)
+		return
+	}
+	metrics_quality.ObserveUsageRecommendationRelativeDiff(usageValue, recommendationValue, isOOM, resource)
 }
 
 // GetMaxMemoryPeak returns maximum memory usage in the sample, possibly estimated from OOM
@@ -129,6 +163,7 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 		container.oomPeak = 0
 		addNewPeak = true
 	}
+	container.observeRecommendationUsageDiff(sample.Usage, isOOM, corev1.ResourceMemory)
 	if addNewPeak {
 		newPeak := ContainerUsageSample{
 			MeasureStart: container.WindowEnd,

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -99,7 +99,7 @@ func (r *recommender) UpdateVPAs() {
 		}
 		resources := r.podResourceRecommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
 		had := vpa.HasRecommendation()
-		vpa.Recommendation = getCappedRecommendation(vpa.ID, resources, observedVpa.Spec.ResourcePolicy)
+		vpa.UpdateRecommendation(getCappedRecommendation(vpa.ID, resources, observedVpa.Spec.ResourcePolicy))
 		if vpa.HasRecommendation() && !had {
 			metrics_recommender.ObserveRecommendationLatency(vpa.Created)
 		}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package quality (aka metrics_quality) - code for VPA quality metrics
+package quality
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = metrics.TopMetricsNamespace + "quality"
+)
+
+var (
+	usageRecommendationRelativeDiff = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "usage_recommendation_relative_diffs",
+			Help:      "Diffs between usage and recommendation, normalized by recommendation value",
+			Buckets: []float64{-1., -.75, -.5, -.25, -.1, -.05, -0.025, -.01, -.005, -0.0025, -.001, 0.,
+				.001, .0025, .005, .01, .025, .05, .1, .25, .5, .75, 1., 2.5, 5., 10., 25., 50., 100.},
+		}, []string{"resource", "is_oom"},
+	)
+	usageMissingRecommendationCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "usage_sample_missing_recommendation_count",
+			Help:      "Count of usage samples when a recommendation should be present but is missing.",
+		}, []string{"resource", "is_oom"},
+	)
+)
+
+// Register initializes all VPA quality metrics
+func Register() {
+	prometheus.MustRegister(usageRecommendationRelativeDiff)
+	prometheus.MustRegister(usageMissingRecommendationCounter)
+}
+
+// ObserveUsageRecommendationRelativeDiff records relative diff between usage and
+// recommendation if recommendation has a positive value.
+func ObserveUsageRecommendationRelativeDiff(usage, recommendation float64, isOOM bool, resource corev1.ResourceName) {
+	if recommendation > 0 {
+		usageRecommendationRelativeDiff.WithLabelValues(string(resource), strconv.FormatBool(isOOM)).Observe((usage - recommendation) / recommendation)
+	}
+}
+
+// ObserveMissingRecommendation counts usage samples with missing recommendations.
+func ObserveMissingRecommendation(isOOM bool, resource corev1.ResourceName) {
+	usageMissingRecommendationCounter.WithLabelValues(string(resource), strconv.FormatBool(isOOM)).Inc()
+}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
@@ -28,6 +28,7 @@ type RecommendationBuilder interface {
 	WithLowerBound(cpu, memory string) RecommendationBuilder
 	WithUpperBound(cpu, memory string) RecommendationBuilder
 	Get() *vpa_types.RecommendedPodResources
+	GetContainerResources() vpa_types.RecommendedContainerResources
 }
 
 // Recommendation returns a new RecommendationBuilder.
@@ -73,10 +74,21 @@ func (b *recommendationBuilder) Get() *vpa_types.RecommendedPodResources {
 	return &vpa_types.RecommendedPodResources{
 		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 			{
-				ContainerName: b.containerName,
-				Target:        b.target,
-				LowerBound:    b.lowerBound,
-				UpperBound:    b.upperBound,
+				ContainerName:  b.containerName,
+				Target:         b.target,
+				UncappedTarget: b.target,
+				LowerBound:     b.lowerBound,
+				UpperBound:     b.upperBound,
 			},
 		}}
+}
+
+func (b *recommendationBuilder) GetContainerResources() vpa_types.RecommendedContainerResources {
+	return vpa_types.RecommendedContainerResources{
+		ContainerName:  b.containerName,
+		Target:         b.target,
+		UncappedTarget: b.target,
+		LowerBound:     b.lowerBound,
+		UpperBound:     b.upperBound,
+	}
 }


### PR DESCRIPTION
Initial stab at monitoring diffs between recommendation and actual usage. Putting this up for discussion.

This has some drawbacks:
- pollutes the ContainerState interface
- When no recommendation is provided, we don't notice (I will work on fixing this one later)

However thanks to this approach we record diff on every usage sample we get (including OOMs).

@kgolab @schylek let me know what you think.