### PR TITLE
priority expander: Documentation updates

### DIFF
--- a/cluster-autoscaler/expander/priority/readme.md
+++ b/cluster-autoscaler/expander/priority/readme.md
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-autoscaler-priority-expander
+  namespace: kube-system
 data:
   priorities: |-
     10: 

--- a/cluster-autoscaler/expander/priority/readme.md
+++ b/cluster-autoscaler/expander/priority/readme.md
@@ -32,4 +32,6 @@ data:
 
 The priority should be a positive value. The highest value wins. For each priority value, a list of regular expressions should be given. If there are multiple node groups matching any of the regular expressions with the highest priority, one group to expand the cluster is selected each time at random. Priority values cannot be duplicated - in that case, only one of the lists will be used. If no match is found, a group will be selected at random.
 
+Note that if a group name doesn't match any of the regular expressions in the priority list it will not be considered for expansion.  To ensure that *all* of your groups are autoscaled you might want to add a "catch-all" regex of `.*` (with a low priority) to your priorities list.
+
 In the example above, the user gives the highest priority to any expansion option, where the scaling group ID matches the regular expression `.*m4\.4xlarge.*`. Assuming all of the used scaling groups are based on AWS Spot instances, the user might now want to give up on all the scaling groups based on the `m4.4xlarge` instance family. To do that, it's enough to either reconfigure the priority to a value `<10` or remove the entry with priority `50` altogether.

--- a/cluster-autoscaler/expander/priority/readme.md
+++ b/cluster-autoscaler/expander/priority/readme.md
@@ -29,6 +29,6 @@ data:
       - .*m4\.4xlarge.*
 ```
 
-The priority should be a positive value. The highest value wins. For each priority value, a list of regular expressions should be given. If there are multiple node groups matching any of the regular expressions with the highest priority, one group to expand the cluster is selected each time at random. Priority values cannot be duplicated - in that case, only one of the lists will be used.
+The priority should be a positive value. The highest value wins. For each priority value, a list of regular expressions should be given. If there are multiple node groups matching any of the regular expressions with the highest priority, one group to expand the cluster is selected each time at random. Priority values cannot be duplicated - in that case, only one of the lists will be used. If no match is found, a group will be selected at random.
 
 In the example above, the user gives the highest priority to any expansion option, where the scaling group ID matches the regular expression `.*m4\.4xlarge.*`. Assuming all of the used scaling groups are based on AWS Spot instances, the user might now want to give up on all the scaling groups based on the `m4.4xlarge` instance family. To do that, it's enough to either reconfigure the priority to a value `<10` or remove the entry with priority `50` altogether.


### PR DESCRIPTION
This contains a few updates to the priority expander docs:

- Document random fallback behavior if no priority specs match.
- Document group skipping behavior when group name doesn't match any priorities.
- Use the `kube-system` namespace in the ConfigMap example.