### PR TITLE
tweak: add CMD options to recommender Dockerfile Entrypoint

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -17,4 +17,5 @@ MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
 
 ADD recommender recommender
 
-ENTRYPOINT ./recommender --v=4 --stderrthreshold=info --prometheus-address=http://prometheus.monitoring.svc
+ENTRYPOINT ["./recommender"]
+CMD ["--v=4 --stderrthreshold=info --prometheus-address=http://prometheus.monitoring.svc"]


### PR DESCRIPTION
PR addresses a recent issue brought up in #2162 

This change will still keep the default behavior of the recommender container the same - if the user does not specify anything the entrypoint and default commands will be executed as before. If the user does specify additional commands to the recommender container when running it those arguments will override the existing defaults. 