### PR TITLE
rename clusterrole system:admission-controller to system:vpa-admission-controller

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -225,7 +225,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:admission-controller
+  name: system:vpa-admission-controller
 rules:
   - apiGroups:
       - ""
@@ -267,11 +267,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:admission-controller
+  name: system:vpa-admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:admission-controller
+  name: system:vpa-admission-controller
 subjects:
   - kind: ServiceAccount
     name: vpa-admission-controller

--- a/vertical-pod-autoscaler/hack/vpa-down.sh
+++ b/vertical-pod-autoscaler/hack/vpa-down.sh
@@ -21,3 +21,5 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
 $SCRIPT_ROOT/hack/vpa-process-yamls.sh delete $*
+
+$SCRIPT_ROOT/hack/warn-obsolete-vpa-objects.sh

--- a/vertical-pod-autoscaler/hack/warn-obsolete-vpa-objects.sh
+++ b/vertical-pod-autoscaler/hack/warn-obsolete-vpa-objects.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function check_obsolete_cluster_role()
+{
+    kubectl get clusterrole system:admission-controller &> /dev/null
+    OBSOLETE_CLUSTERROLE_EXISTS=$?
+    if [[ $ret -eq 0 ]]; then
+        kubectl get clusterrole system:admission-controller -o yaml 2>&1 | grep verticalpodautoscalers &> /dev/null
+        OBSOLETE_CLUSTERROLE_EXISTS=$?
+    fi
+
+    kubectl get clusterrolebinding system:admission-controller &> /dev/null
+    OBSOLETE_CLUSTERROLE_BINDING_EXISTS=$?
+}
+
+check_obsolete_cluster_role
+
+if [[ ${OBSOLETE_CLUSTERROLE_EXISTS} -eq 0 ]]; then
+    echo
+    echo "Older version of vpa-up.sh creates a ClusterRole object named system:admission-controller"
+    echo "that is now renamed to system:vpa-admission-controller to avoid confusion.  A ClusterRole"
+    echo "object of the same name still exists in the cluster and it appears to be created by vpa-up.sh."
+    echo "Please inspect the object and delete manually if it is created by vpa-up.sh"
+    echo
+    echo "You can inspect the object content by running"
+    echo
+    echo "kubectl get clusterrole system:admission-controller -o yaml"
+    echo
+fi
+
+if [[ ${OBSOLETE_CLUSTERROLE_BINDING_EXISTS} -eq 0 ]]; then
+    echo
+    echo "Older version of vpa-up.sh creates a ClusterRoleBinding object named system:admission-controller"
+    echo "that is now renamed to system:vpa-admission-controller to avoid confusion.  A ClusterRoleBinding"
+    echo "object of the same name still exists in the cluster."
+    echo "Please inspect the object and delete manually if it is created by vpa-up.sh"
+    echo
+    echo "You can inspect the object content by running"
+    echo
+    echo "kubectl get clusterrolebinding system:admission-controller -o yaml"
+    echo
+fi


### PR DESCRIPTION

As discussed in #2334, this PR rename the ambiguous clusterrole (also the clusterrolebinding's name).