### PR TITLE
Support Azure user assigned identity

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -471,6 +471,13 @@ func newServicePrincipalTokenFromCredentials(config *Config, env *azure.Environm
 		if err != nil {
 			return nil, fmt.Errorf("getting the managed service identity endpoint: %v", err)
 		}
+		if len(config.UserAssignedIdentityID) > 0 {
+			klog.V(4).Info("azure: using User Assigned MSI ID to retrieve access token")
+			return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint,
+				env.ServiceManagementEndpoint,
+				config.UserAssignedIdentityID)
+		}
+		klog.V(4).Info("azure: using System Assigned MSI to retrieve access token")
 		return adal.NewServicePrincipalTokenFromMSI(
 			msiEndpoint,
 			env.ServiceManagementEndpoint)

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -92,6 +92,7 @@ type Config struct {
 	AADClientCertPath           string `json:"aadClientCertPath" yaml:"aadClientCertPath"`
 	AADClientCertPassword       string `json:"aadClientCertPassword" yaml:"aadClientCertPassword"`
 	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension" yaml:"useManagedIdentityExtension"`
+	UserAssignedIdentityID      string `json:"userAssignedIdentityID" yaml:"userAssignedIdentityID"`
 
 	// Configs only for standard vmType (agent pools).
 	Deployment           string                 `json:"deployment" yaml:"deployment"`
@@ -164,6 +165,11 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		userAssignedIdentityIDFromEnv := os.Getenv("ARM_USER_ASSIGNED_IDENTITY_ID")
+		if userAssignedIdentityIDFromEnv != "" {
+			cfg.UserAssignedIdentityID = userAssignedIdentityIDFromEnv
 		}
 
 		if asgCacheTTL := os.Getenv("AZURE_ASG_CACHE_TTL"); asgCacheTTL != "" {


### PR DESCRIPTION
This PR adds Azure user assigned identity support to cluster-autoscaler.

/kind feature
/area provider/azure