### PR TITLE
AWS: Decrease current size only once

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -277,10 +277,10 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 				return err
 			}
 			klog.V(4).Infof(*resp.Activity.Description)
-		}
 
-		// Proactively decrement the size so autoscaler makes better decisions
-		commonAsg.curSize--
+			// Proactively decrement the size so autoscaler makes better decisions
+			commonAsg.curSize--
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Deleting a placeholder instance introduced in https://github.com/kubernetes/autoscaler/pull/2235 seems to decrease the in-memory ASG size twice, once in the deletion loop itself and once in `decreaseAsgSizeByOneNoLock`, which calls `setAsgSizeNoLock` and also updates the `curSize`

This is actually not causing issues yet, as the ASG cache is force refreshed after a deletion now https://github.com/kubernetes/autoscaler/blob/c3c9fc153c663089c1b02bcd3e788b46a9762d1f/cluster-autoscaler/cloudprovider/aws/aws_manager.go#L283-L284.

I still added a test to confirm that deleting placeholders actually works as expected.

//cc @piontec