### PR TITLE
Don't consider to move pods to empty nodes when scaling down

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -489,7 +489,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	// Look for nodes to remove in the current candidates
 	nodesToRemove, unremovable, newHints, simulatorErr := simulator.FindNodesToRemove(
 		currentCandidates, destinationNodes, nonExpendablePods, nil, sd.context.PredicateChecker,
-		len(currentCandidates), true, sd.podLocationHints, sd.usageTracker, timestamp, pdbs)
+		len(currentCandidates), true, sd.podLocationHints, sd.usageTracker, timestamp, pdbs, emptyNodesList)
 	if simulatorErr != nil {
 		return sd.markSimulationError(simulatorErr, timestamp)
 	}
@@ -512,7 +512,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 		additionalNodesToRemove, additionalUnremovable, additionalNewHints, simulatorErr :=
 			simulator.FindNodesToRemove(currentNonCandidates[:additionalCandidatesPoolSize], destinationNodes, nonExpendablePods, nil,
 				sd.context.PredicateChecker, additionalCandidatesCount, true,
-				sd.podLocationHints, sd.usageTracker, timestamp, pdbs)
+				sd.podLocationHints, sd.usageTracker, timestamp, pdbs, emptyNodesList)
 		if simulatorErr != nil {
 			return sd.markSimulationError(simulatorErr, timestamp)
 		}
