### PR TITLE
fix: ignore agentpool label when looking for similar node groups with Azure provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -18,17 +18,18 @@ package alicloud
 
 import (
 	"fmt"
-	"strings"
-
 	"os"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const (
@@ -229,4 +230,10 @@ func BuildAlicloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 		klog.Fatalf("Failed to create Alicloud cloud provider: %v", err)
 	}
 	return cloudProvider
+}
+
+// IsNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet.
+func (ali *aliCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -26,10 +26,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const (
@@ -230,10 +228,4 @@ func BuildAlicloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 		klog.Fatalf("Failed to create Alicloud cloud provider: %v", err)
 	}
 	return cloudProvider
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet.
-func (ali *aliCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -31,9 +31,6 @@ import (
 )
 
 const (
-	// ProviderName  is the cloud provider name for alicloud
-	ProviderName = "alicloud"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "aliyun.accelerator/nvidia_name"
 )
@@ -99,7 +96,7 @@ func (ali *aliCloudProvider) addAsg(asg *Asg) {
 }
 
 func (ali *aliCloudProvider) Name() string {
-	return ProviderName
+	return cloudprovider.AlicloudProviderName
 }
 
 // GPULabel returns the label added to nodes with GPU resource.

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -356,4 +357,10 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		klog.Fatalf("Failed to create AWS cloud provider: %v", err)
 	}
 	return provider
+}
+
+// IsNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet.
+func (aws *awsCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -357,10 +356,4 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		klog.Fatalf("Failed to create AWS cloud provider: %v", err)
 	}
 	return provider
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet.
-func (aws *awsCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -33,9 +33,6 @@ import (
 )
 
 const (
-	// ProviderName is the cloud provider name for AWS
-	ProviderName = "aws"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "k8s.amazonaws.com/accelerator"
 )
@@ -71,7 +68,7 @@ func (aws *awsCloudProvider) Cleanup() error {
 
 // Name returns name of the cloud provider.
 func (aws *awsCloudProvider) Name() string {
-	return ProviderName
+	return cloudprovider.AwsProviderName
 }
 
 // GPULabel returns the label added to nodes with GPU resource.

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -149,7 +149,7 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 
 func TestName(t *testing.T) {
 	provider := testProvider(t, testAwsManager)
-	assert.Equal(t, provider.Name(), ProviderName)
+	assert.Equal(t, provider.Name(), cloudprovider.AwsProviderName)
 }
 
 func TestNodeGroups(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -24,16 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const (
-	// ProviderName is the cloud provider name for Azure
-	ProviderName = "azure"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )
@@ -170,25 +165,4 @@ func BuildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscov
 		klog.Fatalf("Failed to create Azure cloud provider: %v", err)
 	}
 	return provider
-}
-
-func nodesFromSameAzureNodePool(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLabel]
-	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLabel]
-	return n1AzureNodePool != "" && n1AzureNodePool == n2AzureNodePool
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet. This is true if they either belong to the same Azure agentpool
-// or match usual conditions checked by IsNodeInfoSimilar, even if they have different agentpool labels.
-func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	if nodesFromSameAzureNodePool(n1, n2) {
-		return true
-	}
-	azureIgnoredLabels := make(map[string]bool)
-	for k, v := range nodegroupset.BasicIgnoredLabels {
-		azureIgnoredLabels[k] = v
-	}
-	azureIgnoredLabels[AzureNodepoolLabel] = true
-	return nodegroupset.IsCloudProviderNodeInfoSimilar(n1, n2, azureIgnoredLabels)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -181,14 +181,14 @@ func nodesFromSameAzureNodePool(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 // IsNodeInfoSimilar compares if two nodes should be considered part of the
 // same NodeGroupSet. This is true if they either belong to the same Azure agentpool
 // or match usual conditions checked by IsNodeInfoSimilar, even if they have different agentpool labels.
-func (azure *AzureCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 	if nodesFromSameAzureNodePool(n1, n2) {
 		return true
 	}
 	azureIgnoredLabels := make(map[string]bool)
-	for k, v := range nodegroupset.IgnoredLabels {
+	for k, v := range nodegroupset.BasicIgnoredLabels {
 		azureIgnoredLabels[k] = v
 	}
 	azureIgnoredLabels[AzureNodepoolLabel] = true
-	return nodegroupset.IsNodeInfoSimilarExceptIgnoredLabels(n1, n2, azureIgnoredLabels)
+	return nodegroupset.IsCloudProviderNodeInfoSimilar(n1, n2, azureIgnoredLabels)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -34,11 +34,12 @@ import (
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+
 	"golang.org/x/crypto/pkcs12"
-	"k8s.io/klog"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/client-go/pkg/version"
+	"k8s.io/klog"
 )
 
 const (
@@ -75,6 +76,9 @@ const (
 	k8sWindowsVMAgentPoolPrefixIndex       = 1
 	k8sWindowsVMAgentOrchestratorNameIndex = 2
 	k8sWindowsVMAgentPoolInfoIndex         = 3
+
+	// AzureNodepoolLabel is a label specifying which Azure node pool a particular node belongs to.
+	AzureNodepoolLabel = "agentpool"
 )
 
 var (

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -76,9 +76,6 @@ const (
 	k8sWindowsVMAgentPoolPrefixIndex       = 1
 	k8sWindowsVMAgentOrchestratorNameIndex = 2
 	k8sWindowsVMAgentPoolInfoIndex         = 3
-
-	// AzureNodepoolLabel is a label specifying which Azure node pool a particular node belongs to.
-	AzureNodepoolLabel = "agentpool"
 )
 
 var (

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -33,9 +33,6 @@ import (
 )
 
 const (
-	// ProviderName is the cloud provider name for baiducloud
-	ProviderName = "baiducloud"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )
@@ -147,7 +144,7 @@ func (baiducloud *baiducloudCloudProvider) addAsg(asg *Asg) {
 
 // Name returns name of the cloud provider.
 func (baiducloud *baiducloudCloudProvider) Name() string {
-	return ProviderName
+	return cloudprovider.BaiducloudProviderName
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -368,10 +367,4 @@ func (asg *Asg) Delete() error {
 // was created by CA and can be deleted when scaled to 0.
 func (asg *Asg) Autoprovisioned() bool {
 	return false
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet.
-func (baiducloud *baiducloudCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -367,4 +368,10 @@ func (asg *Asg) Delete() error {
 // was created by CA and can be deleted when scaled to 0.
 func (asg *Asg) Autoprovisioned() bool {
 	return false
+}
+
+// IsNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet.
+func (baiducloud *baiducloudCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider_test.go
@@ -56,7 +56,7 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 
 func TestName(t *testing.T) {
 	provider := testProvider(t, testBaiducloudManager)
-	assert.Equal(t, provider.Name(), ProviderName)
+	assert.Equal(t, provider.Name(), cloudprovider.BaiducloudProviderName)
 }
 
 func TestNodeGroups(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	alicloud.ProviderName,
+	cloudprovider.AlicloudProviderName,
 }
 
 // DefaultCloudProvider for alicloud-only build is alicloud.
-const DefaultCloudProvider = alicloud.ProviderName
+const DefaultCloudProvider = cloudprovider.AlicloudProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case alicloud.ProviderName:
+	case cloudprovider.AlicloudProviderName:
 		return alicloud.BuildAlicloud(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -31,30 +31,30 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	aws.ProviderName,
-	azure.ProviderName,
-	gce.ProviderNameGCE,
-	alicloud.ProviderName,
-	baiducloud.ProviderName,
-	magnum.ProviderName,
+	cloudprovider.AwsProviderName,
+	cloudprovider.AzureProviderName,
+	cloudprovider.GceProviderName,
+	cloudprovider.AlicloudProviderName,
+	cloudprovider.BaiducloudProviderName,
+	cloudprovider.MagnumProviderName,
 }
 
 // DefaultCloudProvider is GCE.
-const DefaultCloudProvider = gce.ProviderNameGCE
+const DefaultCloudProvider = cloudprovider.GceProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case gce.ProviderNameGCE:
+	case cloudprovider.GceProviderName:
 		return gce.BuildGCE(opts, do, rl)
-	case aws.ProviderName:
+	case cloudprovider.AwsProviderName:
 		return aws.BuildAWS(opts, do, rl)
-	case azure.ProviderName:
+	case cloudprovider.AzureProviderName:
 		return azure.BuildAzure(opts, do, rl)
-	case alicloud.ProviderName:
+	case cloudprovider.AlicloudProviderName:
 		return alicloud.BuildAlicloud(opts, do, rl)
-	case baiducloud.ProviderName:
+	case cloudprovider.BaiducloudProviderName:
 		return baiducloud.BuildBaiducloud(opts, do, rl)
-	case magnum.ProviderName:
+	case cloudprovider.MagnumProviderName:
 		return magnum.BuildMagnum(opts, do, rl)
 	}
 	return nil

--- a/cluster-autoscaler/cloudprovider/builder/builder_aws.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_aws.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	aws.ProviderName,
+	cloudprovider.AwsProviderName,
 }
 
 // DefaultCloudProvider for AWS-only build is AWS.
-const DefaultCloudProvider = aws.ProviderName
+const DefaultCloudProvider = cloudprovider.AwsProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case aws.ProviderName:
+	case cloudprovider.AwsProviderName:
 		return aws.BuildAWS(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_azure.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_azure.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	azure.ProviderName,
+	cloudprovider.AzureProviderName,
 }
 
 // DefaultCloudProvider on Azure-only build is Azure.
-const DefaultCloudProvider = azure.ProviderName
+const DefaultCloudProvider = cloudprovider.AzureProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case azure.ProviderName:
+	case cloudprovider.AzureProviderName:
 		return azure.BuildAzure(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
@@ -20,22 +20,21 @@ package builder
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	baiducloud.ProviderName,
+	cloudprovider.BaiducloudProviderName,
 }
 
 // DefaultCloudProvider for baiducloud-only build is baiducloud.
-const DefaultCloudProvider = baiducloud.ProviderName
+const DefaultCloudProvider = cloudprovider.BaiducloudProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case baiducloud.ProviderName:
+	case cloudprovider.BaiducloudProviderName:
 		return baiducloud.BuildBaiducloud(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_gce.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_gce.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	gce.ProviderNameGCE,
+	cloudprovider.GceProviderName,
 }
 
 // DefaultCloudProvider is GCE.
-const DefaultCloudProvider = gce.ProviderNameGCE
+const DefaultCloudProvider = cloudprovider.GceProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case gce.ProviderNameGCE:
+	case cloudprovider.GceProviderName:
 		return gce.BuildGCE(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	kubemark.ProviderName,
+	cloudprovider.KubemarkProviderName,
 }
 
 // DefaultCloudProvider for Kubemark-only build is Kubemark.
-const DefaultCloudProvider = kubemark.ProviderName
+const DefaultCloudProvider = cloudprovider.KubemarkProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case kubemark.ProviderName:
+	case cloudprovider.KubemarkProviderName:
 		return kubemark.BuildKubemark(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	magnum.ProviderName,
+	cloudprovider.MagnumProviderName,
 }
 
 // DefaultCloudProvider for OpenStack-only build is OpenStack.
-const DefaultCloudProvider = magnum.ProviderName
+const DefaultCloudProvider = cloudprovider.MagnumProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case magnum.ProviderName:
+	case cloudprovider.MagnumProviderName:
 		return magnum.BuildMagnum(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -27,9 +27,20 @@ import (
 )
 
 const (
-	// AzureProviderName gets the azure.ProviderName. To prevent the cyclic importation,
-	// `azure.ProviderName` cannot be directly used here.
+	// AzureProviderName gets the provider name of azure
 	AzureProviderName = "azure"
+	// AlicloudProviderName gets the provider name of alicloud
+	AlicloudProviderName = "alicloud"
+	// AwsProviderName gets the provider name of aws
+	AwsProviderName = "aws"
+	// BaiducloudProviderName gets the provider name of baiducloud
+	BaiducloudProviderName = "baiducloud"
+	// GceProviderName gets the provider name of gce
+	GceProviderName = "gce"
+	// MagnumProviderName gets the provider name of magnum
+	MagnumProviderName = "magnum"
+	// KubemarkProviderName gets the provider name of kubemark
+	KubemarkProviderName = "kubemark"
 )
 
 // CloudProvider contains configuration info and functions for interacting with

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -26,6 +26,12 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
+const (
+	// AzureProviderName gets the azure.ProviderName. To prevent the cyclic importation,
+	// `azure.ProviderName` cannot be directly used here.
+	AzureProviderName = "azure"
+)
+
 // CloudProvider contains configuration info and functions for interacting with
 // cloud provider (GCE, AWS, etc).
 type CloudProvider interface {
@@ -69,9 +75,6 @@ type CloudProvider interface {
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 	Refresh() error
-
-	// IsNodeInfoSimilar compare if two nodes are similar
-	IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool
 }
 
 // ErrNotImplemented is returned if a method is not implemented.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -69,6 +69,9 @@ type CloudProvider interface {
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 	Refresh() error
+
+	// IsNodeInfoSimilar compare if two nodes are similar
+	IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool
 }
 
 // ErrNotImplemented is returned if a method is not implemented.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -365,4 +366,10 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	// Register GCE API usage metrics.
 	RegisterMetrics()
 	return provider
+}
+
+// IsNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet.
+func (gce *GceCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -32,9 +32,6 @@ import (
 )
 
 const (
-	// ProviderNameGCE is the name of GCE cloud provider.
-	ProviderNameGCE = "gce"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )
@@ -69,7 +66,7 @@ func (gce *GceCloudProvider) Cleanup() error {
 
 // Name returns name of the cloud provider.
 func (gce *GceCloudProvider) Name() string {
-	return ProviderNameGCE
+	return cloudprovider.GceProviderName
 }
 
 // GPULabel returns the label added to nodes with GPU resource.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -366,10 +365,4 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	// Register GCE API usage metrics.
 	RegisterMetrics()
 	return provider
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet.
-func (gce *GceCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	// ProviderName is the cloud provider name for kubemark
-	ProviderName = "kubemark"
-
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -26,10 +26,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const (
@@ -208,10 +206,4 @@ func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 	}
 
 	return provider
-}
-
-// IsNodeInfoSimilar compares if two nodes should be considered part of the
-// same NodeGroupSet.
-func (mcp *magnumCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const (
@@ -206,4 +208,10 @@ func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 	}
 
 	return provider
+}
+
+// IsNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet.
+func (mcp *magnumCloudProvider) IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return nodegroupset.IsNodeInfoSimilar(n1, n2)
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	// ProviderName is the cloud provider name for Magnum
-	ProviderName = "magnum"
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )
@@ -63,7 +61,7 @@ func buildMagnumCloudProvider(magnumManager magnumManager, resourceLimiter *clou
 
 // Name returns the name of the cloud provider.
 func (mcp *magnumCloudProvider) Name() string {
-	return ProviderName
+	return cloudprovider.MagnumProviderName
 }
 
 // GPULabel returns the label added to nodes with GPU resource.

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -57,8 +57,6 @@ type Autoscaler interface {
 	RunOnce(currentTime time.Time) errors.AutoscalerError
 	// ExitCleanUp is a clean-up performed just before process termination.
 	ExitCleanUp()
-
-	GetCloudProvider() cloudprovider.CloudProvider
 }
 
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -57,6 +57,8 @@ type Autoscaler interface {
 	RunOnce(currentTime time.Time) errors.AutoscalerError
 	// ExitCleanUp is a clean-up performed just before process termination.
 	ExitCleanUp()
+
+	GetCloudProvider() cloudprovider.CloudProvider
 }
 
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -74,11 +74,6 @@ type StaticAutoscaler struct {
 	ignoredTaints taintKeySet
 }
 
-// GetCloudProvider returns the CloudProvider instance in staticAutoscaler
-func (a *StaticAutoscaler) GetCloudProvider() cloudprovider.CloudProvider {
-	return a.CloudProvider
-}
-
 type staticAutoscalerProcessorCallbacks struct {
 	disableScaleDownForLoop bool
 	extraValues             map[string]interface{}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -74,6 +74,11 @@ type StaticAutoscaler struct {
 	ignoredTaints taintKeySet
 }
 
+// GetCloudProvider returns the CloudProvider instance in staticAutoscaler
+func (a *StaticAutoscaler) GetCloudProvider() cloudprovider.CloudProvider {
+	return a.CloudProvider
+}
+
 type staticAutoscalerProcessorCallbacks struct {
 	disableScaleDownForLoop bool
 	extraValues             map[string]interface{}
@@ -165,10 +170,12 @@ func (a *StaticAutoscaler) cleanUpIfRequired() {
 	if readyNodes, err := a.ReadyNodeLister().List(); err != nil {
 		klog.Errorf("Failed to list ready nodes, not cleaning up taints: %v", err)
 	} else {
-		deletetaint.CleanAllToBeDeleted(readyNodes, a.AutoscalingContext.ClientSet, a.Recorder)
+		deletetaint.CleanAllToBeDeleted(readyNodes,
+			a.AutoscalingContext.ClientSet, a.Recorder)
 		if a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount == 0 {
 			// Clean old taints if soft taints handling is disabled
-			deletetaint.CleanAllDeletionCandidates(readyNodes, a.AutoscalingContext.ClientSet, a.Recorder)
+			deletetaint.CleanAllDeletionCandidates(readyNodes,
+				a.AutoscalingContext.ClientSet, a.Recorder)
 		}
 	}
 	a.initialized = true

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -29,8 +29,6 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
 
@@ -292,7 +290,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	processors.PodListProcessor = core.NewFilterOutSchedulablePodListProcessor()
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {
 		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
-			Comparator: azure.IsNodeInfoSimilar}
+			Comparator: nodegroupset.IsAzureNodeInfoSimilar}
 	}
 
 	opts := core.AutoscalerOptions{

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -29,6 +29,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/pflag"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -37,6 +40,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
@@ -48,11 +52,8 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	kube_flag "k8s.io/component-base/cli/flag"
 	componentbaseconfig "k8s.io/component-base/config"
-	"k8s.io/kubernetes/pkg/client/leaderelectionconfig"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/pflag"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/client/leaderelectionconfig"
 )
 
 // MultiStringFlag is a flag for passing multiple parameters using same flag
@@ -298,7 +299,18 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	metrics.UpdateNapEnabled(autoscalingOptions.NodeAutoprovisioningEnabled)
 
 	// Create autoscaler.
-	return core.NewAutoscaler(opts)
+	ca, err := core.NewAutoscaler(opts)
+	if ca == nil || err != nil {
+		return ca, err
+	}
+
+	// Modify the NodeGroupSetProcessor.Comparator in autoscaler
+	cp := ca.GetCloudProvider()
+	processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
+		Comparator: cp.IsNodeInfoSimilar,
+	}
+
+	return ca, err
 }
 
 func run(healthCheck *metrics.HealthCheck) {

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupset
+
+import (
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// AzureNodepoolLabel is a label specifying which Azure node pool a particular node belongs to.
+const AzureNodepoolLabel = "agentpool"
+
+func nodesFromSameAzureNodePool(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLabel]
+	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLabel]
+	return n1AzureNodePool != "" && n1AzureNodePool == n2AzureNodePool
+}
+
+// IsAzureNodeInfoSimilar compares if two nodes should be considered part of the
+// same NodeGroupSet. This is true if they either belong to the same Azure agentpool
+// or match usual conditions checked by IsAzureNodeInfoSimilar, even if they have different agentpool labels.
+func IsAzureNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	if nodesFromSameAzureNodePool(n1, n2) {
+		return true
+	}
+	azureIgnoredLabels := make(map[string]bool)
+	for k, v := range BasicIgnoredLabels {
+		azureIgnoredLabels[k] = v
+	}
+	azureIgnoredLabels[AzureNodepoolLabel] = true
+	return IsCloudProviderNodeInfoSimilar(n1, n2, azureIgnoredLabels)
+}

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupset
+
+import (
+	"testing"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAzureNodeInfoSimilar(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, 2000)
+	n1.ObjectMeta.Labels["test-label"] = "test-value"
+	n1.ObjectMeta.Labels["character"] = "thing"
+	n2 := BuildTestNode("node2", 1000, 2000)
+	n2.ObjectMeta.Labels["test-label"] = "test-value"
+	// No node-pool labels.
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, false)
+	// Empty agentpool labels
+	n1.ObjectMeta.Labels["agentpool"] = ""
+	n2.ObjectMeta.Labels["agentpool"] = ""
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, false)
+	// Only one non empty
+	n1.ObjectMeta.Labels["agentpool"] = ""
+	n2.ObjectMeta.Labels["agentpool"] = "foo"
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, false)
+	// Only one present
+	delete(n1.ObjectMeta.Labels, "agentpool")
+	n2.ObjectMeta.Labels["agentpool"] = "foo"
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, false)
+	// Different vales
+	n1.ObjectMeta.Labels["agentpool"] = "foo1"
+	n2.ObjectMeta.Labels["agentpool"] = "foo2"
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, false)
+	// Same values
+	n1.ObjectMeta.Labels["agentpool"] = "foo"
+	n2.ObjectMeta.Labels["agentpool"] = "foo"
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, true)
+	// Same labels except for agentpool
+	delete(n1.ObjectMeta.Labels, "character")
+	n1.ObjectMeta.Labels["agentpool"] = "foo"
+	n2.ObjectMeta.Labels["agentpool"] = "bar"
+	checkNodesSimilar(t, n1, n2, IsAzureNodeInfoSimilar, true)
+}
+
+func TestFindSimilarNodeGroupsAzureBasic(t *testing.T) {
+	processor := &BalancingNodeGroupSetProcessor{Comparator: IsAzureNodeInfoSimilar}
+	basicSimilarNodeGroupsTest(t, processor)
+}
+
+func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
+	processor := &BalancingNodeGroupSetProcessor{Comparator: IsAzureNodeInfoSimilar}
+	context := &context.AutoscalingContext{}
+
+	n1 := BuildTestNode("n1", 1000, 1000)
+	n2 := BuildTestNode("n2", 2000, 2000)
+
+	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider.AddNodeGroup("ng2", 1, 10, 1)
+	provider.AddNode("ng1", n1)
+	provider.AddNode("ng2", n2)
+
+	ni1 := schedulernodeinfo.NewNodeInfo()
+	ni1.SetNode(n1)
+	ni2 := schedulernodeinfo.NewNodeInfo()
+	ni2.SetNode(n2)
+
+	nodeInfosForGroups := map[string]*schedulernodeinfo.NodeInfo{
+		"ng1": ni1, "ng2": ni2,
+	}
+
+	ng1, _ := provider.NodeGroupForNode(n1)
+	ng2, _ := provider.NodeGroupForNode(n2)
+	context.CloudProvider = provider
+
+	// Groups with different cpu and mem are not similar.
+	similar, err := processor.FindSimilarNodeGroups(context, ng1, nodeInfosForGroups)
+	assert.NoError(t, err)
+	assert.Equal(t, similar, []cloudprovider.NodeGroup{})
+
+	// Unless we give them nodepool label.
+	n1.ObjectMeta.Labels["agentpool"] = "foobar"
+	n2.ObjectMeta.Labels["agentpool"] = "foobar"
+	similar, err = processor.FindSimilarNodeGroups(context, ng1, nodeInfosForGroups)
+	assert.NoError(t, err)
+	assert.Equal(t, similar, []cloudprovider.NodeGroup{ng2})
+
+	// Groups with the same cpu and mem are similar if they belong to different pools.
+	n3 := BuildTestNode("n1", 1000, 1000)
+	provider.AddNodeGroup("ng3", 1, 10, 1)
+	provider.AddNode("ng3", n3)
+	ni3 := schedulernodeinfo.NewNodeInfo()
+	ni3.SetNode(n3)
+	nodeInfosForGroups["ng3"] = ni3
+	ng3, _ := provider.NodeGroupForNode(n3)
+
+	n1.ObjectMeta.Labels["agentpool"] = "foobar1"
+	n2.ObjectMeta.Labels["agentpool"] = "foobar2"
+	n3.ObjectMeta.Labels["agentpool"] = "foobar3"
+
+	similar, err = processor.FindSimilarNodeGroups(context, ng1, nodeInfosForGroups)
+	assert.NoError(t, err)
+	assert.Equal(t, similar, []cloudprovider.NodeGroup{ng3})
+}

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -33,9 +33,10 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 )
 
-// IgnoredLabels define a set of basic labels that should be ignored when comparing the similarity
-// of two nodes
-var IgnoredLabels = map[string]bool{
+// BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity
+// of two nodes. Customized IgnoredLabels can be implemented in the corresponding codes of
+// specific cloud provider and the BasicIgnoredLabels should always be considered part of them.
+var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelHostname:                   true,
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
@@ -85,12 +86,12 @@ func compareLabels(nodes []*schedulernodeinfo.NodeInfo, ignoredLabels map[string
 // are similar enough to likely be the same type of machine and if the set of labels
 // is the same (except for a pre-defined set of labels like hostname or zone).
 func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
-	return IsNodeInfoSimilarExceptIgnoredLabels(n1, n2, IgnoredLabels)
+	return IsCloudProviderNodeInfoSimilar(n1, n2, BasicIgnoredLabels)
 }
 
-// IsNodeInfoSimilarExceptIgnoredLabels returns true if two NodeInfos are similar while
-// ignoring the set of labels provided
-func IsNodeInfoSimilarExceptIgnoredLabels(n1, n2 *schedulernodeinfo.NodeInfo, ignoredLabels map[string]bool) bool {
+// IsCloudProviderNodeInfoSimilar remains the same logic of IsNodeInfoSimilar with the
+// customized set of labels that should be ignored when comparing the similarity of two NodeInfos.
+func IsCloudProviderNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo, ignoredLabels map[string]bool) bool {
 	capacity := make(map[apiv1.ResourceName][]resource.Quantity)
 	allocatable := make(map[apiv1.ResourceName][]resource.Quantity)
 	free := make(map[apiv1.ResourceName][]resource.Quantity)

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -33,6 +33,15 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 )
 
+// IgnoredLabels define a set of basic labels that should be ignored when comparing the similarity
+// of two nodes
+var IgnoredLabels = map[string]bool{
+	apiv1.LabelHostname:                   true,
+	apiv1.LabelZoneFailureDomain:          true,
+	apiv1.LabelZoneRegion:                 true,
+	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+}
+
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups
 // similar enough to be considered a part of a single NodeGroupSet.
 type NodeInfoComparator func(n1, n2 *schedulernodeinfo.NodeInfo) bool
@@ -52,12 +61,36 @@ func compareResourceMapsWithTolerance(resources map[apiv1.ResourceName][]resourc
 	return true
 }
 
+func compareLabels(nodes []*schedulernodeinfo.NodeInfo, ignoredLabels map[string]bool) bool {
+	labels := make(map[string][]string)
+	for _, node := range nodes {
+		for label, value := range node.Node().ObjectMeta.Labels {
+			ignore, _ := ignoredLabels[label]
+			if !ignore {
+				labels[label] = append(labels[label], value)
+			}
+		}
+	}
+	for _, labelValues := range labels {
+		if len(labelValues) != 2 || labelValues[0] != labelValues[1] {
+			return false
+		}
+	}
+	return true
+}
+
 // IsNodeInfoSimilar returns true if two NodeInfos are similar enough to consider
 // that the NodeGroups they come from are part of the same NodeGroupSet. The criteria are
 // somewhat arbitrary, but generally we check if resources provided by both nodes
 // are similar enough to likely be the same type of machine and if the set of labels
 // is the same (except for a pre-defined set of labels like hostname or zone).
 func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	return IsNodeInfoSimilarExceptIgnoredLabels(n1, n2, IgnoredLabels)
+}
+
+// IsNodeInfoSimilarExceptIgnoredLabels returns true if two NodeInfos are similar while
+// ignoring the set of labels provided
+func IsNodeInfoSimilarExceptIgnoredLabels(n1, n2 *schedulernodeinfo.NodeInfo, ignoredLabels map[string]bool) bool {
 	capacity := make(map[apiv1.ResourceName][]resource.Quantity)
 	allocatable := make(map[apiv1.ResourceName][]resource.Quantity)
 	free := make(map[apiv1.ResourceName][]resource.Quantity)
@@ -92,26 +125,9 @@ func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 		return false
 	}
 
-	ignoredLabels := map[string]bool{
-		apiv1.LabelHostname:                   true,
-		apiv1.LabelZoneFailureDomain:          true,
-		apiv1.LabelZoneRegion:                 true,
-		"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+	if !compareLabels(nodes, ignoredLabels) {
+		return false
 	}
 
-	labels := make(map[string][]string)
-	for _, node := range nodes {
-		for label, value := range node.Node().ObjectMeta.Labels {
-			ignore, _ := ignoredLabels[label]
-			if !ignore {
-				labels[label] = append(labels[label], value)
-			}
-		}
-	}
-	for _, labelValues := range labels {
-		if len(labelValues) != 2 || labelValues[0] != labelValues[1] {
-			return false
-		}
-	}
 	return true
 }


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/autoscaler/issues/2044 and pull request https://github.com/kubernetes/autoscaler/pull/2094

Refact the corresponding code in https://github.com/kubernetes/autoscaler/pull/2094.

The instance of cloudprovider.interface can only be obtained after the cluster autoscaler is built. Therefore, we let each cloud provider implement their own node comparator function, which will later be built in autoscaler in main.go.