### PR TITLE
VPA: handle quick OOMs in all containers

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -86,13 +86,14 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, recommendation *vpa
 	updatePriority := calc.getUpdatePriority(pod, processedRecommendation)
 
 	quickOOM := false
-	if len(pod.Status.ContainerStatuses) == 1 {
-		terminationState := pod.Status.ContainerStatuses[0].LastTerminationState
+	for _, cs := range pod.Status.ContainerStatuses {
+		terminationState := cs.LastTerminationState
 		if terminationState.Terminated != nil &&
 			terminationState.Terminated.Reason == "OOMKilled" &&
 			terminationState.Terminated.FinishedAt.Time.Sub(terminationState.Terminated.StartedAt.Time) < *evictAfterOOMThreshold {
 			quickOOM = true
-			klog.V(2).Infof("quick OOM detected in pod %v", pod.Name)
+			klog.V(2).Infof("quick OOM detected in pod %v, container %s", pod.Name, cs.Name)
+			break
 		}
 	}
 


### PR DESCRIPTION
For some reason, the quick OOM handling logic in VPA is currently restricted to pods with just one container. This makes VPA unable to handle crashes in pods that use sidecars, so the user has to delete the pod manually to get the proper recommendations. This PR changes the logic to handle quick OOM crashes in all containers.