### PR TITLE
[aws] use simple string prefix placeholder match

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -19,7 +19,6 @@ package aws
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -287,8 +286,7 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 
 // isPlaceholderInstance checks if the given instance is only a placeholder
 func (m *asgCache) isPlaceholderInstance(instance *AwsInstanceRef) bool {
-	matched, _ := regexp.MatchString(fmt.Sprintf("^%s.*\\d+$", placeholderInstanceNamePrefix), instance.Name)
-	return matched
+	return strings.HasPrefix(instance.Name, placeholderInstanceNamePrefix)
 }
 
 // Fetch automatically discovered ASGs. These ASGs should be unregistered if


### PR DESCRIPTION
Addresses a [comment on PR2235](https://github.com/kubernetes/autoscaler/pull/2235/files#r313536379)
to remove the unnecessary use of a regex with a simpler string prefix
matching for placeholder names.