### PR TITLE
Read subscription ID from instance metadata

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -56,6 +56,8 @@ Cluster autoscaler supports four Kubernetes cluster options on Azure:
 
 > **_NOTE_**: only the `vmss` option supports scaling down to zero nodes.
 
+> **_NOTE_**: The `subscriptionID` parameter is optional. When skipped, the subscription will be fetched from [the instance metadata](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service).
+
 ### VMSS deployment
 
 Prerequisites:

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -551,7 +551,7 @@ func getSubscriptionIdFromInstanceMetadata() (string, error) {
 			return "", err
 		}
 
-		metadata, err := metadataService.GetMetadata()
+		metadata, err := metadataService.GetMetadata(0)
 		if err != nil {
 			return "", err
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -26,11 +26,10 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"gopkg.in/gcfg.v1"
-	"k8s.io/klog"
-	azure2 "k8s.io/legacy-cloud-providers/azure"
-
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	"k8s.io/klog"
+	providerazure "k8s.io/legacy-cloud-providers/azure"
 )
 
 const (
@@ -547,7 +546,7 @@ func parseLabelAutoDiscoverySpec(spec string) (labelAutoDiscoveryConfig, error) 
 func getSubscriptionIdFromInstanceMetadata() (string, error) {
 	subscriptionID, present := os.LookupEnv("ARM_SUBSCRIPTION_ID")
 	if !present {
-		metadataService, err := azure2.NewInstanceMetadataService(metadataURL)
+		metadataService, err := providerazure.NewInstanceMetadataService(metadataURL)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The same way that we don't have to explicitly pass credentials as arguments when using managed identity extension, we could allow people to avoid passing the `subscriptionID` if they don't want to, and fetch it from the instance metadata.