### PR TITLE
Cherry pick #2674 to 1.14: Fix panic when the vmss doesn't exist

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -174,7 +174,7 @@ func (m *asgCache) FindForInstance(instance *azureRef, vmType string) (cloudprov
 		return asg, nil
 	}
 
-	klog.Warningf("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
+	klog.V(4).Infof("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
 	return nil, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -156,6 +156,10 @@ func (scaleSet *ScaleSet) getVMSSInfo() (compute.VirtualMachineScaleSet, error) 
 	scaleSetStatusCache.lastRefresh = time.Now()
 	scaleSetStatusCache.scaleSets = newStatus
 
+	if _, exists := scaleSetStatusCache.scaleSets[scaleSet.Name]; !exists {
+		return compute.VirtualMachineScaleSet{}, fmt.Errorf("could not find vmss: %s", scaleSet.Name)
+	}
+
 	return scaleSetStatusCache.scaleSets[scaleSet.Name], nil
 }
 


### PR DESCRIPTION
Check if the vmss exists, if not return an error to the caller

Fixes #2625