### PR TITLE
add unit tests validating AwsRefFromProviderId

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -161,7 +161,7 @@ type AwsInstanceRef struct {
 
 var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*$|aws\:\/\/\/[-0-9a-z]*\/%s.*$`, placeholderInstanceNamePrefix))
 
-// AwsRefFromProviderId creates InstanceConfig object from provider id which
+// AwsRefFromProviderId creates AwsInstanceRef object from provider id which
 // must be in format: aws:///zone/name
 func AwsRefFromProviderId(id string) (*AwsInstanceRef, error) {
 	if validAwsRefIdRegex.FindStringSubmatch(id) == nil {


### PR DESCRIPTION
In Issue #2285, there are log lines demonstrating that the
`AwsRefFromProviderId()` function in the AWS cloud provider was
returning an error from the provider ID string:

```
W0829 14:14:00.250136       1 utils.go:494] Failed to get node group for aws:///eu-central-1c/i-placeholder-K3-EKS-spotr5xlasgsubnet02af43b02922e710f-10QH9H0C8PG7O-14: wrong id: expected format aws:///<zone>/<name>, got aws:///eu-central-1c/i-placeholder-K3-EKS-spotr5xlasgsubnet02af43b02922e710f-10QH9H0C8PG7O-14
```

So I've added a unit test that uses this exact value and verifies that
the AwsRefFromProviderId function indeed returns the
appropriately-filled-in AwsInstanceRef object correctly.