### PR TITLE
backport of PR #2207 to 1.15

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -97,6 +97,8 @@ func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 		apiv1.LabelZoneFailureDomain:          true,
 		apiv1.LabelZoneRegion:                 true,
 		"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+		"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
+		"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
 	}
 
 	labels := make(map[string][]string)


### PR DESCRIPTION
add kops/eksctl instance group label to ignore list for similar node group identification.

Signed-off-by: Joe Hohertz <joe@viafoura.com>