### PR TITLE
Cherry pick #2385 #2401 #2428 to 1.15

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	sdkaws "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
 func TestBuildAsg(t *testing.T) {
@@ -45,4 +48,65 @@ func validateAsg(t *testing.T, asg *asg, name string, minSize int, maxSize int) 
 	assert.Equal(t, name, asg.Name)
 	assert.Equal(t, minSize, asg.minSize)
 	assert.Equal(t, maxSize, asg.maxSize)
+}
+
+func TestBuildLaunchTemplateFromSpec(t *testing.T) {
+	assert := assert.New(t)
+
+	units := []struct {
+		name string
+		in   *autoscaling.LaunchTemplateSpecification
+		exp  *launchTemplate
+	}{
+		{
+			name: "non-default, specified version",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("1"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "1",
+			},
+		},
+		{
+			name: "non-default, specified $Latest",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("$Latest"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Latest",
+			},
+		},
+		{
+			name: "specified $Default",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            sdkaws.String("$Default"),
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Default",
+			},
+		},
+		{
+			name: "no version specified",
+			in: &autoscaling.LaunchTemplateSpecification{
+				LaunchTemplateName: sdkaws.String("foo"),
+				Version:            nil,
+			},
+			exp: &launchTemplate{
+				name:    "foo",
+				version: "$Default",
+			},
+		},
+	}
+
+	cache := &asgCache{}
+	for _, unit := range units {
+		got := cache.buildLaunchTemplateFromSpec(unit.in)
+		assert.Equal(unit.exp, got)
+	}
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -146,9 +146,14 @@ func newAWSSDKProvider(cfg *provider_aws.CloudConfig) *awsSDKProvider {
 func getRegion(cfg ...*aws.Config) string {
 	region, present := os.LookupEnv("AWS_REGION")
 	if !present {
-		svc := ec2metadata.New(session.New(), cfg...)
-		if r, err := svc.Region(); err == nil {
-			region = r
+		sess, err := session.NewSession()
+		if err != nil {
+			klog.Errorf("Error getting AWS session while retrieving region: %v", err)
+		} else {
+			svc := ec2metadata.New(sess, cfg...)
+			if r, err := svc.Region(); err == nil {
+				region = r
+			}
 		}
 	}
 	return region
@@ -182,8 +187,11 @@ func createAWSManagerInternal(
 
 	if autoScalingService == nil || ec2Service == nil {
 		awsSdkProvider := newAWSSDKProvider(cfg)
-		sess := session.New(aws.NewConfig().WithRegion(getRegion()).
+		sess, err := session.NewSession(aws.NewConfig().WithRegion(getRegion()).
 			WithEndpointResolver(getResolver(awsSdkProvider.cfg)))
+		if err != nil {
+			return nil, err
+		}
 
 		if autoScalingService == nil {
 			autoScalingService = &autoScalingWrapper{autoscaling.New(sess), map[string]string{}}

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -1485,4 +1485,46 @@ var InstanceTypes = map[string]*instanceType{
 		MemoryMb:     32768,
 		GPU:          0,
 	},
+	"g4dn.xlarge": {
+		InstanceType: "g4dn.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          1,
+	},
+	"g4dn.2xlarge": {
+		InstanceType: "g4dn.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          1,
+	},
+	"g4dn.4xlarge": {
+		InstanceType: "g4dn.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          1,
+	},
+	"g4dn.8xlarge": {
+		InstanceType: "g4dn.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          1,
+	},
+	"g4dn.16xlarge": {
+		InstanceType: "g4dn.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          1,
+	},
+	"g4dn.12xlarge": {
+		InstanceType: "g4dn.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          4,
+	},
+	"g4dn.metal": { //coming soon
+		InstanceType: "g4dn.metal",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          8,
+	},
 }


### PR DESCRIPTION
#2385 Ensure valid AWS LaunchTemplate version
#2401 Add g4dn instance type for AWS
#2428 AWS – use `session.NewSession` instead of `session.New` to