### PR TITLE
cluster-autoscaler/hack/update-vendor.sh: fix invocation of git commit

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -189,7 +189,7 @@ set +o errexit
   git add vendor go.mod go.sum >&${BASH_XTRACEFD} 2>&1
   if ! git diff --quiet --cached; then
     echo "Commiting vendor, go.mod and go.sum"
-    git ci -m "Updating vendor against ${K8S_FORK}:${K8S_REV} (${K8S_REV_PARSED})" >&${BASH_XTRACEFD} 2>&1
+    git commit -m "Updating vendor against ${K8S_FORK}:${K8S_REV} (${K8S_REV_PARSED})" >&${BASH_XTRACEFD} 2>&1
   else
     echo "No changes after vendor update; skipping commit"
   fi


### PR DESCRIPTION
Running this script as-is fails as `git ci` is not a recognised
command. Fixed by referencing `git commit` explicitly; I guess it
works form some people as it may be aliased.