### PR TITLE
Cherry pick #2661 to 1.15: fix: properly parse azure cloud provider config #2662

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -17,15 +17,16 @@ limitations under the License.
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
-	"gopkg.in/gcfg.v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/klog"
@@ -103,12 +104,16 @@ func (c *Config) TrimSpace() {
 // CreateAzureManager creates Azure Manager object to work with Azure.
 func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*AzureManager, error) {
 	var err error
-	var cfg Config
+	cfg := &Config{}
 
 	if configReader != nil {
-		if err := gcfg.ReadInto(&cfg, configReader); err != nil {
-			klog.Errorf("Couldn't read config: %v", err)
-			return nil, err
+		body, err := ioutil.ReadAll(configReader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read config: %v", err)
+		}
+		err = json.Unmarshal(body, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config body: %v", err)
 		}
 	} else {
 		cfg.Cloud = os.Getenv("ARM_CLOUD")
@@ -170,20 +175,20 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		}
 	}
 
-	if err := validateConfig(&cfg); err != nil {
+	if err := validateConfig(cfg); err != nil {
 		return nil, err
 	}
 
 	klog.Infof("Starting azure manager with subscription ID %q", cfg.SubscriptionID)
 
-	azClient, err := newAzClient(&cfg, &env)
+	azClient, err := newAzClient(cfg, &env)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create azure manager.
 	manager := &AzureManager{
-		config:               &cfg,
+		config:               cfg,
 		env:                  env,
 		azClient:             azClient,
 		explicitlyConfigured: make(map[string]bool),

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+const validAzureCfg = `{
+	"cloud": "AzurePublicCloud",
+	"tenantId": "fakeId",
+	"subscriptionId": "fakeId",
+	"aadClientId": "fakeId",
+	"aadClientSecret": "fakeId",
+	"resourceGroup": "fakeId",
+	"location": "southeastasia",
+	"subnetName": "fakeName",
+	"securityGroupName": "fakeName",
+	"vnetName": "fakeName",
+	"routeTableName": "fakeName",
+	"primaryAvailabilitySetName": "fakeName",
+	"asgCacheTTL": 900}`
+
+const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
+
+func TestCreateAzureManagerValidConfig(t *testing.T) {
+	manager, err := CreateAzureManager(strings.NewReader(validAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{})
+
+	expectdConfig := &Config{
+		Cloud:           "AzurePublicCloud",
+		TenantID:        "fakeId",
+		SubscriptionID:  "fakeId",
+		ResourceGroup:   "fakeId",
+		VMType:          "vmss",
+		AADClientID:     "fakeId",
+		AADClientSecret: "fakeId",
+		AsgCacheTTL:     900,
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectdConfig, manager.config, "unexpected azure manager configuration")
+}
+
+func TestCreateAzureManagerInvalidConfig(t *testing.T) {
+	_, err := CreateAzureManager(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{})
+	assert.Error(t, err, "failed to unmarshal config body")
+}


### PR DESCRIPTION
azure cloud provider config files aren't INI-formatted so the initial parsing logic would fail