### PR TITLE
Add version to user agent

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -53,7 +53,7 @@ container: .container-$(ARCH)
         /bin/bash -c "\
             go get github.com/tools/godep && \
             cd /go/src/k8s.io/autoscaler/addon-resizer/ && \
-            CGO_ENABLED=0 GOARM=$(GOARM) GOARCH=$(ARCH) godep go build -a -installsuffix cgo --ldflags '-w' -o $(TEMP_DIR)/pod_nanny main.go"
+            CGO_ENABLED=0 GOARM=$(GOARM) GOARCH=$(ARCH) godep go build -a -installsuffix cgo --ldflags '-w -X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=$(TAG)' -o $(TEMP_DIR)/pod_nanny main.go"
 
 	docker build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
 

--- a/addon-resizer/nanny/version.go
+++ b/addon-resizer/nanny/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nanny
+
+// AddonResizerVersion contains version of AddonResizer.
+var AddonResizerVersion = "development"


### PR DESCRIPTION
This adds the tagged version to the build, and includes it in the client user-agent (currently, the user agent appears as `pod_nanny/v0.0.0`)