### PR TITLE
Improve performance of the Azure cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func newTestAzureManager(t *testing.T) *AzureManager {
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
 	manager := &AzureManager{
 		env:                  azure.PublicCloud,
 		explicitlyConfigured: make(map[string]bool),
@@ -48,11 +50,21 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 				FakeStore: make(map[string]map[string]compute.VirtualMachine),
 			},
 			virtualMachineScaleSetsClient: &VirtualMachineScaleSetsClientMock{
-				FakeStore: make(map[string]map[string]compute.VirtualMachineScaleSet),
+				FakeStore: map[string]map[string]compute.VirtualMachineScaleSet{
+					"test": map[string]compute.VirtualMachineScaleSet{
+						"test-asg": compute.VirtualMachineScaleSet{
+							Name: &vmssName,
+							Sku: &compute.Sku{
+								Capacity: &vmssCapacity,
+							},
+						},
+					},
+				},
 			},
 			virtualMachineScaleSetVMsClient: &VirtualMachineScaleSetVMsClientMock{},
 		},
 	}
+
 	cache, error := newAsgCache()
 	assert.NoError(t, error)
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -30,6 +30,7 @@ import (
 
 func newTestAzureManager(t *testing.T) *AzureManager {
 	vmssName := "test-asg"
+	skuName := "Standard_D4_v2"
 	var vmssCapacity int64 = 3
 	manager := &AzureManager{
 		env:                  azure.PublicCloud,
@@ -56,6 +57,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 							Name: &vmssName,
 							Sku: &compute.Sku{
 								Capacity: &vmssCapacity,
+								Name:     &skuName,
 							},
 						},
 					},

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -51,8 +51,8 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 			},
 			virtualMachineScaleSetsClient: &VirtualMachineScaleSetsClientMock{
 				FakeStore: map[string]map[string]compute.VirtualMachineScaleSet{
-					"test": map[string]compute.VirtualMachineScaleSet{
-						"test-asg": compute.VirtualMachineScaleSet{
+					"test": {
+						"test-asg": {
 							Name: &vmssName,
 							Sku: &compute.Sku{
 								Capacity: &vmssCapacity,

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -31,6 +31,7 @@ import (
 func newTestAzureManager(t *testing.T) *AzureManager {
 	vmssName := "test-asg"
 	skuName := "Standard_D4_v2"
+	location := "eastus"
 	var vmssCapacity int64 = 3
 	manager := &AzureManager{
 		env:                  azure.PublicCloud,
@@ -59,6 +60,8 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 								Capacity: &vmssCapacity,
 								Name:     &skuName,
 							},
+							VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{},
+							Location:                         &location,
 						},
 					},
 				},

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -192,16 +192,19 @@ func (scaleSet *ScaleSet) getCurSize() (int64, error) {
 		}
 		return -1, err
 	}
-	klog.V(5).Infof("Getting scale set (%q) capacity: %d\n", scaleSet.Name, *set.Sku.Capacity)
 
-	if scaleSet.curSize != *set.Sku.Capacity {
+	vmssSizeMutex.Lock()
+	curSize := *set.Sku.Capacity
+	vmssSizeMutex.Unlock()
+
+	klog.V(5).Infof("Getting scale set (%q) capacity: %d\n", scaleSet.Name, curSize)
+
+	if scaleSet.curSize != curSize {
 		// Invalidate the instance cache if the capacity has changed.
 		scaleSet.invalidateInstanceCache()
 	}
 
-	vmssSizeMutex.Lock()
-	scaleSet.curSize = *set.Sku.Capacity
-	vmssSizeMutex.Unlock()
+	scaleSet.curSize = curSize
 	scaleSet.lastSizeRefresh = time.Now()
 	return scaleSet.curSize, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -215,12 +215,14 @@ func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) {
 	var isSuccess bool
 	var err error
 
+	scaleSet.sizeMutex.Lock()
+	defer scaleSet.sizeMutex.Unlock()
+
 	defer func() {
 		if err != nil {
 			klog.Errorf("Failed to update the capacity for vmss %s with error %v, invalidate the cache so as to get the real size from API", scaleSet.Name, err)
 			// Invalidate the VMSS size cache in order to fetch the size from the API.
-			scaleSet.sizeMutex.Lock()
-			defer scaleSet.sizeMutex.Unlock()
+
 			scaleSet.lastSizeRefresh = time.Now().Add(-1 * vmssSizeRefreshPeriod)
 		}
 	}()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -65,9 +65,12 @@ func TestTargetSize(t *testing.T) {
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
 
+	ng := provider.NodeGroups()[0]
+	size, err := ng.TargetSize()
+	println(size)
 	targetSize, err := provider.NodeGroups()[0].TargetSize()
 	assert.NoError(t, err)
-	assert.Equal(t, targetSize, 2)
+	assert.Equal(t, 3, targetSize)
 }
 
 func TestIncreaseSize(t *testing.T) {
@@ -80,10 +83,10 @@ func TestIncreaseSize(t *testing.T) {
 	// current target size is 2.
 	targetSize, err := provider.NodeGroups()[0].TargetSize()
 	assert.NoError(t, err)
-	assert.Equal(t, targetSize, 2)
+	assert.Equal(t, 3, targetSize)
 
 	// increase 3 nodes.
-	err = provider.NodeGroups()[0].IncreaseSize(3)
+	err = provider.NodeGroups()[0].IncreaseSize(2)
 	assert.NoError(t, err)
 
 	// new target size should be 5.


### PR DESCRIPTION
Previously, the cloud provider called Get to obtain the status for each node pool.  When running with a large number of node pools, e.g. 10+, these will cause Azure to throttle, not only the autoscaler, but all services operating under the same identity.

This commit replaces the Get call for each node pool with a List call which obtains the status for all the node pools at once.  The frequency of these calls is set with the vmssSizeRefreshPeriod constant.