### PR TITLE
Don't treat lack of queried Kubernetes node in AWS cloud provider cache as error

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -108,7 +108,7 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	asg := aws.awsManager.GetAsgForInstance(*ref)
 
 	if asg == nil {
-		return nil, fmt.Errorf("cannot find ASG for node %v", ref.Name)
+		return nil, nil
 	}
 
 	return &AwsNodeGroup{


### PR DESCRIPTION
Revert "Return error if aws fail to find nodegroup for node" (from #2247)
This reverts commit f65e47a4c4b207625f67cc20ad56971d876a2e71.

The cluster autoscaler periodically looks for associations between Kubernetes node objects and cloud provider-known records for instances in node groups managed by the autoscaler. When the autoscaler considers a Kubernetes node that is not a member of any of these managed node groups, the cloud provider has no such record in its cache. When some callers assumed that these queries would yield either a node or an error, an earlier fix reported this lack of a cached record as an error. However, callers responding to such an error caused the autoscaler to forgo most of its usual pod maintenance responsibilities.

At this point, these callers now expect that the query can fail, can yield a record, or can succeed but without yielding any record. It's that last case that arises when querying a Kubernetes node that's not meant to be managed by the autoscaler. Restoring this three-outcome behavior to the `(*awsCloudProvider).NodeGroupForNode` function allows the autoscaler to ignore such unmanaged nodes and carry on with the rest of its intended behavior.

Fixes #2345.