### PR TITLE
Fix typo in flag for OOM threshold

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -37,9 +37,9 @@ const (
 )
 
 var (
-	evictAfterOOMThreshold = flag.Duration("evict-after-oom-treshold", 10*time.Minute,
+	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", 10*time.Minute,
 		`Evict pod that has only one container and it OOMed in less than
-		evict-after-oom-treshold since start.`)
+		evict-after-oom-threshold since start.`)
 )
 
 // UpdatePriorityCalculator is responsible for prioritizing updates on pods.


### PR DESCRIPTION
Considering that this has never been reported it might have never been used. We can safely change the name given the project is still in beta and the updater will crash with unknown flag and not just silently ignore the name. Also the `misspell` spell checker used in this project seems to be an abandoned project now :( 