### PR TITLE
Add GCE PD CSI zone topology key to node template

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -37,6 +37,10 @@ import (
 // GceTemplateBuilder builds templates for GCE nodes.
 type GceTemplateBuilder struct{}
 
+// TODO: This should be imported from sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common/constants.go
+// This key is applicable to both GCE and GKE
+const gceCSITopologyKeyZone = "topology.gke.io/zone"
+
 func (t *GceTemplateBuilder) getAcceleratorCount(accelerators []*gce.AcceleratorConfig) int64 {
 	count := int64(0)
 	for _, accelerator := range accelerators {
@@ -211,6 +215,7 @@ func BuildGenericLabels(ref GceRef, machineType string, nodeName string, os Oper
 	}
 	result[apiv1.LabelZoneRegion] = ref.Zone[:ix]
 	result[apiv1.LabelZoneFailureDomain] = ref.Zone
+	result[gceCSITopologyKeyZone] = ref.Zone
 	result[apiv1.LabelHostname] = nodeName
 	return result, nil
 }

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -168,6 +168,7 @@ func TestBuildGenericLabels(t *testing.T) {
 			expectedLabels := map[string]string{
 				apiv1.LabelZoneRegion:        "us-central1",
 				apiv1.LabelZoneFailureDomain: "us-central1-b",
+				gceCSITopologyKeyZone:        "us-central1-b",
 				apiv1.LabelHostname:          "sillyname",
 				apiv1.LabelInstanceType:      "n1-standard-8",
 				kubeletapis.LabelArch:        cloudprovider.DefaultArch,


### PR DESCRIPTION
 CSI drivers use their own topology keys instead of Kubernetes labels, and the corresponding Node and PV.Spec.NodeAffinity will use the CSI labels.