### PR TITLE
Increase default GCE operation wait timeout to 20s

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultOperationWaitTimeout  = 5 * time.Second
+	defaultOperationWaitTimeout  = 20 * time.Second
 	defaultOperationPollInterval = 100 * time.Millisecond
 )
 


### PR DESCRIPTION
Increase default GCE operation wait timeout to 20s.