@@ -806,7 +806,7 @@ func (sd *ScaleDown) TryToScaleDown(allNodes []*apiv1.Node, pods []*apiv1.Pod, p
 	// We look for only 1 node so new hints may be incomplete.
 	nodesToRemove, _, _, err := simulator.FindNodesToRemove(candidates, nodesWithoutMaster, nonExpendablePods, sd.context.ListerRegistry,
 		sd.context.PredicateChecker, 1, false,
-		sd.podLocationHints, sd.usageTracker, time.Now(), pdbs)
+		sd.podLocationHints, sd.usageTracker, time.Now(), pdbs, emptyNodes)
 	findNodesToRemoveDuration = time.Now().Sub(findNodesToRemoveStart)
 
 	if err != nil {

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -76,6 +76,7 @@ func FindNodesToRemove(candidates []*apiv1.Node, destinationNodes []*apiv1.Node,
 	fastCheck bool, oldHints map[string]string, usageTracker *UsageTracker,
 	timestamp time.Time,
 	podDisruptionBudgets []*policyv1.PodDisruptionBudget,
+	emptyNodes []*apiv1.Node,
 ) (nodesToRemove []NodeToBeRemoved, unremovableNodes []*apiv1.Node, podReschedulingHints map[string]string, finalError errors.AutoscalerError) {
 
 	nodeNameToNodeInfo := scheduler_util.CreateNodeNameToInfoMap(pods, destinationNodes)
@@ -114,7 +115,7 @@ candidateloop:
 			continue candidateloop
 		}
 		findProblems := findPlaceFor(node.Name, podsToRemove, destinationNodes, nodeNameToNodeInfo, predicateChecker, oldHints, newHints,
-			usageTracker, timestamp)
+			usageTracker, timestamp, emptyNodes)
 
 		if findProblems == nil {
 			result = append(result, NodeToBeRemoved{
@@ -220,7 +221,7 @@ func calculateUtilizationOfResource(node *apiv1.Node, nodeInfo *schedulernodeinf
 // TODO: We don't need to pass list of nodes here as they are already available in nodeInfos.
 func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node, nodeInfos map[string]*schedulernodeinfo.NodeInfo,
 	predicateChecker *PredicateChecker, oldHints map[string]string, newHints map[string]string, usageTracker *UsageTracker,
-	timestamp time.Time) error {
+	timestamp time.Time, emptyNodes []*apiv1.Node) error {
 
 	newNodeInfos := make(map[string]*schedulernodeinfo.NodeInfo)
 	for k, v := range nodeInfos {
@@ -288,6 +289,17 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node, no
 		if !foundPlace {
 			for _, node := range shuffledNodes {
 				if node.Name == removedNode {
+					continue
+				}
+				nodeEmpty := false
+				for _, emptyNode := range emptyNodes {
+					if emptyNode.Name == node.Name {
+						nodeEmpty = true
+						break
+					}
+				}
+				if nodeEmpty {
+					// don't consider empty, unneeded nodes because they will be removed soon anyways and doesn't make much sense to move pods there
 					continue
 				}
 				if tryNodeForPod(node.Name, pod, predicateMeta) {

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -124,7 +124,7 @@ func TestFindPlaceAllOk(t *testing.T) {
 		[]*apiv1.Node{node1, node2},
 		nodeInfos, NewTestPredicateChecker(),
 		oldHints, newHints, tracker, time.Now(),
-		[]*apiv1.Node{})
+		map[string]bool{})
 
 	assert.Len(t, newHints, 2)
 	assert.Contains(t, newHints, new1.Namespace+"/"+new1.Name)
@@ -158,7 +158,7 @@ func TestFindPlaceNotOnEmptyNode(t *testing.T) {
 		[]*apiv1.Node{node1, node2},
 		nodeInfos, NewTestPredicateChecker(),
 		oldHints, newHints, tracker, time.Now(),
-		[]*apiv1.Node{node2})
+		map[string]bool{node2.Name: true})
 
 	assert.Error(t, err)
 	assert.Len(t, newHints, 1)
@@ -197,7 +197,7 @@ func TestFindPlaceAllBas(t *testing.T) {
 		[]*apiv1.Node{nodebad, node1, node2},
 		nodeInfos, NewTestPredicateChecker(),
 		oldHints, newHints, tracker, time.Now(),
-		[]*apiv1.Node{})
+		map[string]bool{})
 
 	assert.Error(t, err)
 	assert.True(t, len(newHints) == 2)
@@ -230,7 +230,7 @@ func TestFindNone(t *testing.T) {
 		make(map[string]string),
 		NewUsageTracker(),
 		time.Now(),
-		[]*apiv1.Node{})
+		map[string]bool{})
 	assert.NoError(t, err)
 }
 
@@ -277,7 +277,7 @@ type findNodesToRemoveTestConfig struct {
 	name        string
 	candidates  []*apiv1.Node
 	allNodes    []*apiv1.Node
-	emptyNodes  []*apiv1.Node
+	emptyNodes  map[string]bool
 	toRemove    []NodeToBeRemoved
 	unremovable []*apiv1.Node
 }
@@ -331,7 +331,7 @@ func TestFindNodesToRemove(t *testing.T) {
 			name:        "just an empty node, should be removed",
 			candidates:  []*apiv1.Node{emptyNode},
 			allNodes:    []*apiv1.Node{emptyNode},
-			emptyNodes:  []*apiv1.Node{emptyNode},
+			emptyNodes:  map[string]bool{emptyNode.Name: true},
 			toRemove:    []NodeToBeRemoved{emptyNodeToRemove},
 			unremovable: []*apiv1.Node{},
 		},
@@ -364,7 +364,7 @@ func TestFindNodesToRemove(t *testing.T) {
 			name:        "4 nodes, 1 empty, 1 drainable",
 			candidates:  []*apiv1.Node{emptyNode, drainableNode},
 			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
-			emptyNodes:  []*apiv1.Node{emptyNode},
+			emptyNodes:  map[string]bool{emptyNode.Name: true},
 			toRemove:    []NodeToBeRemoved{emptyNodeToRemove, drainableNodeToRemove},
 			unremovable: []*apiv1.Node{},
 		},
@@ -373,7 +373,7 @@ func TestFindNodesToRemove(t *testing.T) {
 			name:        "empty node, drainable node and full node",
 			candidates:  []*apiv1.Node{emptyNode, drainableNode},
 			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode},
-			emptyNodes:  []*apiv1.Node{emptyNode},
+			emptyNodes:  map[string]bool{emptyNode.Name: true},
 			toRemove:    []NodeToBeRemoved{emptyNodeToRemove},
 			unremovable: []*apiv1.Node{drainableNode},
 		},

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -123,12 +123,46 @@ func TestFindPlaceAllOk(t *testing.T) {
 		[]*apiv1.Pod{new1, new2},
 		[]*apiv1.Node{node1, node2},
 		nodeInfos, NewTestPredicateChecker(),
-		oldHints, newHints, tracker, time.Now())
+		oldHints, newHints, tracker, time.Now(),
+		[]*apiv1.Node{})
 
 	assert.Len(t, newHints, 2)
 	assert.Contains(t, newHints, new1.Namespace+"/"+new1.Name)
 	assert.Contains(t, newHints, new2.Namespace+"/"+new2.Name)
 	assert.NoError(t, err)
+}
+
+func TestFindPlaceNotOnEmptyNode(t *testing.T) {
+	pod1 := BuildTestPod("p1", 300, 500000)
+	new1 := BuildTestPod("p2", 600, 500000)
+	new2 := BuildTestPod("p3", 500, 500000)
+
+	nodeInfos := map[string]*schedulernodeinfo.NodeInfo{
+		"n1": schedulernodeinfo.NewNodeInfo(pod1),
+		"n2": schedulernodeinfo.NewNodeInfo(),
+	}
+	node1 := BuildTestNode("n1", 1000, 2000000)
+	SetNodeReadyState(node1, true, time.Time{})
+	node2 := BuildTestNode("n2", 1000, 2000000)
+	SetNodeReadyState(node2, true, time.Time{})
+	nodeInfos["n1"].SetNode(node1)
+	nodeInfos["n2"].SetNode(node2)
+
+	oldHints := make(map[string]string)
+	newHints := make(map[string]string)
+	tracker := NewUsageTracker()
+
+	err := findPlaceFor(
+		"x",
+		[]*apiv1.Pod{new1, new2},
+		[]*apiv1.Node{node1, node2},
+		nodeInfos, NewTestPredicateChecker(),
+		oldHints, newHints, tracker, time.Now(),
+		[]*apiv1.Node{node2})
+
+	assert.Error(t, err)
+	assert.Len(t, newHints, 1)
+	assert.Contains(t, newHints, new1.Namespace+"/"+new1.Name)
 }
 
 func TestFindPlaceAllBas(t *testing.T) {
@@ -162,7 +196,8 @@ func TestFindPlaceAllBas(t *testing.T) {
 		[]*apiv1.Pod{new1, new2, new3},
 		[]*apiv1.Node{nodebad, node1, node2},
 		nodeInfos, NewTestPredicateChecker(),
-		oldHints, newHints, tracker, time.Now())
+		oldHints, newHints, tracker, time.Now(),
+		[]*apiv1.Node{})
 
 	assert.Error(t, err)
 	assert.True(t, len(newHints) == 2)
