### PR TITLE
Account for min Limit from LimitRange.

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/recommendation_provider.go
@@ -18,21 +18,20 @@ package logic
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 	"k8s.io/klog"
 )
 
 // RecommendationProvider gets current recommendation, annotations and vpaName for the given pod.
 type RecommendationProvider interface {
-	GetContainersResourcesForPod(pod *v1.Pod) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, string, error)
+	GetContainersResourcesForPod(pod *core.Pod) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, string, error)
 }
 
 type recommendationProvider struct {
@@ -54,36 +53,32 @@ func NewRecommendationProvider(calculator limitrange.LimitRangeCalculator, recom
 }
 
 // GetContainersResources returns the recommended resources for each container in the given pod in the same order they are specified in the pod.Spec.
-func GetContainersResources(pod *v1.Pod, podRecommendation vpa_types.RecommendedPodResources, limitRange *v1.LimitRangeItem,
+func GetContainersResources(pod *core.Pod, podRecommendation vpa_types.RecommendedPodResources, limitRange *core.LimitRangeItem,
 	annotations vpa_api_util.ContainerToAnnotationsMap) []vpa_api_util.ContainerResources {
 	resources := make([]vpa_api_util.ContainerResources, len(pod.Spec.Containers))
-	var defaultCpu, defaultMem, maxCpuLimit, maxMemLimit *resource.Quantity
-	if limitRange != nil {
-		defaultCpu = limitRange.Default.Cpu()
-		defaultMem = limitRange.Default.Memory()
-		maxCpuLimit = limitRange.Max.Cpu()
-		maxMemLimit = limitRange.Max.Memory()
-	}
 	for i, container := range pod.Spec.Containers {
 		recommendation := vpa_api_util.GetRecommendationForContainer(container.Name, &podRecommendation)
 		if recommendation == nil {
 			klog.V(2).Infof("no matching recommendation found for container %s", container.Name)
 			continue
 		}
-		cpuLimit, annotation := vpa_api_util.GetProportionalLimit(container.Resources.Limits.Cpu(), container.Resources.Requests.Cpu(), recommendation.Target.Cpu(), defaultCpu)
-		if annotation != "" {
-			annotations[container.Name] = append(annotations[container.Name], fmt.Sprintf("CPU: %s", annotation))
+		resources[i].Requests = recommendation.Target
+		defaultLimit := core.ResourceList{}
+		if limitRange != nil {
+			defaultLimit = limitRange.Default
 		}
-		memLimit, annotation := vpa_api_util.GetProportionalLimit(container.Resources.Limits.Memory(), container.Resources.Requests.Memory(), recommendation.Target.Memory(), defaultMem)
-		if annotation != "" {
-			annotations[container.Name] = append(annotations[container.Name], fmt.Sprintf("memory: %s", annotation))
+		proportionalLimits, limitAnnotations := vpa_api_util.GetProportionalLimit(container.Resources.Limits, container.Resources.Requests, recommendation.Target, defaultLimit)
+		if proportionalLimits != nil {
+			resources[i].Limits = proportionalLimits
+			if len(limitAnnotations) > 0 {
+				annotations[container.Name] = append(annotations[container.Name], limitAnnotations...)
+			}
 		}
-		resources[i] = vpa_api_util.ProportionallyCapResourcesToMaxLimit(recommendation.Target, cpuLimit, memLimit, maxCpuLimit, maxMemLimit)
 	}
 	return resources
 }
 
-func (p *recommendationProvider) getMatchingVPA(pod *v1.Pod) *vpa_types.VerticalPodAutoscaler {
+func (p *recommendationProvider) getMatchingVPA(pod *core.Pod) *vpa_types.VerticalPodAutoscaler {
 	configs, err := p.vpaLister.VerticalPodAutoscalers(pod.Namespace).List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to get vpa configs: %v", err)
@@ -114,7 +109,7 @@ func (p *recommendationProvider) getMatchingVPA(pod *v1.Pod) *vpa_types.Vertical
 
 // GetContainersResourcesForPod returns recommended request for a given pod, annotations and name of controlling VPA.
 // The returned slice corresponds 1-1 to containers in the Pod.
-func (p *recommendationProvider) GetContainersResourcesForPod(pod *v1.Pod) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, string, error) {
+func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, string, error) {
 	klog.V(2).Infof("updating requirements for pod %s.", pod.Name)
 	vpaConfig := p.getMatchingVPA(pod)
 	if vpaConfig == nil {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package api
 
 import (
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"math"
 	"testing"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func mustParseToPointer(str string) *resource.Quantity {
@@ -28,7 +31,7 @@ func mustParseToPointer(str string) *resource.Quantity {
 	return &val
 }
 
-func TestGetProportionalLimit(t *testing.T) {
+func TestGetProportionalResourceLimit(t *testing.T) {
 	tests := []struct {
 		name               string
 		originalLimit      *resource.Quantity
@@ -82,7 +85,7 @@ func TestGetProportionalLimit(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotLimit, gotAnnotation := GetProportionalLimit(tc.originalLimit, tc.originalRequest, tc.recommendedRequest, tc.defaultLimit)
+			gotLimit, gotAnnotation := getProportionalResourceLimit(core.ResourceCPU, tc.originalLimit, tc.originalRequest, tc.recommendedRequest, tc.defaultLimit)
 			if tc.expectLimit == nil {
 				assert.Nil(t, gotLimit)
 			} else {


### PR DESCRIPTION
Refactoring to make the code consistent.
Removed applying to upper and lower bound - I was mistaken that
it was needed >.<.

Note that since the recommendation is already capped
to max/min limit, there is no additional need for capping
in the GetContainerResources method.