### PR TITLE
Update magnum example deployment with image built by magnum CI

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-master.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-master.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: cluster-autoscaler-account
       containers:
         - name: cluster-autoscaler
-          image: thartland/magnum-autoscaler:v1.0
+          image: openstackmagnum/cluster-autoscaler:v1.15.2
           imagePullPolicy: Always
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: cluster-autoscaler-account
       containers:
         - name: cluster-autoscaler
-          image: thartland/magnum-autoscaler:v1.0
+          image: openstackmagnum/cluster-autoscaler:v1.15.2
           imagePullPolicy: Always
           command:
             - ./cluster-autoscaler


### PR DESCRIPTION
We're now building the cluster autoscaler binary with the build tag for just the magnum provider as part of our CI, and pushing to dockerhub/openstackmagnum [1].

The example deployments no longer need to use the image from my personal dockerhub.


[1] https://review.opendev.org/#/c/688648/