### PR TITLE
tweak: add CMD to updater and admission-controller Dockerfile Entrypoint

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -17,4 +17,5 @@ MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 
 ADD admission-controller admission-controller
 
-ENTRYPOINT ./admission-controller --v=4 --stderrthreshold=info
+ENTRYPOINT ["./admission-controller"]
+CMD ["--v=4 --stderrthreshold=info"]

--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -18,4 +18,4 @@ MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 ADD admission-controller admission-controller
 
 ENTRYPOINT ["./admission-controller"]
-CMD ["--v=4 --stderrthreshold=info"]
+CMD ["--v=4", "--stderrthreshold=info"]

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 FROM k8s.gcr.io/debian-base-amd64:1.0.0
 MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 ADD updater updater
 
-ENTRYPOINT ./updater --v=4 --stderrthreshold=info
+ENTRYPOINT ["./updater"]
+CMD ["--v=4 --stderrthreshold=info"]

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -18,4 +18,4 @@ MAINTAINER Marcin Wielgus "mwielgus@google.com"
 ADD updater updater
 
 ENTRYPOINT ["./updater"]
-CMD ["--v=4 --stderrthreshold=info"]
+CMD ["--v=4", "--stderrthreshold=info"]


### PR DESCRIPTION
PR updates VPA updater and admission-controller Dockerfiles to use CMD
Conversation tracked in previously merged PR (which updated the Dockerfile for the recommender). 
https://github.com/kubernetes/autoscaler/pull/2166#issuecomment-509225247

This change will still keep the default behavior of the updater and admission-controller containers the same - if the user does not specify anything the entrypoint and default commands will be executed as before. If the user does specify additional commands to the container when running it those arguments will override the existing defaults.