### PR TITLE
fix: increase exponential backoff duration regardless of backoff status

### DIFF
--- a/cluster-autoscaler/utils/backoff/exponential_backoff.go
+++ b/cluster-autoscaler/utils/backoff/exponential_backoff.go
@@ -70,10 +70,12 @@ func (b *exponentialBackoff) Backoff(nodeGroup cloudprovider.NodeGroup, nodeInfo
 	duration := b.initialBackoffDuration
 	key := b.nodeGroupKey(nodeGroup)
 	if backoffInfo, found := b.backoffInfo[key]; found {
-		// Multiple concurrent scale-ups failing shouldn't cause backoff
-		// duration to increase, so we only increase it if we're not in
-		// backoff right now.
+		// Multiple concurrent scale-ups failing shouldn't cause
+		// backoff duration to increase exponentially
+		duration = backoffInfo.duration
 		if backoffInfo.backoffUntil.Before(currentTime) {
+			// NodeGroup is not currently in backoff, but was recently
+			// Increase backoff duration exponentially
 			duration = 2 * backoffInfo.duration
 			if duration > b.maxBackoffDuration {
 				duration = b.maxBackoffDuration


### PR DESCRIPTION
PR addresses issue raised in https://github.com/kubernetes/autoscaler/issues/2225.

Backoff duration was not being exponentially increased for cases where the node group was already in a backoff state, instead setting the duration to the initial default duration. This could cause the cluster autoscaler to be in a locked state, where the scale-down-after-scale-up cooldown would always be greater than the duration between scale up attempts. So as scale-up attempts successively failed within the window of cooldown, no scale down could take place. 

The solution is to not set `duration=initialDuration` if `found=true`, instead setting it to the existing`backoffInfo.duration`, which allows for the duration to increase beyond initial. 