### PR TITLE
Update CA version compatibility matrix

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -25,6 +25,8 @@ Starting from Kubernetes 1.12, versioning scheme was changed to match Kubernetes
 
 | Kubernetes Version  | CA Version   |
 |--------|--------|
+| 1.15.X | 1.15.X  |
+| 1.14.X | 1.14.X  |
 | 1.13.X | 1.13.X  |
 | 1.12.X | 1.12.X  |
 | 1.11.X | 1.3.X  |


### PR DESCRIPTION
Updates the Cluster Autoscaler's version compatibility matrix up to v.1.15.X