### PR TITLE
Add rate limiter to the Vertical Pod autoscaler updater component

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -17,8 +17,11 @@ limitations under the License.
 package logic
 
 import (
+	"context"
 	"fmt"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -44,7 +47,7 @@ import (
 // Updater performs updates on pods if recommended by Vertical Pod Autoscaler
 type Updater interface {
 	// RunOnce represents single iteration in the main-loop of Updater
-	RunOnce()
+	RunOnce(context.Context)
 }
 
 type updater struct {
@@ -54,11 +57,13 @@ type updater struct {
 	evictionFactory         eviction.PodsEvictionRestrictionFactory
 	recommendationProcessor vpa_api_util.RecommendationProcessor
 	evictionAdmission       priority.PodEvictionAdmission
+	evictionRateLimiter     *rate.Limiter
 	selectorFetcher         target.VpaTargetSelectorFetcher
 }
 
 // NewUpdater creates Updater with given configuration
-func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvictionAdmission, selectorFetcher target.VpaTargetSelectorFetcher) (Updater, error) {
+func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionRateLimit float64, evictionRateBurst int, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvictionAdmission, selectorFetcher target.VpaTargetSelectorFetcher) (Updater, error) {
+	evictionRateLimiter := getRateLimiter(evictionRateLimit, evictionRateBurst)
 	factory, err := eviction.NewPodsEvictionRestrictionFactory(kubeClient, minReplicasForEvicition, evictionToleranceFraction)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create eviction restriction factory: %v", err)
@@ -69,13 +74,14 @@ func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clien
 		eventRecorder:           newEventRecorder(kubeClient),
 		evictionFactory:         factory,
 		recommendationProcessor: recommendationProcessor,
+		evictionRateLimiter:     evictionRateLimiter,
 		evictionAdmission:       evictionAdmission,
 		selectorFetcher:         selectorFetcher,
 	}, nil
 }
 
 // RunOnce represents single iteration in the main-loop of Updater
-func (u *updater) RunOnce() {
+func (u *updater) RunOnce(ctx context.Context) {
 	timer := metrics_updater.NewExecutionTimer()
 
 	vpaList, err := u.vpaLister.List(labels.Everything())
@@ -144,6 +150,11 @@ func (u *updater) RunOnce() {
 			if !evictionLimiter.CanEvict(pod) {
 				continue
 			}
+			err := u.evictionRateLimiter.Wait(ctx)
+			if err != nil {
+				klog.Warningf("evicting pod %v failed: %v", pod.Name, err)
+				return
+			}
 			klog.V(2).Infof("evicting pod %v", pod.Name)
 			evictErr := evictionLimiter.Evict(pod, u.eventRecorder)
 			if evictErr != nil {
@@ -153,6 +164,19 @@ func (u *updater) RunOnce() {
 	}
 	timer.ObserveStep("EvictPods")
 	timer.ObserveTotal()
+}
+
+func getRateLimiter(evictionRateLimit float64, evictionRateLimitBurst int) *rate.Limiter {
+	var evictionRateLimiter *rate.Limiter
+	if evictionRateLimit <= 0 {
+		// As a special case if the rate is set to rate.Inf, the burst rate is ignored
+		// see https://github.com/golang/time/blob/master/rate/rate.go#L37
+		evictionRateLimiter = rate.NewLimiter(rate.Inf, 0)
+		klog.V(1).Info("Rate limit disabled")
+	} else {
+		evictionRateLimiter = rate.NewLimiter(rate.Limit(evictionRateLimit), evictionRateLimitBurst)
+	}
+	return evictionRateLimiter
 }
 
 // getPodsUpdateOrder returns list of pods that should be updated ordered by update priority

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"time"
 
@@ -44,6 +45,12 @@ var (
 
 	evictionToleranceFraction = flag.Float64("eviction-tolerance", 0.5,
 		`Fraction of replica count that can be evicted for update, if more than one pod can be evicted.`)
+
+	evictionRateLimit = flag.Float64("eviction-rate-limit", -1,
+		`Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable
+		the rate limiter.`)
+
+	evictionRateBurst = flag.Int("eviction-rate-burst", 1, `Burst of pods that can be evicted.`)
 
 	address = flag.String("address", ":8943", "The address to expose Prometheus metrics.")
 )
@@ -76,13 +83,15 @@ func main() {
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
 	// TODO: use SharedInformerFactory in updater
-	updater, err := updater.NewUpdater(kubeClient, vpaClient, *minReplicas, *evictionToleranceFraction, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator), nil, targetSelectorFetcher)
+	updater, err := updater.NewUpdater(kubeClient, vpaClient, *minReplicas, *evictionRateLimit, *evictionRateBurst, *evictionToleranceFraction, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator), nil, targetSelectorFetcher)
 	if err != nil {
 		klog.Fatalf("Failed to create updater: %v", err)
 	}
 	ticker := time.Tick(*updaterInterval)
 	for range ticker {
-		updater.RunOnce()
+		ctx, cancel := context.WithTimeout(context.Background(), *updaterInterval)
+		defer cancel()
+		updater.RunOnce(ctx)
 		healthCheck.UpdateLastActivity()
 	}
 }


### PR DESCRIPTION
This patch adds a rate limiter to the vertical pod autoscaler updater.
It adds two flags
- eviction-rate-limit to control the number of pods that can be evicted
every seconds.
- eviction-rate-limit-burst to control the burst of that can be evicted
immediately.

fixes #2178