### PR TITLE
Decrease the number of calls to VMSS API

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -153,27 +152,12 @@ func (m *asgCache) FindForInstance(instance *azureRef, vmType string) (cloudprov
 		}
 	}
 
-	klog.V(4).Infof("FindForInstance: cache before refresh %v", m.instanceToAsg)
-
 	// Look up caches for the instance.
+	klog.V(4).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instanceToAsg)
 	if asg := m.getInstanceFromCache(inst.Name); asg != nil {
-		klog.V(4).Infof("FindForInstance: returns before refresh, asg: %s", asg.Id())
+		klog.V(4).Infof("FindForInstance: found asg %s in cache", asg.Id())
 		return asg, nil
 	}
-
-	// Not found, regenerate the cache and try again.
-	if err := m.regenerate(); err != nil {
-		klog.Errorf("FindForInstance: error while looking for ASG for instance %q, error: %v", instance.Name, err)
-		return nil, fmt.Errorf("error while looking for ASG for instance %q, error: %v", instance.Name, err)
-	}
-
-	klog.V(4).Infof("FindForInstance: cache after refresh %v", m.instanceToAsg)
-
-	if asg := m.getInstanceFromCache(inst.Name); asg != nil {
-		klog.V(4).Infof("FindForInstance: returns after refresh, asg: %s", asg.Id())
-		return asg, nil
-	}
-
 	klog.V(4).Infof("FindForInstance: Couldn't find NodeGroup of instance %q", inst)
 	return nil, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -126,6 +126,8 @@ func TestNodeGroupForNode(t *testing.T) {
 			ProviderID: "azure://" + fakeVirtualMachineScaleSetVMID,
 		},
 	}
+	// refresh cache
+	provider.azureManager.regenerateCache()
 	group, err := provider.NodeGroupForNode(node)
 	assert.NoError(t, err)
 	assert.NotNil(t, group, "Group should not be nil")

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -314,8 +314,13 @@ func (m *AzureManager) Refresh() error {
 }
 
 func (m *AzureManager) forceRefresh() error {
+	// TODO: Refactor some of this logic out of forceRefresh and
+	// consider merging the list call with the Nodes() call
 	if err := m.fetchAutoAsgs(); err != nil {
 		klog.Errorf("Failed to fetch ASGs: %v", err)
+	}
+	if err := m.regenerateCache(); err != nil {
+		klog.Errorf("Failed to regenerate ASG cache: %v", err)
 		return err
 	}
 	m.lastRefresh = time.Now()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -105,6 +105,9 @@ func TestBelongs(t *testing.T) {
 
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	provider.azureManager.regenerateCache()
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -147,6 +150,9 @@ func TestDeleteNodes(t *testing.T) {
 	}
 	scaleSetClient.On("DeleteInstances", mock.Anything, "test-asg", mock.Anything, mock.Anything).Return(response, nil)
 	manager.azClient.virtualMachineScaleSetsClient = scaleSetClient
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	manager.regenerateCache()
 
 	resourceLimiter := cloudprovider.NewResourceLimiter(
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
@@ -157,6 +163,9 @@ func TestDeleteNodes(t *testing.T) {
 	registered := manager.RegisterAsg(
 		newTestScaleSet(manager, "test-asg"))
 	assert.True(t, registered)
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	manager.regenerateCache()
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -193,6 +202,9 @@ func TestScaleSetNodes(t *testing.T) {
 	provider := newTestProvider(t)
 	registered := provider.azureManager.RegisterAsg(
 		newTestScaleSet(provider.azureManager, "test-asg"))
+	// TODO: this should call manager.Refresh() once the fetchAutoASG
+	// logic is refactored out
+	provider.azureManager.regenerateCache()
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
 


### PR DESCRIPTION
`FindForInstance` is called every autoscaler loop (default 10s). In the case of a large volume scale down, you end up with a bunch of nodes in `NotReady` state until they get cleaned up by cloud-provider. This would lead to several cache misses and a call to `asgCache. regenerate()` which could possibly lead to a VMSS List for every registered node group. This would be multiplied by the number of not ready nodes (cache misses) in the worst case, O(numberOfNodes). This should be O(numberOfVmss).

Move the cache regeneration to `forceRefresh()` which gets called at the start of the autoscaler loop so that the virtual machine details get fetched with one List call for every VMSS. The frequency is now once per VMSS/registered ASG, instead of the node multiplier. This would match the granularity of the `Nodes()` call with 15 seconds calls if vmss size changes and 5 minutes if no change instead of having the vmss calls number scale linearly with the number of not ready nodes or cache misses.


Over a period of 1h: With one nodepool, starting node count of 3 and the same workload. The benefit is amplified in the longer term and larger number of nodes:

Before:
```
GET/VIRTUALMACHINESCALESETS/VIRTUALMACHINES:

324 calls

GET/VIRTUALMACHINESCALESETS

260 calls
```

After:

```
GET/VIRTUALMACHINESCALESETS/VIRTUALMACHINES:

38 calls

GET/VIRTUALMACHINESCALESETS

276 calls
```
