### PR TITLE
VPA: fix bash set options

### DIFF
--- a/vertical-pod-autoscaler/hack/update-kubernetes-deps-in-e2e.sh
+++ b/vertical-pod-autoscaler/hack/update-kubernetes-deps-in-e2e.sh
@@ -19,7 +19,7 @@
 # K8S_TAG - k8s version to use for the dependencies update.
 # Suggested format is K8S_TAG=v1.10.3
 
-set -eou errexit pipefail nounset
+set -euo pipefail
 
 K8S_TAG=${K8S_TAG:-v1.16.2}
 K8S_TAG=${K8S_TAG#v}


### PR DESCRIPTION
The `set` in `hack/update-kubernetes-deps-in-e2e.sh` contains redundant options:
* `errexit` equals `-e`
* `nounset` equals `-u`

Also, I have misunderstood how to correctly set options in https://github.com/kubernetes/autoscaler/pull/2531, the `-o` can take only one argument and `pipefail` doesn't have short variant so it has to remain long.

Resource: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

ptal @bskiba 