### PR TITLE
Generate EC2 Instance Type list in runtime

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -674,6 +674,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `leader-elect-renew-deadline` | The interval between attempts by the acting master to renew a leadership slot before it stops leading.<br>This must be less than or equal to the lease duration.<br>This is only applicable if leader election is enabled | 10 seconds
 | `leader-elect-retry-period` | The duration the clients should wait between attempting acquisition and renewal of a leadership.<br>This is only applicable if leader election is enabled | 2 seconds
 | `leader-elect-resource-lock` | The type of resource object that is used for locking during leader election.<br>Supported options are `endpoints` (default) and `configmaps` | "endpoints"
+| `aws-use-static-instance-list` | Should CA fetch instance types in runtime or use a static list. AWS only | false
 
 # Troubleshooting:
 

--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -204,6 +204,13 @@ spec:
             - r5ad.2xlarge
 ```
 
+## Use Static Instance List
+The set of the latest supported EC2 instance types will be fetched by the CA at run time. You can find all the available instance types in the CA logs.
+If your network access is restricted such that fetching this set is infeasible, you can specify the command-line flag `--aws-use-static-instance-list=true` to switch the CA back to its original use of a statically defined set.
+
+To refresh static list, please run `go run ec2_instance_types/gen.go` under `cluster-autoscaler/cloudprovider/aws/` and update `staticListLastUpdateTime` in `aws_util.go`
+
+
 ### Example usage:
 
 * Create a [Launch Template](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-launchtemplate.html) (LT) with an instance type, for example, r5.2xlarge. Consider this the 'base' instance type. Do not define any spot purchase options here.

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -134,7 +134,8 @@ func testProvider(t *testing.T, m *AwsManager) *awsCloudProvider {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	provider, err := BuildAwsCloudProvider(m, resourceLimiter)
+	instanceTypes, _ := GetStaticEC2InstanceTypes()
+	provider, err := BuildAwsCloudProvider(m, instanceTypes, resourceLimiter)
 	assert.NoError(t, err)
 	return provider.(*awsCloudProvider)
 }
@@ -144,7 +145,8 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	_, err := BuildAwsCloudProvider(testAwsManager, resourceLimiter)
+	instanceTypes, _ := GetStaticEC2InstanceTypes()
+	_, err := BuildAwsCloudProvider(testAwsManager, instanceTypes, resourceLimiter)
 	assert.NoError(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -62,7 +62,7 @@ type AwsManager struct {
 }
 
 type asgTemplate struct {
-	InstanceType *instanceType
+	InstanceType *InstanceType
 	Region       string
 	Zone         string
 	Tags         []*autoscaling.TagDescription

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -70,7 +70,7 @@ func TestGetRegion(t *testing.T) {
 
 func TestBuildGenericLabels(t *testing.T) {
 	labels := buildGenericLabels(&asgTemplate{
-		InstanceType: &instanceType{
+		InstanceType: &InstanceType{
 			InstanceType: "c4.large",
 			VCPU:         2,
 			MemoryMb:     3840,

--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"io/ioutil"
+	"k8s.io/klog"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	ec2MetaDataServiceUrl        = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+	ec2PricingServiceUrlTemplate = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/%s/index.json"
+	staticListLastUpdateTime     = "2019-10-14"
+)
+
+type response struct {
+	Products map[string]product `json:"products"`
+}
+
+type product struct {
+	Attributes productAttributes `json:"attributes"`
+}
+
+type productAttributes struct {
+	InstanceType string `json:"instanceType"`
+	VCPU         string `json:"vcpu"`
+	Memory       string `json:"memory"`
+	GPU          string `json:"gpu"`
+}
+
+// GenerateEC2InstanceTypes returns a map of ec2 resources
+func GenerateEC2InstanceTypes(region string) (map[string]*InstanceType, error) {
+	instanceTypes := make(map[string]*InstanceType)
+
+	resolver := endpoints.DefaultResolver()
+	partitions := resolver.(endpoints.EnumPartitions).Partitions()
+
+	for _, p := range partitions {
+		for _, r := range p.Regions() {
+			if region != "" && region != r.ID() {
+				continue
+			}
+
+			url := fmt.Sprintf(ec2PricingServiceUrlTemplate, r.ID())
+			klog.V(1).Infof("fetching %s\n", url)
+			res, err := http.Get(url)
+			if err != nil {
+				klog.Warningf("Error fetching %s skipping...\n", url)
+				continue
+			}
+
+			defer res.Body.Close()
+
+			body, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				klog.Warningf("Error parsing %s skipping...\n", url)
+				continue
+			}
+
+			var unmarshalled = response{}
+			err = json.Unmarshal(body, &unmarshalled)
+			if err != nil {
+				klog.Warningf("Error unmarshalling %s, skip...\n", url)
+				continue
+			}
+
+			for _, product := range unmarshalled.Products {
+				attr := product.Attributes
+				if attr.InstanceType != "" {
+					instanceTypes[attr.InstanceType] = &InstanceType{
+						InstanceType: attr.InstanceType,
+					}
+					if attr.Memory != "" && attr.Memory != "NA" {
+						instanceTypes[attr.InstanceType].MemoryMb = parseMemory(attr.Memory)
+					}
+					if attr.VCPU != "" {
+						instanceTypes[attr.InstanceType].VCPU = parseCPU(attr.VCPU)
+					}
+					if attr.GPU != "" {
+						instanceTypes[attr.InstanceType].GPU = parseCPU(attr.GPU)
+					}
+				}
+			}
+		}
+	}
+
+	if len(instanceTypes) == 0 {
+		return nil, errors.New("unable to load EC2 Instance Type list")
+	}
+
+	return instanceTypes, nil
+}
+
+// GetStaticEC2InstanceTypes return pregenerated ec2 instance type list
+func GetStaticEC2InstanceTypes() (map[string]*InstanceType, string) {
+	return InstanceTypes, staticListLastUpdateTime
+}
+
+func parseMemory(memory string) int64 {
+	reg, err := regexp.Compile("[^0-9\\.]+")
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	parsed := strings.TrimSpace(reg.ReplaceAllString(memory, ""))
+	mem, err := strconv.ParseFloat(parsed, 64)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	return int64(mem * float64(1024))
+}
+
+func parseCPU(cpu string) int64 {
+	i, err := strconv.ParseInt(cpu, 10, 64)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return i
+}
+
+// GetCurrentAwsRegion return region of current cluster without building awsManager
+func GetCurrentAwsRegion() (string, error) {
+	region, present := os.LookupEnv("AWS_REGION")
+
+	if !present {
+		klog.V(1).Infof("fetching %s\n", ec2MetaDataServiceUrl)
+		res, err := http.Get(ec2MetaDataServiceUrl)
+		if err != nil {
+			return "", fmt.Errorf("Error fetching %s", ec2MetaDataServiceUrl)
+		}
+
+		defer res.Body.Close()
+
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return "", fmt.Errorf("Error parsing %s", ec2MetaDataServiceUrl)
+		}
+
+		var unmarshalled = map[string]string{}
+		err = json.Unmarshal(body, &unmarshalled)
+		if err != nil {
+			klog.Warningf("Error unmarshalling %s, skip...\n", ec2MetaDataServiceUrl)
+		}
+
+		region = unmarshalled["region"]
+	}
+
+	return region, nil
+}

--- a/cluster-autoscaler/cloudprovider/aws/aws_util_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func TestGetStaticEC2InstanceTypes(t *testing.T) {
+	result, _ := GetStaticEC2InstanceTypes()
+	assert.True(t, len(result) != 0)
+}
+
+func TestParseMemory(t *testing.T) {
+	expectedResultInMiB := int64(3.75 * 1024)
+	tests := []struct {
+		input  string
+		expect int64
+	}{
+		{
+			input:  "3.75 GiB",
+			expect: expectedResultInMiB,
+		},
+		{
+			input:  "3.75 Gib",
+			expect: expectedResultInMiB,
+		},
+		{
+			input:  "3.75GiB",
+			expect: expectedResultInMiB,
+		},
+		{
+			input:  "3.75",
+			expect: expectedResultInMiB,
+		},
+	}
+
+	for _, test := range tests {
+		got := parseMemory(test.input)
+		assert.Equal(t, test.expect, got)
+	}
+}
+
+func TestParseCPU(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect int64
+	}{
+		{
+			input:  strconv.FormatInt(8, 10),
+			expect: int64(8),
+		},
+	}
+
+	for _, test := range tests {
+		got := parseCPU(test.input)
+		assert.Equal(t, test.expect, got)
+	}
+}
+
+func TestGetCurrentAwsRegion(t *testing.T) {
+	region := "us-west-2"
+	if oldRegion, found := os.LookupEnv("AWS_REGION"); found {
+		os.Unsetenv("AWS_REGION")
+		defer os.Setenv("AWS_REGION", oldRegion)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte("{\"region\" : \"" + region + "\"}"))
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	ec2MetaDataServiceUrl = server.URL
+	result, err := GetCurrentAwsRegion()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, region, result)
+}
+
+func TestGetCurrentAwsRegionWithRegionEnv(t *testing.T) {
+	region := "us-west-2"
+	if oldRegion, found := os.LookupEnv("AWS_REGION"); found {
+		defer os.Setenv("AWS_REGION", oldRegion)
+	} else {
+		defer os.Unsetenv("AWS_REGION")
+	}
+	os.Setenv("AWS_REGION", region)
+
+	result, err := GetCurrentAwsRegion()
+	assert.Nil(t, err)
+	assert.Equal(t, region, result)
+}

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -18,7 +18,8 @@ limitations under the License.
 
 package aws
 
-type instanceType struct {
+// InstanceType is sepc of EC2 instance
+type InstanceType struct {
 	InstanceType string
 	VCPU         int64
 	MemoryMb     int64
@@ -26,7 +27,7 @@ type instanceType struct {
 }
 
 // InstanceTypes is a map of ec2 resources
-var InstanceTypes = map[string]*instanceType{
+var InstanceTypes = map[string]*InstanceType{
 	"a1": {
 		InstanceType: "a1",
 		VCPU:         16,
@@ -55,6 +56,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "a1.medium",
 		VCPU:         1,
 		MemoryMb:     2048,
+		GPU:          0,
+	},
+	"a1.metal": {
+		InstanceType: "a1.metal",
+		VCPU:         16,
+		MemoryMb:     32768,
 		GPU:          0,
 	},
 	"a1.xlarge": {
@@ -213,10 +220,22 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     0,
 		GPU:          0,
 	},
+	"c5d.12xlarge": {
+		InstanceType: "c5d.12xlarge",
+		VCPU:         48,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
 	"c5d.18xlarge": {
 		InstanceType: "c5d.18xlarge",
 		VCPU:         72,
 		MemoryMb:     147456,
+		GPU:          0,
+	},
+	"c5d.24xlarge": {
+		InstanceType: "c5d.24xlarge",
+		VCPU:         96,
+		MemoryMb:     262144,
 		GPU:          0,
 	},
 	"c5d.2xlarge": {
@@ -241,6 +260,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "c5d.large",
 		VCPU:         2,
 		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"c5d.metal": {
+		InstanceType: "c5d.metal",
+		VCPU:         96,
+		MemoryMb:     262144,
 		GPU:          0,
 	},
 	"c5d.xlarge": {
@@ -283,6 +308,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "c5n.large",
 		VCPU:         2,
 		MemoryMb:     5376,
+		GPU:          0,
+	},
+	"c5n.metal": {
+		InstanceType: "c5n.metal",
+		VCPU:         72,
+		MemoryMb:     196608,
 		GPU:          0,
 	},
 	"c5n.xlarge": {
@@ -403,6 +434,42 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "g3s.xlarge",
 		VCPU:         4,
 		MemoryMb:     31232,
+		GPU:          1,
+	},
+	"g4dn.12xlarge": {
+		InstanceType: "g4dn.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          4,
+	},
+	"g4dn.16xlarge": {
+		InstanceType: "g4dn.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          1,
+	},
+	"g4dn.2xlarge": {
+		InstanceType: "g4dn.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          1,
+	},
+	"g4dn.4xlarge": {
+		InstanceType: "g4dn.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          1,
+	},
+	"g4dn.8xlarge": {
+		InstanceType: "g4dn.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          1,
+	},
+	"g4dn.xlarge": {
+		InstanceType: "g4dn.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
 		GPU:          1,
 	},
 	"h1": {
@@ -559,6 +626,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "i3en.large",
 		VCPU:         2,
 		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"i3en.metal": {
+		InstanceType: "i3en.metal",
+		VCPU:         96,
+		MemoryMb:     786432,
 		GPU:          0,
 	},
 	"i3en.xlarge": {
@@ -795,6 +868,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     196608,
 		GPU:          0,
 	},
+	"m5ad.16xlarge": {
+		InstanceType: "m5ad.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
 	"m5ad.24xlarge": {
 		InstanceType: "m5ad.24xlarge",
 		VCPU:         96,
@@ -811,6 +890,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "m5ad.4xlarge",
 		VCPU:         16,
 		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"m5ad.8xlarge": {
+		InstanceType: "m5ad.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
 		GPU:          0,
 	},
 	"m5ad.large": {
@@ -881,6 +966,126 @@ var InstanceTypes = map[string]*instanceType{
 	},
 	"m5d.xlarge": {
 		InstanceType: "m5d.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"m5dn": {
+		InstanceType: "m5dn",
+		VCPU:         96,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"m5dn.12xlarge": {
+		InstanceType: "m5dn.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          0,
+	},
+	"m5dn.16xlarge": {
+		InstanceType: "m5dn.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"m5dn.24xlarge": {
+		InstanceType: "m5dn.24xlarge",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"m5dn.2xlarge": {
+		InstanceType: "m5dn.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"m5dn.4xlarge": {
+		InstanceType: "m5dn.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"m5dn.8xlarge": {
+		InstanceType: "m5dn.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"m5dn.large": {
+		InstanceType: "m5dn.large",
+		VCPU:         2,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
+	"m5dn.metal": {
+		InstanceType: "m5dn.metal",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"m5dn.xlarge": {
+		InstanceType: "m5dn.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"m5n": {
+		InstanceType: "m5n",
+		VCPU:         96,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"m5n.12xlarge": {
+		InstanceType: "m5n.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          0,
+	},
+	"m5n.16xlarge": {
+		InstanceType: "m5n.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"m5n.24xlarge": {
+		InstanceType: "m5n.24xlarge",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"m5n.2xlarge": {
+		InstanceType: "m5n.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"m5n.4xlarge": {
+		InstanceType: "m5n.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"m5n.8xlarge": {
+		InstanceType: "m5n.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"m5n.large": {
+		InstanceType: "m5n.large",
+		VCPU:         2,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
+	"m5n.metal": {
+		InstanceType: "m5n.metal",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"m5n.xlarge": {
+		InstanceType: "m5n.xlarge",
 		VCPU:         4,
 		MemoryMb:     16384,
 		GPU:          0,
@@ -1137,6 +1342,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     393216,
 		GPU:          0,
 	},
+	"r5ad.16xlarge": {
+		InstanceType: "r5ad.16xlarge",
+		VCPU:         64,
+		MemoryMb:     524288,
+		GPU:          0,
+	},
 	"r5ad.24xlarge": {
 		InstanceType: "r5ad.24xlarge",
 		VCPU:         96,
@@ -1153,6 +1364,12 @@ var InstanceTypes = map[string]*instanceType{
 		InstanceType: "r5ad.4xlarge",
 		VCPU:         16,
 		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"r5ad.8xlarge": {
+		InstanceType: "r5ad.8xlarge",
+		VCPU:         32,
+		MemoryMb:     262144,
 		GPU:          0,
 	},
 	"r5ad.large": {
@@ -1223,6 +1440,126 @@ var InstanceTypes = map[string]*instanceType{
 	},
 	"r5d.xlarge": {
 		InstanceType: "r5d.xlarge",
+		VCPU:         4,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"r5dn": {
+		InstanceType: "r5dn",
+		VCPU:         96,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"r5dn.12xlarge": {
+		InstanceType: "r5dn.12xlarge",
+		VCPU:         48,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"r5dn.16xlarge": {
+		InstanceType: "r5dn.16xlarge",
+		VCPU:         64,
+		MemoryMb:     524288,
+		GPU:          0,
+	},
+	"r5dn.24xlarge": {
+		InstanceType: "r5dn.24xlarge",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          0,
+	},
+	"r5dn.2xlarge": {
+		InstanceType: "r5dn.2xlarge",
+		VCPU:         8,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"r5dn.4xlarge": {
+		InstanceType: "r5dn.4xlarge",
+		VCPU:         16,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"r5dn.8xlarge": {
+		InstanceType: "r5dn.8xlarge",
+		VCPU:         32,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"r5dn.large": {
+		InstanceType: "r5dn.large",
+		VCPU:         2,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"r5dn.metal": {
+		InstanceType: "r5dn.metal",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          0,
+	},
+	"r5dn.xlarge": {
+		InstanceType: "r5dn.xlarge",
+		VCPU:         4,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"r5n": {
+		InstanceType: "r5n",
+		VCPU:         96,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"r5n.12xlarge": {
+		InstanceType: "r5n.12xlarge",
+		VCPU:         48,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"r5n.16xlarge": {
+		InstanceType: "r5n.16xlarge",
+		VCPU:         64,
+		MemoryMb:     524288,
+		GPU:          0,
+	},
+	"r5n.24xlarge": {
+		InstanceType: "r5n.24xlarge",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          0,
+	},
+	"r5n.2xlarge": {
+		InstanceType: "r5n.2xlarge",
+		VCPU:         8,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"r5n.4xlarge": {
+		InstanceType: "r5n.4xlarge",
+		VCPU:         16,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"r5n.8xlarge": {
+		InstanceType: "r5n.8xlarge",
+		VCPU:         32,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"r5n.large": {
+		InstanceType: "r5n.large",
+		VCPU:         2,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"r5n.metal": {
+		InstanceType: "r5n.metal",
+		VCPU:         96,
+		MemoryMb:     786432,
+		GPU:          0,
+	},
+	"r5n.xlarge": {
+		InstanceType: "r5n.xlarge",
 		VCPU:         4,
 		MemoryMb:     32768,
 		GPU:          0,
@@ -1484,47 +1821,5 @@ var InstanceTypes = map[string]*instanceType{
 		VCPU:         4,
 		MemoryMb:     32768,
 		GPU:          0,
-	},
-	"g4dn.xlarge": {
-		InstanceType: "g4dn.xlarge",
-		VCPU:         4,
-		MemoryMb:     16384,
-		GPU:          1,
-	},
-	"g4dn.2xlarge": {
-		InstanceType: "g4dn.2xlarge",
-		VCPU:         8,
-		MemoryMb:     32768,
-		GPU:          1,
-	},
-	"g4dn.4xlarge": {
-		InstanceType: "g4dn.4xlarge",
-		VCPU:         16,
-		MemoryMb:     65536,
-		GPU:          1,
-	},
-	"g4dn.8xlarge": {
-		InstanceType: "g4dn.8xlarge",
-		VCPU:         32,
-		MemoryMb:     131072,
-		GPU:          1,
-	},
-	"g4dn.16xlarge": {
-		InstanceType: "g4dn.16xlarge",
-		VCPU:         64,
-		MemoryMb:     262144,
-		GPU:          1,
-	},
-	"g4dn.12xlarge": {
-		InstanceType: "g4dn.12xlarge",
-		VCPU:         48,
-		MemoryMb:     196608,
-		GPU:          4,
-	},
-	"g4dn.metal": { //coming soon
-		InstanceType: "g4dn.metal",
-		VCPU:         96,
-		MemoryMb:     393216,
-		GPU:          8,
 	},
 }

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -139,4 +139,6 @@ type AutoscalingOptions struct {
 	FilterOutSchedulablePodsUsesPacking bool
 	// IgnoredTaints is a list of taints to ignore when considering a node template for scheduling.
 	IgnoredTaints []string
+	// AWSUseStaticInstanceList tells if AWS cloud provider use static instance type list or dynamically fetch from remote APIs.
+	AWSUseStaticInstanceList bool
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -170,7 +170,8 @@ var (
 			"Setting it to false employs a more lenient filtering approach that does not try to pack the pods on the nodes."+
 			"Pods with nominatedNodeName set are always filtered out.")
 
-	ignoreTaintsFlag = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	ignoreTaintsFlag         = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	awsUseStaticInstanceList = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
 )
 
 func createAutoscalingOptions() config.AutoscalingOptions {
@@ -237,6 +238,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		FilterOutSchedulablePodsUsesPacking: *filterOutSchedulablePodsUsesPacking,
 		IgnoredTaints:                       *ignoreTaintsFlag,
 		NodeDeletionDelayTimeout:            *nodeDeletionDelayTimeout,
+		AWSUseStaticInstanceList:            *awsUseStaticInstanceList,
 	}
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/issues/2240

We have some discussion here. https://github.com/kubernetes/autoscaler/pull/2231

Consider the case not all k8s clusters has network to aws pricing API, I still keep the static instance type list. If network is not accessible, it will fall back to static dict. 

dynamic loading will reuse code snippet from gen.go

I am trying reach out to folks who worked on this, not sure if we have any internal IP like EC2 metadata service. If so, we can use that and assume it can always get updated list in the same network. 

@jaypipes