### PR TITLE
Add DigitalOcean to AvailableCloudProviders

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -38,6 +38,7 @@ var AvailableCloudProviders = []string{
 	cloudprovider.AlicloudProviderName,
 	cloudprovider.BaiducloudProviderName,
 	cloudprovider.MagnumProviderName,
+	cloudprovider.DigitalOceanProviderName,
 }
 
 // DefaultCloudProvider is GCE.


### PR DESCRIPTION
DigitalOcean was missing in the list of supported clouds that the `--cloud-provider` option displays.

/cc @snormore

/assign @andrewsykim 