### PR TITLE
Bump go to 1.12.10 to mitigate security issues

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.11.2
+FROM golang:1.12.10
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/


### PR DESCRIPTION
More context:
https://groups.google.com/forum/m/#!topic/kubernetes-security-announce/wlHLHit1BqA