### PR TITLE
Use git reset instead of git restore

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -185,7 +185,7 @@ set +o errexit
   fi
 
   # Commit go.mod* and vendor
-  git restore --staged . >&${BASH_XTRACEFD} 2>&1
+  git reset . >&${BASH_XTRACEFD} 2>&1
   git add vendor go.mod go.sum >&${BASH_XTRACEFD} 2>&1
   if ! git diff --quiet --cached; then
     echo "Commiting vendor, go.mod and go.sum"


### PR DESCRIPTION
The `git restore` command was introduced in Git version 2.23.0, which
was released in August 2019. Even late Linux distributions do not
include this modern of a Git binary. For example, Ubuntu 19.10 as of Nov
26, 2019 only includes Git 2.20.1.

In order to run hack/update-vendor.sh on machines with Git <2.23.0, I've
modified the script to use `git reset .` instead of `git restore
--staged`.

Issue #2560