### PR TITLE
track the scale down duration metric correctly for non-empty node case

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -693,7 +693,9 @@ func (sd *ScaleDown) TryToScaleDown(allNodes []*apiv1.Node, pods []*apiv1.Pod, p
 	nodeDeletionDuration := time.Duration(0)
 	findNodesToRemoveDuration := time.Duration(0)
 	scaleDownFnStartTime := time.Now()
+	metrics.UpdateLastTime(metrics.ScaleDown, scaleDownFnStartTime)
 	defer updateScaleDownMetrics(scaleDownFnStartTime, &findNodesToRemoveDuration, &nodeDeletionDuration)
+
 	nodesWithoutMaster := filterOutMasters(allNodes, pods)
 	candidates := make([]*apiv1.Node, 0)
 	readinessMap := make(map[string]bool)
@@ -875,6 +877,7 @@ func (sd *ScaleDown) TryToScaleDown(allNodes []*apiv1.Node, pods []*apiv1.Pod, p
 func updateScaleDownMetrics(scaleDownStart time.Time, findNodesToRemoveDuration *time.Duration, nodeDeletionDuration *time.Duration) {
 	stop := time.Now()
 	miscDuration := stop.Sub(scaleDownStart) - *nodeDeletionDuration - *findNodesToRemoveDuration
+	metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 	metrics.UpdateDuration(metrics.ScaleDownNodeDeletion, *nodeDeletionDuration)
 	metrics.UpdateDuration(metrics.ScaleDownFindNodesToRemove, *findNodesToRemoveDuration)
 	metrics.UpdateDuration(metrics.ScaleDownMiscOperations, miscDuration)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -454,10 +454,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 				klog.Errorf("Error while removing unneeded node groups: %v", err)
 			}
 
-			scaleDownStart := time.Now()
-			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
 			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(allNodes, originalScheduledPods, pdbs, currentTime)
-			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 
 			scaleDownStatus.RemovedNodeGroups = removedNodeGroups
 


### PR DESCRIPTION
It seemed that the node deletion duration has been broken for the non-empty node case since the node drainage/deletion was refactored into a goroutine.
 
Fixes: #2425 