### PR TITLE
VPA - Handling empty vpa observed containers annotation

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_observed_containers.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_observed_containers.go
@@ -42,6 +42,9 @@ func GetVpaObservedContainersValue(pod *v1.Pod) string {
 // ParseVpaObservedContainersValue returns list of containers
 // based on a given vpa observed containers annotation value.
 func ParseVpaObservedContainersValue(value string) ([]string, error) {
+	if value == "" {
+		return []string{}, nil
+	}
 	containerNames := strings.Split(value, listSeparator)
 	for i := range containerNames {
 		if errs := validation.IsDNS1123Label(containerNames[i]); len(errs) != 0 {

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_observed_containers_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_observed_containers_test.go
@@ -64,9 +64,15 @@ func TestParseVpaObservedContainersValue(t *testing.T) {
 		},
 		{
 			name:       "parsing vpa observed containers annotation with incorrect container name",
-			annotation: "[test1, test2, test3_;';s]",
+			annotation: "test1, test2, test3_;';s",
 			want:       []string(nil),
 			wantErr:    true,
+		},
+		{
+			name:       "parsing empty vpa observed containers annotation",
+			annotation: "",
+			want:       []string{},
+			wantErr:    false,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Empty string should be a correct case of VpaObservedContainers annotation.