### PR TITLE
Improved logging for errors during updating state

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -367,7 +367,9 @@ func (feeder *clusterStateFeeder) LoadPods() {
 		}
 		feeder.clusterState.AddOrUpdatePod(pod.ID, pod.PodLabels, pod.Phase)
 		for _, container := range pod.Containers {
-			feeder.clusterState.AddOrUpdateContainer(container.ID, container.Request)
+			if err = feeder.clusterState.AddOrUpdateContainer(container.ID, container.Request); err != nil {
+				klog.Warningf("Failed to add container %+v. Reason: %+v", container.ID, err)
+			}
 		}
 	}
 }
@@ -383,6 +385,10 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics() {
 	for _, containerMetrics := range containersMetrics {
 		for _, sample := range newContainerUsageSamplesWithKey(containerMetrics) {
 			if err := feeder.clusterState.AddSample(sample); err != nil {
+				// Not all pod states are tracked in memory saver mode
+				if _, isKeyError := err.(model.KeyError); isKeyError && feeder.memorySaveMode {
+					continue
+				}
 				klog.Warningf("Error adding metric sample for container %v: %v", sample.Container, err)
 				droppedSampleCount++
 			} else {
@@ -396,7 +402,9 @@ Loop:
 		select {
 		case oomInfo := <-feeder.oomChan:
 			klog.V(3).Infof("OOM detected %+v", oomInfo)
-			feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, oomInfo.Memory)
+			if err = feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, oomInfo.Memory); err != nil {
+				klog.Warningf("Failed to record OOM %+v. Reason: %+v", oomInfo, err)
+			}
 		default:
 			break Loop
 		}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -155,7 +155,9 @@ func getCappedRecommendation(vpaID model.VpaID, resources logic.RecommendedPodRe
 func (r *recommender) MaintainCheckpoints(ctx context.Context, minCheckpointsPerRun int) {
 	now := time.Now()
 	if r.useCheckpoints {
-		r.checkpointWriter.StoreCheckpoints(ctx, now, minCheckpointsPerRun)
+		if err := r.checkpointWriter.StoreCheckpoints(ctx, now, minCheckpointsPerRun); err != nil {
+			klog.Warningf("Failed to store checkpoints. Reason: %+v", err)
+		}
 		if time.Now().Sub(r.lastCheckpointGC) > r.checkpointsGCInterval {
 			r.lastCheckpointGC = now
 			r.clusterStateFeeder.GarbageCollectCheckpoints()


### PR DESCRIPTION
In an earlier PR #1868 I added a memory saver mode which stores only pod info and container metrics for those pods which have a VPA. In later PR some logging was added when container metrics could not be stored regardless of the mode. This causes a lot of false error logs when the memory saver mode is on. So I've added a similar skip condition when the container does not have a matching VPA.

Also there are a couple of places where errors are not logged when the pod and container states cannot be added/updated. So I have added appropriate warnings in those places.    