### PR TITLE
cluster-autoscaler/metrics: add a summary for function duration

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -142,6 +142,15 @@ var (
 		}, []string{"function"},
 	)
 
+	functionDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: caNamespace,
+			Name:      "function_duration_quantile_seconds",
+			Help:      "Quantiles of time taken by various parts of CA main loop.",
+			MaxAge:    time.Hour,
+		}, []string{"function"},
+	)
+
 	/**** Metrics related to autoscaler operations ****/
 	errorsCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -249,6 +258,7 @@ func RegisterAll() {
 	prometheus.MustRegister(unschedulablePodsCount)
 	prometheus.MustRegister(lastActivity)
 	prometheus.MustRegister(functionDuration)
+	prometheus.MustRegister(functionDurationSummary)
 	prometheus.MustRegister(errorsCount)
 	prometheus.MustRegister(scaleUpCount)
 	prometheus.MustRegister(gpuScaleUpCount)
@@ -278,6 +288,7 @@ func UpdateDuration(label FunctionLabel, duration time.Duration) {
 		klog.V(4).Infof("Function %s took %v to complete", label, duration)
 	}
 	functionDuration.WithLabelValues(string(label)).Observe(duration.Seconds())
+	functionDurationSummary.WithLabelValues(string(label)).Observe(duration.Seconds())
 }
 
 // UpdateLastTime records the time the step identified by the label was started


### PR DESCRIPTION
The purpose of this metric is to provide quantiles directly in the exporter.

As the cluster autoscaler is leader election based, there is only one instance reporting these quantiles at a time so we have a limited risk of aggregating this aggregation.
