### PR TITLE
fix: doc inaccuracy for azure auto-discovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -86,7 +86,7 @@ Note that:
 
 * It is recommended to use a second tag like `cluster-autoscaler-name=<YOUR CLUSTER NAME>` when `cluster-autoscaler-enabled=true` is used across many clusters to prevent VMSSs from different clusters recognized as the node groups
 * There are no `--nodes` flags passed to cluster-autoscaler because the node groups are automatically discovered by tags
-* No min/max values are provided when using Auto-Discovery, cluster-autoscaler will respect the current min and max values of the VMSS being targeted, and it will adjust only the "desired" value.
+* No min/max values are provided when using Auto-Discovery, cluster-autoscaler will detect the "min" and "max" tags on the VMSS resource in Azure, adjusting the desired number of nodes within these limits.
 
 ```
 kubectl apply -f examples/cluster-autoscaler-autodiscover.yaml


### PR DESCRIPTION
The existing text is not how auto-discovery works, it detects the pre-existing tags for min/max and sets those to the parsed values. This is the same as GCE, while AWS uses ASG scaling policies and respects the external min/max. 

https://github.com/kubernetes/autoscaler/blob/50840bf43f681871465a2a4d3d6eeba9056463c4/cluster-autoscaler/cloudprovider/gce/gce_manager.go#L566-L577

https://github.com/kubernetes/autoscaler/blob/50840bf43f681871465a2a4d3d6eeba9056463c4/cluster-autoscaler/cloudprovider/azure/azure_manager.go#L410-L440

Seems like the text is a copy paste from AWS, it's not correct for azure.