### PR TITLE
Fix typo in autoscaler azure example

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
@@ -117,7 +117,7 @@ data:
   ClientID: <base64-encoded-client-id>
   ClientSecret: <base64-encoded-client-secret>
   ResourceGroup: <base64-encoded-resource-group>
-  SubscriptionID: <base64-encode-subscription-id>
+  SubscriptionID: <base64-encoded-subscription-id>
   TenantID: <base64-encoded-tenant-id>
   Deployment: <base64-encoded-azure-initial-deploy-name>
   VMType: c3RhbmRhcmQ=


### PR DESCRIPTION
- SubscriptionID placeholder does not match documentation or surrounding placeholders