### PR TITLE
CA: Make error message in scale down node draining consistent

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -1148,7 +1148,7 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 		for _, pod := range pods {
 			podreturned, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 			if err == nil && (podreturned == nil || podreturned.Spec.NodeName == node.Name) {
-				klog.Errorf("Not deleted yet %v", podreturned)
+				klog.Errorf("Not deleted yet %s/%s", pod.Namespace, pod.Name)
 				allGone = false
 				break
 			}


### PR DESCRIPTION
In the error branch below it simply prints the namespace/name of the pod.

If there's a good reason to log the actual returned pod I can put it back in as well. At the very least since the returned object could be nil in this branch, the namespace/name of the pod should also be logged.