### PR TITLE
Fix bug in balancing processor. 

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
@@ -103,7 +103,9 @@ func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(context *co
 			NewSize:     currentSize,
 			MaxSize:     maxSize}
 		scaleUpInfos = append(scaleUpInfos, info)
-		totalCapacity += maxSize - currentSize
+		if maxSize-currentSize > 0 {
+			totalCapacity += maxSize - currentSize
+		}
 	}
 	if totalCapacity < newNodes {
 		klog.V(2).Infof("Requested scale-up (%v) exceeds node group set capacity, capping to %v", newNodes, totalCapacity)

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
@@ -155,6 +155,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	provider.AddNodeGroup("ng2", 1, 3, 1)
 	provider.AddNodeGroup("ng3", 1, 10, 3)
 	provider.AddNodeGroup("ng4", 1, 7, 5)
+	provider.AddNodeGroup("ng5", 1, 3, 6)
 	groupsMap := make(map[string]cloudprovider.NodeGroup)
 	for _, group := range provider.NodeGroups() {
 		groupsMap[group.Id()] = group
@@ -217,4 +218,10 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
 	assert.Equal(t, 10, scaleUpMap["ng3"].NewSize)
 	assert.Equal(t, 7, scaleUpMap["ng4"].NewSize)
+
+	// One node group exceeds max.
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context, getGroups("ng2", "ng5"), 1)
+	assert.Equal(t, 1, len(scaleUpInfo))
+	scaleUpMap = toMap(scaleUpInfo)
+	assert.Equal(t, 2, scaleUpMap["ng2"].NewSize)
 }


### PR DESCRIPTION
Cluster Autoscaler was stopping scaling up when there was a multizonal node pool pool with number of nodes exceeding limit for one zone. For example if we have multizonal node pool with 2 zones with max set to 3. Node pools have sizes of 2 and 4 then Cluster Autoscaler gets stuck as it tries to scale only this node pool and balancing processor prevents it as total size is already 6.