### PR TITLE
Add AWS ignore labels and increase max memory difference.

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -295,6 +295,9 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {
 		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
 			Comparator: nodegroupset.IsAzureNodeInfoSimilar}
+	} else if autoscalingOptions.CloudProviderName == cloudprovider.AwsProviderName {
+		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
+			Comparator: nodegroupset.IsAwsNodeInfoSimilar}
 	}
 
 	opts := core.AutoscalerOptions{

--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupset
+
+import (
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// IsAwsNodeInfoSimilar adds AWS specific node labels to the list of ignored labels.
+func IsAwsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	awsIgnoredLabels := map[string]bool{
+		"alpha.eksctl.io/instance-id":    true, // this is a label used by eksctl to identify instances.
+		"alpha.eksctl.io/nodegroup-name": true, // this is a label used by eksctl to identify "node group" names.
+		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
+		"lifecycle":                      true, // this is a label used by the AWS for spot.
+	}
+
+	for k, v := range BasicIgnoredLabels {
+		awsIgnoredLabels[k] = v
+	}
+	return IsCloudProviderNodeInfoSimilar(n1, n2, awsIgnoredLabels)
+}

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -45,7 +45,6 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
 	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
-	"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -33,7 +33,7 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 	// MaxMemoryDifferenceInKiloBytes describes how much memory
 	// capacity can differ but still be considered equal.
-	MaxMemoryDifferenceInKiloBytes = 128000
+	MaxMemoryDifferenceInKiloBytes = 256000
 )
 
 // BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity


### PR DESCRIPTION
AWS M5 instance types may differ in memory capacity by more than 128MB.

Whitelist additional node labels for AWS CNI custom networking and
EC2 lifecycle.

As I documented in https://github.com/kubernetes/autoscaler/issues/2020, the m5 instance type memory varies by more that 128MB .  I'm not sure what the basis of the max memory capacity difference is.  There are quite a few options if there are good reasons not to touch it.  Perhaps making it modifiable through a command argument.   