### PR TITLE
Explicitly set SideEffects=None for mutating webhook

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -74,6 +74,7 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace 
 	} else {
 		RegisterClientConfig.URL = &url
 	}
+	sideEffects := v1beta1.SideEffectClassNone
 	RegisterClientConfig.CABundle = caCert
 	webhookConfig := &v1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -101,6 +102,7 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace 
 					},
 				},
 				ClientConfig: RegisterClientConfig,
+				SideEffects:  &sideEffects,
 			},
 		},
 	}


### PR DESCRIPTION
This closes #2278.

I believe that there are no SideEffects of the `vpa.k8s.io` controller, so I am setting that explicitly, instead of taking the default of `None`.