### PR TITLE
Remove taints with specific prefix from template node

### DIFF
--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,6 +42,8 @@ import (
 const (
 	// ReschedulerTaintKey is the name of the taint created by rescheduler.
 	ReschedulerTaintKey = "CriticalAddonsOnly"
+	// IgnoreTaintPrefix any taint starting with it will be filtered out from autoscaler template node.
+	IgnoreTaintPrefix = "ignore-taint.cluster-autoscaler.kubernetes.io/"
 )
 
 type equivalenceGroupId int
@@ -281,6 +284,11 @@ func sanitizeTemplateNode(node *apiv1.Node, nodeGroup string, ignoredTaints Tain
 
 		if exists := ignoredTaints[taint.Key]; exists {
 			klog.V(4).Infof("Removing ignored taint %s, when creating template from node %s", taint.Key, node.Name)
+			continue
+		}
+
+		if strings.HasPrefix(taint.Key, IgnoreTaintPrefix) {
+			klog.V(4).Infof("Removing taint %s based on prefix, when creation template from node %s", taint.Key, node.Name)
 			continue
 		}
 

--- a/cluster-autoscaler/core/utils/utils_test.go
+++ b/cluster-autoscaler/core/utils/utils_test.go
@@ -274,6 +274,11 @@ func TestSanitizeTaints(t *testing.T) {
 		Value:  "1",
 		Effect: apiv1.TaintEffectNoSchedule,
 	})
+	taints = append(taints, apiv1.Taint{
+		Key:    "ignore-taint.cluster-autoscaler.kubernetes.io/to-be-ignored",
+		Value:  "I-am-the-invisible-man-Incredible-how-you-can",
+		Effect: apiv1.TaintEffectNoSchedule,
+	})
 
 	ignoredTaints := map[string]bool{"ignore-me": true}
 


### PR DESCRIPTION
This is the same functionality as what you get with --ignore-taint
flag, but it doesn't require updating CA config to add a new taint
to ignore.