### PR TITLE
Don't attempt to delete aggregation from VPA if it doesn't exist

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -155,7 +155,10 @@ func (vpa *Vpa) UsesAggregation(aggregationKey AggregateStateKey) bool {
 
 // DeleteAggregation deletes aggregation used by this container
 func (vpa *Vpa) DeleteAggregation(aggregationKey AggregateStateKey) {
-	state := vpa.aggregateContainerStates[aggregationKey]
+	state, ok := vpa.aggregateContainerStates[aggregationKey]
+	if !ok {
+		return
+	}
 	state.MarkNotAutoscaled()
 	delete(vpa.aggregateContainerStates, aggregationKey)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -336,6 +336,50 @@ func TestUseAggregationIfMatching(t *testing.T) {
 	}
 }
 
+func TestDeleteAggregation(t *testing.T) {
+	cases := []struct {
+		name                     string
+		aggregateContainerStates aggregateContainerStatesMap
+		delet                    AggregateStateKey
+	}{
+		{
+			name: "delet dis",
+			aggregateContainerStates: aggregateContainerStatesMap{
+				aggregateStateKey{
+					namespace:     "ns",
+					containerName: "container",
+					labelSetKey:   "labelSetKey",
+					labelSetMap:   nil,
+				}: &AggregateContainerState{},
+			},
+			delet: aggregateStateKey{
+				namespace:     "ns",
+				containerName: "container",
+				labelSetKey:   "labelSetKey",
+				labelSetMap:   nil,
+			},
+		},
+		{
+			name: "no delet",
+			delet: aggregateStateKey{
+				namespace:     "ns",
+				containerName: "container",
+				labelSetKey:   "labelSetKey",
+				labelSetMap:   nil,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vpa := Vpa{
+				aggregateContainerStates: tc.aggregateContainerStates,
+			}
+			vpa.DeleteAggregation(tc.delet)
+			assert.Equal(t, 0, len(vpa.aggregateContainerStates))
+		})
+	}
+}
+
 type mockAggregateStateKey struct {
 	namespace     string
 	containerName string


### PR DESCRIPTION
I saw VPA failing in that MarkNotAutoscaled because it was accessing nil.I think it's when it tires to clean up aggregation from key for which there is no aggregation yet.