### PR TITLE
Simplify building equivalence groups in scale up

### DIFF
--- a/cluster-autoscaler/core/equivalence_groups.go
+++ b/cluster-autoscaler/core/equivalence_groups.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"reflect"
+
+	apiv1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+)
+
+type podEquivalenceGroup struct {
+	pods             []*apiv1.Pod
+	schedulingErrors map[string]status.Reasons
+	schedulable      bool
+}
+
+// buildPodEquivalenceGroups prepares pod groups with equivalent scheduling properties.
+func buildPodEquivalenceGroups(pods []*apiv1.Pod) []*podEquivalenceGroup {
+	podEquivalenceGroups := []*podEquivalenceGroup{}
+	for _, pods := range groupPodsBySchedulingProperties(pods) {
+		podEquivalenceGroups = append(podEquivalenceGroups, &podEquivalenceGroup{
+			pods:             pods,
+			schedulingErrors: map[string]status.Reasons{},
+			schedulable:      false,
+		})
+	}
+	return podEquivalenceGroups
+}
+
+type equivalenceGroupId int
+type equivalenceGroup struct {
+	id           equivalenceGroupId
+	representant *apiv1.Pod
+}
+
+// groupPodsBySchedulingProperties groups pods based on scheduling properties. Group ID is meaningless.
+func groupPodsBySchedulingProperties(pods []*apiv1.Pod) map[equivalenceGroupId][]*apiv1.Pod {
+	podEquivalenceGroups := map[equivalenceGroupId][]*apiv1.Pod{}
+	equivalenceGroupsByController := make(map[types.UID][]equivalenceGroup)
+
+	var nextGroupId equivalenceGroupId
+	for _, pod := range pods {
+		controllerRef := drain.ControllerRef(pod)
+		if controllerRef == nil {
+			podEquivalenceGroups[nextGroupId] = []*apiv1.Pod{pod}
+			nextGroupId++
+			continue
+		}
+
+		matchingFound := false
+		for _, g := range equivalenceGroupsByController[controllerRef.UID] {
+			if reflect.DeepEqual(pod.Labels, g.representant.Labels) && apiequality.Semantic.DeepEqual(pod.Spec, g.representant.Spec) {
+				matchingFound = true
+				podEquivalenceGroups[g.id] = append(podEquivalenceGroups[g.id], pod)
+				break
+			}
+		}
+
+		if !matchingFound {
+			newGroup := equivalenceGroup{
+				id:           nextGroupId,
+				representant: pod,
+			}
+			equivalenceGroupsByController[controllerRef.UID] = append(equivalenceGroupsByController[controllerRef.UID], newGroup)
+			podEquivalenceGroups[newGroup.id] = append(podEquivalenceGroups[newGroup.id], pod)
+			nextGroupId++
+		}
+	}
+
+	return podEquivalenceGroups
+}

