### PR TITLE
Look up Azure instance types case-insensitively

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -43,12 +43,16 @@ type VirtualMachineScaleSetsClientMock struct {
 // Get gets the VirtualMachineScaleSet by vmScaleSetName.
 func (client *VirtualMachineScaleSetsClientMock) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error) {
 	capacity := int64(2)
+	name := "Standard_D8_V3" // typo to test case-insensitive lookup
+	location := "switzerlandwest"
 	properties := compute.VirtualMachineScaleSetProperties{}
 	return compute.VirtualMachineScaleSet{
 		Name: &vmScaleSetName,
 		Sku: &compute.Sku{
 			Capacity: &capacity,
+			Name:     &name,
 		},
+		Location:                         &location,
 		VirtualMachineScaleSetProperties: &properties,
 	}, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -404,7 +404,13 @@ func (scaleSet *ScaleSet) buildNodeFromTemplate(template compute.VirtualMachineS
 		Capacity: apiv1.ResourceList{},
 	}
 
-	vmssType := InstanceTypes[*template.Sku.Name]
+	var vmssType *instanceType
+	for k := range InstanceTypes {
+		if strings.EqualFold(k, *template.Sku.Name) {
+			vmssType = InstanceTypes[k]
+			break
+		}
+	}
 	if vmssType == nil {
 		return nil, fmt.Errorf("instance type %q not supported", *template.Sku.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -187,3 +187,23 @@ func TestScaleSetNodes(t *testing.T) {
 	assert.Equal(t, len(instances), 1)
 	assert.Equal(t, instances[0], cloudprovider.Instance{Id: fakeProviderID})
 }
+
+func TestTemplateNodeInfo(t *testing.T) {
+	provider := newTestProvider(t)
+	registered := provider.azureManager.RegisterAsg(
+		newTestScaleSet(provider.azureManager, "test-asg"))
+	assert.True(t, registered)
+	assert.Equal(t, len(provider.NodeGroups()), 1)
+
+	asg := ScaleSet{
+		manager: newTestAzureManager(t),
+		minSize: 1,
+		maxSize: 5,
+	}
+	asg.Name = "test-scale-set"
+
+	nodeInfo, err := asg.TemplateNodeInfo()
+	assert.NoError(t, err)
+	assert.NotNil(t, nodeInfo)
+	assert.NotEmpty(t, nodeInfo.Pods())
+}


### PR DESCRIPTION
Fixes #1608 

I verified that the new test case fails without the case-insensitive lookup.