### PR TITLE
[addon-resizer 1.8] Add version to user agent

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -35,7 +35,7 @@ deps:
 		go get -u github.com/tools/godep
 
 compile: nanny/ deps
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -o $(OUT_DIR)/pod_nanny nanny/main/pod_nanny.go
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build --ldflags '-X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=$(TAG)' -a -o $(OUT_DIR)/pod_nanny nanny/main/pod_nanny.go
 
 test: nanny/
 		godep go test ${PACKAGE}/nanny -v

--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -63,6 +63,7 @@ var (
 func main() {
 	// First log our starting config, and then set up.
 	glog.Infof("Invoked by %v", os.Args)
+	glog.Infof("Version: %s", nanny.AddonResizerVersion)
 	flag.Parse()
 
 	// Perform further validation of flags.
@@ -86,6 +87,7 @@ func main() {
 	if err != nil {
 		glog.Fatal(err)
 	}
+	config.UserAgent = userAgent()
 	// Use protobufs for communication with apiserver
 	config.ContentType = "application/vnd.kubernetes.protobuf"
 
@@ -156,6 +158,17 @@ func main() {
 
 	// Begin nannying.
 	nanny.PollAPIServer(k8s, est, *containerName, pollPeriod, uint64(*threshold))
+}
+
+func userAgent() string {
+	command := ""
+	if len(os.Args) > 0 && len(os.Args[0]) > 0 {
+		command = filepath.Base(os.Args[0])
+	}
+	if len(command) == 0 {
+		command = "addon-resizer"
+	}
+	return command + "/" + nanny.AddonResizerVersion
 }
 
 func loadNannyConfiguration(configDir string, defaultConfig *nannyconfigalpha.NannyConfiguration) (*nannyconfig.NannyConfiguration, error) {

--- a/addon-resizer/nanny/version.go
+++ b/addon-resizer/nanny/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nanny
+
+// AddonResizerVersion contains version of AddonResizer.
+var AddonResizerVersion = "development"


### PR DESCRIPTION
1.8 pick of https://github.com/kubernetes/autoscaler/pull/2577

This adds the tagged version to the build, and includes it in the client user-agent (currently, the user agent appears as pod_nanny/v0.0.0)