--- a/cluster-autoscaler/core/equivalence_groups_test.go
+++ b/cluster-autoscaler/core/equivalence_groups_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api/testapi"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupSchedulablePodsForNode(t *testing.T) {
+	rc1 := apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc1",
+			Namespace: "default",
+			SelfLink:  testapi.Default.SelfLink("replicationcontrollers", "rc"),
+			UID:       "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	rc2 := apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc2",
+			Namespace: "default",
+			SelfLink:  testapi.Default.SelfLink("replicationcontrollers", "rc"),
+			UID:       "12345678-1234-1234-1234-12345678901a",
+		},
+	}
+
+	p1 := BuildTestPod("p1", 1500, 200000)
+	p2_1 := BuildTestPod("p2_1", 3000, 200000)
+	p2_1.OwnerReferences = GenerateOwnerReferences(rc1.Name, "ReplicationController", "extensions/v1beta1", rc1.UID)
+	p2_2 := BuildTestPod("p2_2", 3000, 200000)
+	p2_2.OwnerReferences = GenerateOwnerReferences(rc1.Name, "ReplicationController", "extensions/v1beta1", rc1.UID)
+	p3_1 := BuildTestPod("p3_1", 100, 200000)
+	p3_1.OwnerReferences = GenerateOwnerReferences(rc2.Name, "ReplicationController", "extensions/v1beta1", rc2.UID)
+	p3_2 := BuildTestPod("p3_2", 100, 200000)
+	p3_2.OwnerReferences = GenerateOwnerReferences(rc2.Name, "ReplicationController", "extensions/v1beta1", rc2.UID)
+	unschedulablePods := []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2}
+
+	podGroups := groupPodsBySchedulingProperties(unschedulablePods)
+	assert.Equal(t, 3, len(podGroups))
+
+	wantedGroups := []struct {
+		pods  []*apiv1.Pod
+		found bool
+	}{
+		{pods: []*apiv1.Pod{p1}},
+		{pods: []*apiv1.Pod{p2_1, p2_2}},
+		{pods: []*apiv1.Pod{p3_1, p3_2}},
+	}
+
+	equal := func(a, b []*apiv1.Pod) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		ma := map[*apiv1.Pod]bool{}
+		for _, ea := range a {
+			ma[ea] = true
+		}
+		for _, eb := range b {
+			if !ma[eb] {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, g := range podGroups {
+		found := false
+		for i, wanted := range wantedGroups {
+			if equal(g, wanted.pods) {
+				wanted.found = true
+				wantedGroups[i] = wanted
+				found = true
+			}
+		}
+		assert.True(t, found, fmt.Errorf("Unexpected pod group: %+v", g))
+	}
+
+	for _, w := range wantedGroups {
+		assert.True(t, w.found, fmt.Errorf("Expected pod group: %+v", w))
+	}
+}

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -612,11 +612,7 @@ func simpleScaleUpTest(t *testing.T, config *scaleTestConfig, expectedResults *s
 		assert.Contains(t, expectedResults.expansionOptions, config.expansionOptionToChoose, "final expected expansion option must be in expected expansion options")
 		assert.Contains(t, results.expansionOptions, config.expansionOptionToChoose, "final expected expansion option must be in expected expansion options")
 
-		assert.Subset(t, results.expansionOptions, expectedResults.expansionOptions,
-			"actual and expected expansion options should be the same")
-		assert.Subset(t, expectedResults.expansionOptions, results.expansionOptions,
-			"actual and expected expansion options should be the same")
-		assert.Equal(t, len(expectedResults.expansionOptions), len(results.expansionOptions),
+		assert.ElementsMatch(t, results.expansionOptions, expectedResults.expansionOptions,
 			"actual and expected expansion options should be the same")
 	}
 

--- a/cluster-autoscaler/core/utils/pod_schedulable.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable.go
@@ -17,6 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
+
 	apiv1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,7 +27,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/glogx"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
-	"reflect"
 
 	"k8s.io/klog"
 )
@@ -107,12 +108,12 @@ func NewPodsSchedulableOnNodeChecker(context *context.AutoscalingContext, pods [
 
 	// compute the podsEquivalenceGroups
 	var nextGroupId equivalenceGroupId
-	type equivalanceGroup struct {
+	type equivalenceGroup struct {
 		id           equivalenceGroupId
 		representant *apiv1.Pod
 	}
 
-	equivalenceGroupsByController := make(map[types.UID][]equivalanceGroup)
+	equivalenceGroupsByController := make(map[types.UID][]equivalenceGroup)
 
 	for _, pod := range pods {
 		controllerRef := drain.ControllerRef(pod)
@@ -132,7 +133,7 @@ func NewPodsSchedulableOnNodeChecker(context *context.AutoscalingContext, pods [
 		}
 
 		if !matchingFound {
-			newGroup := equivalanceGroup{
+			newGroup := equivalenceGroup{
 				id:           nextGroupId,
 				representant: pod,
 			}

--- a/cluster-autoscaler/core/utils/pod_schedulable_test.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable_test.go
@@ -19,17 +19,14 @@ package utils
 import (
 	"testing"
 
-	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 
 	"github.com/stretchr/testify/assert"
-	"time"
 )
 
 func TestPodSchedulableMap(t *testing.T) {
@@ -107,61 +104,4 @@ func TestPodSchedulableMap(t *testing.T) {
 	err, found = pMap.Get(podInRc1_1)
 	assert.True(t, found)
 	assert.Nil(t, err)
-}
-
-func TestFilterSchedulablePodsForNode(t *testing.T) {
-	rc1 := apiv1.ReplicationController{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rc1",
-			Namespace: "default",
-			SelfLink:  testapi.Default.SelfLink("replicationcontrollers", "rc"),
-			UID:       "12345678-1234-1234-1234-123456789012",
-		},
-	}
-
-	rc2 := apiv1.ReplicationController{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rc2",
-			Namespace: "default",
-			SelfLink:  testapi.Default.SelfLink("replicationcontrollers", "rc"),
-			UID:       "12345678-1234-1234-1234-12345678901a",
-		},
-	}
-
-	p1 := BuildTestPod("p1", 1500, 200000)
-	p2_1 := BuildTestPod("p2_1", 3000, 200000)
-	p2_1.OwnerReferences = GenerateOwnerReferences(rc1.Name, "ReplicationController", "extensions/v1beta1", rc1.UID)
-	p2_2 := BuildTestPod("p2_2", 3000, 200000)
-	p2_2.OwnerReferences = GenerateOwnerReferences(rc1.Name, "ReplicationController", "extensions/v1beta1", rc1.UID)
-	p3_1 := BuildTestPod("p3_1", 100, 200000)
-	p3_1.OwnerReferences = GenerateOwnerReferences(rc2.Name, "ReplicationController", "extensions/v1beta1", rc2.UID)
-	p3_2 := BuildTestPod("p3_2", 100, 200000)
-	p3_2.OwnerReferences = GenerateOwnerReferences(rc2.Name, "ReplicationController", "extensions/v1beta1", rc2.UID)
-	unschedulablePods := []*apiv1.Pod{p1, p2_1, p2_2, p3_1, p3_2}
-
-	tn := BuildTestNode("T1-abc", 2000, 2000000)
-	SetNodeReadyState(tn, true, time.Time{})
-	tni := schedulernodeinfo.NewNodeInfo()
-	tni.SetNode(tn)
-
-	context := &context.AutoscalingContext{
-		PredicateChecker: simulator.NewTestPredicateChecker(),
-	}
-
-	checker := NewPodsSchedulableOnNodeChecker(context, unschedulablePods)
-	res := checker.CheckPodsSchedulableOnNode("T1-abc", tni)
-	wantedSchedulable := []*apiv1.Pod{p1, p3_1, p3_2}
-	wantedUnschedulable := []*apiv1.Pod{p2_1, p2_2}
-
-	assert.Equal(t, 5, len(res))
-	for _, pod := range wantedSchedulable {
-		err, found := res[pod]
-		assert.True(t, found)
-		assert.Nil(t, err)
-	}
-	for _, pod := range wantedUnschedulable {
-		err, found := res[pod]
-		assert.True(t, found)
-		assert.NotNil(t, err)
-	}
 }

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -46,8 +46,6 @@ const (
 	IgnoreTaintPrefix = "ignore-taint.cluster-autoscaler.kubernetes.io/"
 )
 
-type equivalenceGroupId int
-
 // GetNodeInfosForGroups finds NodeInfos for all node groups used to manage the given nodes. It also returns a node group to sample node mapping.
 func GetNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedulernodeinfo.NodeInfo, cloudProvider cloudprovider.CloudProvider, listers kube_util.ListerRegistry,
 	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.


### PR DESCRIPTION
Minor refactor to separate pod equivalence computation from running predicates.

Possible TODO for improving messages in events: pass equivalence groups to scale up status processor, rather than build a full NoScaleUpInfo per pod.