### PR TITLE
doks: fix max size check, support increase to max

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -79,7 +79,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 
 	targetSize := n.nodePool.Count + delta
 
-	if targetSize >= n.MaxSize() {
+	if targetSize > n.MaxSize() {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
 			n.nodePool.Count, targetSize, n.MaxSize())
 	}


### PR DESCRIPTION
Fixes `size increase is too large` issue when `targetSize == n.MaxSize()`, where we were incorrectly checking for `targetSize >= n.MaxSize()` instead of `targetSize > n.MaxSize()`.

@timoreimann @andrewsykim 