### PR TITLE
Use DO node pool autoscale API integration

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
@@ -73,7 +73,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 						{ID: "7", Status: &godo.KubernetesNodeStatus{State: "draining"}},
 						{ID: "8", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					AutoScale: true,
+					AutoScale: false,
 				},
 			},
 			&godo.Response{},
@@ -109,7 +109,7 @@ func TestDigitalOceanCloudProvider_NodeGroups(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		nodes := provider.NodeGroups()
-		assert.Equal(t, len(nodes), 4, "number of nodes do not match")
+		assert.Equal(t, len(nodes), 3, "number of nodes do not match")
 	})
 
 	t.Run("zero groups", func(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
@@ -49,9 +49,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 						{ID: "1", Status: &godo.KubernetesNodeStatus{State: "running"}},
 						{ID: "2", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "2",
@@ -59,9 +57,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 						{ID: "3", Status: &godo.KubernetesNodeStatus{State: "deleting"}},
 						{ID: "4", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "3",
@@ -69,9 +65,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 						{ID: "5", Status: &godo.KubernetesNodeStatus{State: "provisioning"}},
 						{ID: "6", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "4",
@@ -79,9 +73,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 						{ID: "7", Status: &godo.KubernetesNodeStatus{State: "draining"}},
 						{ID: "8", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 			},
 			&godo.Response{},
@@ -142,9 +134,7 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 						{ID: "2", Status: &godo.KubernetesNodeStatus{State: "deleting"}},
 						{ID: "3", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "2",
@@ -152,9 +142,7 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 						{ID: "4", Status: &godo.KubernetesNodeStatus{State: "provisioning"}},
 						{ID: "5", Status: &godo.KubernetesNodeStatus{State: "draining"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 			},
 			&godo.Response{},

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
@@ -23,20 +23,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"strconv"
-	"strings"
 
 	"golang.org/x/oauth2"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean/godo"
 	"k8s.io/klog"
-)
-
-const (
-	tagPrefix  = "k8s-cluster-autoscaler-"
-	tagEnabled = tagPrefix + "enabled:"
-	tagMin     = tagPrefix + "min:"
-	tagMax     = tagPrefix + "max:"
 )
 
 var (
@@ -134,39 +125,20 @@ func (m *Manager) Refresh() error {
 
 	var group []*NodeGroup
 	for _, nodePool := range nodePools {
-		spec, err := parseTags(nodePool.Tags)
-		if err != nil {
-			// we should not return an error here, because one misconfigured
-			// node pool shouldn't bring down the whole cluster-autoscaler
-			klog.V(4).Infof("skipping misconfigured node pool: %q name: %s tags: %+v err: %s",
-				nodePool.ID, nodePool.Name, nodePool.Tags, err)
+		if !nodePool.AutoScale {
 			continue
-		}
-
-		if !spec.enabled {
-			continue
-		}
-
-		minSize := minNodePoolSize
-		if spec.min != 0 {
-			minSize = spec.min
-		}
-
-		maxSize := maxNodePoolSize
-		if spec.max != 0 {
-			maxSize = spec.max
 		}
 
 		klog.V(4).Infof("adding node pool: %q name: %s min: %d max: %d",
-			nodePool.ID, nodePool.Name, minSize, maxSize)
+			nodePool.ID, nodePool.Name, nodePool.MinNodes, nodePool.MaxNodes)
 
 		group = append(group, &NodeGroup{
 			id:        nodePool.ID,
 			clusterID: m.clusterID,
 			client:    m.client,
 			nodePool:  nodePool,
-			minSize:   minSize,
-			maxSize:   maxSize,
+			minSize:   nodePool.MinNodes,
+			maxSize:   nodePool.MaxNodes,
 		})
 	}
 
@@ -176,65 +148,4 @@ func (m *Manager) Refresh() error {
 
 	m.nodeGroups = group
 	return nil
-}
-
-// nodeSpec defines a custom specification for a given node
-type nodeSpec struct {
-	min     int
-	max     int
-	enabled bool
-}
-
-// parseTags parses a list of tags from a DigitalOcean node pool
-func parseTags(tags []string) (*nodeSpec, error) {
-	spec := &nodeSpec{}
-
-	for _, tag := range tags {
-		if !strings.HasPrefix(tag, tagPrefix) {
-			continue
-		}
-
-		splitted := strings.Split(strings.TrimPrefix(tag, tagPrefix), ":")
-		if len(splitted) != 2 {
-			return nil, fmt.Errorf("malformed tag: %q", tag)
-		}
-
-		key, value := splitted[0], splitted[1]
-
-		switch key {
-		case "enabled":
-			if value == "true" {
-				spec.enabled = true
-			}
-		case "min":
-			min, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, fmt.Errorf("invalid minimum nodes: %q", value)
-			}
-
-			if min <= 0 {
-				return nil, fmt.Errorf("minimum nodes: %d can't be set to zero or less", min)
-			}
-
-			spec.min = min
-		case "max":
-			max, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, fmt.Errorf("invalid maximum nodes: %q", value)
-			}
-
-			if max <= 0 {
-				return nil, fmt.Errorf("maximum nodes: %d can't be set to zero or less", max)
-			}
-
-			spec.max = max
-		}
-	}
-
-	if spec.min != 0 && spec.max != 0 && spec.min > spec.max {
-		return nil, fmt.Errorf("minimum nodes: %d can't be higher than maximum nodes: %d",
-			spec.min, spec.max)
-	}
-
-	return spec, nil
 }

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager_test.go
@@ -68,9 +68,7 @@ func TestDigitalOceanManager_Refresh(t *testing.T) {
 						{ID: "1", Status: &godo.KubernetesNodeStatus{State: "running"}},
 						{ID: "2", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "2",
@@ -78,9 +76,7 @@ func TestDigitalOceanManager_Refresh(t *testing.T) {
 						{ID: "3", Status: &godo.KubernetesNodeStatus{State: "deleting"}},
 						{ID: "4", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "3",
@@ -88,9 +84,7 @@ func TestDigitalOceanManager_Refresh(t *testing.T) {
 						{ID: "5", Status: &godo.KubernetesNodeStatus{State: "provisioning"}},
 						{ID: "6", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 				{
 					ID: "4",
@@ -98,9 +92,7 @@ func TestDigitalOceanManager_Refresh(t *testing.T) {
 						{ID: "7", Status: &godo.KubernetesNodeStatus{State: "draining"}},
 						{ID: "8", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-					},
+					AutoScale: true,
 				},
 			},
 			&godo.Response{},
@@ -133,11 +125,9 @@ func TestDigitalOceanManager_RefreshWithNodeSpec(t *testing.T) {
 						{ID: "1", Status: &godo.KubernetesNodeStatus{State: "running"}},
 						{ID: "2", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-						"k8s-cluster-autoscaler-min:3",
-						"k8s-cluster-autoscaler-max:10",
-					},
+					AutoScale: true,
+					MinNodes:  3,
+					MaxNodes:  10,
 				},
 				{
 					ID: "2",
@@ -145,23 +135,17 @@ func TestDigitalOceanManager_RefreshWithNodeSpec(t *testing.T) {
 						{ID: "3", Status: &godo.KubernetesNodeStatus{State: "running"}},
 						{ID: "4", Status: &godo.KubernetesNodeStatus{State: "running"}},
 					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
-						"k8s-cluster-autoscaler-min:5",
-						"k8s-cluster-autoscaler-max:20",
-					},
+					AutoScale: true,
+					MinNodes:  5,
+					MaxNodes:  20,
 				},
 				{
-					// this node pool doesn't have any min and max tags,
-					// therefore this should get assigned the default minimum
-					// and maximum defaults
+					// this node pool doesn't have autoscale config, therefore
+					// this should default to disabled auto-scale.
 					ID: "3",
 					Nodes: []*godo.KubernetesNode{
 						{ID: "5", Status: &godo.KubernetesNodeStatus{State: "running"}},
 						{ID: "6", Status: &godo.KubernetesNodeStatus{State: "running"}},
-					},
-					Tags: []string{
-						"k8s-cluster-autoscaler-enabled:true",
 					},
 				},
 			},
@@ -172,7 +156,7 @@ func TestDigitalOceanManager_RefreshWithNodeSpec(t *testing.T) {
 		manager.client = client
 		err = manager.Refresh()
 		assert.NoError(t, err)
-		assert.Equal(t, len(manager.nodeGroups), 3, "number of nodes do not match")
+		assert.Equal(t, len(manager.nodeGroups), 2, "number of node groups do not match")
 
 		// first node group
 		assert.Equal(t, manager.nodeGroups[0].minSize, 3, "minimum node for first group does not match")
@@ -181,136 +165,5 @@ func TestDigitalOceanManager_RefreshWithNodeSpec(t *testing.T) {
 		// second node group
 		assert.Equal(t, manager.nodeGroups[1].minSize, 5, "minimum node for second group does not match")
 		assert.Equal(t, manager.nodeGroups[1].maxSize, 20, "maximum node for second group does not match")
-
-		// third node group
-		assert.Equal(t, manager.nodeGroups[2].minSize, minNodePoolSize, "minimum node for third group should match the default")
-		assert.Equal(t, manager.nodeGroups[2].maxSize, maxNodePoolSize, "maximum node for third group should match the default")
 	})
-}
-
-func Test_parseTags(t *testing.T) {
-	cases := []struct {
-		name    string
-		tags    []string
-		want    *nodeSpec
-		wantErr bool
-	}{
-		{
-			name: "good config (single)",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:3",
-				"k8s-cluster-autoscaler-max:10",
-			},
-			want: &nodeSpec{
-				min:     3,
-				max:     10,
-				enabled: true,
-			},
-		},
-		{
-			name: "good config (disabled)",
-			tags: []string{
-				"k8s-cluster-autoscaler-min:3",
-				"k8s-cluster-autoscaler-max:10",
-			},
-			want: &nodeSpec{
-				min: 3,
-				max: 10,
-			},
-		},
-		{
-			name: "good config (disabled with no values)",
-			tags: []string{},
-			want: &nodeSpec{},
-		},
-		{
-			name: "good config - empty tags",
-			tags: []string{""},
-			want: &nodeSpec{},
-		},
-		{
-			name: "bad tags - malformed",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min=3",
-				"k8s-cluster-autoscaler-max=10",
-			},
-			wantErr: true,
-		},
-		{
-			name: "bad tags - no numerical min node size",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:three",
-				"k8s-cluster-autoscaler-max:10",
-			},
-			wantErr: true,
-		},
-		{
-			name: "bad tags - no numerical max node size",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:3",
-				"k8s-cluster-autoscaler-max:ten",
-			},
-			wantErr: true,
-		},
-		{
-			name: "bad tags - min is higher than max",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:5",
-				"k8s-cluster-autoscaler-max:4",
-			},
-			wantErr: true,
-		},
-		{
-			name: "bad tags - max is set to zero",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:5",
-				"k8s-cluster-autoscaler-max:0",
-			},
-			wantErr: true,
-		},
-		{
-			name: "bad tags - max is set to negative, no min",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-max:-5",
-			},
-			wantErr: true,
-		},
-		{
-			// TODO(arslan): remove this once we support zero count node pools on our end
-			name: "bad tags - min is set to zero",
-			tags: []string{
-				"k8s-cluster-autoscaler-enabled:true",
-				"k8s-cluster-autoscaler-min:0",
-				"k8s-cluster-autoscaler-max:5",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, ts := range cases {
-		ts := ts
-
-		t.Run(ts.name, func(t *testing.T) {
-			got, err := parseTags(ts.tags)
-			if ts.wantErr && err == nil {
-				assert.Error(t, err)
-				return
-			}
-
-			if ts.wantErr {
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, ts.want, got, "\ngot: %#v\nwant: %#v", got, ts.want)
-		})
-	}
-
 }

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -28,11 +28,6 @@ import (
 )
 
 const (
-	// These are internal DO values, not publicly available and configurable at
-	// this point.
-	minNodePoolSize = 1
-	maxNodePoolSize = 200
-
 	doksLabelNamespace = "doks.digitalocean.com"
 	nodeIDLabel        = doksLabelNamespace + "/node-id"
 )
@@ -90,7 +85,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	}
 
 	req := &godo.KubernetesNodePoolUpdateRequest{
-		Count: targetSize,
+		Count: &targetSize,
 	}
 
 	ctx := context.Background()
@@ -154,7 +149,7 @@ func (n *NodeGroup) DecreaseTargetSize(delta int) error {
 	}
 
 	req := &godo.KubernetesNodePoolUpdateRequest{
-		Count: targetSize,
+		Count: &targetSize,
 	}
 
 	ctx := context.Background()

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -57,15 +57,16 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 		delta := 2
 
+		newCount := numberOfNodes + delta
 		client.On("UpdateNodePool",
 			ctx,
 			ng.clusterID,
 			ng.id,
 			&godo.KubernetesNodePoolUpdateRequest{
-				Count: numberOfNodes + delta,
+				Count: &newCount,
 			},
 		).Return(
-			&godo.KubernetesNodePool{Count: numberOfNodes + delta},
+			&godo.KubernetesNodePool{Count: newCount},
 			&godo.Response{},
 			nil,
 		).Once()
@@ -130,15 +131,16 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 
 		delta := -2
 
+		newCount := numberOfNodes + delta
 		client.On("UpdateNodePool",
 			ctx,
 			ng.clusterID,
 			ng.id,
 			&godo.KubernetesNodePoolUpdateRequest{
-				Count: numberOfNodes + delta,
+				Count: &newCount,
 			},
 		).Return(
-			&godo.KubernetesNodePool{Count: numberOfNodes + delta},
+			&godo.KubernetesNodePool{Count: newCount},
 			&godo.Response{},
 			nil,
 		).Once()
@@ -358,8 +360,8 @@ func testNodeGroup(client nodeGroupClient, np *godo.KubernetesNodePool) *NodeGro
 		clusterID: "1",
 		client:    client,
 		nodePool:  np,
-		minSize:   minNodePoolSize,
-		maxSize:   maxNodePoolSize,
+		minSize:   1,
+		maxSize:   200,
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/CHANGELOG.md
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v1.20.0] - 2019-09-06
+
+- #252 Add Kubernetes autoscale config fields - @snormore
+- #251 Support unset fields on Kubernetes cluster and node pool updates - @snormore
+- #250 Add Kubernetes GetUser method - @snormore
+
+## [v1.19.0] - 2019-07-19
+
+- #244 dbaas: add private-network-uuid field to create request
+
 ## [v1.18.0] - 2019-07-17
 
 - #241 Databases: support for custom VPC UUID on migrate @mikejholly

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/README.md
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/README.md
@@ -1,6 +1,7 @@
-[![Build Status](https://travis-ci.org/digitalocean/godo.svg)](https://travis-ci.org/digitalocean/godo)
-
 # Godo
+
+[![Build Status](https://travis-ci.org/digitalocean/godo.svg)](https://travis-ci.org/digitalocean/godo)
+[![GoDoc](https://godoc.org/github.com/digitalocean/godo?status.svg)](https://godoc.org/github.com/digitalocean/godo)
 
 Godo is a Go client library for accessing the DigitalOcean V2 API.
 

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/databases.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/databases.go
@@ -123,12 +123,13 @@ type DatabaseBackup struct {
 
 // DatabaseCreateRequest represents a request to create a database cluster
 type DatabaseCreateRequest struct {
-	Name       string `json:"name,omitempty"`
-	EngineSlug string `json:"engine,omitempty"`
-	Version    string `json:"version,omitempty"`
-	SizeSlug   string `json:"size,omitempty"`
-	Region     string `json:"region,omitempty"`
-	NumNodes   int    `json:"num_nodes,omitempty"`
+	Name               string `json:"name,omitempty"`
+	EngineSlug         string `json:"engine,omitempty"`
+	Version            string `json:"version,omitempty"`
+	SizeSlug           string `json:"size,omitempty"`
+	Region             string `json:"region,omitempty"`
+	NumNodes           int    `json:"num_nodes,omitempty"`
+	PrivateNetworkUUID string `json:"private_network_uuid"`
 }
 
 // DatabaseResizeRequest can be used to initiate a database resize operation.

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/databases_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/databases_test.go
@@ -36,7 +36,7 @@ var db = Database{
 		SSL:      true,
 	},
 	Users: []DatabaseUser{
-		DatabaseUser{
+		{
 			Name:     "doadmin",
 			Role:     "primary",
 			Password: "zt91mum075ofzyww",
@@ -361,11 +361,11 @@ func TestDatabases_ListBackups(t *testing.T) {
 	defer teardown()
 
 	want := []DatabaseBackup{
-		DatabaseBackup{
+		{
 			CreatedAt:     time.Date(2019, 1, 11, 18, 42, 27, 0, time.UTC),
 			SizeGigabytes: 0.03357696,
 		},
-		DatabaseBackup{
+		{
 			CreatedAt:     time.Date(2019, 1, 12, 18, 42, 29, 0, time.UTC),
 			SizeGigabytes: 0.03364864,
 		},

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/firewalls_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/firewalls_test.go
@@ -799,7 +799,7 @@ func TestFirewalls_RemoveRules(t *testing.T) {
 
 func makeExpectedFirewalls() []Firewall {
 	return []Firewall{
-		Firewall{
+		{
 			ID:   "fe6b88f2-b42b-4bf7-bbd3-5ae20208f0b0",
 			Name: "f-i-r-e-w-a-l-l",
 			InboundRules: []InboundRule{

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/godo.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.18.0"
+	libraryVersion = "1.20.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/godo_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/godo_test.go
@@ -539,3 +539,11 @@ func TestCustomBaseURL_badURL(t *testing.T) {
 
 	testURLParseError(t, err)
 }
+
+func intPtr(val int) *int {
+	return &val
+}
+
+func boolPtr(val bool) *bool {
+	return &val
+}

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/kubernetes_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/kubernetes_test.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -316,6 +317,34 @@ func TestKubernetesClusters_Get(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestKubernetesClusters_GetUser(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+	want := &KubernetesClusterUser{
+		Username: "foo@example.com",
+		Groups: []string{
+			"foo:bar",
+		},
+	}
+	jBlob := `
+{
+	"kubernetes_cluster_user": {
+		"username": "foo@example.com",
+		"groups": ["foo:bar"]
+	}
+}`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/deadbeef-dead-4aa5-beef-deadbeef347d/user", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, jBlob)
+	})
+	got, _, err := kubeSvc.GetUser(ctx, "deadbeef-dead-4aa5-beef-deadbeef347d")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
 func TestKubernetesClusters_GetKubeConfig(t *testing.T) {
 	setup()
 	defer teardown()
@@ -408,10 +437,13 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		VPCUUID:     want.VPCUUID,
 		NodePools: []*KubernetesNodePoolCreateRequest{
 			&KubernetesNodePoolCreateRequest{
-				Size:  want.NodePools[0].Size,
-				Count: want.NodePools[0].Count,
-				Name:  want.NodePools[0].Name,
-				Tags:  want.NodePools[0].Tags,
+				Size:      want.NodePools[0].Size,
+				Count:     want.NodePools[0].Count,
+				Name:      want.NodePools[0].Name,
+				Tags:      want.NodePools[0].Tags,
+				AutoScale: want.NodePools[0].AutoScale,
+				MinNodes:  want.NodePools[0].MinNodes,
+				MaxNodes:  want.NodePools[0].MaxNodes,
 			},
 		},
 		MaintenancePolicy: want.MaintenancePolicy,
@@ -440,6 +472,110 @@ func TestKubernetesClusters_Create(t *testing.T) {
 				"tags": [
 					"tag-1"
 				]
+			}
+		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
+		}
+	}
+}`
+
+	mux.HandleFunc("/v2/kubernetes/clusters", func(w http.ResponseWriter, r *http.Request) {
+		v := new(KubernetesClusterCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, v, createRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.Create(ctx, createRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_Create_AutoScalePool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesCluster{
+		ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		Name:          "antoine-test-cluster",
+		RegionSlug:    "s2r1",
+		VersionSlug:   "1.10.0-gen0",
+		ClusterSubnet: "10.244.0.0/16",
+		ServiceSubnet: "10.245.0.0/16",
+		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
+		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
+		NodePools: []*KubernetesNodePool{
+			&KubernetesNodePool{
+				ID:        "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				Size:      "s-1vcpu-1gb",
+				Count:     2,
+				Name:      "pool-a",
+				Tags:      []string{"tag-1"},
+				AutoScale: true,
+				MinNodes:  0,
+				MaxNodes:  10,
+			},
+		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
+	}
+	createRequest := &KubernetesClusterCreateRequest{
+		Name:        want.Name,
+		RegionSlug:  want.RegionSlug,
+		VersionSlug: want.VersionSlug,
+		Tags:        want.Tags,
+		VPCUUID:     want.VPCUUID,
+		NodePools: []*KubernetesNodePoolCreateRequest{
+			&KubernetesNodePoolCreateRequest{
+				Size:      want.NodePools[0].Size,
+				Count:     want.NodePools[0].Count,
+				Name:      want.NodePools[0].Name,
+				Tags:      want.NodePools[0].Tags,
+				AutoScale: want.NodePools[0].AutoScale,
+				MinNodes:  want.NodePools[0].MinNodes,
+				MaxNodes:  want.NodePools[0].MaxNodes,
+			},
+		},
+		MaintenancePolicy: want.MaintenancePolicy,
+	}
+
+	jBlob := `
+{
+	"kubernetes_cluster": {
+		"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		"name": "antoine-test-cluster",
+		"region": "s2r1",
+		"version": "1.10.0-gen0",
+		"cluster_subnet": "10.244.0.0/16",
+		"service_subnet": "10.245.0.0/16",
+		"tags": [
+			"cluster-tag-1",
+			"cluster-tag-2"
+		],
+		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
+		"node_pools": [
+			{
+				"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				"size": "s-1vcpu-1gb",
+				"count": 2,
+				"name": "pool-a",
+				"tags": [
+					"tag-1"
+				],
+				"auto_scale": true,
+				"min_nodes": 0,
+				"max_nodes": 10
 			}
 		],
 		"maintenance_policy": {
@@ -533,12 +669,104 @@ func TestKubernetesClusters_Update(t *testing.T) {
 	}
 }`
 
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"}}
+`
+
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
 		v := new(KubernetesClusterUpdateRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatal(err)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
+
+		testMethod(t, r, http.MethodPut)
+		require.Equal(t, v, updateRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.Update(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_Update_FalseAutoUpgrade(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesCluster{
+		ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		Name:          "antoine-test-cluster",
+		RegionSlug:    "s2r1",
+		VersionSlug:   "1.10.0-gen0",
+		ClusterSubnet: "10.244.0.0/16",
+		ServiceSubnet: "10.245.0.0/16",
+		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
+		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
+		NodePools: []*KubernetesNodePool{
+			&KubernetesNodePool{
+				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				Size:  "s-1vcpu-1gb",
+				Count: 2,
+				Name:  "pool-a",
+				Tags:  []string{"tag-1"},
+			},
+		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
+	}
+	updateRequest := &KubernetesClusterUpdateRequest{
+		AutoUpgrade: boolPtr(false),
+	}
+
+	jBlob := `
+{
+	"kubernetes_cluster": {
+		"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		"name": "antoine-test-cluster",
+		"region": "s2r1",
+		"version": "1.10.0-gen0",
+		"cluster_subnet": "10.244.0.0/16",
+		"service_subnet": "10.245.0.0/16",
+		"tags": [
+			"cluster-tag-1",
+			"cluster-tag-2"
+		],
+		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
+		"node_pools": [
+			{
+				"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				"size": "s-1vcpu-1gb",
+				"count": 2,
+				"name": "pool-a",
+				"tags": [
+					"tag-1"
+				]
+			}
+		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
 		}
+	}
+}`
+
+	expectedReqJSON := `{"auto_upgrade":false}
+`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
+		v := new(KubernetesClusterUpdateRequest)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
 
 		testMethod(t, r, http.MethodPut)
 		require.Equal(t, v, updateRequest)
@@ -596,11 +824,14 @@ func TestKubernetesClusters_CreateNodePool(t *testing.T) {
 	kubeSvc := client.Kubernetes
 
 	want := &KubernetesNodePool{
-		ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
-		Size:  "s-1vcpu-1gb",
-		Count: 2,
-		Name:  "pool-a",
-		Tags:  []string{"tag-1"},
+		ID:        "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		Size:      "s-1vcpu-1gb",
+		Count:     2,
+		Name:      "pool-a",
+		Tags:      []string{"tag-1"},
+		AutoScale: false,
+		MinNodes:  0,
+		MaxNodes:  0,
 	}
 	createRequest := &KubernetesNodePoolCreateRequest{
 		Size:  want.Size,
@@ -619,6 +850,65 @@ func TestKubernetesClusters_CreateNodePool(t *testing.T) {
 		"tags": [
 			"tag-1"
 		]
+	}
+}`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f/node_pools", func(w http.ResponseWriter, r *http.Request) {
+		v := new(KubernetesNodePoolCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, v, createRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.CreateNodePool(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", createRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_CreateNodePool_AutoScale(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesNodePool{
+		ID:        "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		Size:      "s-1vcpu-1gb",
+		Count:     2,
+		Name:      "pool-a",
+		Tags:      []string{"tag-1"},
+		AutoScale: true,
+		MinNodes:  0,
+		MaxNodes:  10,
+	}
+	createRequest := &KubernetesNodePoolCreateRequest{
+		Size:      want.Size,
+		Count:     want.Count,
+		Name:      want.Name,
+		Tags:      want.Tags,
+		AutoScale: want.AutoScale,
+		MinNodes:  want.MinNodes,
+		MaxNodes:  want.MaxNodes,
+	}
+
+	jBlob := `
+{
+	"node_pool": {
+		"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		"size": "s-1vcpu-1gb",
+		"count": 2,
+		"name": "pool-a",
+		"tags": [
+			"tag-1"
+		],
+		"auto_scale": true,
+		"min_nodes": 0,
+		"max_nodes": 10
 	}
 }`
 
@@ -757,15 +1047,18 @@ func TestKubernetesClusters_UpdateNodePool(t *testing.T) {
 	kubeSvc := client.Kubernetes
 
 	want := &KubernetesNodePool{
-		ID:    "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
-		Name:  "a better name",
-		Size:  "s-1vcpu-1gb",
-		Count: 4,
-		Tags:  []string{"tag-1", "tag-2"},
+		ID:        "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
+		Name:      "a better name",
+		Size:      "s-1vcpu-1gb",
+		Count:     4,
+		Tags:      []string{"tag-1", "tag-2"},
+		AutoScale: false,
+		MinNodes:  0,
+		MaxNodes:  0,
 	}
 	updateRequest := &KubernetesNodePoolUpdateRequest{
 		Name:  "a better name",
-		Count: 4,
+		Count: intPtr(4),
 		Tags:  []string{"tag-1", "tag-2"},
 	}
 
@@ -788,6 +1081,121 @@ func TestKubernetesClusters_UpdateNodePool(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		testMethod(t, r, http.MethodPut)
+		require.Equal(t, v, updateRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.UpdateNodePool(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a", updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_UpdateNodePool_ZeroCount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesNodePool{
+		ID:        "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
+		Name:      "name",
+		Size:      "s-1vcpu-1gb",
+		Count:     0,
+		Tags:      []string{"tag-1", "tag-2"},
+		AutoScale: false,
+		MinNodes:  0,
+		MaxNodes:  0,
+	}
+	updateRequest := &KubernetesNodePoolUpdateRequest{
+		Count: intPtr(0),
+	}
+
+	jBlob := `
+{
+	"node_pool": {
+		"id": "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
+		"size": "s-1vcpu-1gb",
+		"count": 0,
+		"name": "name",
+		"tags": [
+			"tag-1", "tag-2"
+		]
+	}
+}`
+
+	expectedReqJSON := `{"count":0}
+`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f/node_pools/8d91899c-nodepool-4a1a-acc5-deadbeefbb8a", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
+		v := new(KubernetesNodePoolUpdateRequest)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
+
+		testMethod(t, r, http.MethodPut)
+		require.Equal(t, v, updateRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.UpdateNodePool(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a", updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_UpdateNodePool_AutoScale(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesNodePool{
+		ID:        "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
+		Name:      "name",
+		Size:      "s-1vcpu-1gb",
+		Count:     4,
+		Tags:      []string{"tag-1", "tag-2"},
+		AutoScale: true,
+		MinNodes:  0,
+		MaxNodes:  10,
+	}
+	updateRequest := &KubernetesNodePoolUpdateRequest{
+		AutoScale: boolPtr(true),
+		MinNodes:  intPtr(0),
+		MaxNodes:  intPtr(10),
+	}
+
+	jBlob := `
+{
+	"node_pool": {
+		"id": "8d91899c-nodepool-4a1a-acc5-deadbeefbb8a",
+		"size": "s-1vcpu-1gb",
+		"count": 4,
+		"name": "name",
+		"tags": [
+			"tag-1", "tag-2"
+		],
+		"auto_scale": true,
+		"min_nodes": 0,
+		"max_nodes": 10
+	}
+}`
+
+	expectedReqJSON := `{"auto_scale":true,"min_nodes":0,"max_nodes":10}
+`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f/node_pools/8d91899c-nodepool-4a1a-acc5-deadbeefbb8a", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
+		v := new(KubernetesNodePoolUpdateRequest)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
 
 		testMethod(t, r, http.MethodPut)
 		require.Equal(t, v, updateRequest)

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/kubernetes_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/kubernetes_test.go
@@ -18,7 +18,7 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 	kubeSvc := client.Kubernetes
 
 	want := []*KubernetesCluster{
-		&KubernetesCluster{
+		{
 			ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
 			Name:          "blablabla",
 			RegionSlug:    "nyc1",
@@ -58,7 +58,7 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 			CreatedAt: time.Date(2018, 6, 21, 8, 44, 38, 0, time.UTC),
 			UpdatedAt: time.Date(2018, 6, 21, 8, 44, 38, 0, time.UTC),
 		},
-		&KubernetesCluster{
+		{
 			ID:            "deadbeef-dead-4aa5-beef-deadbeef347d",
 			Name:          "antoine",
 			RegionSlug:    "nyc1",
@@ -416,7 +416,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		NodePools: []*KubernetesNodePool{
-			&KubernetesNodePool{
+			{
 				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
 				Size:  "s-1vcpu-1gb",
 				Count: 2,
@@ -436,7 +436,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		Tags:        want.Tags,
 		VPCUUID:     want.VPCUUID,
 		NodePools: []*KubernetesNodePoolCreateRequest{
-			&KubernetesNodePoolCreateRequest{
+			{
 				Size:      want.NodePools[0].Size,
 				Count:     want.NodePools[0].Count,
 				Name:      want.NodePools[0].Name,
@@ -514,7 +514,7 @@ func TestKubernetesClusters_Create_AutoScalePool(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		NodePools: []*KubernetesNodePool{
-			&KubernetesNodePool{
+			{
 				ID:        "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
 				Size:      "s-1vcpu-1gb",
 				Count:     2,
@@ -537,7 +537,7 @@ func TestKubernetesClusters_Create_AutoScalePool(t *testing.T) {
 		Tags:        want.Tags,
 		VPCUUID:     want.VPCUUID,
 		NodePools: []*KubernetesNodePoolCreateRequest{
-			&KubernetesNodePoolCreateRequest{
+			{
 				Size:      want.NodePools[0].Size,
 				Count:     want.NodePools[0].Count,
 				Name:      want.NodePools[0].Name,
@@ -618,7 +618,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		NodePools: []*KubernetesNodePool{
-			&KubernetesNodePool{
+			{
 				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
 				Size:  "s-1vcpu-1gb",
 				Count: 2,
@@ -707,7 +707,7 @@ func TestKubernetesClusters_Update_FalseAutoUpgrade(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		NodePools: []*KubernetesNodePool{
-			&KubernetesNodePool{
+			{
 				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
 				Size:  "s-1vcpu-1gb",
 				Count: 2,

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/load_balancers_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/load_balancers_test.go
@@ -844,7 +844,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 		Name:      "test-loadbalancer",
 		Algorithm: "least_connections",
 		Region:    "lon1",
-		ForwardingRules: []ForwardingRule{ForwardingRule{
+		ForwardingRules: []ForwardingRule{{
 			EntryProtocol:  "http",
 			EntryPort:      80,
 			TargetProtocol: "http",
@@ -894,13 +894,13 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 	})
 	assert.Equal(t, []int{12345, 54321}, r.DropletIDs)
 	assert.Equal(t, []ForwardingRule{
-		ForwardingRule{
+		{
 			EntryProtocol:  "http",
 			EntryPort:      80,
 			TargetProtocol: "http",
 			TargetPort:     80,
 		},
-		ForwardingRule{
+		{
 			EntryProtocol:  "https",
 			EntryPort:      443,
 			TargetProtocol: "https",

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+const (
+	// activeFailure is the amount of times we can fail before deciding
+	// the check for active is a total failure. This can help account
+	// for servers randomly not answering.
+	activeFailure = 3
+)
+
+// WaitForActive waits for a droplet to become active
+func WaitForActive(ctx context.Context, client *godo.Client, monitorURI string) error {
+	if len(monitorURI) == 0 {
+		return fmt.Errorf("create had no monitor uri")
+	}
+
+	completed := false
+	failCount := 0
+	for !completed {
+		action, _, err := client.DropletActions.GetByURI(ctx, monitorURI)
+
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return err
+			default:
+			}
+			if failCount <= activeFailure {
+				failCount++
+				continue
+			}
+			return err
+		}
+
+		switch action.Status {
+		case godo.ActionInProgress:
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return err
+			}
+		case godo.ActionCompleted:
+			completed = true
+		default:
+			return fmt.Errorf("unknown status: [%s]", action.Status)
+		}
+	}
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/digitalocean/godo"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean/godo"
 )
 
 const (

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+
+	"github.com/digitalocean/godo"
+)
+
+func ExampleWaitForActive() {
+	// build client
+	pat := "mytoken"
+	token := &oauth2.Token{AccessToken: pat}
+	t := oauth2.StaticTokenSource(token)
+
+	ctx := context.TODO()
+	oauthClient := oauth2.NewClient(ctx, t)
+	client := godo.NewClient(oauthClient)
+
+	// create your droplet and retrieve the create action uri
+	uri := "https://api.digitalocean.com/v2/actions/xxxxxxxx"
+
+	// block until until the action is complete
+	err := WaitForActive(ctx, client, uri)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/godo/util/droplet_test.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/digitalocean/godo"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean/godo"
 )
 
 func ExampleWaitForActive() {


### PR DESCRIPTION
Previously this was implemented to use tags to maintain the autoscale config/state (enabled, min, max). This PR switches it to use the proper DO API for managing this config.