### PR TITLE
Add required selector to VPA deployment examples for apps/v1

### DIFF
--- a/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
@@ -20,6 +20,9 @@ kind: Deployment
 metadata:
   name: hamster
 spec:
+  selector:
+    matchLabels:
+      app: hamster
   replicas: 2
   template:
     metadata:

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -20,6 +20,9 @@ kind: Deployment
 metadata:
   name: hamster
 spec:
+  selector:
+    matchLabels:
+      app: hamster
   replicas: 2
   template:
     metadata:


### PR DESCRIPTION
The VPA example deployments were recently switched to apps/v1. [#2209 ]

While attempting `kubectl create -f examples/hamster.yaml` the following error was revealed:

`error: error validating "examples/hamster.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec`

I found this was due to `apps/v1` requiring that .spec.selector and .metadata.labels be explicitly set:
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#selector

This PR updates the examples to conform to `apps/v1`