### PR TITLE
Add magnum to list of supported cloud providers

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -139,3 +139,4 @@ Supported cloud providers:
 * AWS https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md
 * Azure https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/README.md
 * Alibaba Cloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/alicloud/README.md
+* OpenStack Magnum https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/magnum/README.md


### PR DESCRIPTION
This was mentioned in the sig-autoscaling slack.

Maybe some others need adding as well?