### PR TITLE
add kops instance group label to ignore list for similar node group identification.

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -41,7 +41,8 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
-	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
+	"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -41,6 +41,7 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups


### PR DESCRIPTION
For kops-built clusters, an instance label added by that tooling will prevent the balance-similar-nodegroups feature from working as intended.

This patch simply adds the kops instance group label to the ignored list.

It looks like this should apply cleanly as far back as the release 1.13 branch, and I have a PR for the 1.12 branch ready to make as well since it's still in common use. (And in fact the most recent version released for kops)

Signed-off-by: Joe Hohertz <joe@viafoura.com>