### PR TITLE
Update README.md

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -29,8 +29,8 @@ This will create a new [service principal][] with "Contributor" role scoped to y
 
 Cluster autoscaler supports four Kubernetes cluster options on Azure:
 
-- [**vmss**](#vmss-deployment): Autoscale VMSS instances by setting the Azure cloud provider's `vmType` parameter to `vmss`. This supports clusters deployed with [aks-engine][].
-- [**standard**](#standard-deployment): Autoscale VMAS instances by setting the Azure cloud provider's `vmType` parameter to `standard` or to an empty string. This supports clusters deployed with [aks-engine][].
+- [**vmss**](#vmss-deployment): Autoscale VMSS instances by setting the Azure cloud provider's `vmType` parameter to `vmss` or to an empty string. This supports clusters deployed with [aks-engine][].
+- [**standard**](#standard-deployment): Autoscale VMAS instances by setting the Azure cloud provider's `vmType` parameter to `standard`. This supports clusters deployed with [aks-engine][].
 - [**aks**](#aks-deployment): Supports an Azure Kubernetes Service ([AKS][]) cluster.
 - *DEPRECATED* [**acs**](#acs-deployment): Supports an Azure Container Service ([ACS][]) cluster.
 


### PR DESCRIPTION
Referring to `azure_manager.go` on 59b0087eeb, The default value of `vmType` is `vmTypeVMSS`.

See: https://github.com/kubernetes/autoscaler/commit/59b0087eeb3333657835e4a64fbf21cbbdbdad4a#diff-260f9ffb803a074dcf5da1b73734869fR174-R177