### PR TITLE
Delete outdated deployments.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestAgentPool(manager *AzureManager, name string) *AgentPool {
+	return &AgentPool{
+		azureRef: azureRef{
+			Name: name,
+		},
+		manager: manager,
+		minSize: 1,
+		maxSize: 5,
+	}
+}
+
+func TestDeleteOutdatedDeployments(t *testing.T) {
+	timeLayout := "2006-01-02 15:04:05"
+	timeBenchMark, _ := time.Parse(timeLayout, "2000-01-01 00:00:00")
+
+	testCases := []struct {
+		deployments              map[string]resources.DeploymentExtended
+		expectedDeploymentsNames map[string]bool
+		expectedErr              error
+		desc                     string
+	}{
+		{
+			deployments: map[string]resources.DeploymentExtended{
+				"non-cluster-autoscaler-0000": {
+					Name: to.StringPtr("non-cluster-autoscaler-0000"),
+					Properties: &resources.DeploymentPropertiesExtended{
+						ProvisioningState: to.StringPtr("Succeeded"),
+						Timestamp:         &date.Time{Time: timeBenchMark.Add(2 * time.Minute)},
+					},
+				},
+				"cluster-autoscaler-0000": {
+					Name: to.StringPtr("cluster-autoscaler-0000"),
+					Properties: &resources.DeploymentPropertiesExtended{
+						ProvisioningState: to.StringPtr("Succeeded"),
+						Timestamp:         &date.Time{Time: timeBenchMark},
+					},
+				},
+				"cluster-autoscaler-0001": {
+					Name: to.StringPtr("cluster-autoscaler-0001"),
+					Properties: &resources.DeploymentPropertiesExtended{
+						ProvisioningState: to.StringPtr("Succeeded"),
+						Timestamp:         &date.Time{Time: timeBenchMark.Add(time.Minute)},
+					},
+				},
+				"cluster-autoscaler-0002": {
+					Name: to.StringPtr("cluster-autoscaler-0002"),
+					Properties: &resources.DeploymentPropertiesExtended{
+						ProvisioningState: to.StringPtr("Succeeded"),
+						Timestamp:         &date.Time{Time: timeBenchMark.Add(2 * time.Minute)},
+					},
+				},
+			},
+			expectedDeploymentsNames: map[string]bool{
+				"non-cluster-autoscaler-0000": true,
+				"cluster-autoscaler-0001":     true,
+				"cluster-autoscaler-0002":     true,
+			},
+			expectedErr: nil,
+			desc:        "cluster autoscaler provider azure should delete outdated deployments created by cluster autoscaler",
+		},
+	}
+
+	for _, test := range testCases {
+		testAS := newTestAgentPool(newTestAzureManager(t), "testAS")
+		testAS.manager.azClient.deploymentsClient = &DeploymentsClientMock{
+			FakeStore: test.deployments,
+		}
+
+		err := testAS.deleteOutdatedDeployments()
+		assert.Equal(t, test.expectedErr, err, test.desc)
+		existedDeployments, err := testAS.manager.azClient.deploymentsClient.List(context.Background(), "", "", to.Int32Ptr(0))
+		existedDeploymentsNames := make(map[string]bool)
+		for _, deployment := range existedDeployments {
+			existedDeploymentsNames[*deployment.Name] = true
+		}
+		assert.Equal(t, test.expectedDeploymentsNames, existedDeploymentsNames, test.desc)
+	}
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -37,8 +37,9 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 		env:                  azure.PublicCloud,
 		explicitlyConfigured: make(map[string]bool),
 		config: &Config{
-			ResourceGroup: "test",
-			VMType:        vmTypeVMSS,
+			ResourceGroup:       "test",
+			VMType:              vmTypeVMSS,
+			MaxDeploymentsCount: 2,
 		},
 
 		azClient: &azClient{

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -258,3 +258,30 @@ func (m *DeploymentsClientMock) CreateOrUpdate(ctx context.Context, resourceGrou
 	deploy.Properties.Template = parameters.Properties.Template
 	return nil, nil
 }
+
+// List gets all the deployments for a resource group.
+func (m *DeploymentsClientMock) List(ctx context.Context, resourceGroupName, filter string, top *int32) (result []resources.DeploymentExtended, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	result = make([]resources.DeploymentExtended, 0)
+	for i := range m.FakeStore {
+		result = append(result, m.FakeStore[i])
+	}
+
+	return result, nil
+}
+
+// Delete deletes the given deployment
+func (m *DeploymentsClientMock) Delete(ctx context.Context, resourceGroupName, deploymentName string) (resp *http.Response, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if _, ok := m.FakeStore[deploymentName]; !ok {
+		return nil, fmt.Errorf("there is no such a deployment with name %s", deploymentName)
+	}
+
+	delete(m.FakeStore, deploymentName)
+
+	return
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -106,6 +106,9 @@ type Config struct {
 
 	// ASG cache TTL in seconds
 	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
+
+	// number of latest deployments that will not be deleted
+	MaxDeploymentsCount int64 `json:"maxDeploymentsCount" yaml:"maxDeploymentsCount"`
 }
 
 // TrimSpace removes all leading and trailing white spaces.
@@ -171,6 +174,13 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
 			}
 		}
+
+		if threshold := os.Getenv("AZURE_MAX_DEPLOYMENT_COUNT"); threshold != "" {
+			cfg.MaxDeploymentsCount, err = strconv.ParseInt(threshold, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_MAX_DEPLOYMENT_COUNT %q: %v", threshold, err)
+			}
+		}
 	}
 	cfg.TrimSpace()
 
@@ -192,6 +202,10 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 
 	if cfg.AsgCacheTTL == 0 {
 		cfg.AsgCacheTTL = int64(defaultAsgCacheTTL)
+	}
+
+	if cfg.MaxDeploymentsCount == 0 {
+		cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	}
 
 	// Defaulting env to Azure Public Cloud.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -37,26 +37,28 @@ const validAzureCfg = `{
 	"vnetName": "fakeName",
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
-	"asgCacheTTL": 900}`
+	"asgCacheTTL": 900,
+	"maxDeploymentsCount": 8}`
 
 const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
 
 func TestCreateAzureManagerValidConfig(t *testing.T) {
 	manager, err := CreateAzureManager(strings.NewReader(validAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{})
 
-	expectdConfig := &Config{
-		Cloud:           "AzurePublicCloud",
-		TenantID:        "fakeId",
-		SubscriptionID:  "fakeId",
-		ResourceGroup:   "fakeId",
-		VMType:          "vmss",
-		AADClientID:     "fakeId",
-		AADClientSecret: "fakeId",
-		AsgCacheTTL:     900,
+	expectedConfig := &Config{
+		Cloud:               "AzurePublicCloud",
+		TenantID:            "fakeId",
+		SubscriptionID:      "fakeId",
+		ResourceGroup:       "fakeId",
+		VMType:              "vmss",
+		AADClientID:         "fakeId",
+		AADClientSecret:     "fakeId",
+		AsgCacheTTL:         900,
+		MaxDeploymentsCount: 8,
 	}
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectdConfig, manager.config, "unexpected azure manager configuration")
+	assert.Equal(t, expectedConfig, manager.config, "unexpected azure manager configuration")
 }
 
 func TestCreateAzureManagerInvalidConfig(t *testing.T) {


### PR DESCRIPTION
Fixes: #2154 

To prevent the potential `DeploymentQuotaExceeded` error, we keep the latest 10 cluster autoscaler deployments and delete others.

/kind bug
/area provider/azure