### PR TITLE
VPA Recommender: Use WSS from Prometheus provider

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -194,7 +194,7 @@ func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHis
 	if err != nil {
 		return nil, fmt.Errorf("cannot get usage history: %v", err)
 	}
-	err = p.readResourceHistory(res, fmt.Sprintf("container_memory_usage_bytes{%s}[%s]", podSelector, p.config.HistoryLength), model.ResourceMemory)
+	err = p.readResourceHistory(res, fmt.Sprintf("container_memory_working_set_bytes{%s}[%s]", podSelector, p.config.HistoryLength), model.ResourceMemory)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get usage history: %v", err)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	cpuQuery    = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[8d])"
-	memoryQuery = "container_memory_usage_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[8d]"
+	memoryQuery = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[8d]"
 	labelsQuery = "up{job=\"kubernetes-pods\"}[8d]"
 )
 


### PR DESCRIPTION
Currently, VPA Recommender uses `container_memory_usage_bytes` cAdvisor metric from Prometheus history provider.
This metric includes page cache into container memory usage total.
As a result, cache-heavy workloads keep getting larger and larger memory recommendation.

This change takes memory held for page cache out of VPA's calculation removing the primary driver behind memory over-requesting.

A similar suggestion was mentioned twice ([[1]](https://github.com/kubernetes/autoscaler/issues/1551#issuecomment-456386360), [[2]](https://github.com/kubernetes/autoscaler/pull/1613#issuecomment-458918134)), but no PRs / issues were raised to discuss it.

This change harmonizes the metric which VPA Recommender Prometheus history provider uses with that of [k8s-prometheus-adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter/pull/106/commits/c5801455ecdbecec363bb2d87927172690a7d983#diff-a24e018d491475644c4bb928d27db3c9R103).


Illustration:
![thanos-store-wss-vs-total](https://user-images.githubusercontent.com/2144010/63262181-3789f780-c27d-11e9-8140-66751b8210e5.png)

On the screenshot above you see an example process which would use significant memory of memory for the page cache.

Since VPA keep taking into account page cache into memory requests, a container would be able to use more and more memory for it without experiencing memory pressure.

This creates a condition for over-requesting if not runaway(-ish) memory adjustments by VPA.