### PR TITLE
CSR: fix a bug in GetClusterSize

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -979,16 +979,18 @@ func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances ma
 	return notRegistered
 }
 
-// GetClusterSize calculates and returns cluster's current size and target size. The current size is the
-// actual number of nodes provisioned in Kubernetes, the target size is the number of nodes the CA wants.
-func (csr *ClusterStateRegistry) GetClusterSize() (currentSize, targetSize int) {
+// GetAutoscaledNodesCount calculates and returns the actual and the target number of nodes
+// belonging to autoscaled node groups in the cluster.
+func (csr *ClusterStateRegistry) GetAutoscaledNodesCount() (currentSize, targetSize int) {
 	csr.Lock()
 	defer csr.Unlock()
 
 	for _, accRange := range csr.acceptableRanges {
 		targetSize += accRange.CurrentTarget
 	}
-	currentSize = csr.totalReadiness.Registered - csr.totalReadiness.NotStarted - csr.totalReadiness.LongNotStarted
+	for _, readiness := range csr.perNodeGroupReadiness {
+		currentSize += readiness.Registered - readiness.NotStarted - readiness.LongNotStarted
+	}
 	return currentSize, targetSize
 }
 


### PR DESCRIPTION
Currently, GetClusterSize reports the target number for all autoscaled
node groups, but the actual number for _all_ node groups, even those
that are not autoscaled. This commit fixes that behavior so that both
target and actual size reported are from autoscaled node groups only.