### PR TITLE
Stop disabling Cluster Autoscaler when there is no ready nodes.

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -362,7 +362,7 @@ func (csr *ClusterStateRegistry) IsClusterHealthy() bool {
 	csr.Lock()
 	defer csr.Unlock()
 
-	totalUnready := csr.totalReadiness.Unready + csr.totalReadiness.LongNotStarted + csr.totalReadiness.LongUnregistered
+	totalUnready := csr.totalReadiness.Unready
 
 	if totalUnready > csr.config.OkTotalUnreadyCount &&
 		float64(totalUnready) > csr.config.MaxTotalUnreadyPercentage/100.0*float64(len(csr.nodes)) {

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -76,6 +76,8 @@ type AutoscalingOptions struct {
 	MaxTotalUnreadyPercentage float64
 	// OkTotalUnreadyCount is the number of allowed unready nodes, irrespective of max-total-unready-percentage
 	OkTotalUnreadyCount int
+	// ScaleUpFromZero defines if CA should scale up when there 0 ready nodes.
+	ScaleUpFromZero bool
 	// CloudConfig is the path to the cloud provider configuration file. Empty string for no configuration file.
 	CloudConfig string
 	// CloudProviderName sets the type of the cloud provider CA is about to run in. Allowed values: gce, aws

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -589,6 +589,9 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 
 // actOnEmptyCluster returns true if the cluster was empty and thus acted upon
 func (a *StaticAutoscaler) actOnEmptyCluster(allNodes, readyNodes []*apiv1.Node, currentTime time.Time) bool {
+	if a.AutoscalingContext.AutoscalingOptions.ScaleUpFromZero {
+		return false
+	}
 	if len(allNodes) == 0 {
 		a.onEmptyCluster("Cluster has no nodes.", true)
 		return true

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -130,6 +130,7 @@ var (
 	maxGracefulTerminationFlag = flag.Int("max-graceful-termination-sec", 10*60, "Maximum number of seconds CA waits for pod termination when trying to scale down a node.")
 	maxTotalUnreadyPercentage  = flag.Float64("max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
 	okTotalUnreadyCount        = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
+	scaleUpFromZero            = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there 0 ready nodes.")
 	maxNodeProvisionTime       = flag.Duration("max-node-provision-time", 15*time.Minute, "Maximum time CA waits for node to be provisioned")
 	nodeGroupsFlag             = multiStringFlag(
 		"nodes",
@@ -195,6 +196,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		NodeGroupAutoDiscovery:              *nodeGroupAutoDiscoveryFlag,
 		MaxTotalUnreadyPercentage:           *maxTotalUnreadyPercentage,
 		OkTotalUnreadyCount:                 *okTotalUnreadyCount,
+		ScaleUpFromZero:                     *scaleUpFromZero,
 		EstimatorName:                       *estimatorFlag,
 		ExpanderName:                        *expanderFlag,
 		IgnoreDaemonSetsUtilization:         *ignoreDaemonSetsUtilization,


### PR DESCRIPTION
Fixes #2218 