### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/hack/scripts/break_mig.py
+++ b/hack/scripts/break_mig.py
@@ -41,6 +41,11 @@ import subprocess
 import sys
 import time
 
+try:
+  range = xrange   # Python 2
+except NameError:  # Python 3
+  pass
+
 
 InstanceInfo = collections.namedtuple("InstanceInfo", 'name ip')
 
@@ -128,7 +133,7 @@ def clean_up(master, broken, verbose):
     '''
     if verbose:
         print('Cleaning up top {} iptable rules'.format(len(broken)))
-    for i in xrange(len(broken)):
+    for i in range(len(broken)):
         subprocess.call(['gcloud', 'compute', 'ssh', master, '--', 'sudo iptables -D INPUT 1'])
 
 

--- a/hack/scripts/ca_metrics_parser.py
+++ b/hack/scripts/ca_metrics_parser.py
@@ -22,6 +22,11 @@ from __future__ import print_function
 import argparse
 import json
 
+try:
+  range = xrange   # Python 2
+except NameError:  # Python 3
+  pass
+
 
 class CAMetric(object):
 
@@ -59,7 +64,7 @@ def upper_bound(buckets):
   Going from the rightmost bucket, find the first one that has some samples
   and return its upper bound.
   '''
-  for i in xrange(len(buckets) - 1, -1, -1):
+  for i in range(len(buckets) - 1, -1, -1):
     le, count = buckets[i]
     if i == 0:
       return le
@@ -73,7 +78,7 @@ def parse_metrics_file(metrics_file):
   '''
   Return interesting metrics for all Cluster Autoscaler functions.
 
-  Metrics are stored in a map keyed by function name and are expressed in 
+  Metrics are stored in a map keyed by function name and are expressed in
   seconds. They include
   * sum of all samples
   * count of sumples
@@ -115,10 +120,10 @@ def main():
   parser.add_argument('metrics_file', help='File to read metrics from')
   args = parser.parse_args()
 
-  summary = parse_metrics_file(args.metrics_file)  
+  summary = parse_metrics_file(args.metrics_file)
   print_summary(summary)
 
 
 if __name__ == '__main__':
   main()
-  
+


### PR DESCRIPTION
This PR ensures equivalent functionality in both Python 2 and Python 3.