### PR TITLE
feat: add NV6Promo instance type to CA

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_instance_types.go
@@ -529,6 +529,12 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     57344,
 		GPU:          1,
 	},
+	"Standard_NV6_Promo": {
+		InstanceType: "Standard_NV6_Promo",
+		VCPU:         6,
+		MemoryMb:     57344,
+		GPU:          1,
+	},
 	"Standard_D15_v2": {
 		InstanceType: "Standard_D15_v2",
 		VCPU:         20,


### PR DESCRIPTION
PR adds an instance type to the `azure_instance_type.go` map to potentially solve #2327 