### PR TITLE
Sync e2e_test file with k/k master

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/e2e_test.go
+++ b/vertical-pod-autoscaler/e2e/v1/e2e_test.go
@@ -50,7 +50,6 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/lifecycle/bootstrap"
 	_ "k8s.io/kubernetes/test/e2e/network"
 	_ "k8s.io/kubernetes/test/e2e/node"
-	_ "k8s.io/kubernetes/test/e2e/scalability"
 	_ "k8s.io/kubernetes/test/e2e/scheduling"
 	_ "k8s.io/kubernetes/test/e2e/servicecatalog"
 	_ "k8s.io/kubernetes/test/e2e/storage"
@@ -69,7 +68,7 @@ func handleFlags() {
 	flag.Parse()
 }
 
-func init() {
+func TestMain(m *testing.M) {
 	// Register test flags, then parse flags.
 	handleFlags()
 
@@ -105,9 +104,6 @@ func init() {
 		AssetNames: generated.AssetNames,
 	})
 
-}
-
-func TestMain(m *testing.M) {
 	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }

--- a/vertical-pod-autoscaler/e2e/v1beta2/e2e_test.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/e2e_test.go
@@ -50,7 +50,6 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/lifecycle/bootstrap"
 	_ "k8s.io/kubernetes/test/e2e/network"
 	_ "k8s.io/kubernetes/test/e2e/node"
-	_ "k8s.io/kubernetes/test/e2e/scalability"
 	_ "k8s.io/kubernetes/test/e2e/scheduling"
 	_ "k8s.io/kubernetes/test/e2e/servicecatalog"
 	_ "k8s.io/kubernetes/test/e2e/storage"
@@ -69,7 +68,7 @@ func handleFlags() {
 	flag.Parse()
 }
 
-func init() {
+func TestMain(m *testing.M) {
 	// Register test flags, then parse flags.
 	handleFlags()
 
@@ -105,9 +104,6 @@ func init() {
 		AssetNames: generated.AssetNames,
 	})
 
-}
-
-func TestMain(m *testing.M) {
 	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }

--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -48,9 +48,9 @@ case ${SUITE} in
   recommender|updater|admission-controller|actuation|full-vpa)
     export KUBECONFIG=$HOME/.kube/config
     pushd ${SCRIPT_ROOT}/e2e
-    go test -mod vendor ./v1beta2/*go -v --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
+    go test -mod vendor ./v1beta2/*go -v --test.timeout=60m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
     FIRST_RESULT=$?
-    go test -mod vendor ./v1/*go -v --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
+    go test -mod vendor ./v1/*go -v --test.timeout=60m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
     popd
     echo First test result: ${FIRST_RESULT}
     if [ $FIRST_RESULT -gt 0 ]; then


### PR DESCRIPTION
Without this change test flags are not registered and this fails with go1.13

Also reinstate the timeout