### PR TITLE
Add required IAM action 'autoscaling:DescribeLaunchConfigurations' to AWS readme

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -18,6 +18,7 @@ A minimum IAM policy would look like:
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
@@ -38,6 +39,7 @@ If you'd like to auto-discover node groups by specifying the `--node-group-auto-
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"


### PR DESCRIPTION
Hi,

I rant into the following error when starting with an empty ASG on AWS:
```
Failed LaunchConfiguration info request for ASG_NAME: AccessDenied: User: arn:aws:sts::1234567890:assumed-role/ROLE_NAME/INSTANCE_ID is not authorized to perform: autoscaling:DescribeLaunchConfigurations
```

Reference: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/auto_scaling.go#L51-L55

The issue was resolved after adding the `autoscaling:DescribeLaunchConfigurations` action to the IAM policy.