### PR TITLE
Fix a bug in GCE scale-from-0 template construction

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -109,8 +109,8 @@ func getKubeEnvValueFromTemplateMetadata(template *gce.InstanceTemplate) (string
 			if item.Value == nil {
 				return "", fmt.Errorf("no kube-env content in metadata")
 			}
+			return *item.Value, nil
 		}
-		return *item.Value, nil
 	}
 	return "", nil
 }


### PR DESCRIPTION
Side note: we really should improve our error handling - this bug
completely crashes CA if at least a single node group is at 0 nodes.