### PR TITLE
compare_nodegroups: Tolerate small differences in memory capacity

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
@@ -96,6 +96,20 @@ func TestNodesSimilarVariousRequirementsAndPods(t *testing.T) {
 	checkNodesSimilarWithPods(t, n1, n4, []*apiv1.Pod{p1}, []*apiv1.Pod{p4}, IsNodeInfoSimilar, true)
 }
 
+func TestNodesSimilarVariousMemoryRequirements(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, MaxMemoryDifferenceInKiloBytes)
+
+	// Different memory capacity within tolerance
+	n2 := BuildTestNode("node2", 1000, MaxMemoryDifferenceInKiloBytes)
+	n2.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(2*MaxMemoryDifferenceInKiloBytes, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, true)
+
+	// Different memory capacity exceeds tolerance
+	n3 := BuildTestNode("node3", 1000, MaxMemoryDifferenceInKiloBytes)
+	n3.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(2*MaxMemoryDifferenceInKiloBytes+1, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n3, IsNodeInfoSimilar, false)
+}
+
 func TestNodesSimilarVariousLabels(t *testing.T) {
 	n1 := BuildTestNode("node1", 1000, 2000)
 	n1.ObjectMeta.Labels["test-label"] = "test-value"


### PR DESCRIPTION
The current comparator expects memory capacity values to be identical.
However across AWS, Azure and GCP I quite often see very small
differences in capacity, typically 8-16Ki. When this occurs the
nodegroups are considered not equal when balancing is in effect which
is unfortunate because, in reality, they are identical.

This change will now tolerate a 128Ki difference before memory
capacity values are considered unequal.