### PR TITLE
Dockerfile changes and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/$YOUR_GITHUB_USERNAME/autoscaler.git
 # Replace "GO_Versiom" below with the version of go you want to use(eg. go1.11)
 wget https://dl.google.com/go/$GO_Version.linux-amd64.tar.gz
 # Extract the tar file
-tar -xvf go1.11.linux-amd64.tar.gz
+tar -xvf $GO_Version.linux-amd64.tar.gz
 # Move go to /usr/local
 mv go /usr/local
 # Set GOROOT,GOPATH,PATH and add to profile

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler
 # start the build
 GOOS=linux make build-binary
 #Copy  run.sh and Run the Dockerfile from $GOPATH/src/k8s.io/autoscaler directory
-cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler ..
+cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/run.sh ..
 docker build -t autoscaler -f cluster-autoscaler/Dockerfile .
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ of our weekly meetings.  See [the Kubernetes Community Repo](https://github.com/
 
 Fork the repository in the cloud:
 1. Visit https://github.com/kubernetes/autoscaler
-1. Click Fork button (top right) to establish a cloud-based fork.
+2. Click Fork button (top right) to establish a cloud-based fork.
 
 The code must be checked out as a subdirectory of `k8s.io`, and not `github.com`.
 
@@ -37,6 +37,16 @@ cd $GOPATH/src/k8s.io
 git clone https://github.com/$YOUR_GITHUB_USERNAME/autoscaler.git
 cd autoscaler
 ```
+
+## Building the Cluster autoscaler
+
+```shell
+# Replace "$YOUR_GITHUB_USERNAME" below with your github username
+git clone https://github.com/$YOUR_GITHUB_USERNAME/autoscaler.git
+cd autoscaler
+docker build -t autoscaler cluster-autoscaler/Dockerfile .
+```
+
 
 Please refer to Kubernetes [Github workflow guide] for more details.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler
 # start the build
 GOOS=linux make build-binary
 #Run the Dockerfile from $GOPATH/src/k8s.io/autoscaler directory
-docker build -t autoscaler cluster-autoscaler/Dockerfile .
+docker build -t autoscaler -f cluster-autoscaler/Dockerfile .
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,30 @@ git clone https://github.com/$YOUR_GITHUB_USERNAME/autoscaler.git
 cd autoscaler
 ```
 
-## Building the Cluster autoscaler
+## Building the Cluster autoscaler from master
 
 ```shell
 # Replace "$YOUR_GITHUB_USERNAME" below with your github username
 git clone https://github.com/$YOUR_GITHUB_USERNAME/autoscaler.git
-cd autoscaler
+# Replace "GO_Versiom" below with the version of go you want to use(eg. go1.11)
+wget https://dl.google.com/go/$GO_Version.linux-amd64.tar.gz
+# Extract the tar file
+tar -xvf go1.11.linux-amd64.tar.gz
+# Move go to /usr/local
+mv go /usr/local
+# Set GOROOT,GOPATH,PATH and add to profile
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+source ~/.profile
+# Create directory $GOPATH/src/k8s.io and copy autoscaler cloned earlier
+cp -r ./autoscaler/  $GOPATH/src/k8s.io/
+# get godep and move to the copied location 
+go get github.com/tools/godep
+cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler 
+# start the build
+GOOS=linux make build-binary
+#Run the Dockerfile from $GOPATH/src/k8s.io/autoscaler directory
 docker build -t autoscaler cluster-autoscaler/Dockerfile .
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ go get github.com/tools/godep
 cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler 
 # start the build
 GOOS=linux make build-binary
-#Run the Dockerfile from $GOPATH/src/k8s.io/autoscaler directory
+#Copy  run.sh and Run the Dockerfile from $GOPATH/src/k8s.io/autoscaler directory
+cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler ..
 docker build -t autoscaler -f cluster-autoscaler/Dockerfile .
 ```
 

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -24,9 +24,9 @@ RUN cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/run.sh /run.sh
 
 FROM k8s.gcr.io/debian-base-amd64:v1.0.0
 ENV DEBIAN_FRONTEND noninteractive
-#ADD cluster-autoscaler cluster-autoscaler
+ADD cluster-autoscaler cluster-autoscaler
 RUN clean-install ca-certificates tzdata
-COPY --from=0 /cluster-autoscaler /
+#COPY --from=0 /cluster-autoscaler /
 ADD cluster-autoscaler/run.sh /run.sh
 
 CMD ./run.sh

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=k8s.gcr.io/debian-base-amd64:v1.0.0
-FROM $BASEIMAGE
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
+FROM golang:1.11.2
+ENV GOPATH /gopath
+ENV PATH $GOPATH/bin:$PATH
+ADD ./cluster-autoscaler/ $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/
+RUN go get github.com/tools/godep
+RUN rm -Rf $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler && cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler && GOOS=linux make build-binary
+RUN chmod 755 $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler
+RUN cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /cluster-autoscaler
+RUN cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/run.sh /run.sh
 
+FROM k8s.gcr.io/debian-base-amd64:v1.0.0
 ENV DEBIAN_FRONTEND noninteractive
+#ADD cluster-autoscaler cluster-autoscaler
 RUN clean-install ca-certificates tzdata
-
-ADD cluster-autoscaler cluster-autoscaler
-ADD run.sh run.sh
+COPY --from=0 /cluster-autoscaler /
+ADD cluster-autoscaler/run.sh /run.sh
 
 CMD ./run.sh

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -12,20 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.11.2
-ENV GOPATH /gopath
-ENV PATH $GOPATH/bin:$PATH
-ADD ./cluster-autoscaler/ $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/
-RUN go get github.com/tools/godep
-RUN rm -Rf $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler && cd $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler && GOOS=linux make build-binary
-RUN chmod 755 $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler
-RUN cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /cluster-autoscaler
-RUN cp $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler/run.sh /run.sh
+ARG BASEIMAGE=k8s.gcr.io/debian-base-amd64:v1.0.0
+FROM $BASEIMAGE
+LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
-FROM k8s.gcr.io/debian-base-amd64:v1.0.0
 ENV DEBIAN_FRONTEND noninteractive
-ADD cluster-autoscaler cluster-autoscaler
 RUN clean-install ca-certificates tzdata
-ADD cluster-autoscaler/run.sh /run.sh
+
+ADD cluster-autoscaler cluster-autoscaler
+ADD run.sh run.sh
 
 CMD ./run.sh

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -26,7 +26,6 @@ FROM k8s.gcr.io/debian-base-amd64:v1.0.0
 ENV DEBIAN_FRONTEND noninteractive
 ADD cluster-autoscaler cluster-autoscaler
 RUN clean-install ca-certificates tzdata
-#COPY --from=0 /cluster-autoscaler /
 ADD cluster-autoscaler/run.sh /run.sh
 
 CMD ./run.sh


### PR DESCRIPTION
In order to test out the new features that are getting added each day in the  autoscaler it becomes very common for developers to build the code from master branch , currently there is no such way to build from the Dockerfile as the current Dockerfile expects the code to be prebuilt from the master. 
So I have added the build step using go Docker image and some configs for the cluster autoscaler to be build the code and get the image baked from the master(with no additional step).

Also I have updated the readme file for building the cluster autoscaler from the Dockerfile (including one type from the previous Readme).