### PR TITLE
CA 1.12: cherry pick of #1261

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -66,19 +66,31 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*aut
 	if len(names) == 0 {
 		return nil, nil
 	}
-	input := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: aws.StringSlice(names),
-		MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
-	}
+
 	asgs := make([]*autoscaling.Group, 0)
-	if err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
-		asgs = append(asgs, output.AutoScalingGroups...)
-		// We return true while we want to be called with the next page of
-		// results, if any.
-		return true
-	}); err != nil {
-		return nil, err
+
+	// AWS only accepts up to 50 ASG names as input, describe them in batches
+	for i := 0; i < len(names); i += maxAsgNamesPerDescribe {
+		end := i + maxAsgNamesPerDescribe
+
+		if end > len(names) {
+			end = len(names)
+		}
+
+		input := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice(names[i:end]),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		}
+		if err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
+			asgs = append(asgs, output.AutoScalingGroups...)
+			// We return true while we want to be called with the next page of
+			// results, if any.
+			return true
+		}); err != nil {
+			return nil, err
+		}
 	}
+
 	return asgs, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestMoreThen50Groups(t *testing.T) {
+	service := &AutoScalingMock{}
+	autoScalingWrapper := &autoScalingWrapper{
+		autoScaling: service,
+	}
+
+	// Generate 51 ASG names
+	names := make([]string, 51)
+	for i := 0; i < len(names); i++ {
+		names[i] = fmt.Sprintf("asg-%d", i)
+	}
+
+	// First batch, first 50 elements
+	service.On("DescribeAutoScalingGroupsPages",
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice(names[:50]),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		},
+		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
+		fn(testNamedDescribeAutoScalingGroupsOutput("asg-1", 1, "test-instance-id"), false)
+	}).Return(nil)
+
+	// Second batch, element 51
+	service.On("DescribeAutoScalingGroupsPages",
+		&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice([]string{"asg-50"}),
+			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+		},
+		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool)
+		fn(testNamedDescribeAutoScalingGroupsOutput("asg-2", 1, "test-instance-id"), false)
+	}).Return(nil)
+
+	asgs, err := autoScalingWrapper.getAutoscalingGroupsByNames(names)
+	assert.Nil(t, err)
+	assert.Equal(t, len(asgs), 2)
+	assert.Equal(t, *asgs[0].AutoScalingGroupName, "asg-1")
+	assert.Equal(t, *asgs[1].AutoScalingGroupName, "asg-2")
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -47,6 +47,7 @@ const (
 	operationWaitTimeout    = 5 * time.Second
 	operationPollInterval   = 100 * time.Millisecond
 	maxRecordsReturnedByAPI = 100
+	maxAsgNamesPerDescribe  = 50
 	refreshInterval         = 1 * time.Minute
 )
 


### PR DESCRIPTION
I propose having the > 50 asgs code in the 1.12 release which I'm copying from master