### PR TITLE
Provide ScaleUpStatusProcessor with info about all rejected node groups

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -400,10 +400,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 
 		for pod, err := range podsNotPassing {
 			_, found := podsRemainUnschedulable[pod]
-			if found && nodeGroup.Exist() {
-				// Aggregate errors across existing node groups.
-				// TODO(aleksandra-malinowska): figure out how to communicate
-				// reasons NAP can't create a node-pool, if it's enabled.
+			if found {
 				podsRemainUnschedulable[pod][nodeGroup.Id()] = err
 			}
 		}

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -18,10 +18,13 @@ package status
 
 import (
 	"fmt"
-	"k8s.io/klog"
 	"strings"
 
+	"k8s.io/klog"
+
 	apiv1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 )
 
@@ -33,11 +36,12 @@ type EventingScaleUpStatusProcessor struct{}
 // Process processes the state of the cluster after a scale-up by emitting
 // relevant events for pods depending on their post scale-up status.
 func (p *EventingScaleUpStatusProcessor) Process(context *context.AutoscalingContext, status *ScaleUpStatus) {
+	consideredNodeGroupsMap := nodeGroupListToMapById(status.ConsideredNodeGroups)
 	if status.Result != ScaleUpSuccessful && status.Result != ScaleUpError {
 		for _, noScaleUpInfo := range status.PodsRemainUnschedulable {
 			context.Recorder.Event(noScaleUpInfo.Pod, apiv1.EventTypeNormal, "NotTriggerScaleUp",
 				fmt.Sprintf("pod didn't trigger scale-up (it wouldn't fit if a new node is"+
-					" added): %s", ReasonsMessage(noScaleUpInfo)))
+					" added): %s", ReasonsMessage(noScaleUpInfo, consideredNodeGroupsMap)))
 		}
 	} else {
 		klog.V(4).Infof("Skipping event processing for unschedulable pods since there is a" +
@@ -56,21 +60,39 @@ func (p *EventingScaleUpStatusProcessor) CleanUp() {
 }
 
 // ReasonsMessage aggregates reasons from NoScaleUpInfos.
-func ReasonsMessage(noScaleUpInfo NoScaleUpInfo) string {
+func ReasonsMessage(noScaleUpInfo NoScaleUpInfo, consideredNodeGroups map[string]cloudprovider.NodeGroup) string {
 	messages := []string{}
 	aggregated := map[string]int{}
-	for _, reasons := range noScaleUpInfo.RejectedNodeGroups {
+	for nodeGroupId, reasons := range noScaleUpInfo.RejectedNodeGroups {
+		if nodeGroup, present := consideredNodeGroups[nodeGroupId]; !present || !nodeGroup.Exist() {
+			continue
+		}
+
 		for _, reason := range reasons.Reasons() {
 			aggregated[reason]++
 		}
 	}
-	for _, reasons := range noScaleUpInfo.SkippedNodeGroups {
+
+	for nodeGroupId, reasons := range noScaleUpInfo.SkippedNodeGroups {
+		if nodeGroup, present := consideredNodeGroups[nodeGroupId]; !present || !nodeGroup.Exist() {
+			continue
+		}
+
 		for _, reason := range reasons.Reasons() {
 			aggregated[reason]++
 		}
 	}
+
 	for msg, count := range aggregated {
 		messages = append(messages, fmt.Sprintf("%d %s", count, msg))
 	}
 	return strings.Join(messages, ", ")
+}
+
+func nodeGroupListToMapById(nodeGroups []cloudprovider.NodeGroup) map[string]cloudprovider.NodeGroup {
+	result := make(map[string]cloudprovider.NodeGroup)
+	for _, nodeGroup := range nodeGroups {
+		result[nodeGroup.Id()] = nodeGroup
+	}
+	return result
 }

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
@@ -21,10 +21,13 @@ import (
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
+	kube_record "k8s.io/client-go/tools/record"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	cp_test "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	kube_record "k8s.io/client-go/tools/record"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -134,15 +137,27 @@ func TestReasonsMessage(t *testing.T) {
 	alsoNotSchedulableReason := &testReason{"also not schedulable"}
 	maxLimitReached := &testReason{"max limit reached"}
 	notReady := &testReason{"not ready"}
+	considered := map[string]cloudprovider.NodeGroup{
+		"group 1":     cp_test.NewTestNodeGroup("group 1", 1, 1, 1, true, false, "", nil, nil),
+		"group 2":     cp_test.NewTestNodeGroup("group 2", 1, 1, 1, true, false, "", nil, nil),
+		"group 3":     cp_test.NewTestNodeGroup("group 3", 1, 1, 1, true, false, "", nil, nil),
+		"group 4":     cp_test.NewTestNodeGroup("group 4", 1, 1, 1, true, false, "", nil, nil),
+		"group 5":     cp_test.NewTestNodeGroup("group 5", 1, 1, 1, true, false, "", nil, nil),
+		"group 6":     cp_test.NewTestNodeGroup("group 6", 1, 1, 1, true, false, "", nil, nil),
+		"tmp group 1": cp_test.NewTestNodeGroup("tmp group 1", 1, 1, 1, false, false, "", nil, nil),
+		"tmp group 2": cp_test.NewTestNodeGroup("tmp group 2", 1, 1, 1, false, false, "", nil, nil),
+	}
 	rejected := map[string]Reasons{
-		"group 1": notSchedulableReason,
-		"group 2": notSchedulableReason,
-		"group 3": alsoNotSchedulableReason,
+		"group 1":     notSchedulableReason,
+		"group 2":     notSchedulableReason,
+		"group 3":     alsoNotSchedulableReason,
+		"tmp group 1": alsoNotSchedulableReason,
 	}
 	skipped := map[string]Reasons{
-		"group 4": maxLimitReached,
-		"group 5": notReady,
-		"group 6": maxLimitReached,
+		"group 4":     maxLimitReached,
+		"group 5":     notReady,
+		"group 6":     maxLimitReached,
+		"tmp group 2": maxLimitReached,
 	}
 
 	expected := []string{
@@ -151,7 +166,7 @@ func TestReasonsMessage(t *testing.T) {
 		"2 max limit reached",
 		"1 not ready",
 	}
-	result := ReasonsMessage(NoScaleUpInfo{nil, rejected, skipped})
+	result := ReasonsMessage(NoScaleUpInfo{nil, rejected, skipped}, considered)
 
 	for _, part := range expected {
 		assert.Contains(t, result, part)


### PR DESCRIPTION
Previously, it had info only about the ones that actually exist.

The changes to the eventing processor are done to keep its previous
behavior the same.