### PR TITLE
Change the regular expression to match the Fargate's ProviderIDs.

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -159,7 +159,7 @@ type AwsInstanceRef struct {
 	Name       string
 }
 
-var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*$|aws\:\/\/\/[-0-9a-z]*\/%s.*$`, placeholderInstanceNamePrefix))
+var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*(\/[-0-9a-z\.]*)?$|aws\:\/\/\/[-0-9a-z]*\/%s.*$`, placeholderInstanceNamePrefix))
 
 // AwsRefFromProviderId creates AwsInstanceRef object from provider id which
 // must be in format: aws:///zone/name


### PR DESCRIPTION
EKS now supports pods running on Fargate. The providerID has a different format:

"aws:///eu-west-1b/120328e333-369fe1b7ba8b4416ab87216be91dc4f1/fargate-ip-192-168-159-181.eu-west-1.compute.internal"

I just adapted the regex to match both patterns. Without this, the autoscaler will not work if you have one node (one pod) running on Fargate.