### PR TITLE
Validation to verify if node.Spec.ProviderID is null and exit - for GCE

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -94,7 +94,12 @@ func (gce *GceCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
-	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
+        id := node.Spec.ProviderID
+        if (len(id) ==0) {
+                panic(fmt.Sprintf("node.Spec.ProviderID not set for node: %v - expected format gce://<project-id>/<zone>/<name>, got empty", node.Name))
+        }
+
+	ref, err := GceRefFromProviderId(id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
node.Spec.ProviderID is used throughout the autoscaler code.
However, for self-managed clusters in gce, if node.Spec.ProviderID is not set in the node configuration  via the kubelet process, the autoscaler crashes with an unexplained error - "panic: runtime error: slice bounds out of range". 

The Fix is to address this validation and present a self-explicable message to the user. 