### PR TITLE
ensure valid AWS LaunchTemplate version

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	sdkaws "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
 func TestBuildAsg(t *testing.T) {
@@ -45,4 +48,65 @@ func validateAsg(t *testing.T, asg *asg, name string, minSize int, maxSize int) 
 	assert.Equal(t, name, asg.Name)
 	assert.Equal(t, minSize, asg.minSize)
 	assert.Equal(t, maxSize, asg.maxSize)
+}
+
+func TestBuildLaunchTemplateFromSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	units := []struct {
+		name string
+		in   *autoscaling.LaunchTemplateSpecification
+		exp  *launchTemplate
+	}{
+		{
+			name: "non-default, specified version",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("1"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "1",
+			},
+		},
+		{
+			name: "non-default, specified $Latest",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("$Latest"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Latest",
+			},
+		},
+		{
+			name: "specified $Default",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("$Default"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Default",
+			},
+		},
+		{
+			name: "no version specified",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            nil,
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Default",
+			},
+		},
+	}
+
+	cache := &asgCache{}
+	for _, unit := range units {
+		got := cache.buildLaunchTemplateFromSpec(unit.in)
+		assert.Equal(unit.exp, got)
+	}
 }


### PR DESCRIPTION
The LaunchTemplateSpecification.Version is a pointer to
string. When the pointer is nil, EC2 AutoScaling API considers the value
to be "$Default", however aws.StringValue(ltSpec.Version) will return an
empty string (which is not considered the same as "$Default" or a nil
string pointer. So, in order to not pass an empty string as the version
for the launch template when we communicate with the EC2 AutoScaling API
using the information in the launchTemplate, we store the string
"$Default" when the ltSpec.Version is a nil pointer.

Fixes #1728