@@ -194,7 +229,8 @@ func TestFindNone(t *testing.T) {
 		make(map[string]string),
 		make(map[string]string),
 		NewUsageTracker(),
-		time.Now())
+		time.Now(),
+		[]*apiv1.Node{})
 	assert.NoError(t, err)
 }
 
@@ -241,6 +277,7 @@ type findNodesToRemoveTestConfig struct {
 	name        string
 	candidates  []*apiv1.Node
 	allNodes    []*apiv1.Node
+	emptyNodes  []*apiv1.Node
 	toRemove    []NodeToBeRemoved
 	unremovable []*apiv1.Node
 }
@@ -294,6 +331,7 @@ func TestFindNodesToRemove(t *testing.T) {
 			name:        "just an empty node, should be removed",
 			candidates:  []*apiv1.Node{emptyNode},
 			allNodes:    []*apiv1.Node{emptyNode},
+			emptyNodes:  []*apiv1.Node{emptyNode},
 			toRemove:    []NodeToBeRemoved{emptyNodeToRemove},
 			unremovable: []*apiv1.Node{},
 		},
@@ -326,8 +364,18 @@ func TestFindNodesToRemove(t *testing.T) {
 			name:        "4 nodes, 1 empty, 1 drainable",
 			candidates:  []*apiv1.Node{emptyNode, drainableNode},
 			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
+			emptyNodes:  []*apiv1.Node{emptyNode},
 			toRemove:    []NodeToBeRemoved{emptyNodeToRemove, drainableNodeToRemove},
 			unremovable: []*apiv1.Node{},
+		},
+		//  empty node, drainable node and full node
+		{
+			name:        "empty node, drainable node and full node",
+			candidates:  []*apiv1.Node{emptyNode, drainableNode},
+			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode},
+			emptyNodes:  []*apiv1.Node{emptyNode},
+			toRemove:    []NodeToBeRemoved{emptyNodeToRemove},
+			unremovable: []*apiv1.Node{drainableNode},
 		},
 	}
 
@@ -335,7 +383,8 @@ func TestFindNodesToRemove(t *testing.T) {
 		toRemove, unremovable, _, err := FindNodesToRemove(
 			test.candidates, test.allNodes, pods, nil,
 			predicateChecker, len(test.allNodes), true, map[string]string{},
-			tracker, time.Now(), []*policyv1.PodDisruptionBudget{})
+			tracker, time.Now(), []*policyv1.PodDisruptionBudget{},
+			test.emptyNodes)
 		assert.NoError(t, err)
 		fmt.Printf("Test scenario: %s, found len(toRemove)=%v, expected len(test.toRemove)=%v\n", test.name, len(toRemove), len(test.toRemove))
 		assert.Equal(t, toRemove, test.toRemove)


### PR DESCRIPTION
We had noticed the following happening in our clusters:
* some node A becomes empty after previously running a workload that blocked some host ports
* some other node B that is running the same type of workload (blocking the same host ports) is now considered unneeded because the resource utilization is low and the pod could be evicted onto the now empty node
* apparently node A is only marked as unneeded _slightly_ after node B is marked as unneeded
* the 10 minute timer elapses first for node B and the node B is selected for scale down, the pod is evicted and another one is being started as a replacement on node A; afterwards node B is terminated and node A is now longer unneeded

From my point of view this behavior doesn't really make sense as it would have been better to just wait for the already empty node to be scaled-down instead of moving pods around to scale down another node instead.

This pull request changes this behavior to not consider empty nodes for targets of possible pod evictions. As far as I could tell, nodes are only considered as empty in the code if they are actually removable (e.g. minimum size in the node group is not yet reached), therefor empty nodes should _always_ be scaled down before scaling down any other node.