### PR TITLE
Skip acceptable range check before it has data

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -432,6 +432,11 @@ func (csr *ClusterStateRegistry) IsNodeGroupSafeToScaleUp(nodeGroup cloudprovide
 }
 
 func (csr *ClusterStateRegistry) getProvisionedAndTargetSizesForNodeGroup(nodeGroupName string) (provisioned, target int, ok bool) {
+	if len(csr.acceptableRanges) == 0 {
+		klog.Warningf("AcceptableRanges have not been populated yet. Skip checking")
+		return 0, 0, false
+	}
+
 	acceptable, found := csr.acceptableRanges[nodeGroupName]
 	if !found {
 		klog.Warningf("Failed to find acceptable ranges for %v", nodeGroupName)


### PR DESCRIPTION
Resolve #2250 

https://github.com/kubernetes/autoscaler/blob/a258103f8ec9c24a333338468fa51262df0ef24a/cluster-autoscaler/clusterstate/clusterstate.go#L307-L326

`csr.getCloudProviderNodeInstances()` is called before `updateAcceptableRanges`  and at that time, acceptable range doesn't have any data, current error message is misleading. 


Please have a check and let me know if it makes sense.