### PR TITLE
CA: Updating AWS-SDK-Go to 1.26.6

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
@@ -56,13 +58,13 @@ func TestGetRegion(t *testing.T) {
 	expected1 := "the-shire-1"
 	os.Setenv(key, expected1)
 	assert.Equal(t, expected1, getRegion())
-	// Ensure without environment variable, EC2 Metadata used... and it merely
-	// chops the last character off the Availability Zone.
+	// Ensure without environment variable, EC2 Metadata is used.
 	expected2 := "mordor-2"
-	expected2a := expected2 + "a"
+	expectedjson := ec2metadata.EC2InstanceIdentityDocument{Region: expected2}
+	js, _ := json.Marshal(expectedjson)
 	os.Unsetenv(key)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(expected2a))
+		w.Write(js)
 	}))
 	cfg := aws.NewConfig().WithEndpoint(server.URL)
 	assert.Equal(t, expected2, getRegion(cfg))

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -11,8 +11,9 @@ require (
 	github.com/Azure/azure-sdk-for-go v35.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.0
 	github.com/Azure/go-autorest/autorest/adal v0.5.0
+	github.com/Azure/go-autorest/autorest/date v0.1.0
 	github.com/Azure/go-autorest/autorest/to v0.2.0
-	github.com/aws/aws-sdk-go v1.23.18
+	github.com/aws/aws-sdk-go v1.26.6
 	github.com/digitalocean/godo v1.27.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -70,7 +71,7 @@ replace (
 	github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
 	github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
-	github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.23.18
+	github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.26.6
 	github.com/bazelbuild/bazel-gazelle => github.com/bazelbuild/bazel-gazelle v0.19.1-0.20191105222053-70208cbdc798
 	github.com/bazelbuild/buildtools => github.com/bazelbuild/buildtools v0.0.0-20190917191645-69366ca98f89
 	github.com/bazelbuild/rules_go => github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab
@@ -391,35 +392,35 @@ replace (
 	gotest.tools/gotestsum => gotest.tools/gotestsum v0.3.5
 	grpc.go4.org => grpc.go4.org v0.0.0-20170609214715-11d0a25b4919
 	honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.2
-	k8s.io/api => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/api
-	k8s.io/apiextensions-apiserver => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apiextensions-apiserver
-	k8s.io/apimachinery => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apimachinery
-	k8s.io/apiserver => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apiserver
-	k8s.io/cli-runtime => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cli-runtime
-	k8s.io/client-go => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/client-go
-	k8s.io/cloud-provider => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cloud-provider
-	k8s.io/cluster-bootstrap => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cluster-bootstrap
-	k8s.io/code-generator => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/code-generator
-	k8s.io/component-base => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/component-base
-	k8s.io/cri-api => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cri-api
-	k8s.io/csi-translation-lib => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/csi-translation-lib
+	k8s.io/api => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/api
+	k8s.io/apiextensions-apiserver => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apiextensions-apiserver
+	k8s.io/apimachinery => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apimachinery
+	k8s.io/apiserver => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apiserver
+	k8s.io/cli-runtime => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cli-runtime
+	k8s.io/client-go => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/client-go
+	k8s.io/cloud-provider => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cloud-provider
+	k8s.io/cluster-bootstrap => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cluster-bootstrap
+	k8s.io/code-generator => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/code-generator
+	k8s.io/component-base => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/component-base
+	k8s.io/cri-api => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cri-api
+	k8s.io/csi-translation-lib => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/csi-translation-lib
 	k8s.io/gengo => k8s.io/gengo v0.0.0-20190822140433-26a664648505
 	k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog => k8s.io/klog v1.0.0
-	k8s.io/kube-aggregator => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-aggregator
-	k8s.io/kube-controller-manager => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-controller-manager
+	k8s.io/kube-aggregator => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-aggregator
+	k8s.io/kube-controller-manager => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-controller-manager
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
-	k8s.io/kube-proxy => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-proxy
-	k8s.io/kube-scheduler => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-scheduler
-	k8s.io/kubectl => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kubectl
-	k8s.io/kubelet => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kubelet
-	k8s.io/legacy-cloud-providers => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/legacy-cloud-providers
-	k8s.io/metrics => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/metrics
-	k8s.io/node-api => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/node-api
+	k8s.io/kube-proxy => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-proxy
+	k8s.io/kube-scheduler => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-scheduler
+	k8s.io/kubectl => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kubectl
+	k8s.io/kubelet => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kubelet
+	k8s.io/legacy-cloud-providers => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/legacy-cloud-providers
+	k8s.io/metrics => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/metrics
+	k8s.io/node-api => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/node-api
 	k8s.io/repo-infra => k8s.io/repo-infra v0.0.1-alpha.1
-	k8s.io/sample-apiserver => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/sample-apiserver
-	k8s.io/sample-cli-plugin => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/sample-cli-plugin
-	k8s.io/sample-controller => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/sample-controller
+	k8s.io/sample-apiserver => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/sample-apiserver
+	k8s.io/sample-cli-plugin => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/sample-cli-plugin
+	k8s.io/sample-controller => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/sample-controller
 	k8s.io/system-validators => k8s.io/system-validators v1.0.4
 	k8s.io/utils => k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	modernc.org/cc => modernc.org/cc v1.0.0
@@ -441,4 +442,4 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
 
 replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
 
-replace k8s.io/kubernetes => /tmp/ca-update-vendor.Mm8E/kubernetes
+replace k8s.io/kubernetes => /tmp/ca-update-vendor.eHTc/kubernetes

--- a/cluster-autoscaler/go.mod-extra
+++ b/cluster-autoscaler/go.mod-extra
@@ -4,7 +4,7 @@ go 1.12
 require (
   github.com/digitalocean/godo v1.27.0
   github.com/rancher/go-rancher v0.1.0
-  github.com/aws/aws-sdk-go v1.23.18
+  github.com/aws/aws-sdk-go v1.26.6
 )
 
 replace (

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -54,8 +54,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7 h1:irR1cO6eek3n5uquIVaRAsQmZnlsfPuHNz31cXo4eyk=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
-github.com/aws/aws-sdk-go v1.23.18 h1:ADU/y1EO8yPzUJJYjcvJ0V9/suezxPh0u6hb5bSYIGQ=
-github.com/aws/aws-sdk-go v1.23.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.26.6 h1:LinjO5+t9K/TyrZbSU1BaVJ5wIG3DlX5SffZ32Eg+kU=
+github.com/aws/aws-sdk-go v1.26.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/bazelbuild/bazel-gazelle v0.19.1-0.20191105222053-70208cbdc798/go.mod h1:rPwzNHUqEzngx1iVBfO/2X2npKaT3tqPqqHW6rVsn/A=
 github.com/bazelbuild/buildtools v0.0.0-20190917191645-69366ca98f89/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/path_value.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/path_value.go
@@ -70,7 +70,7 @@ func rValuesAtPath(v interface{}, path string, createPath, caseSensitive, nilTer
 			value = value.FieldByNameFunc(func(name string) bool {
 				if c == name {
 					return true
-				} else if !caseSensitive && strings.ToLower(name) == strings.ToLower(c) {
+				} else if !caseSensitive && strings.EqualFold(name, c) {
 					return true
 				}
 				return false

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	Config        *aws.Config
 	Handlers      request.Handlers
+	PartitionID   string
 	Endpoint      string
 	SigningRegion string
 	SigningName   string
@@ -64,7 +65,7 @@ func New(cfg aws.Config, info metadata.ClientInfo, handlers request.Handlers, op
 	default:
 		maxRetries := aws.IntValue(cfg.MaxRetries)
 		if cfg.MaxRetries == nil || maxRetries == aws.UseServiceDefaultRetries {
-			maxRetries = 3
+			maxRetries = DefaultRetryerMaxNumRetries
 		}
 		svc.Retryer = DefaultRetryer{NumMaxRetries: maxRetries}
 	}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"math"
 	"strconv"
 	"time"
 
@@ -9,20 +10,47 @@ import (
 )
 
 // DefaultRetryer implements basic retry logic using exponential backoff for
-// most services. If you want to implement custom retry logic, implement the
-// request.Retryer interface or create a structure type that composes this
-// struct and override the specific methods. For example, to override only
-// the MaxRetries method:
+// most services. If you want to implement custom retry logic, you can implement the
+// request.Retryer interface.
 //
-//   type retryer struct {
-//       client.DefaultRetryer
-//   }
-//
-//   // This implementation always has 100 max retries
-//   func (d retryer) MaxRetries() int { return 100 }
 type DefaultRetryer struct {
+	// Num max Retries is the number of max retries that will be performed.
+	// By default, this is zero.
 	NumMaxRetries int
+
+	// MinRetryDelay is the minimum retry delay after which retry will be performed.
+	// If not set, the value is 0ns.
+	MinRetryDelay time.Duration
+
+	// MinThrottleRetryDelay is the minimum retry delay when throttled.
+	// If not set, the value is 0ns.
+	MinThrottleDelay time.Duration
+
+	// MaxRetryDelay is the maximum retry delay before which retry must be performed.
+	// If not set, the value is 0ns.
+	MaxRetryDelay time.Duration
+
+	// MaxThrottleDelay is the maximum retry delay when throttled.
+	// If not set, the value is 0ns.
+	MaxThrottleDelay time.Duration
 }
+
+const (
+	// DefaultRetryerMaxNumRetries sets maximum number of retries
+	DefaultRetryerMaxNumRetries = 3
+
+	// DefaultRetryerMinRetryDelay sets minimum retry delay
+	DefaultRetryerMinRetryDelay = 30 * time.Millisecond
+
+	// DefaultRetryerMinThrottleDelay sets minimum delay when throttled
+	DefaultRetryerMinThrottleDelay = 500 * time.Millisecond
+
+	// DefaultRetryerMaxRetryDelay sets maximum retry delay
+	DefaultRetryerMaxRetryDelay = 300 * time.Second
+
+	// DefaultRetryerMaxThrottleDelay sets maximum delay when throttled
+	DefaultRetryerMaxThrottleDelay = 300 * time.Second
+)
 
 // MaxRetries returns the number of maximum returns the service will use to make
 // an individual API request.
@@ -30,10 +58,36 @@ func (d DefaultRetryer) MaxRetries() int {
 	return d.NumMaxRetries
 }
 
+// setRetryerDefaults sets the default values of the retryer if not set
+func (d *DefaultRetryer) setRetryerDefaults() {
+	if d.MinRetryDelay == 0 {
+		d.MinRetryDelay = DefaultRetryerMinRetryDelay
+	}
+	if d.MaxRetryDelay == 0 {
+		d.MaxRetryDelay = DefaultRetryerMaxRetryDelay
+	}
+	if d.MinThrottleDelay == 0 {
+		d.MinThrottleDelay = DefaultRetryerMinThrottleDelay
+	}
+	if d.MaxThrottleDelay == 0 {
+		d.MaxThrottleDelay = DefaultRetryerMaxThrottleDelay
+	}
+}
+
 // RetryRules returns the delay duration before retrying this request again
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
-	// Set the upper limit of delay in retrying at ~five minutes
-	var minTime int64 = 30
+
+	// if number of max retries is zero, no retries will be performed.
+	if d.NumMaxRetries == 0 {
+		return 0
+	}
+
+	// Sets default value for retryer members
+	d.setRetryerDefaults()
+
+	// minDelay is the minimum retryer delay
+	minDelay := d.MinRetryDelay
+
 	var initialDelay time.Duration
 
 	isThrottle := r.IsErrorThrottle()
@@ -41,34 +95,51 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 		if delay, ok := getRetryAfterDelay(r); ok {
 			initialDelay = delay
 		}
-
-		minTime = 500
+		minDelay = d.MinThrottleDelay
 	}
 
 	retryCount := r.RetryCount
-	if isThrottle && retryCount > 8 {
-		retryCount = 8
-	} else if retryCount > 12 {
-		retryCount = 12
+
+	// maxDelay the maximum retryer delay
+	maxDelay := d.MaxRetryDelay
+
+	if isThrottle {
+		maxDelay = d.MaxThrottleDelay
 	}
 
-	delay := (1 << uint(retryCount)) * (sdkrand.SeededRand.Int63n(minTime) + minTime)
-	return (time.Duration(delay) * time.Millisecond) + initialDelay
+	var delay time.Duration
 
+	// Logic to cap the retry count based on the minDelay provided
+	actualRetryCount := int(math.Log2(float64(minDelay))) + 1
+	if actualRetryCount < 63-retryCount {
+		delay = time.Duration(1<<uint64(retryCount)) * getJitterDelay(minDelay)
+		if delay > maxDelay {
+			delay = getJitterDelay(maxDelay / 2)
+		}
+	} else {
+		delay = getJitterDelay(maxDelay / 2)
+	}
+	return delay + initialDelay
+}
+
+// getJitterDelay returns a jittered delay for retry
+func getJitterDelay(duration time.Duration) time.Duration {
+	return time.Duration(sdkrand.SeededRand.Int63n(int64(duration)) + int64(duration))
 }
 
 // ShouldRetry returns true if the request should be retried.
 func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
+
+	// ShouldRetry returns false if number of max retries is 0.
+	if d.NumMaxRetries == 0 {
+		return false
+	}
+
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
 	if r.Retryable != nil {
 		return *r.Retryable
 	}
-
-	if r.HTTPResponse.StatusCode >= 500 && r.HTTPResponse.StatusCode != 501 {
-		return true
-	}
-
 	return r.IsErrorRetryable() || r.IsErrorThrottle()
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
@@ -5,6 +5,7 @@ type ClientInfo struct {
 	ServiceName   string
 	ServiceID     string
 	APIVersion    string
+	PartitionID   string
 	Endpoint      string
 	SigningName   string
 	SigningRegion string

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/no_op_retryer.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/no_op_retryer.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// NoOpRetryer provides a retryer that performs no retries.
+// It should be used when we do not want retries to be performed.
+type NoOpRetryer struct{}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API; For NoOpRetryer the MaxRetries will always be zero.
+func (d NoOpRetryer) MaxRetries() int {
+	return 0
+}
+
+// ShouldRetry will always return false for NoOpRetryer, as it should never retry.
+func (d NoOpRetryer) ShouldRetry(_ *request.Request) bool {
+	return false
+}
+
+// RetryRules returns the delay duration before retrying this request again;
+// since NoOpRetryer does not retry, RetryRules always returns 0.
+func (d NoOpRetryer) RetryRules(_ *request.Request) time.Duration {
+	return 0
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/config.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/config.go
@@ -161,6 +161,10 @@ type Config struct {
 	// on GetObject API calls.
 	S3DisableContentMD5Validation *bool
 
+	// Set this to `true` to have the S3 service client to use the region specified
+	// in the ARN, when an ARN is provided as an argument to a bucket parameter.
+	S3UseARNRegion *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the
 	// EC2Metadata client to create a new http.Client. This options is only
@@ -246,6 +250,12 @@ type Config struct {
 	// Disabling this feature is useful when you want to use local endpoints
 	// for testing that do not support the modeled host prefix pattern.
 	DisableEndpointHostPrefix *bool
+
+	// STSRegionalEndpoint will enable regional or legacy endpoint resolving
+	STSRegionalEndpoint endpoints.STSRegionalEndpoint
+
+	// S3UsEast1RegionalEndpoint will enable regional or legacy endpoint resolving
+	S3UsEast1RegionalEndpoint endpoints.S3UsEast1RegionalEndpoint
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder
@@ -379,6 +389,13 @@ func (c *Config) WithS3DisableContentMD5Validation(enable bool) *Config {
 
 }
 
+// WithS3UseARNRegion sets a config S3UseARNRegion value and
+// returning a Config pointer for chaining
+func (c *Config) WithS3UseARNRegion(enable bool) *Config {
+	c.S3UseARNRegion = &enable
+	return c
+}
+
 // WithUseDualStack sets a config UseDualStack value returning a Config
 // pointer for chaining.
 func (c *Config) WithUseDualStack(enable bool) *Config {
@@ -418,6 +435,20 @@ func (c *Config) MergeIn(cfgs ...*Config) {
 	for _, other := range cfgs {
 		mergeInConfig(c, other)
 	}
+}
+
+// WithSTSRegionalEndpoint will set whether or not to use regional endpoint flag
+// when resolving the endpoint for a service
+func (c *Config) WithSTSRegionalEndpoint(sre endpoints.STSRegionalEndpoint) *Config {
+	c.STSRegionalEndpoint = sre
+	return c
+}
+
+// WithS3UsEast1RegionalEndpoint will set whether or not to use regional endpoint flag
+// when resolving the endpoint for a service
+func (c *Config) WithS3UsEast1RegionalEndpoint(sre endpoints.S3UsEast1RegionalEndpoint) *Config {
+	c.S3UsEast1RegionalEndpoint = sre
+	return c
 }
 
 func mergeInConfig(dst *Config, other *Config) {
@@ -493,6 +524,10 @@ func mergeInConfig(dst *Config, other *Config) {
 		dst.S3DisableContentMD5Validation = other.S3DisableContentMD5Validation
 	}
 
+	if other.S3UseARNRegion != nil {
+		dst.S3UseARNRegion = other.S3UseARNRegion
+	}
+
 	if other.UseDualStack != nil {
 		dst.UseDualStack = other.UseDualStack
 	}
@@ -519,6 +554,14 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.DisableEndpointHostPrefix != nil {
 		dst.DisableEndpointHostPrefix = other.DisableEndpointHostPrefix
+	}
+
+	if other.STSRegionalEndpoint != endpoints.UnsetSTSEndpoint {
+		dst.STSRegionalEndpoint = other.STSRegionalEndpoint
+	}
+
+	if other.S3UsEast1RegionalEndpoint != endpoints.UnsetS3UsEast1Endpoint {
+		dst.S3UsEast1RegionalEndpoint = other.S3UsEast1RegionalEndpoint
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/convert_types.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/convert_types.go
@@ -179,6 +179,242 @@ func IntValueMap(src map[string]*int) map[string]int {
 	return dst
 }
 
+// Uint returns a pointer to the uint value passed in.
+func Uint(v uint) *uint {
+	return &v
+}
+
+// UintValue returns the value of the uint pointer passed in or
+// 0 if the pointer is nil.
+func UintValue(v *uint) uint {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UintSlice converts a slice of uint values uinto a slice of
+// uint pointers
+func UintSlice(src []uint) []*uint {
+	dst := make([]*uint, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// UintValueSlice converts a slice of uint pointers uinto a slice of
+// uint values
+func UintValueSlice(src []*uint) []uint {
+	dst := make([]uint, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// UintMap converts a string map of uint values uinto a string
+// map of uint pointers
+func UintMap(src map[string]uint) map[string]*uint {
+	dst := make(map[string]*uint)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// UintValueMap converts a string map of uint pointers uinto a string
+// map of uint values
+func UintValueMap(src map[string]*uint) map[string]uint {
+	dst := make(map[string]uint)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int8 returns a pointer to the int8 value passed in.
+func Int8(v int8) *int8 {
+	return &v
+}
+
+// Int8Value returns the value of the int8 pointer passed in or
+// 0 if the pointer is nil.
+func Int8Value(v *int8) int8 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int8Slice converts a slice of int8 values into a slice of
+// int8 pointers
+func Int8Slice(src []int8) []*int8 {
+	dst := make([]*int8, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int8ValueSlice converts a slice of int8 pointers into a slice of
+// int8 values
+func Int8ValueSlice(src []*int8) []int8 {
+	dst := make([]int8, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int8Map converts a string map of int8 values into a string
+// map of int8 pointers
+func Int8Map(src map[string]int8) map[string]*int8 {
+	dst := make(map[string]*int8)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int8ValueMap converts a string map of int8 pointers into a string
+// map of int8 values
+func Int8ValueMap(src map[string]*int8) map[string]int8 {
+	dst := make(map[string]int8)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int16 returns a pointer to the int16 value passed in.
+func Int16(v int16) *int16 {
+	return &v
+}
+
+// Int16Value returns the value of the int16 pointer passed in or
+// 0 if the pointer is nil.
+func Int16Value(v *int16) int16 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int16Slice converts a slice of int16 values into a slice of
+// int16 pointers
+func Int16Slice(src []int16) []*int16 {
+	dst := make([]*int16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int16ValueSlice converts a slice of int16 pointers into a slice of
+// int16 values
+func Int16ValueSlice(src []*int16) []int16 {
+	dst := make([]int16, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int16Map converts a string map of int16 values into a string
+// map of int16 pointers
+func Int16Map(src map[string]int16) map[string]*int16 {
+	dst := make(map[string]*int16)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int16ValueMap converts a string map of int16 pointers into a string
+// map of int16 values
+func Int16ValueMap(src map[string]*int16) map[string]int16 {
+	dst := make(map[string]int16)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int32 returns a pointer to the int32 value passed in.
+func Int32(v int32) *int32 {
+	return &v
+}
+
+// Int32Value returns the value of the int32 pointer passed in or
+// 0 if the pointer is nil.
+func Int32Value(v *int32) int32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int32Slice converts a slice of int32 values into a slice of
+// int32 pointers
+func Int32Slice(src []int32) []*int32 {
+	dst := make([]*int32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int32ValueSlice converts a slice of int32 pointers into a slice of
+// int32 values
+func Int32ValueSlice(src []*int32) []int32 {
+	dst := make([]int32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int32Map converts a string map of int32 values into a string
+// map of int32 pointers
+func Int32Map(src map[string]int32) map[string]*int32 {
+	dst := make(map[string]*int32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int32ValueMap converts a string map of int32 pointers into a string
+// map of int32 values
+func Int32ValueMap(src map[string]*int32) map[string]int32 {
+	dst := make(map[string]int32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
 // Int64 returns a pointer to the int64 value passed in.
 func Int64(v int64) *int64 {
 	return &v
@@ -230,6 +466,301 @@ func Int64Map(src map[string]int64) map[string]*int64 {
 // map of int64 values
 func Int64ValueMap(src map[string]*int64) map[string]int64 {
 	dst := make(map[string]int64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint8 returns a pointer to the uint8 value passed in.
+func Uint8(v uint8) *uint8 {
+	return &v
+}
+
+// Uint8Value returns the value of the uint8 pointer passed in or
+// 0 if the pointer is nil.
+func Uint8Value(v *uint8) uint8 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint8Slice converts a slice of uint8 values into a slice of
+// uint8 pointers
+func Uint8Slice(src []uint8) []*uint8 {
+	dst := make([]*uint8, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint8ValueSlice converts a slice of uint8 pointers into a slice of
+// uint8 values
+func Uint8ValueSlice(src []*uint8) []uint8 {
+	dst := make([]uint8, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint8Map converts a string map of uint8 values into a string
+// map of uint8 pointers
+func Uint8Map(src map[string]uint8) map[string]*uint8 {
+	dst := make(map[string]*uint8)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint8ValueMap converts a string map of uint8 pointers into a string
+// map of uint8 values
+func Uint8ValueMap(src map[string]*uint8) map[string]uint8 {
+	dst := make(map[string]uint8)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint16 returns a pointer to the uint16 value passed in.
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+// Uint16Value returns the value of the uint16 pointer passed in or
+// 0 if the pointer is nil.
+func Uint16Value(v *uint16) uint16 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint16Slice converts a slice of uint16 values into a slice of
+// uint16 pointers
+func Uint16Slice(src []uint16) []*uint16 {
+	dst := make([]*uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint16ValueSlice converts a slice of uint16 pointers into a slice of
+// uint16 values
+func Uint16ValueSlice(src []*uint16) []uint16 {
+	dst := make([]uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint16Map converts a string map of uint16 values into a string
+// map of uint16 pointers
+func Uint16Map(src map[string]uint16) map[string]*uint16 {
+	dst := make(map[string]*uint16)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint16ValueMap converts a string map of uint16 pointers into a string
+// map of uint16 values
+func Uint16ValueMap(src map[string]*uint16) map[string]uint16 {
+	dst := make(map[string]uint16)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint32 returns a pointer to the uint32 value passed in.
+func Uint32(v uint32) *uint32 {
+	return &v
+}
+
+// Uint32Value returns the value of the uint32 pointer passed in or
+// 0 if the pointer is nil.
+func Uint32Value(v *uint32) uint32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint32Slice converts a slice of uint32 values into a slice of
+// uint32 pointers
+func Uint32Slice(src []uint32) []*uint32 {
+	dst := make([]*uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint32ValueSlice converts a slice of uint32 pointers into a slice of
+// uint32 values
+func Uint32ValueSlice(src []*uint32) []uint32 {
+	dst := make([]uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint32Map converts a string map of uint32 values into a string
+// map of uint32 pointers
+func Uint32Map(src map[string]uint32) map[string]*uint32 {
+	dst := make(map[string]*uint32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint32ValueMap converts a string map of uint32 pointers into a string
+// map of uint32 values
+func Uint32ValueMap(src map[string]*uint32) map[string]uint32 {
+	dst := make(map[string]uint32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint64 returns a pointer to the uint64 value passed in.
+func Uint64(v uint64) *uint64 {
+	return &v
+}
+
+// Uint64Value returns the value of the uint64 pointer passed in or
+// 0 if the pointer is nil.
+func Uint64Value(v *uint64) uint64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint64Slice converts a slice of uint64 values into a slice of
+// uint64 pointers
+func Uint64Slice(src []uint64) []*uint64 {
+	dst := make([]*uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint64ValueSlice converts a slice of uint64 pointers into a slice of
+// uint64 values
+func Uint64ValueSlice(src []*uint64) []uint64 {
+	dst := make([]uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint64Map converts a string map of uint64 values into a string
+// map of uint64 pointers
+func Uint64Map(src map[string]uint64) map[string]*uint64 {
+	dst := make(map[string]*uint64)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint64ValueMap converts a string map of uint64 pointers into a string
+// map of uint64 values
+func Uint64ValueMap(src map[string]*uint64) map[string]uint64 {
+	dst := make(map[string]uint64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Float32 returns a pointer to the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float32Slice converts a slice of float32 values into a slice of
+// float32 pointers
+func Float32Slice(src []float32) []*float32 {
+	dst := make([]*float32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Float32ValueSlice converts a slice of float32 pointers into a slice of
+// float32 values
+func Float32ValueSlice(src []*float32) []float32 {
+	dst := make([]float32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Float32Map converts a string map of float32 values into a string
+// map of float32 pointers
+func Float32Map(src map[string]float32) map[string]*float32 {
+	dst := make(map[string]*float32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Float32ValueMap converts a string map of float32 pointers into a string
+// map of float32 values
+func Float32ValueMap(src map[string]*float32) map[string]float32 {
+	dst := make(map[string]float32)
 	for k, val := range src {
 		if val != nil {
 			dst[k] = *val

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
@@ -90,6 +90,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
 const (
@@ -142,7 +143,7 @@ const (
 
 	// DefaultBufSize limits buffer size from growing to an enormous
 	// amount due to a faulty process.
-	DefaultBufSize = 1024
+	DefaultBufSize = int(8 * sdkio.KibiByte)
 
 	// DefaultTimeout default limit on time a process can run.
 	DefaultTimeout = time.Duration(1) * time.Minute

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds/assume_role_provider.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds/assume_role_provider.go
@@ -144,6 +144,13 @@ type AssumeRoleProvider struct {
 	// Session name, if you wish to reuse the credentials elsewhere.
 	RoleSessionName string
 
+	// Optional, you can pass tag key-value pairs to your session. These tags are called session tags.
+	Tags []*sts.Tag
+
+	// A list of keys for session tags that you want to set as transitive.
+	// If you set a tag key as transitive, the corresponding key and value passes to subsequent sessions in a role chain.
+	TransitiveTagKeys []*string
+
 	// Expiry duration of the STS credentials. Defaults to 15 minutes if not set.
 	Duration time.Duration
 
@@ -269,10 +276,12 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 	}
 	jitter := time.Duration(sdkrand.SeededRand.Float64() * p.MaxJitterFrac * float64(p.Duration))
 	input := &sts.AssumeRoleInput{
-		DurationSeconds: aws.Int64(int64((p.Duration - jitter) / time.Second)),
-		RoleArn:         aws.String(p.RoleARN),
-		RoleSessionName: aws.String(p.RoleSessionName),
-		ExternalId:      p.ExternalID,
+		DurationSeconds:   aws.Int64(int64((p.Duration - jitter) / time.Second)),
+		RoleArn:           aws.String(p.RoleARN),
+		RoleSessionName:   aws.String(p.RoleSessionName),
+		ExternalId:        p.ExternalID,
+		Tags:              p.Tags,
+		TransitiveTagKeys: p.TransitiveTagKeys,
 	}
 	if p.Policy != nil {
 		input.Policy = p.Policy

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
@@ -66,7 +66,6 @@ func (rep *Reporter) sendAPICallAttemptMetric(r *request.Request) {
 
 		XAmzRequestID: aws.String(r.RequestID),
 
-		AttemptCount:   aws.Int(r.RetryCount + 1),
 		AttemptLatency: aws.Int(int(now.Sub(r.AttemptTime).Nanoseconds() / int64(time.Millisecond))),
 		AccessKey:      aws.String(creds.AccessKeyID),
 	}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,9 +25,25 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
-// ServiceName is the name of the service.
-const ServiceName = "ec2metadata"
-const disableServiceEnvVar = "AWS_EC2_METADATA_DISABLED"
+const (
+	// ServiceName is the name of the service.
+	ServiceName          = "ec2metadata"
+	disableServiceEnvVar = "AWS_EC2_METADATA_DISABLED"
+
+	// Headers for Token and TTL
+	ttlHeader   = "x-aws-ec2-metadata-token-ttl-seconds"
+	tokenHeader = "x-aws-ec2-metadata-token"
+
+	// Named Handler constants
+	fetchTokenHandlerName          = "FetchTokenHandler"
+	unmarshalMetadataHandlerName   = "unmarshalMetadataHandler"
+	unmarshalTokenHandlerName      = "unmarshalTokenHandler"
+	enableTokenProviderHandlerName = "enableTokenProviderHandler"
+
+	// TTL constants
+	defaultTTL = 21600 * time.Second
+	ttlExpirationWindow = 30 * time.Second
+)
 
 // A EC2Metadata is an EC2 Metadata service Client.
 type EC2Metadata struct {
@@ -80,13 +97,27 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 		),
 	}
 
-	svc.Handlers.Unmarshal.PushBack(unmarshalHandler)
+	// token provider instance
+	tp := newTokenProvider(svc, defaultTTL)
+
+	// NamedHandler for fetching token
+	svc.Handlers.Sign.PushBackNamed(request.NamedHandler{
+		Name: fetchTokenHandlerName,
+		Fn:   tp.fetchTokenHandler,
+	})
+	// NamedHandler for enabling token provider
+	svc.Handlers.Complete.PushBackNamed(request.NamedHandler{
+		Name: enableTokenProviderHandlerName,
+		Fn:   tp.enableTokenProviderHandler,
+	})
+
+	svc.Handlers.Unmarshal.PushBackNamed(unmarshalHandler)
 	svc.Handlers.UnmarshalError.PushBack(unmarshalError)
 	svc.Handlers.Validate.Clear()
 	svc.Handlers.Validate.PushBack(validateEndpointHandler)
 
 	// Disable the EC2 Metadata service if the environment variable is set.
-	// This shortcirctes the service's functionality to always fail to send
+	// This short-circuits the service's functionality to always fail to send
 	// requests.
 	if strings.ToLower(os.Getenv(disableServiceEnvVar)) == "true" {
 		svc.Handlers.Send.SwapNamed(request.NamedHandler{
@@ -107,7 +138,6 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 	for _, option := range opts {
 		option(svc.Client)
 	}
-
 	return svc
 }
 
@@ -119,30 +149,74 @@ type metadataOutput struct {
 	Content string
 }
 
-func unmarshalHandler(r *request.Request) {
-	defer r.HTTPResponse.Body.Close()
-	b := &bytes.Buffer{}
-	if _, err := io.Copy(b, r.HTTPResponse.Body); err != nil {
-		r.Error = awserr.New(request.ErrCodeSerialization, "unable to unmarshal EC2 metadata response", err)
-		return
-	}
+type tokenOutput struct {
+	Token string
+	TTL   time.Duration
+}
 
-	if data, ok := r.Data.(*metadataOutput); ok {
-		data.Content = b.String()
-	}
+// unmarshal token handler is used to parse the response of a getToken operation
+var unmarshalTokenHandler = request.NamedHandler{
+	Name: unmarshalTokenHandlerName,
+	Fn: func(r *request.Request) {
+		defer r.HTTPResponse.Body.Close()
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, r.HTTPResponse.Body); err != nil {
+			r.Error = awserr.NewRequestFailure(awserr.New(request.ErrCodeSerialization,
+				"unable to unmarshal EC2 metadata response", err), r.HTTPResponse.StatusCode, r.RequestID)
+			return
+		}
+
+		v := r.HTTPResponse.Header.Get(ttlHeader)
+		data, ok := r.Data.(*tokenOutput)
+		if !ok {
+			return
+		}
+
+		data.Token = b.String()
+		// TTL is in seconds
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			r.Error = awserr.NewRequestFailure(awserr.New(request.ParamFormatErrCode,
+				"unable to parse EC2 token TTL response", err), r.HTTPResponse.StatusCode, r.RequestID)
+			return
+		}
+		t := time.Duration(i) * time.Second
+		data.TTL = t
+	},
+}
+
+var unmarshalHandler = request.NamedHandler{
+	Name: unmarshalMetadataHandlerName,
+	Fn: func(r *request.Request) {
+		defer r.HTTPResponse.Body.Close()
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, r.HTTPResponse.Body); err != nil {
+			r.Error = awserr.NewRequestFailure(awserr.New(request.ErrCodeSerialization,
+				"unable to unmarshal EC2 metadata response", err), r.HTTPResponse.StatusCode, r.RequestID)
+			return
+		}
+
+		if data, ok := r.Data.(*metadataOutput); ok {
+			data.Content = b.String()
+		}
+	},
 }
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
-	b := &bytes.Buffer{}
-	if _, err := io.Copy(b, r.HTTPResponse.Body); err != nil {
-		r.Error = awserr.New(request.ErrCodeSerialization, "unable to unmarshal EC2 metadata error response", err)
+	var b bytes.Buffer
+
+	if _, err := io.Copy(&b, r.HTTPResponse.Body); err != nil {
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(request.ErrCodeSerialization, "unable to unmarshal EC2 metadata error response", err),
+			r.HTTPResponse.StatusCode, r.RequestID)
 		return
 	}
 
 	// Response body format is not consistent between metadata endpoints.
 	// Grab the error message as a string and include that as the source error
-	r.Error = awserr.New("EC2MetadataError", "failed to make EC2Metadata request", errors.New(b.String()))
+	r.Error = awserr.NewRequestFailure(awserr.New("EC2MetadataError", "failed to make EC2Metadata request", errors.New(b.String())),
+		r.HTTPResponse.StatusCode, r.RequestID)
 }
 
 func validateEndpointHandler(r *request.Request) {

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/token_provider.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/token_provider.go
@@ -1,0 +1,92 @@
+package ec2metadata
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// A tokenProvider struct provides access to EC2Metadata client
+// and atomic instance of a token, along with configuredTTL for it.
+// tokenProvider also provides an atomic flag to disable the
+// fetch token operation.
+// The disabled member will use 0 as false, and 1 as true.
+type tokenProvider struct {
+	client        *EC2Metadata
+	token         atomic.Value
+	configuredTTL time.Duration
+	disabled      uint32
+}
+
+// A ec2Token struct helps use of token in EC2 Metadata service ops
+type ec2Token struct {
+	token string
+	credentials.Expiry
+}
+
+// newTokenProvider provides a pointer to a tokenProvider instance
+func newTokenProvider(c *EC2Metadata, duration time.Duration) *tokenProvider {
+	return &tokenProvider{client: c, configuredTTL: duration}
+}
+
+// fetchTokenHandler fetches token for EC2Metadata service client by default.
+func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
+
+	// short-circuits to insecure data flow if tokenProvider is disabled.
+	if v := atomic.LoadUint32(&t.disabled); v == 1 {
+		return
+	}
+
+	if ec2Token, ok := t.token.Load().(ec2Token); ok && !ec2Token.IsExpired() {
+		r.HTTPRequest.Header.Set(tokenHeader, ec2Token.token)
+		return
+	}
+
+	output, err := t.client.getToken(t.configuredTTL)
+
+	if err != nil {
+
+		// change the disabled flag on token provider to true,
+		// when error is request timeout error.
+		if requestFailureError, ok := err.(awserr.RequestFailure); ok {
+			switch requestFailureError.StatusCode() {
+			case http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed:
+				atomic.StoreUint32(&t.disabled, 1)
+			case http.StatusBadRequest:
+				r.Error = requestFailureError
+			}
+
+			// Check if request timed out while waiting for response
+			if e, ok := requestFailureError.OrigErr().(awserr.Error); ok {
+				if e.Code() == "RequestError" {
+					atomic.StoreUint32(&t.disabled, 1)
+				}
+			}
+		}
+		return
+	}
+
+	newToken := ec2Token{
+		token: output.Token,
+	}
+	newToken.SetExpiration(time.Now().Add(output.TTL), ttlExpirationWindow)
+	t.token.Store(newToken)
+
+	// Inject token header to the request.
+	if ec2Token, ok := t.token.Load().(ec2Token); ok {
+		r.HTTPRequest.Header.Set(tokenHeader, ec2Token.token)
+	}
+}
+
+// enableTokenProviderHandler enables the token provider
+func (t *tokenProvider) enableTokenProviderHandler(r *request.Request) {
+	// If the error code status is 401, we enable the token provider
+	if e, ok := r.Error.(awserr.RequestFailure); ok && e != nil &&
+		e.StatusCode() == http.StatusUnauthorized {
+		atomic.StoreUint32(&t.disabled, 0)
+	}
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
@@ -83,6 +83,7 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		p := &ps[i]
 		custAddEC2Metadata(p)
 		custAddS3DualStack(p)
+		custRegionalS3(p)
 		custRmIotDataService(p)
 		custFixAppAutoscalingChina(p)
 		custFixAppAutoscalingUsGov(p)
@@ -98,6 +99,33 @@ func custAddS3DualStack(p *partition) {
 
 	custAddDualstack(p, "s3")
 	custAddDualstack(p, "s3-control")
+}
+
+func custRegionalS3(p *partition) {
+	if p.ID != "aws" {
+		return
+	}
+
+	service, ok := p.Services["s3"]
+	if !ok {
+		return
+	}
+
+	// If global endpoint already exists no customization needed.
+	if _, ok := service.Endpoints["aws-global"]; ok {
+		return
+	}
+
+	service.PartitionEndpoint = "aws-global"
+	service.Endpoints["us-east-1"] = endpoint{}
+	service.Endpoints["aws-global"] = endpoint{
+		Hostname: "s3.amazonaws.com",
+		CredentialScope: credentialScope{
+			Region: "us-east-1",
+		},
+	}
+
+	p.Services["s3"] = service
 }
 
 func custAddDualstack(p *partition, svcName string) {

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -209,10 +209,42 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "acm-pca-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "acm-pca-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "acm-pca-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "acm-pca-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"api.ecr": service{
@@ -366,6 +398,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -422,11 +455,7 @@ var awsPartition = partition{
 		},
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com",
 				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "application-autoscaling",
-				},
 			},
 			Endpoints: endpoints{
 				"ap-east-1":      endpoint{},
@@ -461,6 +490,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -481,8 +511,14 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips": endpoint{
+					Hostname: "appstream2-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"appsync": service{
@@ -504,6 +540,7 @@ var awsPartition = partition{
 		"athena": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -514,8 +551,12 @@ var awsPartition = partition{
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -546,11 +587,7 @@ var awsPartition = partition{
 		},
 		"autoscaling-plans": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com",
 				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "autoscaling-plans",
-				},
 			},
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
@@ -571,14 +608,20 @@ var awsPartition = partition{
 		"backup": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -749,6 +792,7 @@ var awsPartition = partition{
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
 				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -843,6 +887,7 @@ var awsPartition = partition{
 		"codecommit": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -860,11 +905,12 @@ var awsPartition = partition{
 						Region: "ca-central-1",
 					},
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"codedeploy": service{
@@ -1053,6 +1099,16 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"connect": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"cur": service{
 
 			Endpoints: endpoints{
@@ -1072,6 +1128,22 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"dataexchange": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"datapipeline": service{
 
 			Endpoints: endpoints{
@@ -1085,12 +1157,18 @@ var awsPartition = partition{
 		"datasync": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"fips-us-east-1": endpoint{
 					Hostname: "datasync-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -1116,6 +1194,7 @@ var awsPartition = partition{
 					},
 				},
 				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
 				"us-east-1":  endpoint{},
 				"us-east-2":  endpoint{},
 				"us-west-1":  endpoint{},
@@ -1131,6 +1210,8 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1170,7 +1251,8 @@ var awsPartition = partition{
 		"discovery": service{
 
 			Endpoints: endpoints{
-				"us-west-2": endpoint{},
+				"eu-central-1": endpoint{},
+				"us-west-2":    endpoint{},
 			},
 		},
 		"dms": service{
@@ -1211,10 +1293,28 @@ var awsPartition = partition{
 						Region: "ap-northeast-2",
 					},
 				},
+				"ap-south-1": endpoint{
+					Hostname: "rds.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				"ap-southeast-1": endpoint{
+					Hostname: "rds.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
 				"ap-southeast-2": endpoint{
 					Hostname: "rds.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
+					},
+				},
+				"ca-central-1": endpoint{
+					Hostname: "rds.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
 					},
 				},
 				"eu-central-1": endpoint{
@@ -1233,6 +1333,12 @@ var awsPartition = partition{
 					Hostname: "rds.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
+					},
+				},
+				"eu-west-3": endpoint{
+					Hostname: "rds.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
 					},
 				},
 				"us-east-1": endpoint{
@@ -1258,6 +1364,7 @@ var awsPartition = partition{
 		"ds": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -1451,6 +1558,7 @@ var awsPartition = partition{
 		"elasticfilesystem": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -1458,9 +1566,12 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1623,6 +1734,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1637,14 +1749,41 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"forecast": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"forecastquery": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1775,6 +1914,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -1864,6 +2004,7 @@ var awsPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -1875,6 +2016,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1897,9 +2039,12 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
@@ -1912,6 +2057,18 @@ var awsPartition = partition{
 					Hostname: "data.iotevents.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
+					},
+				},
+				"ap-northeast-2": endpoint{
+					Hostname: "data.iotevents.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				"ap-southeast-1": endpoint{
+					Hostname: "data.iotevents.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
 					},
 				},
 				"ap-southeast-2": endpoint{
@@ -1930,6 +2087,12 @@ var awsPartition = partition{
 					Hostname: "data.iotevents.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
+					},
+				},
+				"eu-west-2": endpoint{
+					Hostname: "data.iotevents.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
 					},
 				},
 				"us-east-1": endpoint{
@@ -1952,6 +2115,27 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"iotsecuredtunneling": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"iotthingsgraph": service{
 			Defaults: endpoint{
 				CredentialScope: credentialScope{
@@ -1960,6 +2144,7 @@ var awsPartition = partition{
 			},
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -1969,18 +2154,22 @@ var awsPartition = partition{
 		"kafka": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -2063,9 +2252,17 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -2220,8 +2417,11 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -2235,6 +2435,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -2285,7 +2486,8 @@ var awsPartition = partition{
 		"mgh": service{
 
 			Endpoints: endpoints{
-				"us-west-2": endpoint{},
+				"eu-central-1": endpoint{},
+				"us-west-2":    endpoint{},
 			},
 		},
 		"mobileanalytics": service{
@@ -2301,9 +2503,10 @@ var awsPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"monitoring": service{
@@ -2344,10 +2547,34 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "mq-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "mq-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "mq-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "mq-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"mturk-requester": service{
@@ -2393,6 +2620,12 @@ var awsPartition = partition{
 						Region: "ap-southeast-2",
 					},
 				},
+				"ca-central-1": endpoint{
+					Hostname: "rds.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
 				"eu-central-1": endpoint{
 					Hostname: "rds.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -2417,6 +2650,12 @@ var awsPartition = partition{
 						Region: "eu-west-2",
 					},
 				},
+				"me-south-1": endpoint{
+					Hostname: "rds.me-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "me-south-1",
+					},
+				},
 				"us-east-1": endpoint{
 					Hostname: "rds.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -2431,6 +2670,65 @@ var awsPartition = partition{
 				},
 				"us-west-2": endpoint{
 					Hostname: "rds.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+		"oidc": service{
+
+			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{
+					Hostname: "oidc.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				"ap-southeast-2": endpoint{
+					Hostname: "oidc.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				"ca-central-1": endpoint{
+					Hostname: "oidc.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"eu-central-1": endpoint{
+					Hostname: "oidc.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				"eu-west-1": endpoint{
+					Hostname: "oidc.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				"eu-west-2": endpoint{
+					Hostname: "oidc.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				"us-east-1": endpoint{
+					Hostname: "oidc.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"us-east-2": endpoint{
+					Hostname: "oidc.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"us-west-2": endpoint{
+					Hostname: "oidc.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
@@ -2495,8 +2793,30 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "pinpoint-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "pinpoint-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{
+					Hostname: "pinpoint.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"us-west-2": endpoint{
+					Hostname: "pinpoint.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 			},
 		},
 		"polly": service{
@@ -2520,6 +2840,65 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"portal.sso": service{
+
+			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{
+					Hostname: "portal.sso.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				"ap-southeast-2": endpoint{
+					Hostname: "portal.sso.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				"ca-central-1": endpoint{
+					Hostname: "portal.sso.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"eu-central-1": endpoint{
+					Hostname: "portal.sso.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				"eu-west-1": endpoint{
+					Hostname: "portal.sso.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				"eu-west-2": endpoint{
+					Hostname: "portal.sso.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				"us-east-1": endpoint{
+					Hostname: "portal.sso.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"us-east-2": endpoint{
+					Hostname: "portal.sso.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"us-west-2": endpoint{
+					Hostname: "portal.sso.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
 		"projects.iot1click": service{
 
 			Endpoints: endpoints{
@@ -2536,6 +2915,10 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2556,6 +2939,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -2642,12 +3026,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"robomaker": service{
@@ -2709,9 +3117,10 @@ var awsPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"runtime.sagemaker": service{
@@ -2729,6 +3138,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -2761,7 +3171,7 @@ var awsPartition = partition{
 			},
 		},
 		"s3": service{
-			PartitionEndpoint: "us-east-1",
+			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedTrue,
 			Defaults: endpoint{
 				Protocols:         []string{"http", "https"},
@@ -2786,6 +3196,13 @@ var awsPartition = partition{
 					Hostname:          "s3.ap-southeast-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
+				"aws-global": endpoint{
+					Hostname:          "s3.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
 				"ca-central-1": endpoint{},
 				"eu-central-1": endpoint{},
 				"eu-north-1":   endpoint{},
@@ -2808,7 +3225,7 @@ var awsPartition = partition{
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
 				"us-east-1": endpoint{
-					Hostname:          "s3.amazonaws.com",
+					Hostname:          "s3.us-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
 				"us-east-2": endpoint{},
@@ -2973,6 +3390,29 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"savingsplans": service{
+			PartitionEndpoint: "aws-global",
+			IsRegionalized:    boxedFalse,
+
+			Endpoints: endpoints{
+				"aws-global": endpoint{
+					Hostname: "savingsplans.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+			},
+		},
+		"schemas": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"sdb": service{
 			Defaults: endpoint{
 				Protocols:         []string{"http", "https"},
@@ -2994,6 +3434,7 @@ var awsPartition = partition{
 		"secretsmanager": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -3005,6 +3446,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -3051,6 +3493,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -3063,6 +3506,9 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"ap-east-1": endpoint{
+					Protocols: []string{"https"},
+				},
 				"ap-northeast-1": endpoint{
 					Protocols: []string{"https"},
 				},
@@ -3094,6 +3540,9 @@ var awsPartition = partition{
 					Protocols: []string{"https"},
 				},
 				"eu-west-3": endpoint{
+					Protocols: []string{"https"},
+				},
+				"me-south-1": endpoint{
 					Protocols: []string{"https"},
 				},
 				"sa-east-1": endpoint{
@@ -3161,6 +3610,7 @@ var awsPartition = partition{
 		"servicediscovery": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -3168,9 +3618,11 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -3182,6 +3634,10 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -3453,44 +3909,29 @@ var awsPartition = partition{
 		},
 		"sts": service{
 			PartitionEndpoint: "aws-global",
-			Defaults: endpoint{
-				Hostname: "sts.amazonaws.com",
-				CredentialScope: credentialScope{
-					Region: "us-east-1",
-				},
-			},
+
 			Endpoints: endpoints{
-				"ap-east-1": endpoint{
-					Hostname: "sts.ap-east-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-east-1",
-					},
-				},
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{
-					Hostname: "sts.ap-northeast-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-northeast-2",
-					},
-				},
+				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
-				"aws-global":     endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1": endpoint{
-					Hostname: "sts.me-south-1.amazonaws.com",
+				"aws-global": endpoint{
+					Hostname: "sts.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "me-south-1",
+						Region: "us-east-1",
 					},
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
+				"ca-central-1": endpoint{},
+				"eu-central-1": endpoint{},
+				"eu-north-1":   endpoint{},
+				"eu-west-1":    endpoint{},
+				"eu-west-2":    endpoint{},
+				"eu-west-3":    endpoint{},
+				"me-south-1":   endpoint{},
+				"sa-east-1":    endpoint{},
+				"us-east-1":    endpoint{},
 				"us-east-1-fips": endpoint{
 					Hostname: "sts-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -3578,6 +4019,41 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"transcribe": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"transcribestreaming": service{
+
+			Endpoints: endpoints{
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"transfer": service{
 
 			Endpoints: endpoints{
@@ -3604,13 +4080,18 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
 					Hostname: "translate-fips.us-east-1.amazonaws.com",
@@ -3625,6 +4106,7 @@ var awsPartition = partition{
 						Region: "us-east-2",
 					},
 				},
+				"us-west-1": endpoint{},
 				"us-west-2": endpoint{},
 				"us-west-2-fips": endpoint{
 					Hostname: "translate-fips.us-west-2.amazonaws.com",
@@ -3786,11 +4268,7 @@ var awscnPartition = partition{
 		},
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com.cn",
 				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "application-autoscaling",
-				},
 			},
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
@@ -3801,6 +4279,13 @@ var awscnPartition = partition{
 			Defaults: endpoint{
 				Protocols: []string{"http", "https"},
 			},
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"batch": service{
+
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
 				"cn-northwest-1": endpoint{},
@@ -3858,6 +4343,12 @@ var awscnPartition = partition{
 
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"dax": service{
+
+			Endpoints: endpoints{
 				"cn-northwest-1": endpoint{},
 			},
 		},
@@ -3983,6 +4474,12 @@ var awscnPartition = partition{
 			},
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"glue": service{
+
+			Endpoints: endpoints{
 				"cn-northwest-1": endpoint{},
 			},
 		},
@@ -4126,6 +4623,13 @@ var awscnPartition = partition{
 				},
 			},
 		},
+		"secretsmanager": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"sms": service{
 
 			Endpoints: endpoints{
@@ -4202,7 +4706,7 @@ var awscnPartition = partition{
 
 			Endpoints: endpoints{
 				"aws-cn-global": endpoint{
-					Hostname: "support.cn-north-1.amazonaws.com",
+					Hostname: "support.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
@@ -4220,6 +4724,31 @@ var awscnPartition = partition{
 
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"transcribe": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{
+					Hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				"cn-northwest-1": endpoint{
+					Hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
+			},
+		},
+		"workspaces": service{
+
+			Endpoints: endpoints{
 				"cn-northwest-1": endpoint{},
 			},
 		},
@@ -4303,13 +4832,31 @@ var awsusgovPartition = partition{
 		},
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname: "autoscaling.{region}.amazonaws.com",
+				Hostname:  "autoscaling.{region}.amazonaws.com",
+				Protocols: []string{"http", "https"},
 				CredentialScope: credentialScope{
 					Service: "application-autoscaling",
 				},
 			},
 			Endpoints: endpoints{
 				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"appstream2": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+				CredentialScope: credentialScope{
+					Service: "appstream",
+				},
+			},
+			Endpoints: endpoints{
+				"fips": endpoint{
+					Hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -4423,6 +4970,7 @@ var awsusgovPartition = partition{
 						Region: "us-gov-west-1",
 					},
 				},
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -4599,7 +5147,6 @@ var awsusgovPartition = partition{
 		"health": service{
 
 			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -4761,6 +5308,25 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"resource-groups": service{
+
+			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"route53": service{
 			PartitionEndpoint: "aws-us-gov-global",
 			IsRegionalized:    boxedFalse,
@@ -4772,6 +5338,13 @@ var awsusgovPartition = partition{
 						Region: "us-gov-west-1",
 					},
 				},
+			},
+		},
+		"route53resolver": service{
+
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
 			},
 		},
 		"runtime.sagemaker": service{
@@ -4840,6 +5413,13 @@ var awsusgovPartition = partition{
 		"secretsmanager": service{
 
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-east-1-fips": endpoint{
+					Hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
 				"us-gov-west-1": endpoint{},
 				"us-gov-west-1-fips": endpoint{
 					Hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
@@ -4859,6 +5439,18 @@ var awsusgovPartition = partition{
 				},
 				"us-gov-west-1": endpoint{
 					Protocols: []string{"https"},
+				},
+			},
+		},
+		"servicecatalog": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+				"us-gov-west-1-fips": endpoint{
+					Hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
 				},
 			},
 		},
@@ -4959,6 +5551,14 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"transcribe": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"translate": service{
 			Defaults: endpoint{
 				Protocols: []string{"https"},
@@ -5025,13 +5625,22 @@ var awsisoPartition = partition{
 				},
 			},
 		},
+		"api.sagemaker": service{
+
+			Endpoints: endpoints{
+				"us-iso-east-1": endpoint{},
+			},
+		},
+		"apigateway": service{
+
+			Endpoints: endpoints{
+				"us-iso-east-1": endpoint{},
+			},
+		},
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com",
+				Hostname:  "autoscaling.us-iso-east-1.c2s.ic.gov",
 				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "application-autoscaling",
-				},
 			},
 			Endpoints: endpoints{
 				"us-iso-east-1": endpoint{},
@@ -5227,6 +5836,25 @@ var awsisoPartition = partition{
 				"us-iso-east-1": endpoint{},
 			},
 		},
+		"route53": service{
+			PartitionEndpoint: "aws-iso-global",
+			IsRegionalized:    boxedFalse,
+
+			Endpoints: endpoints{
+				"aws-iso-global": endpoint{
+					Hostname: "route53.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+				},
+			},
+		},
+		"runtime.sagemaker": service{
+
+			Endpoints: endpoints{
+				"us-iso-east-1": endpoint{},
+			},
+		},
 		"s3": service{
 			Defaults: endpoint{
 				SignatureVersions: []string{"s3v4"},
@@ -5340,11 +5968,8 @@ var awsisobPartition = partition{
 	Services: services{
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com",
+				Hostname:  "autoscaling.us-isob-east-1.sc2s.sgov.gov",
 				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "application-autoscaling",
-				},
 			},
 			Endpoints: endpoints{
 				"us-isob-east-1": endpoint{},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
@@ -3,6 +3,7 @@ package endpoints
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -46,6 +47,108 @@ type Options struct {
 	//
 	// This option is ignored if StrictMatching is enabled.
 	ResolveUnknownService bool
+
+	// STS Regional Endpoint flag helps with resolving the STS endpoint
+	STSRegionalEndpoint STSRegionalEndpoint
+
+	// S3 Regional Endpoint flag helps with resolving the S3 endpoint
+	S3UsEast1RegionalEndpoint S3UsEast1RegionalEndpoint
+}
+
+// STSRegionalEndpoint is an enum for the states of the STS Regional Endpoint
+// options.
+type STSRegionalEndpoint int
+
+func (e STSRegionalEndpoint) String() string {
+	switch e {
+	case LegacySTSEndpoint:
+		return "legacy"
+	case RegionalSTSEndpoint:
+		return "regional"
+	case UnsetSTSEndpoint:
+		return ""
+	default:
+		return "unknown"
+	}
+}
+
+const (
+
+	// UnsetSTSEndpoint represents that STS Regional Endpoint flag is not specified.
+	UnsetSTSEndpoint STSRegionalEndpoint = iota
+
+	// LegacySTSEndpoint represents when STS Regional Endpoint flag is specified
+	// to use legacy endpoints.
+	LegacySTSEndpoint
+
+	// RegionalSTSEndpoint represents when STS Regional Endpoint flag is specified
+	// to use regional endpoints.
+	RegionalSTSEndpoint
+)
+
+// GetSTSRegionalEndpoint function returns the STSRegionalEndpointFlag based
+// on the input string provided in env config or shared config by the user.
+//
+// `legacy`, `regional` are the only case-insensitive valid strings for
+// resolving the STS regional Endpoint flag.
+func GetSTSRegionalEndpoint(s string) (STSRegionalEndpoint, error) {
+	switch {
+	case strings.EqualFold(s, "legacy"):
+		return LegacySTSEndpoint, nil
+	case strings.EqualFold(s, "regional"):
+		return RegionalSTSEndpoint, nil
+	default:
+		return UnsetSTSEndpoint, fmt.Errorf("unable to resolve the value of STSRegionalEndpoint for %v", s)
+	}
+}
+
+// S3UsEast1RegionalEndpoint is an enum for the states of the S3 us-east-1
+// Regional Endpoint options.
+type S3UsEast1RegionalEndpoint int
+
+func (e S3UsEast1RegionalEndpoint) String() string {
+	switch e {
+	case LegacyS3UsEast1Endpoint:
+		return "legacy"
+	case RegionalS3UsEast1Endpoint:
+		return "regional"
+	case UnsetS3UsEast1Endpoint:
+		return ""
+	default:
+		return "unknown"
+	}
+}
+
+const (
+
+	// UnsetS3UsEast1Endpoint represents that S3 Regional Endpoint flag is not
+	// specified.
+	UnsetS3UsEast1Endpoint S3UsEast1RegionalEndpoint = iota
+
+	// LegacyS3UsEast1Endpoint represents when S3 Regional Endpoint flag is
+	// specified to use legacy endpoints.
+	LegacyS3UsEast1Endpoint
+
+	// RegionalS3UsEast1Endpoint represents when S3 Regional Endpoint flag is
+	// specified to use regional endpoints.
+	RegionalS3UsEast1Endpoint
+)
+
+// GetS3UsEast1RegionalEndpoint function returns the S3UsEast1RegionalEndpointFlag based
+// on the input string provided in env config or shared config by the user.
+//
+// `legacy`, `regional` are the only case-insensitive valid strings for
+// resolving the S3 regional Endpoint flag.
+func GetS3UsEast1RegionalEndpoint(s string) (S3UsEast1RegionalEndpoint, error) {
+	switch {
+	case strings.EqualFold(s, "legacy"):
+		return LegacyS3UsEast1Endpoint, nil
+	case strings.EqualFold(s, "regional"):
+		return RegionalS3UsEast1Endpoint, nil
+	default:
+		return UnsetS3UsEast1Endpoint,
+			fmt.Errorf("unable to resolve the value of S3UsEast1RegionalEndpoint for %v", s)
+	}
 }
 
 // Set combines all of the option functions together.
@@ -77,6 +180,12 @@ func StrictMatchingOption(o *Options) {
 // as a functional option when resolving endpoints.
 func ResolveUnknownServiceOption(o *Options) {
 	o.ResolveUnknownService = true
+}
+
+// STSRegionalEndpointOption enables the STS endpoint resolver behavior to resolve
+// STS endpoint to their regional endpoint, instead of the global endpoint.
+func STSRegionalEndpointOption(o *Options) {
+	o.STSRegionalEndpoint = RegionalSTSEndpoint
 }
 
 // A Resolver provides the interface for functionality to resolve endpoints.
@@ -194,7 +303,7 @@ func (p Partition) ID() string { return p.id }
 // require the provided service and region to be known by the partition.
 // If the endpoint cannot be strictly resolved an error will be returned. This
 // mode is useful to ensure the endpoint resolved is valid. Without
-// StrictMatching enabled the endpoint returned my look valid but may not work.
+// StrictMatching enabled the endpoint returned may look valid but may not work.
 // StrictMatching requires the SDK to be updated if you want to take advantage
 // of new regions and services expansions.
 //
@@ -208,7 +317,7 @@ func (p Partition) EndpointFor(service, region string, opts ...func(*Options)) (
 // Regions returns a map of Regions indexed by their ID. This is useful for
 // enumerating over the regions in a partition.
 func (p Partition) Regions() map[string]Region {
-	rs := map[string]Region{}
+	rs := make(map[string]Region, len(p.p.Regions))
 	for id, r := range p.p.Regions {
 		rs[id] = Region{
 			id:   id,
@@ -223,7 +332,7 @@ func (p Partition) Regions() map[string]Region {
 // Services returns a map of Service indexed by their ID. This is useful for
 // enumerating over the services in a partition.
 func (p Partition) Services() map[string]Service {
-	ss := map[string]Service{}
+	ss := make(map[string]Service, len(p.p.Services))
 	for id := range p.p.Services {
 		ss[id] = Service{
 			id: id,
@@ -310,7 +419,7 @@ func (s Service) Regions() map[string]Region {
 // A region is the AWS region the service exists in. Whereas a Endpoint is
 // an URL that can be resolved to a instance of a service.
 func (s Service) Endpoints() map[string]Endpoint {
-	es := map[string]Endpoint{}
+	es := make(map[string]Endpoint, len(s.p.Services[s.id].Endpoints))
 	for id := range s.p.Services[s.id].Endpoints {
 		es[id] = Endpoint{
 			id:        id,
@@ -349,6 +458,9 @@ func (e Endpoint) ResolveEndpoint(opts ...func(*Options)) (ResolvedEndpoint, err
 type ResolvedEndpoint struct {
 	// The endpoint URL
 	URL string
+
+	// The endpoint partition
+	PartitionID string
 
 	// The region that should be used for signing requests.
 	SigningRegion string

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/legacy_regions.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/legacy_regions.go
@@ -1,0 +1,24 @@
+package endpoints
+
+var legacyGlobalRegions = map[string]map[string]struct{}{
+	"sts": {
+		"ap-northeast-1": {},
+		"ap-south-1":     {},
+		"ap-southeast-1": {},
+		"ap-southeast-2": {},
+		"ca-central-1":   {},
+		"eu-central-1":   {},
+		"eu-north-1":     {},
+		"eu-west-1":      {},
+		"eu-west-2":      {},
+		"eu-west-3":      {},
+		"sa-east-1":      {},
+		"us-east-1":      {},
+		"us-east-2":      {},
+		"us-west-1":      {},
+		"us-west-2":      {},
+	},
+	"s3": {
+		"us-east-1": {},
+	},
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
@@ -75,24 +75,56 @@ func (p partition) canResolveEndpoint(service, region string, strictMatch bool) 
 	return p.RegionRegex.MatchString(region)
 }
 
+func allowLegacyEmptyRegion(service string) bool {
+	legacy := map[string]struct{}{
+		"budgets":       {},
+		"ce":            {},
+		"chime":         {},
+		"cloudfront":    {},
+		"ec2metadata":   {},
+		"iam":           {},
+		"importexport":  {},
+		"organizations": {},
+		"route53":       {},
+		"sts":           {},
+		"support":       {},
+		"waf":           {},
+	}
+
+	_, allowed := legacy[service]
+	return allowed
+}
+
 func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (resolved ResolvedEndpoint, err error) {
 	var opt Options
 	opt.Set(opts...)
 
 	s, hasService := p.Services[service]
-	if !(hasService || opt.ResolveUnknownService) {
+	if len(service) == 0 || !(hasService || opt.ResolveUnknownService) {
 		// Only return error if the resolver will not fallback to creating
 		// endpoint based on service endpoint ID passed in.
 		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
 	}
 
+	if len(region) == 0 && allowLegacyEmptyRegion(service) && len(s.PartitionEndpoint) != 0 {
+		region = s.PartitionEndpoint
+	}
+
+	if (service == "sts" && opt.STSRegionalEndpoint != RegionalSTSEndpoint) ||
+		(service == "s3" && opt.S3UsEast1RegionalEndpoint != RegionalS3UsEast1Endpoint) {
+		if _, ok := legacyGlobalRegions[service][region]; ok {
+			region = "aws-global"
+		}
+	}
+
 	e, hasEndpoint := s.endpointForRegion(region)
-	if !hasEndpoint && opt.StrictMatching {
+	if len(region) == 0 || (!hasEndpoint && opt.StrictMatching) {
 		return resolved, NewUnknownEndpointError(p.ID, service, region, endpointList(s.Endpoints))
 	}
 
 	defs := []endpoint{p.Defaults, s.Defaults}
-	return e.resolve(service, region, p.DNSSuffix, defs, opt), nil
+
+	return e.resolve(service, p.ID, region, p.DNSSuffix, defs, opt), nil
 }
 
 func serviceList(ss services) []string {
@@ -201,27 +233,13 @@ func getByPriority(s []string, p []string, def string) string {
 	return s[0]
 }
 
-func (e endpoint) resolve(service, region, dnsSuffix string, defs []endpoint, opts Options) ResolvedEndpoint {
+func (e endpoint) resolve(service, partitionID, region, dnsSuffix string, defs []endpoint, opts Options) ResolvedEndpoint {
 	var merged endpoint
 	for _, def := range defs {
 		merged.mergeIn(def)
 	}
 	merged.mergeIn(e)
 	e = merged
-
-	hostname := e.Hostname
-
-	// Offset the hostname for dualstack if enabled
-	if opts.UseDualStack && e.HasDualStack == boxedTrue {
-		hostname = e.DualStackHostname
-	}
-
-	u := strings.Replace(hostname, "{service}", service, 1)
-	u = strings.Replace(u, "{region}", region, 1)
-	u = strings.Replace(u, "{dnsSuffix}", dnsSuffix, 1)
-
-	scheme := getEndpointScheme(e.Protocols, opts.DisableSSL)
-	u = fmt.Sprintf("%s://%s", scheme, u)
 
 	signingRegion := e.CredentialScope.Region
 	if len(signingRegion) == 0 {
@@ -235,8 +253,23 @@ func (e endpoint) resolve(service, region, dnsSuffix string, defs []endpoint, op
 		signingNameDerived = true
 	}
 
+	hostname := e.Hostname
+	// Offset the hostname for dualstack if enabled
+	if opts.UseDualStack && e.HasDualStack == boxedTrue {
+		hostname = e.DualStackHostname
+		region = signingRegion
+	}
+
+	u := strings.Replace(hostname, "{service}", service, 1)
+	u = strings.Replace(u, "{region}", region, 1)
+	u = strings.Replace(u, "{dnsSuffix}", dnsSuffix, 1)
+
+	scheme := getEndpointScheme(e.Protocols, opts.DisableSSL)
+	u = fmt.Sprintf("%s://%s", scheme, u)
+
 	return ResolvedEndpoint{
 		URL:                u,
+		PartitionID:        partitionID,
 		SigningRegion:      signingRegion,
 		SigningName:        signingName,
 		SigningNameDerived: signingNameDerived,

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go
@@ -23,7 +23,7 @@ type Handlers struct {
 	Complete         HandlerList
 }
 
-// Copy returns of this handler's lists.
+// Copy returns a copy of this handler's lists.
 func (h *Handlers) Copy() Handlers {
 	return Handlers{
 		Validate:         h.Validate.copy(),
@@ -42,7 +42,7 @@ func (h *Handlers) Copy() Handlers {
 	}
 }
 
-// Clear removes callback functions for all handlers
+// Clear removes callback functions for all handlers.
 func (h *Handlers) Clear() {
 	h.Validate.Clear()
 	h.Build.Clear()

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -99,14 +99,22 @@ type Operation struct {
 	BeforePresignFn func(r *Request) error
 }
 
-// New returns a new Request pointer for the service API
-// operation and parameters.
+// New returns a new Request pointer for the service API operation and
+// parameters.
+//
+// A Retryer should be provided to direct how the request is retried. If
+// Retryer is nil, a default no retry value will be used. You can use
+// NoOpRetryer in the Client package to disable retry behavior directly.
 //
 // Params is any value of input parameters to be the request payload.
 // Data is pointer value to an object which the request's response
 // payload will be deserialized to.
 func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 	retryer Retryer, operation *Operation, params interface{}, data interface{}) *Request {
+
+	if retryer == nil {
+		retryer = noOpRetryer{}
+	}
 
 	method := operation.HTTPMethod
 	if method == "" {

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_pagination.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_pagination.go
@@ -17,11 +17,13 @@ import (
 // does the pagination between API operations, and Paginator defines the
 // configuration that will be used per page request.
 //
-//     cont := true
-//     for p.Next() && cont {
+//     for p.Next() {
 //         data := p.Page().(*s3.ListObjectsOutput)
 //         // process the page's data
+//         // ...
+//         // break out of loop to stop fetching additional pages
 //     }
+//
 //     return p.Err()
 //
 // See service client API operation Pages methods for examples how the SDK will

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -35,10 +35,41 @@ type Retryer interface {
 }
 
 // WithRetryer sets a Retryer value to the given Config returning the Config
-// value for chaining.
+// value for chaining. The value must not be nil.
 func WithRetryer(cfg *aws.Config, retryer Retryer) *aws.Config {
+	if retryer == nil {
+		if cfg.Logger != nil {
+			cfg.Logger.Log("ERROR: Request.WithRetryer called with nil retryer. Replacing with retry disabled Retryer.")
+		}
+		retryer = noOpRetryer{}
+	}
 	cfg.Retryer = retryer
 	return cfg
+
+}
+
+// noOpRetryer is a internal no op retryer used when a request is created
+// without a retryer.
+//
+// Provides a retryer that performs no retries.
+// It should be used when we do not want retries to be performed.
+type noOpRetryer struct{}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API; For NoOpRetryer the MaxRetries will always be zero.
+func (d noOpRetryer) MaxRetries() int {
+	return 0
+}
+
+// ShouldRetry will always return false for NoOpRetryer, as it should never retry.
+func (d noOpRetryer) ShouldRetry(_ *Request) bool {
+	return false
+}
+
+// RetryRules returns the delay duration before retrying this request again;
+// since NoOpRetryer does not retry, RetryRules always returns 0.
+func (d noOpRetryer) RetryRules(_ *Request) time.Duration {
+	return 0
 }
 
 // retryableCodes is a collection of service response codes which are retry-able
@@ -52,6 +83,7 @@ var retryableCodes = map[string]struct{}{
 
 var throttleCodes = map[string]struct{}{
 	"ProvisionedThroughputExceededException": {},
+	"ThrottledException":                     {}, // SNS, XRay, ResourceGroupsTagging API
 	"Throttling":                             {},
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
@@ -94,10 +126,6 @@ var validParentCodes = map[string]struct{}{
 	ErrCodeRead:          {},
 }
 
-type temporaryError interface {
-	Temporary() bool
-}
-
 func isNestedErrorRetryable(parentErr awserr.Error) bool {
 	if parentErr == nil {
 		return false
@@ -116,7 +144,7 @@ func isNestedErrorRetryable(parentErr awserr.Error) bool {
 		return isCodeRetryable(aerr.Code())
 	}
 
-	if t, ok := err.(temporaryError); ok {
+	if t, ok := err.(temporary); ok {
 		return t.Temporary() || isErrConnectionReset(err)
 	}
 
@@ -149,7 +177,7 @@ func shouldRetryError(origErr error) bool {
 		origErr := err.OrigErr()
 		var shouldRetry bool
 		if origErr != nil {
-			shouldRetry := shouldRetryError(origErr)
+			shouldRetry = shouldRetryError(origErr)
 			if err.Code() == "RequestError" && !shouldRetry {
 				return false
 			}
@@ -223,6 +251,16 @@ func (r *Request) IsErrorRetryable() bool {
 		return true
 	}
 
+	// HTTP response status code 501 should not be retried.
+	// 501 represents Not Implemented which means the request method is not
+	// supported by the server and cannot be handled.
+	if r.HTTPResponse != nil {
+		// HTTP response status code 500 represents internal server error and
+		// should be retried without any throttle.
+		if r.HTTPResponse.StatusCode == 500 {
+			return true
+		}
+	}
 	return IsErrorRetryable(r.Error)
 }
 
@@ -237,7 +275,11 @@ func (r *Request) IsErrorThrottle() bool {
 
 	if r.HTTPResponse != nil {
 		switch r.HTTPResponse.StatusCode {
-		case 429, 502, 503, 504:
+		case
+			429, // error caused due to too many requests
+			502, // Bad Gateway error should be throttled
+			503, // caused when service is unavailable
+			504: // error occurred due to gateway timeout
 			return true
 		}
 	}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
@@ -47,10 +47,10 @@ func resolveCredentials(cfg *aws.Config,
 }
 
 // WebIdentityEmptyRoleARNErr will occur if 'AWS_WEB_IDENTITY_TOKEN_FILE' was set but
-// 'AWS_IAM_ROLE_ARN' was not set.
+// 'AWS_ROLE_ARN' was not set.
 var WebIdentityEmptyRoleARNErr = awserr.New(stscreds.ErrCodeWebIdentity, "role ARN is not set", nil)
 
-// WebIdentityEmptyTokenFilePathErr will occur if 'AWS_IAM_ROLE_ARN' was set but
+// WebIdentityEmptyTokenFilePathErr will occur if 'AWS_ROLE_ARN' was set but
 // 'AWS_WEB_IDENTITY_TOKEN_FILE' was not set.
 var WebIdentityEmptyTokenFilePathErr = awserr.New(stscreds.ErrCodeWebIdentity, "token file path is not set", nil)
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -73,7 +73,7 @@ type Session struct {
 // func is called instead of waiting to receive an error until a request is made.
 func New(cfgs ...*aws.Config) *Session {
 	// load initial config from environment
-	envCfg := loadEnvConfig()
+	envCfg, envErr := loadEnvConfig()
 
 	if envCfg.EnableSharedConfig {
 		var cfg aws.Config
@@ -93,17 +93,17 @@ func New(cfgs ...*aws.Config) *Session {
 			// Session creation failed, need to report the error and prevent
 			// any requests from succeeding.
 			s = &Session{Config: defaults.Config()}
-			s.Config.MergeIn(cfgs...)
-			s.Config.Logger.Log("ERROR:", msg, "Error:", err)
-			s.Handlers.Validate.PushBack(func(r *request.Request) {
-				r.Error = err
-			})
+			s.logDeprecatedNewSessionError(msg, err, cfgs)
 		}
 
 		return s
 	}
 
 	s := deprecatedNewSession(cfgs...)
+	if envErr != nil {
+		msg := "failed to load env config"
+		s.logDeprecatedNewSessionError(msg, envErr, cfgs)
+	}
 
 	if csmCfg, err := loadCSMConfig(envCfg, []string{}); err != nil {
 		if l := s.Config.Logger; l != nil {
@@ -112,11 +112,8 @@ func New(cfgs ...*aws.Config) *Session {
 	} else if csmCfg.Enabled {
 		err := enableCSM(&s.Handlers, csmCfg, s.Config.Logger)
 		if err != nil {
-			err = fmt.Errorf("failed to enable CSM, %v", err)
-			s.Config.Logger.Log("ERROR:", err.Error())
-			s.Handlers.Validate.PushBack(func(r *request.Request) {
-				r.Error = err
-			})
+			msg := "failed to enable CSM"
+			s.logDeprecatedNewSessionError(msg, err, cfgs)
 		}
 	}
 
@@ -136,7 +133,7 @@ func New(cfgs ...*aws.Config) *Session {
 // to be built with retrieving credentials with AssumeRole set in the config.
 //
 // See the NewSessionWithOptions func for information on how to override or
-// control through code how the Session will be created. Such as specifying the
+// control through code how the Session will be created, such as specifying the
 // config profile, and controlling if shared config is enabled or not.
 func NewSession(cfgs ...*aws.Config) (*Session, error) {
 	opts := Options{}
@@ -279,10 +276,17 @@ type Options struct {
 //     }))
 func NewSessionWithOptions(opts Options) (*Session, error) {
 	var envCfg envConfig
+	var err error
 	if opts.SharedConfigState == SharedConfigEnable {
-		envCfg = loadSharedEnvConfig()
+		envCfg, err = loadSharedEnvConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load shared config, %v", err)
+		}
 	} else {
-		envCfg = loadEnvConfig()
+		envCfg, err = loadEnvConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load environment config, %v", err)
+		}
 	}
 
 	if len(opts.Profile) != 0 {
@@ -550,6 +554,22 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 		}
 	}
 
+	// Regional Endpoint flag for STS endpoint resolving
+	mergeSTSRegionalEndpointConfig(cfg, []endpoints.STSRegionalEndpoint{
+		userCfg.STSRegionalEndpoint,
+		envCfg.STSRegionalEndpoint,
+		sharedCfg.STSRegionalEndpoint,
+		endpoints.LegacySTSEndpoint,
+	})
+
+	// Regional Endpoint flag for S3 endpoint resolving
+	mergeS3UsEast1RegionalEndpointConfig(cfg, []endpoints.S3UsEast1RegionalEndpoint{
+		userCfg.S3UsEast1RegionalEndpoint,
+		envCfg.S3UsEast1RegionalEndpoint,
+		sharedCfg.S3UsEast1RegionalEndpoint,
+		endpoints.LegacyS3UsEast1Endpoint,
+	})
+
 	// Configure credentials if not already set by the user when creating the
 	// Session.
 	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
@@ -560,7 +580,33 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 		cfg.Credentials = creds
 	}
 
+	cfg.S3UseARNRegion = userCfg.S3UseARNRegion
+	if cfg.S3UseARNRegion == nil {
+		cfg.S3UseARNRegion = &envCfg.S3UseARNRegion
+	}
+	if cfg.S3UseARNRegion == nil {
+		cfg.S3UseARNRegion = &sharedCfg.S3UseARNRegion
+	}
+
 	return nil
+}
+
+func mergeSTSRegionalEndpointConfig(cfg *aws.Config, values []endpoints.STSRegionalEndpoint) {
+	for _, v := range values {
+		if v != endpoints.UnsetSTSEndpoint {
+			cfg.STSRegionalEndpoint = v
+			break
+		}
+	}
+}
+
+func mergeS3UsEast1RegionalEndpointConfig(cfg *aws.Config, values []endpoints.S3UsEast1RegionalEndpoint) {
+	for _, v := range values {
+		if v != endpoints.UnsetS3UsEast1Endpoint {
+			cfg.S3UsEast1RegionalEndpoint = v
+			break
+		}
+	}
 }
 
 func initHandlers(s *Session) {
@@ -571,7 +617,7 @@ func initHandlers(s *Session) {
 	}
 }
 
-// Copy creates and returns a copy of the current Session, coping the config
+// Copy creates and returns a copy of the current Session, copying the config
 // and handlers. If any additional configs are provided they will be merged
 // on top of the Session's copied config.
 //
@@ -591,47 +637,61 @@ func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 // ClientConfig satisfies the client.ConfigProvider interface and is used to
 // configure the service client instances. Passing the Session to the service
 // client's constructor (New) will use this method to configure the client.
-func (s *Session) ClientConfig(serviceName string, cfgs ...*aws.Config) client.Config {
-	// Backwards compatibility, the error will be eaten if user calls ClientConfig
-	// directly. All SDK services will use ClientconfigWithError.
-	cfg, _ := s.clientConfigWithErr(serviceName, cfgs...)
-
-	return cfg
-}
-
-func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (client.Config, error) {
+func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 
-	var resolved endpoints.ResolvedEndpoint
-	var err error
-
 	region := aws.StringValue(s.Config.Region)
-
-	if endpoint := aws.StringValue(s.Config.Endpoint); len(endpoint) != 0 {
-		resolved.URL = endpoints.AddScheme(endpoint, aws.BoolValue(s.Config.DisableSSL))
-		resolved.SigningRegion = region
-	} else {
-		resolved, err = s.Config.EndpointResolver.EndpointFor(
-			serviceName, region,
-			func(opt *endpoints.Options) {
-				opt.DisableSSL = aws.BoolValue(s.Config.DisableSSL)
-				opt.UseDualStack = aws.BoolValue(s.Config.UseDualStack)
-
-				// Support the condition where the service is modeled but its
-				// endpoint metadata is not available.
-				opt.ResolveUnknownService = true
-			},
-		)
+	resolved, err := s.resolveEndpoint(service, region, s.Config)
+	if err != nil && s.Config.Logger != nil {
+		s.Config.Logger.Log(fmt.Sprintf(
+			"ERROR: unable to resolve endpoint for service %q, region %q, err: %v",
+			service, region, err))
 	}
 
 	return client.Config{
 		Config:             s.Config,
 		Handlers:           s.Handlers,
+		PartitionID:        resolved.PartitionID,
 		Endpoint:           resolved.URL,
 		SigningRegion:      resolved.SigningRegion,
 		SigningNameDerived: resolved.SigningNameDerived,
 		SigningName:        resolved.SigningName,
-	}, err
+	}
+}
+
+func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endpoints.ResolvedEndpoint, error) {
+
+	if ep := aws.StringValue(cfg.Endpoint); len(ep) != 0 {
+		return endpoints.ResolvedEndpoint{
+			URL:           endpoints.AddScheme(ep, aws.BoolValue(cfg.DisableSSL)),
+			SigningRegion: region,
+		}, nil
+	}
+
+	resolved, err := cfg.EndpointResolver.EndpointFor(service, region,
+		func(opt *endpoints.Options) {
+			opt.DisableSSL = aws.BoolValue(cfg.DisableSSL)
+			opt.UseDualStack = aws.BoolValue(cfg.UseDualStack)
+			// Support for STSRegionalEndpoint where the STSRegionalEndpoint is
+			// provided in envConfig or sharedConfig with envConfig getting
+			// precedence.
+			opt.STSRegionalEndpoint = cfg.STSRegionalEndpoint
+
+			// Support for S3UsEast1RegionalEndpoint where the S3UsEast1RegionalEndpoint is
+			// provided in envConfig or sharedConfig with envConfig getting
+			// precedence.
+			opt.S3UsEast1RegionalEndpoint = cfg.S3UsEast1RegionalEndpoint
+
+			// Support the condition where the service is modeled but its
+			// endpoint metadata is not available.
+			opt.ResolveUnknownService = true
+		},
+	)
+	if err != nil {
+		return endpoints.ResolvedEndpoint{}, err
+	}
+
+	return resolved, nil
 }
 
 // ClientConfigNoResolveEndpoint is the same as ClientConfig with the exception
@@ -641,12 +701,9 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 	s = s.Copy(cfgs...)
 
 	var resolved endpoints.ResolvedEndpoint
-
-	region := aws.StringValue(s.Config.Region)
-
 	if ep := aws.StringValue(s.Config.Endpoint); len(ep) > 0 {
 		resolved.URL = endpoints.AddScheme(ep, aws.BoolValue(s.Config.DisableSSL))
-		resolved.SigningRegion = region
+		resolved.SigningRegion = aws.StringValue(s.Config.Region)
 	}
 
 	return client.Config{
@@ -657,4 +714,15 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 		SigningNameDerived: resolved.SigningNameDerived,
 		SigningName:        resolved.SigningName,
 	}
+}
+
+// logDeprecatedNewSessionError function enables error handling for session
+func (s *Session) logDeprecatedNewSessionError(msg string, err error, cfgs []*aws.Config) {
+	// Session creation failed, need to report the error and prevent
+	// any requests from succeeding.
+	s.Config.MergeIn(cfgs...)
+	s.Config.Logger.Log("ERROR:", msg, "Error:", err)
+	s.Handlers.Validate.PushBack(func(r *request.Request) {
+		r.Error = err
+	})
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/shared_config.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/shared_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/internal/ini"
 )
 
@@ -40,10 +41,19 @@ const (
 	// Web Identity Token File
 	webIdentityTokenFileKey = `web_identity_token_file` // optional
 
+	// Additional config fields for regional or legacy endpoints
+	stsRegionalEndpointSharedKey = `sts_regional_endpoints`
+
+	// Additional config fields for regional or legacy endpoints
+	s3UsEast1RegionalSharedKey = `s3_us_east_1_regional_endpoint`
+
 	// DefaultSharedConfigProfile is the default profile to be used when
 	// loading configuration from the config files if another profile name
 	// is not provided.
 	DefaultSharedConfigProfile = `default`
+
+	// S3 ARN Region Usage
+	s3UseARNRegionKey = "s3_use_arn_region"
 )
 
 // sharedConfig represents the configuration fields of the SDK config files.
@@ -88,6 +98,24 @@ type sharedConfig struct {
 	CSMHost     string
 	CSMPort     string
 	CSMClientID string
+
+	// Specifies the Regional Endpoint flag for the SDK to resolve the endpoint for a service
+	//
+	// sts_regional_endpoints = regional
+	// This can take value as `LegacySTSEndpoint` or `RegionalSTSEndpoint`
+	STSRegionalEndpoint endpoints.STSRegionalEndpoint
+
+	// Specifies the Regional Endpoint flag for the SDK to resolve the endpoint for a service
+	//
+	// s3_us_east_1_regional_endpoint = regional
+	// This can take value as `LegacyS3UsEast1Endpoint` or `RegionalS3UsEast1Endpoint`
+	S3UsEast1RegionalEndpoint endpoints.S3UsEast1RegionalEndpoint
+
+	// Specifies if the S3 service should allow ARNs to direct the region
+	// the client's requests are sent to.
+	//
+	// s3_use_arn_region=true
+	S3UseARNRegion bool
 }
 
 type sharedConfigFile struct {
@@ -244,8 +272,25 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 		updateString(&cfg.RoleSessionName, section, roleSessionNameKey)
 		updateString(&cfg.SourceProfileName, section, sourceProfileKey)
 		updateString(&cfg.CredentialSource, section, credentialSourceKey)
-
 		updateString(&cfg.Region, section, regionKey)
+
+		if v := section.String(stsRegionalEndpointSharedKey); len(v) != 0 {
+			sre, err := endpoints.GetSTSRegionalEndpoint(v)
+			if err != nil {
+				return fmt.Errorf("failed to load %s from shared config, %s, %v",
+					stsRegionalEndpointSharedKey, file.Filename, err)
+			}
+			cfg.STSRegionalEndpoint = sre
+		}
+
+		if v := section.String(s3UsEast1RegionalSharedKey); len(v) != 0 {
+			sre, err := endpoints.GetS3UsEast1RegionalEndpoint(v)
+			if err != nil {
+				return fmt.Errorf("failed to load %s from shared config, %s, %v",
+					s3UsEast1RegionalSharedKey, file.Filename, err)
+			}
+			cfg.S3UsEast1RegionalEndpoint = sre
+		}
 	}
 
 	updateString(&cfg.CredentialProcess, section, credentialProcessKey)
@@ -270,6 +315,8 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 	updateString(&cfg.CSMHost, section, csmHostKey)
 	updateString(&cfg.CSMPort, section, csmPortKey)
 	updateString(&cfg.CSMClientID, section, csmClientIDKey)
+
+	updateBool(&cfg.S3UseARNRegion, section, s3UseARNRegionKey)
 
 	return nil
 }
@@ -361,6 +408,15 @@ func updateString(dst *string, section ini.Section, key string) {
 		return
 	}
 	*dst = section.String(key)
+}
+
+// updateBool will only update the dst with the value in the section key, key
+// is present in the section.
+func updateBool(dst *bool, section ini.Section, key string) {
+	if !section.Has(key) {
+		return
+	}
+	*dst = section.Bool(key)
 }
 
 // updateBoolPtr will only update the dst with the value in the section key,

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.23.18"
+const SDKVersion = "1.26.6"

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_parser.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_parser.go
@@ -162,7 +162,7 @@ loop:
 			if len(tokens) == 0 {
 				break loop
 			}
-
+			// if should skip is true, we skip the tokens until should skip is set to false.
 			step = SkipTokenState
 		}
 
@@ -218,7 +218,7 @@ loop:
 			// S -> equal_expr' expr_stmt'
 			switch k.Kind {
 			case ASTKindEqualExpr:
-				// assiging a value to some key
+				// assigning a value to some key
 				k.AppendChild(newExpression(tok))
 				stack.Push(newExprStatement(k))
 			case ASTKindExpr:
@@ -249,6 +249,13 @@ loop:
 		case OpenScopeState:
 			if !runeCompare(tok.Raw(), openBrace) {
 				return nil, NewParseError("expected '['")
+			}
+			// If OpenScopeState is not at the start, we must mark the previous ast as complete
+			//
+			// for example: if previous ast was a skip statement;
+			// we should mark it as complete before we create a new statement
+			if k.Kind != ASTKindStart {
+				stack.MarkComplete(k)
 			}
 
 			stmt := newStatement()

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/skipper.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/skipper.go
@@ -22,24 +22,24 @@ func newSkipper() skipper {
 }
 
 func (s *skipper) ShouldSkip(tok Token) bool {
+	// should skip state will be modified only if previous token was new line (NL);
+	// and the current token is not WhiteSpace (WS).
 	if s.shouldSkip &&
 		s.prevTok.Type() == TokenNL &&
 		tok.Type() != TokenWS {
-
 		s.Continue()
 		return false
 	}
 	s.prevTok = tok
-
 	return s.shouldSkip
 }
 
 func (s *skipper) Skip() {
 	s.shouldSkip = true
-	s.prevTok = emptyToken
 }
 
 func (s *skipper) Continue() {
 	s.shouldSkip = false
+	// empty token is assigned as we return to default state, when should skip is false
 	s.prevTok = emptyToken
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/byte.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/byte.go
@@ -1,0 +1,12 @@
+package sdkio
+
+const (
+	// Byte is 8 bits
+	Byte int64 = 1
+	// KibiByte (KiB) is 1024 Bytes
+	KibiByte = Byte * 1024
+	// MebiByte (MiB) is 1024 KiB
+	MebiByte = KibiByte * 1024
+	// GibiByte (GiB) is 1024 MiB
+	GibiByte = MebiByte * 1024
+)

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
@@ -1,0 +1,11 @@
+// +build go1.6
+
+package sdkrand
+
+import "math/rand"
+
+// Read provides the stub for math.Rand.Read method support for go version's
+// 1.6 and greater.
+func Read(r *rand.Rand, p []byte) (int, error) {
+	return r.Read(p)
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
@@ -1,0 +1,24 @@
+// +build !go1.6
+
+package sdkrand
+
+import "math/rand"
+
+// Read backfills Go 1.6's math.Rand.Reader for Go 1.5
+func Read(r *rand.Rand, p []byte) (n int, err error) {
+	// Copy of Go standard libraries math package's read function not added to
+	// standard library until Go 1.6.
+	var pos int8
+	var val int64
+	for n = 0; n < len(p); n++ {
+		if pos == 0 {
+			val = r.Int63()
+			pos = 7
+		}
+		p[n] = byte(val)
+		val >>= 8
+		pos--
+	}
+
+	return n, err
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/sort.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/sort.go
@@ -1,0 +1,32 @@
+package xmlutil
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+type xmlAttrSlice []xml.Attr
+
+func (x xmlAttrSlice) Len() int {
+	return len(x)
+}
+
+func (x xmlAttrSlice) Less(i, j int) bool {
+	spaceI, spaceJ := x[i].Name.Space, x[j].Name.Space
+	localI, localJ := x[i].Name.Local, x[j].Name.Local
+	valueI, valueJ := x[i].Value, x[j].Value
+
+	spaceCmp := strings.Compare(spaceI, spaceJ)
+	localCmp := strings.Compare(localI, localJ)
+	valueCmp := strings.Compare(valueI, valueJ)
+
+	if spaceCmp == -1 || (spaceCmp == 0 && (localCmp == -1 || (localCmp == 0 && valueCmp == -1))) {
+		return true
+	}
+
+	return false
+}
+
+func (x xmlAttrSlice) Swap(i, j int) {
+	x[i], x[j] = x[j], x[i]
+}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
@@ -119,7 +119,18 @@ func (n *XMLNode) findElem(name string) (string, bool) {
 
 // StructToXML writes an XMLNode to a xml.Encoder as tokens.
 func StructToXML(e *xml.Encoder, node *XMLNode, sorted bool) error {
-	e.EncodeToken(xml.StartElement{Name: node.Name, Attr: node.Attr})
+	// Sort Attributes
+	attrs := node.Attr
+	if sorted {
+		sortedAttrs := make([]xml.Attr, len(attrs))
+		for _, k := range node.Attr {
+			sortedAttrs = append(sortedAttrs, k)
+		}
+		sort.Sort(xmlAttrSlice(sortedAttrs))
+		attrs = sortedAttrs
+	}
+
+	e.EncodeToken(xml.StartElement{Name: node.Name, Attr: attrs})
 
 	if node.Text != "" {
 		e.EncodeToken(xml.CharData([]byte(node.Text)))

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -1780,10 +1780,12 @@ func (c *AutoScaling) DescribeAutoScalingGroupsPagesWithContext(ctx aws.Context,
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeAutoScalingGroupsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeAutoScalingGroupsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1919,10 +1921,12 @@ func (c *AutoScaling) DescribeAutoScalingInstancesPagesWithContext(ctx aws.Conte
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeAutoScalingInstancesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeAutoScalingInstancesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2138,10 +2142,12 @@ func (c *AutoScaling) DescribeLaunchConfigurationsPagesWithContext(ctx aws.Conte
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeLaunchConfigurationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeLaunchConfigurationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2691,10 +2697,12 @@ func (c *AutoScaling) DescribeNotificationConfigurationsPagesWithContext(ctx aws
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeNotificationConfigurationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeNotificationConfigurationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2833,10 +2841,12 @@ func (c *AutoScaling) DescribePoliciesPagesWithContext(ctx aws.Context, input *D
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribePoliciesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribePoliciesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2972,10 +2982,12 @@ func (c *AutoScaling) DescribeScalingActivitiesPagesWithContext(ctx aws.Context,
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeScalingActivitiesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeScalingActivitiesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3193,10 +3205,12 @@ func (c *AutoScaling) DescribeScheduledActionsPagesWithContext(ctx aws.Context, 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeScheduledActionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeScheduledActionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3341,10 +3355,12 @@ func (c *AutoScaling) DescribeTagsPagesWithContext(ctx aws.Context, input *Descr
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTagsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTagsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3909,6 +3925,15 @@ func (c *AutoScaling) EnterStandbyRequest(input *EnterStandbyInput) (req *reques
 //
 // Moves the specified instances into the standby state.
 //
+// If you choose to decrement the desired capacity of the Auto Scaling group,
+// the instances can enter standby as long as the desired capacity of the Auto
+// Scaling group after the instances are placed into standby is equal to or
+// greater than the minimum capacity of the group.
+//
+// If you choose not to decrement the desired capacity of the Auto Scaling group,
+// the Auto Scaling group launches new instances to replace the instances on
+// standby.
+//
 // For more information, see Temporarily Removing Instances from Your Auto Scaling
 // Group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
 // in the Amazon EC2 Auto Scaling User Guide.
@@ -4077,6 +4102,8 @@ func (c *AutoScaling) ExitStandbyRequest(input *ExitStandbyInput) (req *request.
 // ExitStandby API operation for Auto Scaling.
 //
 // Moves the specified instances out of the standby state.
+//
+// After you put the instances back in service, the desired capacity is incremented.
 //
 // For more information, see Temporarily Removing Instances from Your Auto Scaling
 // Group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
@@ -5209,8 +5236,7 @@ func (c *AutoScaling) UpdateAutoScalingGroupRequest(input *UpdateAutoScalingGrou
 // To update an Auto Scaling group, specify the name of the group and the parameter
 // that you want to change. Any parameters that you don't specify are not changed
 // by this update request. The new settings take effect on any scaling activities
-// after this call returns. Scaling activities that are currently in progress
-// aren't affected.
+// after this call returns.
 //
 // If you associate a new launch configuration or template with an Auto Scaling
 // group, all new instances will get the updated configuration. Existing instances
@@ -6120,6 +6146,11 @@ type CreateAutoScalingGroupInput struct {
 	// in the Amazon EC2 Auto Scaling User Guide.
 	LoadBalancerNames []*string `type:"list"`
 
+	// The maximum amount of time, in seconds, that an instance can be in service.
+	//
+	// Valid Range: Minimum value of 604800.
+	MaxInstanceLifetime *int64 `type:"integer"`
+
 	// The maximum size of the group.
 	//
 	// MaxSize is a required field
@@ -6354,6 +6385,12 @@ func (s *CreateAutoScalingGroupInput) SetLoadBalancerNames(v []*string) *CreateA
 	return s
 }
 
+// SetMaxInstanceLifetime sets the MaxInstanceLifetime field's value.
+func (s *CreateAutoScalingGroupInput) SetMaxInstanceLifetime(v int64) *CreateAutoScalingGroupInput {
+	s.MaxInstanceLifetime = &v
+	return s
+}
+
 // SetMaxSize sets the MaxSize field's value.
 func (s *CreateAutoScalingGroupInput) SetMaxSize(v int64) *CreateAutoScalingGroupInput {
 	s.MaxSize = &v
@@ -6562,7 +6599,7 @@ type CreateLaunchConfigurationInput struct {
 	// For more information, see Instance Placement Tenancy (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html#as-vpc-tenancy)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	//
-	// Valid values: default | dedicated
+	// Valid Values: default | dedicated
 	PlacementTenancy *string `min:"1" type:"string"`
 
 	// The ID of the RAM disk to select.
@@ -6582,17 +6619,13 @@ type CreateLaunchConfigurationInput struct {
 
 	// The maximum hourly price to be paid for any Spot Instance launched to fulfill
 	// the request. Spot Instances are launched when the price you specify exceeds
-	// the current Spot market price. For more information, see Launching Spot Instances
+	// the current Spot price. For more information, see Launching Spot Instances
 	// in Your Auto Scaling Group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-spot-instances.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	//
-	// If a Spot price is set, then the Auto Scaling group will only launch instances
-	// when the Spot price has been met, regardless of the setting in the Auto Scaling
-	// group's DesiredCapacity.
-	//
-	// When you change your Spot price by creating a new launch configuration, running
-	// instances will continue to run as long as the Spot price for those running
-	// instances is higher than the current Spot market price.
+	// When you change your maximum price by creating a new launch configuration,
+	// running instances will continue to run as long as the maximum price for those
+	// running instances is higher than the current Spot price.
 	SpotPrice *string `min:"1" type:"string"`
 
 	// The Base64-encoded user data to make available to the launched EC2 instances.
@@ -9117,7 +9150,7 @@ type Ebs struct {
 	// or sc1 for Cold HDD. For more information, see Amazon EBS Volume Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon EC2 User Guide for Linux Instances.
 	//
-	// Valid values: standard | io1 | gp2 | st1 | sc1
+	// Valid Values: standard | io1 | gp2 | st1 | sc1
 	VolumeType *string `min:"1" type:"string"`
 }
 
@@ -9749,6 +9782,11 @@ type Group struct {
 	// One or more load balancers associated with the group.
 	LoadBalancerNames []*string `type:"list"`
 
+	// The maximum amount of time, in seconds, that an instance can be in service.
+	//
+	// Valid Range: Minimum value of 604800.
+	MaxInstanceLifetime *int64 `type:"integer"`
+
 	// The maximum size of the group.
 	//
 	// MaxSize is a required field
@@ -9880,6 +9918,12 @@ func (s *Group) SetLoadBalancerNames(v []*string) *Group {
 	return s
 }
 
+// SetMaxInstanceLifetime sets the MaxInstanceLifetime field's value.
+func (s *Group) SetMaxInstanceLifetime(v int64) *Group {
+	s.MaxInstanceLifetime = &v
+	return s
+}
+
 // SetMaxSize sets the MaxSize field's value.
 func (s *Group) SetMaxSize(v int64) *Group {
 	s.MaxSize = &v
@@ -9974,6 +10018,9 @@ type Instance struct {
 	// InstanceId is a required field
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
+	// The instance type of the EC2 instance.
+	InstanceType *string `min:"1" type:"string"`
+
 	// The launch configuration associated with the instance.
 	LaunchConfigurationName *string `min:"1" type:"string"`
 
@@ -9991,6 +10038,12 @@ type Instance struct {
 	//
 	// ProtectedFromScaleIn is a required field
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
+
+	// The number of capacity units contributed by the instance based on its instance
+	// type.
+	//
+	// Valid Range: Minimum value of 1. Maximum value of 999.
+	WeightedCapacity *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -10021,6 +10074,12 @@ func (s *Instance) SetInstanceId(v string) *Instance {
 	return s
 }
 
+// SetInstanceType sets the InstanceType field's value.
+func (s *Instance) SetInstanceType(v string) *Instance {
+	s.InstanceType = &v
+	return s
+}
+
 // SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
 func (s *Instance) SetLaunchConfigurationName(v string) *Instance {
 	s.LaunchConfigurationName = &v
@@ -10042,6 +10101,12 @@ func (s *Instance) SetLifecycleState(v string) *Instance {
 // SetProtectedFromScaleIn sets the ProtectedFromScaleIn field's value.
 func (s *Instance) SetProtectedFromScaleIn(v bool) *Instance {
 	s.ProtectedFromScaleIn = &v
+	return s
+}
+
+// SetWeightedCapacity sets the WeightedCapacity field's value.
+func (s *Instance) SetWeightedCapacity(v string) *Instance {
+	s.WeightedCapacity = &v
 	return s
 }
 
@@ -10072,6 +10137,9 @@ type InstanceDetails struct {
 	// InstanceId is a required field
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
+	// The instance type of the EC2 instance.
+	InstanceType *string `min:"1" type:"string"`
+
 	// The launch configuration used to launch the instance. This value is not available
 	// if you attached the instance to the Auto Scaling group.
 	LaunchConfigurationName *string `min:"1" type:"string"`
@@ -10089,6 +10157,12 @@ type InstanceDetails struct {
 	//
 	// ProtectedFromScaleIn is a required field
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
+
+	// The number of capacity units contributed by the instance based on its instance
+	// type.
+	//
+	// Valid Range: Minimum value of 1. Maximum value of 999.
+	WeightedCapacity *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -10125,6 +10199,12 @@ func (s *InstanceDetails) SetInstanceId(v string) *InstanceDetails {
 	return s
 }
 
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceDetails) SetInstanceType(v string) *InstanceDetails {
+	s.InstanceType = &v
+	return s
+}
+
 // SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
 func (s *InstanceDetails) SetLaunchConfigurationName(v string) *InstanceDetails {
 	s.LaunchConfigurationName = &v
@@ -10146,6 +10226,12 @@ func (s *InstanceDetails) SetLifecycleState(v string) *InstanceDetails {
 // SetProtectedFromScaleIn sets the ProtectedFromScaleIn field's value.
 func (s *InstanceDetails) SetProtectedFromScaleIn(v bool) *InstanceDetails {
 	s.ProtectedFromScaleIn = &v
+	return s
+}
+
+// SetWeightedCapacity sets the WeightedCapacity field's value.
+func (s *InstanceDetails) SetWeightedCapacity(v string) *InstanceDetails {
+	s.WeightedCapacity = &v
 	return s
 }
 
@@ -10179,6 +10265,14 @@ func (s *InstanceMonitoring) SetEnabled(v bool) *InstanceMonitoring {
 // and Spot Instances, the maximum price to pay for Spot Instances, and how
 // the Auto Scaling group allocates instance types to fulfill On-Demand and
 // Spot capacity.
+//
+// When you update SpotAllocationStrategy, SpotInstancePools, or SpotMaxPrice,
+// this update action does not deploy any changes across the running Amazon
+// EC2 instances in the group. Your existing Spot Instances continue to run
+// as long as the maximum price for those instances is higher than the current
+// Spot price. When scale out occurs, Amazon EC2 Auto Scaling launches instances
+// based on the new settings. When scale in occurs, Amazon EC2 Auto Scaling
+// terminates instances according to the group's termination policies.
 type InstancesDistribution struct {
 	_ struct{} `type:"structure"`
 
@@ -10197,16 +10291,28 @@ type InstancesDistribution struct {
 	// by On-Demand Instances. This base portion is provisioned first as your group
 	// scales.
 	//
-	// The default value is 0. If you leave this parameter set to 0, On-Demand Instances
-	// are launched as a percentage of the Auto Scaling group's desired capacity,
-	// per the OnDemandPercentageAboveBaseCapacity setting.
+	// Default if not set is 0. If you leave it set to 0, On-Demand Instances are
+	// launched as a percentage of the Auto Scaling group's desired capacity, per
+	// the OnDemandPercentageAboveBaseCapacity setting.
+	//
+	// An update to this setting means a gradual replacement of instances to maintain
+	// the specified number of On-Demand Instances for your base capacity. When
+	// replacing instances, Amazon EC2 Auto Scaling launches new instances before
+	// terminating the old ones.
 	OnDemandBaseCapacity *int64 `type:"integer"`
 
 	// Controls the percentages of On-Demand Instances and Spot Instances for your
-	// additional capacity beyond OnDemandBaseCapacity. The range is 0–100.
+	// additional capacity beyond OnDemandBaseCapacity.
 	//
-	// The default value is 100. If you leave this parameter set to 100, the percentages
-	// are 100% for On-Demand Instances and 0% for Spot Instances.
+	// Default if not set is 100. If you leave it set to 100, the percentages are
+	// 100% for On-Demand Instances and 0% for Spot Instances.
+	//
+	// An update to this setting means a gradual replacement of instances to maintain
+	// the percentage of On-Demand Instances for your additional capacity above
+	// the base capacity. When replacing instances, Amazon EC2 Auto Scaling launches
+	// new instances before terminating the old ones.
+	//
+	// Valid Range: Minimum value of 0. Maximum value of 100.
 	OnDemandPercentageAboveBaseCapacity *int64 `type:"integer"`
 
 	// Indicates how to allocate instances across Spot Instance pools.
@@ -10226,9 +10332,11 @@ type InstancesDistribution struct {
 
 	// The number of Spot Instance pools across which to allocate your Spot Instances.
 	// The Spot pools are determined from the different instance types in the Overrides
-	// array of LaunchTemplate. The range is 1–20. The default value is 2.
+	// array of LaunchTemplate. Default if not set is 2.
 	//
-	// Valid only when the Spot allocation strategy is lowest-price.
+	// Used only when the Spot allocation strategy is lowest-price.
+	//
+	// Valid Range: Minimum value of 1. Maximum value of 20.
 	SpotInstancePools *int64 `type:"integer"`
 
 	// The maximum price per unit hour that you are willing to pay for a Spot Instance.
@@ -10402,7 +10510,7 @@ type LaunchConfiguration struct {
 
 	// The maximum hourly price to be paid for any Spot Instance launched to fulfill
 	// the request. Spot Instances are launched when the price you specify exceeds
-	// the current Spot market price.
+	// the current Spot price.
 	//
 	// For more information, see Launching Spot Instances in Your Auto Scaling Group
 	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-spot-instances.html)
@@ -10545,6 +10653,11 @@ func (s *LaunchConfiguration) SetUserData(v string) *LaunchConfiguration {
 // The overrides are used to override the instance type specified by the launch
 // template with multiple instance types that can be used to launch On-Demand
 // Instances and Spot Instances.
+//
+// When you update the launch template or overrides, existing Amazon EC2 instances
+// continue to run. When scale out occurs, Amazon EC2 Auto Scaling launches
+// instances to match the new settings. When scale in occurs, Amazon EC2 Auto
+// Scaling terminates instances according to the group's termination policies.
 type LaunchTemplate struct {
 	_ struct{} `type:"structure"`
 
@@ -10552,9 +10665,9 @@ type LaunchTemplate struct {
 	// or launch template name in the request.
 	LaunchTemplateSpecification *LaunchTemplateSpecification `type:"structure"`
 
-	// Any parameters that you specify override the same parameters in the launch
-	// template. Currently, the only supported override is instance type. You must
-	// specify between 2 and 20 overrides.
+	// An optional setting. Any parameters that you specify override the same parameters
+	// in the launch template. Currently, the only supported override is instance
+	// type. You can specify between 1 and 20 instance types.
 	Overrides []*LaunchTemplateOverrides `type:"list"`
 }
 
@@ -10615,6 +10728,15 @@ type LaunchTemplateOverrides struct {
 	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	InstanceType *string `min:"1" type:"string"`
+
+	// The number of capacity units, which gives the instance type a proportional
+	// weight to other instance types. For example, larger instance types are generally
+	// weighted more than smaller instance types. These are the same units that
+	// you chose to set the desired capacity in terms of instances, or a performance
+	// attribute such as vCPUs, memory, or I/O.
+	//
+	// Valid Range: Minimum value of 1. Maximum value of 999.
+	WeightedCapacity *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -10633,6 +10755,9 @@ func (s *LaunchTemplateOverrides) Validate() error {
 	if s.InstanceType != nil && len(*s.InstanceType) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("InstanceType", 1))
 	}
+	if s.WeightedCapacity != nil && len(*s.WeightedCapacity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WeightedCapacity", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10643,6 +10768,12 @@ func (s *LaunchTemplateOverrides) Validate() error {
 // SetInstanceType sets the InstanceType field's value.
 func (s *LaunchTemplateOverrides) SetInstanceType(v string) *LaunchTemplateOverrides {
 	s.InstanceType = &v
+	return s
+}
+
+// SetWeightedCapacity sets the WeightedCapacity field's value.
+func (s *LaunchTemplateOverrides) SetWeightedCapacity(v string) *LaunchTemplateOverrides {
+	s.WeightedCapacity = &v
 	return s
 }
 
@@ -11234,8 +11365,8 @@ type MixedInstancesPolicy struct {
 
 	// The instances distribution to use.
 	//
-	// If you leave this parameter unspecified when creating a mixed instances policy,
-	// the default values are used.
+	// If you leave this parameter unspecified, the value for each parameter in
+	// InstancesDistribution uses a default value.
 	InstancesDistribution *InstancesDistribution `type:"structure"`
 
 	// The launch template and instance types (overrides).
@@ -11339,13 +11470,7 @@ func (s *NotificationConfiguration) SetTopicARN(v string) *NotificationConfigura
 type PredefinedMetricSpecification struct {
 	_ struct{} `type:"structure"`
 
-	// The metric type.
-	//
-	// PredefinedMetricType is a required field
-	PredefinedMetricType *string `type:"string" required:"true" enum:"MetricType"`
-
-	// Identifies the resource associated with the metric type. The following predefined
-	// metrics are available:
+	// The metric type. The following predefined metrics are available:
 	//
 	//    * ASGAverageCPUUtilization - Average CPU utilization of the Auto Scaling
 	//    group.
@@ -11359,15 +11484,21 @@ type PredefinedMetricSpecification struct {
 	//    * ALBRequestCountPerTarget - Number of requests completed per target in
 	//    an Application Load Balancer target group.
 	//
-	// For predefined metric types ASGAverageCPUUtilization, ASGAverageNetworkIn,
-	// and ASGAverageNetworkOut, the parameter must not be specified as the resource
-	// associated with the metric type is the Auto Scaling group. For predefined
-	// metric type ALBRequestCountPerTarget, the parameter must be specified in
-	// the format: app/load-balancer-name/load-balancer-id/targetgroup/target-group-name/target-group-id
-	// , where app/load-balancer-name/load-balancer-id is the final portion of the
-	// load balancer ARN, and targetgroup/target-group-name/target-group-id is the
-	// final portion of the target group ARN. The target group must be attached
-	// to the Auto Scaling group.
+	// PredefinedMetricType is a required field
+	PredefinedMetricType *string `type:"string" required:"true" enum:"MetricType"`
+
+	// Identifies the resource associated with the metric type. You can't specify
+	// a resource label unless the metric type is ALBRequestCountPerTarget and there
+	// is a target group attached to the Auto Scaling group.
+	//
+	// The format is app/load-balancer-name/load-balancer-id/targetgroup/target-group-name/target-group-id
+	// , where
+	//
+	//    * app/load-balancer-name/load-balancer-id is the final portion of the
+	//    load balancer ARN, and
+	//
+	//    * targetgroup/target-group-name/target-group-id is the final portion of
+	//    the target group ARN.
 	ResourceLabel *string `min:"1" type:"string"`
 }
 
@@ -13419,11 +13550,6 @@ type UpdateAutoScalingGroupInput struct {
 
 	// The name of the launch configuration. If you specify LaunchConfigurationName
 	// in your update request, you can't specify LaunchTemplate or MixedInstancesPolicy.
-	//
-	// To update an Auto Scaling group with a launch configuration with InstanceMonitoring
-	// set to false, you must first disable the collection of group metrics. Otherwise,
-	// you get an error. If you have previously enabled the collection of group
-	// metrics, you can disable it using DisableMetricsCollection.
 	LaunchConfigurationName *string `min:"1" type:"string"`
 
 	// The launch template and version to use to specify the updates. If you specify
@@ -13433,6 +13559,11 @@ type UpdateAutoScalingGroupInput struct {
 	// For more information, see LaunchTemplateSpecification (https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateSpecification.html)
 	// in the Amazon EC2 Auto Scaling API Reference.
 	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
+
+	// The maximum amount of time, in seconds, that an instance can be in service.
+	//
+	// Valid Range: Minimum value of 604800.
+	MaxInstanceLifetime *int64 `type:"integer"`
 
 	// The maximum size of the Auto Scaling group.
 	MaxSize *int64 `type:"integer"`
@@ -13587,6 +13718,12 @@ func (s *UpdateAutoScalingGroupInput) SetLaunchConfigurationName(v string) *Upda
 // SetLaunchTemplate sets the LaunchTemplate field's value.
 func (s *UpdateAutoScalingGroupInput) SetLaunchTemplate(v *LaunchTemplateSpecification) *UpdateAutoScalingGroupInput {
 	s.LaunchTemplate = v
+	return s
+}
+
+// SetMaxInstanceLifetime sets the MaxInstanceLifetime field's value.
+func (s *UpdateAutoScalingGroupInput) SetMaxInstanceLifetime(v int64) *UpdateAutoScalingGroupInput {
+	s.MaxInstanceLifetime = &v
 	return s
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "autoscaling"  // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "Auto Scaling" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Auto Scaling" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AutoScaling client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a AutoScaling client from just a session.
 //     svc := autoscaling.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := autoscaling.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AutoScaling {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *AutoScaling {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *AutoScaling {
 	svc := &AutoScaling{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2011-01-01",
 			},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -88,6 +88,81 @@ func (c *EC2) AcceptReservedInstancesExchangeQuoteWithContext(ctx aws.Context, i
 	return out, req.Send()
 }
 
+const opAcceptTransitGatewayPeeringAttachment = "AcceptTransitGatewayPeeringAttachment"
+
+// AcceptTransitGatewayPeeringAttachmentRequest generates a "aws/request.Request" representing the
+// client's request for the AcceptTransitGatewayPeeringAttachment operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AcceptTransitGatewayPeeringAttachment for more information on using the AcceptTransitGatewayPeeringAttachment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AcceptTransitGatewayPeeringAttachmentRequest method.
+//    req, resp := client.AcceptTransitGatewayPeeringAttachmentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/AcceptTransitGatewayPeeringAttachment
+func (c *EC2) AcceptTransitGatewayPeeringAttachmentRequest(input *AcceptTransitGatewayPeeringAttachmentInput) (req *request.Request, output *AcceptTransitGatewayPeeringAttachmentOutput) {
+	op := &request.Operation{
+		Name:       opAcceptTransitGatewayPeeringAttachment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AcceptTransitGatewayPeeringAttachmentInput{}
+	}
+
+	output = &AcceptTransitGatewayPeeringAttachmentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AcceptTransitGatewayPeeringAttachment API operation for Amazon Elastic Compute Cloud.
+//
+// Accepts a transit gateway peering attachment request. The peering attachment
+// must be in the pendingAcceptance state.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation AcceptTransitGatewayPeeringAttachment for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/AcceptTransitGatewayPeeringAttachment
+func (c *EC2) AcceptTransitGatewayPeeringAttachment(input *AcceptTransitGatewayPeeringAttachmentInput) (*AcceptTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.AcceptTransitGatewayPeeringAttachmentRequest(input)
+	return out, req.Send()
+}
+
+// AcceptTransitGatewayPeeringAttachmentWithContext is the same as AcceptTransitGatewayPeeringAttachment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AcceptTransitGatewayPeeringAttachment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) AcceptTransitGatewayPeeringAttachmentWithContext(ctx aws.Context, input *AcceptTransitGatewayPeeringAttachmentInput, opts ...request.Option) (*AcceptTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.AcceptTransitGatewayPeeringAttachmentRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opAcceptTransitGatewayVpcAttachment = "AcceptTransitGatewayVpcAttachment"
 
 // AcceptTransitGatewayVpcAttachmentRequest generates a "aws/request.Request" representing the
@@ -551,8 +626,9 @@ func (c *EC2) AllocateHostsRequest(input *AllocateHostsInput) (req *request.Requ
 
 // AllocateHosts API operation for Amazon Elastic Compute Cloud.
 //
-// Allocates a Dedicated Host to your account. At a minimum, specify the instance
-// size type, Availability Zone, and quantity of hosts to allocate.
+// Allocates a Dedicated Host to your account. At a minimum, specify the supported
+// instance type or instance family, the Availability Zone in which to allocate
+// the host, and the number of hosts to allocate.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1211,11 +1287,12 @@ func (c *EC2) AssociateRouteTableRequest(input *AssociateRouteTableInput) (req *
 
 // AssociateRouteTable API operation for Amazon Elastic Compute Cloud.
 //
-// Associates a subnet with a route table. The subnet and route table must be
-// in the same VPC. This association causes traffic originating from the subnet
-// to be routed according to the routes in the route table. The action returns
-// an association ID, which you need in order to disassociate the route table
-// from the subnet later. A route table can be associated with multiple subnets.
+// Associates a subnet in your VPC or an internet gateway or virtual private
+// gateway attached to your VPC with a route table in your VPC. This association
+// causes traffic from the subnet or gateway to be routed according to the routes
+// in the route table. The action returns an association ID, which you need
+// in order to disassociate the route table later. A route table can be associated
+// with multiple subnets.
 //
 // For more information, see Route Tables (https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html)
 // in the Amazon Virtual Private Cloud User Guide.
@@ -1319,6 +1396,85 @@ func (c *EC2) AssociateSubnetCidrBlock(input *AssociateSubnetCidrBlockInput) (*A
 // for more information on using Contexts.
 func (c *EC2) AssociateSubnetCidrBlockWithContext(ctx aws.Context, input *AssociateSubnetCidrBlockInput, opts ...request.Option) (*AssociateSubnetCidrBlockOutput, error) {
 	req, out := c.AssociateSubnetCidrBlockRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opAssociateTransitGatewayMulticastDomain = "AssociateTransitGatewayMulticastDomain"
+
+// AssociateTransitGatewayMulticastDomainRequest generates a "aws/request.Request" representing the
+// client's request for the AssociateTransitGatewayMulticastDomain operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AssociateTransitGatewayMulticastDomain for more information on using the AssociateTransitGatewayMulticastDomain
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AssociateTransitGatewayMulticastDomainRequest method.
+//    req, resp := client.AssociateTransitGatewayMulticastDomainRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/AssociateTransitGatewayMulticastDomain
+func (c *EC2) AssociateTransitGatewayMulticastDomainRequest(input *AssociateTransitGatewayMulticastDomainInput) (req *request.Request, output *AssociateTransitGatewayMulticastDomainOutput) {
+	op := &request.Operation{
+		Name:       opAssociateTransitGatewayMulticastDomain,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AssociateTransitGatewayMulticastDomainInput{}
+	}
+
+	output = &AssociateTransitGatewayMulticastDomainOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AssociateTransitGatewayMulticastDomain API operation for Amazon Elastic Compute Cloud.
+//
+// Associates the specified subnets and transit gateway attachments with the
+// specified transit gateway multicast domain.
+//
+// The transit gateway attachment must be in the available state before you
+// can add a resource. Use DescribeTransitGatewayAttachments (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayAttachments.html)
+// to see the state of the attachment.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation AssociateTransitGatewayMulticastDomain for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/AssociateTransitGatewayMulticastDomain
+func (c *EC2) AssociateTransitGatewayMulticastDomain(input *AssociateTransitGatewayMulticastDomainInput) (*AssociateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.AssociateTransitGatewayMulticastDomainRequest(input)
+	return out, req.Send()
+}
+
+// AssociateTransitGatewayMulticastDomainWithContext is the same as AssociateTransitGatewayMulticastDomain with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AssociateTransitGatewayMulticastDomain for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) AssociateTransitGatewayMulticastDomainWithContext(ctx aws.Context, input *AssociateTransitGatewayMulticastDomainInput, opts ...request.Option) (*AssociateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.AssociateTransitGatewayMulticastDomainRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1609,9 +1765,10 @@ func (c *EC2) AttachInternetGatewayRequest(input *AttachInternetGatewayInput) (r
 
 // AttachInternetGateway API operation for Amazon Elastic Compute Cloud.
 //
-// Attaches an internet gateway to a VPC, enabling connectivity between the
-// internet and the VPC. For more information about your VPC and internet gateway,
-// see the Amazon Virtual Private Cloud User Guide (https://docs.aws.amazon.com/vpc/latest/userguide/).
+// Attaches an internet gateway or a virtual private gateway to a VPC, enabling
+// connectivity between the internet and the VPC. For more information about
+// your VPC and internet gateway, see the Amazon Virtual Private Cloud User
+// Guide (https://docs.aws.amazon.com/vpc/latest/userguide/).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3493,11 +3650,10 @@ func (c *EC2) CreateCustomerGatewayRequest(input *CreateCustomerGatewayInput) (r
 // For more information, see AWS Site-to-Site VPN (https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
 // in the AWS Site-to-Site VPN User Guide.
 //
-// You cannot create more than one customer gateway with the same VPN type,
-// IP address, and BGP ASN parameter values. If you run an identical request
-// more than one time, the first request creates the customer gateway, and subsequent
-// requests return information about the existing customer gateway. The subsequent
-// requests do not create new customer gateway resources.
+// To create more than one customer gateway with the same VPN type, IP address,
+// and BGP ASN, specify a unique device name for each customer gateway. Identical
+// requests return information about the existing customer gateway and do not
+// create new customer gateways.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4610,6 +4766,154 @@ func (c *EC2) CreateLaunchTemplateVersionWithContext(ctx aws.Context, input *Cre
 	return out, req.Send()
 }
 
+const opCreateLocalGatewayRoute = "CreateLocalGatewayRoute"
+
+// CreateLocalGatewayRouteRequest generates a "aws/request.Request" representing the
+// client's request for the CreateLocalGatewayRoute operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateLocalGatewayRoute for more information on using the CreateLocalGatewayRoute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateLocalGatewayRouteRequest method.
+//    req, resp := client.CreateLocalGatewayRouteRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateLocalGatewayRoute
+func (c *EC2) CreateLocalGatewayRouteRequest(input *CreateLocalGatewayRouteInput) (req *request.Request, output *CreateLocalGatewayRouteOutput) {
+	op := &request.Operation{
+		Name:       opCreateLocalGatewayRoute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateLocalGatewayRouteInput{}
+	}
+
+	output = &CreateLocalGatewayRouteOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateLocalGatewayRoute API operation for Amazon Elastic Compute Cloud.
+//
+// Creates a static route for the specified local gateway route table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation CreateLocalGatewayRoute for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateLocalGatewayRoute
+func (c *EC2) CreateLocalGatewayRoute(input *CreateLocalGatewayRouteInput) (*CreateLocalGatewayRouteOutput, error) {
+	req, out := c.CreateLocalGatewayRouteRequest(input)
+	return out, req.Send()
+}
+
+// CreateLocalGatewayRouteWithContext is the same as CreateLocalGatewayRoute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateLocalGatewayRoute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) CreateLocalGatewayRouteWithContext(ctx aws.Context, input *CreateLocalGatewayRouteInput, opts ...request.Option) (*CreateLocalGatewayRouteOutput, error) {
+	req, out := c.CreateLocalGatewayRouteRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateLocalGatewayRouteTableVpcAssociation = "CreateLocalGatewayRouteTableVpcAssociation"
+
+// CreateLocalGatewayRouteTableVpcAssociationRequest generates a "aws/request.Request" representing the
+// client's request for the CreateLocalGatewayRouteTableVpcAssociation operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateLocalGatewayRouteTableVpcAssociation for more information on using the CreateLocalGatewayRouteTableVpcAssociation
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateLocalGatewayRouteTableVpcAssociationRequest method.
+//    req, resp := client.CreateLocalGatewayRouteTableVpcAssociationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateLocalGatewayRouteTableVpcAssociation
+func (c *EC2) CreateLocalGatewayRouteTableVpcAssociationRequest(input *CreateLocalGatewayRouteTableVpcAssociationInput) (req *request.Request, output *CreateLocalGatewayRouteTableVpcAssociationOutput) {
+	op := &request.Operation{
+		Name:       opCreateLocalGatewayRouteTableVpcAssociation,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateLocalGatewayRouteTableVpcAssociationInput{}
+	}
+
+	output = &CreateLocalGatewayRouteTableVpcAssociationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateLocalGatewayRouteTableVpcAssociation API operation for Amazon Elastic Compute Cloud.
+//
+// Associates the specified VPC with the specified local gateway route table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation CreateLocalGatewayRouteTableVpcAssociation for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateLocalGatewayRouteTableVpcAssociation
+func (c *EC2) CreateLocalGatewayRouteTableVpcAssociation(input *CreateLocalGatewayRouteTableVpcAssociationInput) (*CreateLocalGatewayRouteTableVpcAssociationOutput, error) {
+	req, out := c.CreateLocalGatewayRouteTableVpcAssociationRequest(input)
+	return out, req.Send()
+}
+
+// CreateLocalGatewayRouteTableVpcAssociationWithContext is the same as CreateLocalGatewayRouteTableVpcAssociation with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateLocalGatewayRouteTableVpcAssociation for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) CreateLocalGatewayRouteTableVpcAssociationWithContext(ctx aws.Context, input *CreateLocalGatewayRouteTableVpcAssociationInput, opts ...request.Option) (*CreateLocalGatewayRouteTableVpcAssociationOutput, error) {
+	req, out := c.CreateLocalGatewayRouteTableVpcAssociationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateNatGateway = "CreateNatGateway"
 
 // CreateNatGatewayRequest generates a "aws/request.Request" representing the
@@ -5245,7 +5549,7 @@ func (c *EC2) CreateRouteRequest(input *CreateRouteInput) (req *request.Request,
 //
 // You must specify one of the following targets: internet gateway or virtual
 // private gateway, NAT instance, NAT gateway, VPC peering connection, network
-// interface, or egress-only internet gateway.
+// interface, egress-only internet gateway, or transit gateway.
 //
 // When determining how to route traffic, we use the route with the most specific
 // match. For example, traffic is destined for the IPv4 address 192.0.2.3, and
@@ -5619,7 +5923,7 @@ func (c *EC2) CreateSnapshotsRequest(input *CreateSnapshotsInput) (req *request.
 // Creates crash-consistent snapshots of multiple EBS volumes and stores the
 // data in S3. Volumes are chosen by specifying an instance. Any attached volumes
 // will produce one snapshot each that is crash-consistent across the instance.
-// Boot volumes can be excluded by changing the paramaters.
+// Boot volumes can be excluded by changing the parameters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5958,8 +6262,10 @@ func (c *EC2) CreateTrafficMirrorFilterRequest(input *CreateTrafficMirrorFilterI
 // A Traffic Mirror filter is a set of rules that defines the traffic to mirror.
 //
 // By default, no traffic is mirrored. To mirror traffic, use CreateTrafficMirrorFilterRule
+// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTrafficMirrorFilterRule.htm)
 // to add Traffic Mirror rules to the filter. The rules you add define what
 // traffic gets mirrored. You can also use ModifyTrafficMirrorFilterNetworkServices
+// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyTrafficMirrorFilterNetworkServices.html)
 // to mirror supported network services.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -6034,7 +6340,7 @@ func (c *EC2) CreateTrafficMirrorFilterRuleRequest(input *CreateTrafficMirrorFil
 
 // CreateTrafficMirrorFilterRule API operation for Amazon Elastic Compute Cloud.
 //
-// Creates a Traffic Mirror rule.
+// Creates a Traffic Mirror filter rule.
 //
 // A Traffic Mirror rule defines the Traffic Mirror source traffic to mirror.
 //
@@ -6122,8 +6428,8 @@ func (c *EC2) CreateTrafficMirrorSessionRequest(input *CreateTrafficMirrorSessio
 // can be in the same VPC, or in a different VPC connected via VPC peering or
 // a transit gateway.
 //
-// By default, no traffic is mirrored. Use CreateTrafficMirrorFilter to create
-// filter rules that specify the traffic to mirror.
+// By default, no traffic is mirrored. Use CreateTrafficMirrorFilter (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTrafficMirrorFilter.htm)
+// to create filter rules that specify the traffic to mirror.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6206,7 +6512,8 @@ func (c *EC2) CreateTrafficMirrorTargetRequest(input *CreateTrafficMirrorTargetI
 //
 // A Traffic Mirror target can be a network interface, or a Network Load Balancer.
 //
-// To use the target in a Traffic Mirror session, use CreateTrafficMirrorSession.
+// To use the target in a Traffic Mirror session, use CreateTrafficMirrorSession
+// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTrafficMirrorSession.htm).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6324,6 +6631,164 @@ func (c *EC2) CreateTransitGateway(input *CreateTransitGatewayInput) (*CreateTra
 // for more information on using Contexts.
 func (c *EC2) CreateTransitGatewayWithContext(ctx aws.Context, input *CreateTransitGatewayInput, opts ...request.Option) (*CreateTransitGatewayOutput, error) {
 	req, out := c.CreateTransitGatewayRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateTransitGatewayMulticastDomain = "CreateTransitGatewayMulticastDomain"
+
+// CreateTransitGatewayMulticastDomainRequest generates a "aws/request.Request" representing the
+// client's request for the CreateTransitGatewayMulticastDomain operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateTransitGatewayMulticastDomain for more information on using the CreateTransitGatewayMulticastDomain
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateTransitGatewayMulticastDomainRequest method.
+//    req, resp := client.CreateTransitGatewayMulticastDomainRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateTransitGatewayMulticastDomain
+func (c *EC2) CreateTransitGatewayMulticastDomainRequest(input *CreateTransitGatewayMulticastDomainInput) (req *request.Request, output *CreateTransitGatewayMulticastDomainOutput) {
+	op := &request.Operation{
+		Name:       opCreateTransitGatewayMulticastDomain,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateTransitGatewayMulticastDomainInput{}
+	}
+
+	output = &CreateTransitGatewayMulticastDomainOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateTransitGatewayMulticastDomain API operation for Amazon Elastic Compute Cloud.
+//
+// Creates a multicast domain using the specified transit gateway.
+//
+// The transit gateway must be in the available state before you create a domain.
+// Use DescribeTransitGateways (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGateways.html)
+// to see the state of transit gateway.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation CreateTransitGatewayMulticastDomain for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateTransitGatewayMulticastDomain
+func (c *EC2) CreateTransitGatewayMulticastDomain(input *CreateTransitGatewayMulticastDomainInput) (*CreateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.CreateTransitGatewayMulticastDomainRequest(input)
+	return out, req.Send()
+}
+
+// CreateTransitGatewayMulticastDomainWithContext is the same as CreateTransitGatewayMulticastDomain with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateTransitGatewayMulticastDomain for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) CreateTransitGatewayMulticastDomainWithContext(ctx aws.Context, input *CreateTransitGatewayMulticastDomainInput, opts ...request.Option) (*CreateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.CreateTransitGatewayMulticastDomainRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateTransitGatewayPeeringAttachment = "CreateTransitGatewayPeeringAttachment"
+
+// CreateTransitGatewayPeeringAttachmentRequest generates a "aws/request.Request" representing the
+// client's request for the CreateTransitGatewayPeeringAttachment operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateTransitGatewayPeeringAttachment for more information on using the CreateTransitGatewayPeeringAttachment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateTransitGatewayPeeringAttachmentRequest method.
+//    req, resp := client.CreateTransitGatewayPeeringAttachmentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateTransitGatewayPeeringAttachment
+func (c *EC2) CreateTransitGatewayPeeringAttachmentRequest(input *CreateTransitGatewayPeeringAttachmentInput) (req *request.Request, output *CreateTransitGatewayPeeringAttachmentOutput) {
+	op := &request.Operation{
+		Name:       opCreateTransitGatewayPeeringAttachment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateTransitGatewayPeeringAttachmentInput{}
+	}
+
+	output = &CreateTransitGatewayPeeringAttachmentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateTransitGatewayPeeringAttachment API operation for Amazon Elastic Compute Cloud.
+//
+// Requests a transit gateway peering attachment between the specified transit
+// gateway (requester) and a peer transit gateway (accepter). The transit gateways
+// must be in different Regions. The peer transit gateway can be in your account
+// or a different AWS account.
+//
+// After you create the peering attachment, the owner of the accepter transit
+// gateway must accept the attachment request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation CreateTransitGatewayPeeringAttachment for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateTransitGatewayPeeringAttachment
+func (c *EC2) CreateTransitGatewayPeeringAttachment(input *CreateTransitGatewayPeeringAttachmentInput) (*CreateTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.CreateTransitGatewayPeeringAttachmentRequest(input)
+	return out, req.Send()
+}
+
+// CreateTransitGatewayPeeringAttachmentWithContext is the same as CreateTransitGatewayPeeringAttachment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateTransitGatewayPeeringAttachment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) CreateTransitGatewayPeeringAttachmentWithContext(ctx aws.Context, input *CreateTransitGatewayPeeringAttachmentInput, opts ...request.Option) (*CreateTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.CreateTransitGatewayPeeringAttachmentRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -8247,6 +8712,154 @@ func (c *EC2) DeleteLaunchTemplateVersionsWithContext(ctx aws.Context, input *De
 	return out, req.Send()
 }
 
+const opDeleteLocalGatewayRoute = "DeleteLocalGatewayRoute"
+
+// DeleteLocalGatewayRouteRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteLocalGatewayRoute operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteLocalGatewayRoute for more information on using the DeleteLocalGatewayRoute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteLocalGatewayRouteRequest method.
+//    req, resp := client.DeleteLocalGatewayRouteRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteLocalGatewayRoute
+func (c *EC2) DeleteLocalGatewayRouteRequest(input *DeleteLocalGatewayRouteInput) (req *request.Request, output *DeleteLocalGatewayRouteOutput) {
+	op := &request.Operation{
+		Name:       opDeleteLocalGatewayRoute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteLocalGatewayRouteInput{}
+	}
+
+	output = &DeleteLocalGatewayRouteOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteLocalGatewayRoute API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes the specified route from the specified local gateway route table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteLocalGatewayRoute for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteLocalGatewayRoute
+func (c *EC2) DeleteLocalGatewayRoute(input *DeleteLocalGatewayRouteInput) (*DeleteLocalGatewayRouteOutput, error) {
+	req, out := c.DeleteLocalGatewayRouteRequest(input)
+	return out, req.Send()
+}
+
+// DeleteLocalGatewayRouteWithContext is the same as DeleteLocalGatewayRoute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteLocalGatewayRoute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteLocalGatewayRouteWithContext(ctx aws.Context, input *DeleteLocalGatewayRouteInput, opts ...request.Option) (*DeleteLocalGatewayRouteOutput, error) {
+	req, out := c.DeleteLocalGatewayRouteRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteLocalGatewayRouteTableVpcAssociation = "DeleteLocalGatewayRouteTableVpcAssociation"
+
+// DeleteLocalGatewayRouteTableVpcAssociationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteLocalGatewayRouteTableVpcAssociation operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteLocalGatewayRouteTableVpcAssociation for more information on using the DeleteLocalGatewayRouteTableVpcAssociation
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteLocalGatewayRouteTableVpcAssociationRequest method.
+//    req, resp := client.DeleteLocalGatewayRouteTableVpcAssociationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteLocalGatewayRouteTableVpcAssociation
+func (c *EC2) DeleteLocalGatewayRouteTableVpcAssociationRequest(input *DeleteLocalGatewayRouteTableVpcAssociationInput) (req *request.Request, output *DeleteLocalGatewayRouteTableVpcAssociationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteLocalGatewayRouteTableVpcAssociation,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteLocalGatewayRouteTableVpcAssociationInput{}
+	}
+
+	output = &DeleteLocalGatewayRouteTableVpcAssociationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteLocalGatewayRouteTableVpcAssociation API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes the specified association between a VPC and local gateway route table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteLocalGatewayRouteTableVpcAssociation for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteLocalGatewayRouteTableVpcAssociation
+func (c *EC2) DeleteLocalGatewayRouteTableVpcAssociation(input *DeleteLocalGatewayRouteTableVpcAssociationInput) (*DeleteLocalGatewayRouteTableVpcAssociationOutput, error) {
+	req, out := c.DeleteLocalGatewayRouteTableVpcAssociationRequest(input)
+	return out, req.Send()
+}
+
+// DeleteLocalGatewayRouteTableVpcAssociationWithContext is the same as DeleteLocalGatewayRouteTableVpcAssociation with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteLocalGatewayRouteTableVpcAssociation for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteLocalGatewayRouteTableVpcAssociationWithContext(ctx aws.Context, input *DeleteLocalGatewayRouteTableVpcAssociationInput, opts ...request.Option) (*DeleteLocalGatewayRouteTableVpcAssociationOutput, error) {
+	req, out := c.DeleteLocalGatewayRouteTableVpcAssociationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteNatGateway = "DeleteNatGateway"
 
 // DeleteNatGatewayRequest generates a "aws/request.Request" representing the
@@ -8701,6 +9314,80 @@ func (c *EC2) DeletePlacementGroup(input *DeletePlacementGroupInput) (*DeletePla
 // for more information on using Contexts.
 func (c *EC2) DeletePlacementGroupWithContext(ctx aws.Context, input *DeletePlacementGroupInput, opts ...request.Option) (*DeletePlacementGroupOutput, error) {
 	req, out := c.DeletePlacementGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteQueuedReservedInstances = "DeleteQueuedReservedInstances"
+
+// DeleteQueuedReservedInstancesRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteQueuedReservedInstances operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteQueuedReservedInstances for more information on using the DeleteQueuedReservedInstances
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteQueuedReservedInstancesRequest method.
+//    req, resp := client.DeleteQueuedReservedInstancesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteQueuedReservedInstances
+func (c *EC2) DeleteQueuedReservedInstancesRequest(input *DeleteQueuedReservedInstancesInput) (req *request.Request, output *DeleteQueuedReservedInstancesOutput) {
+	op := &request.Operation{
+		Name:       opDeleteQueuedReservedInstances,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteQueuedReservedInstancesInput{}
+	}
+
+	output = &DeleteQueuedReservedInstancesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteQueuedReservedInstances API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes the queued purchases for the specified Reserved Instances.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteQueuedReservedInstances for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteQueuedReservedInstances
+func (c *EC2) DeleteQueuedReservedInstances(input *DeleteQueuedReservedInstancesInput) (*DeleteQueuedReservedInstancesOutput, error) {
+	req, out := c.DeleteQueuedReservedInstancesRequest(input)
+	return out, req.Send()
+}
+
+// DeleteQueuedReservedInstancesWithContext is the same as DeleteQueuedReservedInstances with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteQueuedReservedInstances for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteQueuedReservedInstancesWithContext(ctx aws.Context, input *DeleteQueuedReservedInstancesInput, opts ...request.Option) (*DeleteQueuedReservedInstancesOutput, error) {
+	req, out := c.DeleteQueuedReservedInstancesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -9627,6 +10314,154 @@ func (c *EC2) DeleteTransitGateway(input *DeleteTransitGatewayInput) (*DeleteTra
 // for more information on using Contexts.
 func (c *EC2) DeleteTransitGatewayWithContext(ctx aws.Context, input *DeleteTransitGatewayInput, opts ...request.Option) (*DeleteTransitGatewayOutput, error) {
 	req, out := c.DeleteTransitGatewayRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteTransitGatewayMulticastDomain = "DeleteTransitGatewayMulticastDomain"
+
+// DeleteTransitGatewayMulticastDomainRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteTransitGatewayMulticastDomain operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteTransitGatewayMulticastDomain for more information on using the DeleteTransitGatewayMulticastDomain
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteTransitGatewayMulticastDomainRequest method.
+//    req, resp := client.DeleteTransitGatewayMulticastDomainRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteTransitGatewayMulticastDomain
+func (c *EC2) DeleteTransitGatewayMulticastDomainRequest(input *DeleteTransitGatewayMulticastDomainInput) (req *request.Request, output *DeleteTransitGatewayMulticastDomainOutput) {
+	op := &request.Operation{
+		Name:       opDeleteTransitGatewayMulticastDomain,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteTransitGatewayMulticastDomainInput{}
+	}
+
+	output = &DeleteTransitGatewayMulticastDomainOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteTransitGatewayMulticastDomain API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes the specified transit gateway multicast domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteTransitGatewayMulticastDomain for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteTransitGatewayMulticastDomain
+func (c *EC2) DeleteTransitGatewayMulticastDomain(input *DeleteTransitGatewayMulticastDomainInput) (*DeleteTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.DeleteTransitGatewayMulticastDomainRequest(input)
+	return out, req.Send()
+}
+
+// DeleteTransitGatewayMulticastDomainWithContext is the same as DeleteTransitGatewayMulticastDomain with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteTransitGatewayMulticastDomain for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteTransitGatewayMulticastDomainWithContext(ctx aws.Context, input *DeleteTransitGatewayMulticastDomainInput, opts ...request.Option) (*DeleteTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.DeleteTransitGatewayMulticastDomainRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteTransitGatewayPeeringAttachment = "DeleteTransitGatewayPeeringAttachment"
+
+// DeleteTransitGatewayPeeringAttachmentRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteTransitGatewayPeeringAttachment operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteTransitGatewayPeeringAttachment for more information on using the DeleteTransitGatewayPeeringAttachment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteTransitGatewayPeeringAttachmentRequest method.
+//    req, resp := client.DeleteTransitGatewayPeeringAttachmentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteTransitGatewayPeeringAttachment
+func (c *EC2) DeleteTransitGatewayPeeringAttachmentRequest(input *DeleteTransitGatewayPeeringAttachmentInput) (req *request.Request, output *DeleteTransitGatewayPeeringAttachmentOutput) {
+	op := &request.Operation{
+		Name:       opDeleteTransitGatewayPeeringAttachment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteTransitGatewayPeeringAttachmentInput{}
+	}
+
+	output = &DeleteTransitGatewayPeeringAttachmentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteTransitGatewayPeeringAttachment API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes a transit gateway peering attachment.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteTransitGatewayPeeringAttachment for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteTransitGatewayPeeringAttachment
+func (c *EC2) DeleteTransitGatewayPeeringAttachment(input *DeleteTransitGatewayPeeringAttachmentInput) (*DeleteTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.DeleteTransitGatewayPeeringAttachmentRequest(input)
+	return out, req.Send()
+}
+
+// DeleteTransitGatewayPeeringAttachmentWithContext is the same as DeleteTransitGatewayPeeringAttachment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteTransitGatewayPeeringAttachment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteTransitGatewayPeeringAttachmentWithContext(ctx aws.Context, input *DeleteTransitGatewayPeeringAttachmentInput, opts ...request.Option) (*DeleteTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.DeleteTransitGatewayPeeringAttachmentRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -10726,6 +11561,156 @@ func (c *EC2) DeregisterImageWithContext(ctx aws.Context, input *DeregisterImage
 	return out, req.Send()
 }
 
+const opDeregisterTransitGatewayMulticastGroupMembers = "DeregisterTransitGatewayMulticastGroupMembers"
+
+// DeregisterTransitGatewayMulticastGroupMembersRequest generates a "aws/request.Request" representing the
+// client's request for the DeregisterTransitGatewayMulticastGroupMembers operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeregisterTransitGatewayMulticastGroupMembers for more information on using the DeregisterTransitGatewayMulticastGroupMembers
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeregisterTransitGatewayMulticastGroupMembersRequest method.
+//    req, resp := client.DeregisterTransitGatewayMulticastGroupMembersRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeregisterTransitGatewayMulticastGroupMembers
+func (c *EC2) DeregisterTransitGatewayMulticastGroupMembersRequest(input *DeregisterTransitGatewayMulticastGroupMembersInput) (req *request.Request, output *DeregisterTransitGatewayMulticastGroupMembersOutput) {
+	op := &request.Operation{
+		Name:       opDeregisterTransitGatewayMulticastGroupMembers,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeregisterTransitGatewayMulticastGroupMembersInput{}
+	}
+
+	output = &DeregisterTransitGatewayMulticastGroupMembersOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeregisterTransitGatewayMulticastGroupMembers API operation for Amazon Elastic Compute Cloud.
+//
+// Deregisters the specified members (network interfaces) from the transit gateway
+// multicast group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeregisterTransitGatewayMulticastGroupMembers for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeregisterTransitGatewayMulticastGroupMembers
+func (c *EC2) DeregisterTransitGatewayMulticastGroupMembers(input *DeregisterTransitGatewayMulticastGroupMembersInput) (*DeregisterTransitGatewayMulticastGroupMembersOutput, error) {
+	req, out := c.DeregisterTransitGatewayMulticastGroupMembersRequest(input)
+	return out, req.Send()
+}
+
+// DeregisterTransitGatewayMulticastGroupMembersWithContext is the same as DeregisterTransitGatewayMulticastGroupMembers with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeregisterTransitGatewayMulticastGroupMembers for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeregisterTransitGatewayMulticastGroupMembersWithContext(ctx aws.Context, input *DeregisterTransitGatewayMulticastGroupMembersInput, opts ...request.Option) (*DeregisterTransitGatewayMulticastGroupMembersOutput, error) {
+	req, out := c.DeregisterTransitGatewayMulticastGroupMembersRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeregisterTransitGatewayMulticastGroupSources = "DeregisterTransitGatewayMulticastGroupSources"
+
+// DeregisterTransitGatewayMulticastGroupSourcesRequest generates a "aws/request.Request" representing the
+// client's request for the DeregisterTransitGatewayMulticastGroupSources operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeregisterTransitGatewayMulticastGroupSources for more information on using the DeregisterTransitGatewayMulticastGroupSources
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeregisterTransitGatewayMulticastGroupSourcesRequest method.
+//    req, resp := client.DeregisterTransitGatewayMulticastGroupSourcesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeregisterTransitGatewayMulticastGroupSources
+func (c *EC2) DeregisterTransitGatewayMulticastGroupSourcesRequest(input *DeregisterTransitGatewayMulticastGroupSourcesInput) (req *request.Request, output *DeregisterTransitGatewayMulticastGroupSourcesOutput) {
+	op := &request.Operation{
+		Name:       opDeregisterTransitGatewayMulticastGroupSources,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeregisterTransitGatewayMulticastGroupSourcesInput{}
+	}
+
+	output = &DeregisterTransitGatewayMulticastGroupSourcesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeregisterTransitGatewayMulticastGroupSources API operation for Amazon Elastic Compute Cloud.
+//
+// Deregisters the specified sources (network interfaces) from the transit gateway
+// multicast group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeregisterTransitGatewayMulticastGroupSources for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeregisterTransitGatewayMulticastGroupSources
+func (c *EC2) DeregisterTransitGatewayMulticastGroupSources(input *DeregisterTransitGatewayMulticastGroupSourcesInput) (*DeregisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	req, out := c.DeregisterTransitGatewayMulticastGroupSourcesRequest(input)
+	return out, req.Send()
+}
+
+// DeregisterTransitGatewayMulticastGroupSourcesWithContext is the same as DeregisterTransitGatewayMulticastGroupSources with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeregisterTransitGatewayMulticastGroupSources for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeregisterTransitGatewayMulticastGroupSourcesWithContext(ctx aws.Context, input *DeregisterTransitGatewayMulticastGroupSourcesInput, opts ...request.Option) (*DeregisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	req, out := c.DeregisterTransitGatewayMulticastGroupSourcesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeAccountAttributes = "DescribeAccountAttributes"
 
 // DescribeAccountAttributesRequest generates a "aws/request.Request" representing the
@@ -10778,8 +11763,10 @@ func (c *EC2) DescribeAccountAttributesRequest(input *DescribeAccountAttributesI
 //
 //    * default-vpc: The ID of the default VPC for your account, or none.
 //
-//    * max-instances: The maximum number of On-Demand Instances that you can
-//    run.
+//    * max-instances: This attribute is no longer supported. The returned value
+//    does not reflect your actual vCPU limit for running On-Demand Instances.
+//    For more information, see On-Demand Instance Limits (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-on-demand-instances.html#ec2-on-demand-instances-limits)
+//    in the Amazon Elastic Compute Cloud User Guide.
 //
 //    * vpc-max-security-groups-per-interface: The maximum number of security
 //    groups that you can assign to a network interface.
@@ -11028,12 +12015,13 @@ func (c *EC2) DescribeAvailabilityZonesRequest(input *DescribeAvailabilityZonesI
 
 // DescribeAvailabilityZones API operation for Amazon Elastic Compute Cloud.
 //
-// Describes the Availability Zones that are available to you. The results include
-// zones only for the Region you're currently using. If there is an event impacting
-// an Availability Zone, you can use this request to view the state and any
-// provided message for that Availability Zone.
+// Describes the Availability Zones and Local Zones that are available to you.
+// If there is an event impacting an Availability Zone or Local Zone, you can
+// use this request to view the state and any provided messages for that Availability
+// Zone or Local Zone.
 //
-// For more information, see Regions and Availability Zones (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)
+// For more information about Availability Zones and Local Zones, see Regions
+// and Availability Zones (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -11269,10 +12257,12 @@ func (c *EC2) DescribeByoipCidrsPagesWithContext(ctx aws.Context, input *Describ
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeByoipCidrsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeByoipCidrsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -11400,10 +12390,12 @@ func (c *EC2) DescribeCapacityReservationsPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeCapacityReservationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeCapacityReservationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -11533,10 +12525,12 @@ func (c *EC2) DescribeClassicLinkInstancesPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClassicLinkInstancesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClassicLinkInstancesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -11663,10 +12657,12 @@ func (c *EC2) DescribeClientVpnAuthorizationRulesPagesWithContext(ctx aws.Contex
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClientVpnAuthorizationRulesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClientVpnAuthorizationRulesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -11794,10 +12790,12 @@ func (c *EC2) DescribeClientVpnConnectionsPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClientVpnConnectionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClientVpnConnectionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -11924,10 +12922,12 @@ func (c *EC2) DescribeClientVpnEndpointsPagesWithContext(ctx aws.Context, input 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClientVpnEndpointsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClientVpnEndpointsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -12054,10 +13054,12 @@ func (c *EC2) DescribeClientVpnRoutesPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClientVpnRoutesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClientVpnRoutesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -12184,11 +13186,88 @@ func (c *EC2) DescribeClientVpnTargetNetworksPagesWithContext(ctx aws.Context, i
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeClientVpnTargetNetworksOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeClientVpnTargetNetworksOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
+}
+
+const opDescribeCoipPools = "DescribeCoipPools"
+
+// DescribeCoipPoolsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeCoipPools operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeCoipPools for more information on using the DescribeCoipPools
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeCoipPoolsRequest method.
+//    req, resp := client.DescribeCoipPoolsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeCoipPools
+func (c *EC2) DescribeCoipPoolsRequest(input *DescribeCoipPoolsInput) (req *request.Request, output *DescribeCoipPoolsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeCoipPools,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeCoipPoolsInput{}
+	}
+
+	output = &DescribeCoipPoolsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeCoipPools API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the specified customer-owned address pools or all of your customer-owned
+// address pools.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeCoipPools for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeCoipPools
+func (c *EC2) DescribeCoipPools(input *DescribeCoipPoolsInput) (*DescribeCoipPoolsOutput, error) {
+	req, out := c.DescribeCoipPoolsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeCoipPoolsWithContext is the same as DescribeCoipPools with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeCoipPools for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeCoipPoolsWithContext(ctx aws.Context, input *DescribeCoipPoolsInput, opts ...request.Option) (*DescribeCoipPoolsOutput, error) {
+	req, out := c.DescribeCoipPoolsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opDescribeConversionTasks = "DescribeConversionTasks"
@@ -12472,10 +13551,12 @@ func (c *EC2) DescribeDhcpOptionsPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeDhcpOptionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeDhcpOptionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -12602,10 +13683,12 @@ func (c *EC2) DescribeEgressOnlyInternetGatewaysPagesWithContext(ctx aws.Context
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeEgressOnlyInternetGatewaysOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeEgressOnlyInternetGatewaysOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -12716,6 +13799,12 @@ func (c *EC2) DescribeExportImageTasksRequest(input *DescribeExportImageTasksInp
 		Name:       opDescribeExportImageTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -12757,6 +13846,58 @@ func (c *EC2) DescribeExportImageTasksWithContext(ctx aws.Context, input *Descri
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// DescribeExportImageTasksPages iterates over the pages of a DescribeExportImageTasks operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeExportImageTasks method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeExportImageTasks operation.
+//    pageNum := 0
+//    err := client.DescribeExportImageTasksPages(params,
+//        func(page *ec2.DescribeExportImageTasksOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *EC2) DescribeExportImageTasksPages(input *DescribeExportImageTasksInput, fn func(*DescribeExportImageTasksOutput, bool) bool) error {
+	return c.DescribeExportImageTasksPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeExportImageTasksPagesWithContext same as DescribeExportImageTasksPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeExportImageTasksPagesWithContext(ctx aws.Context, input *DescribeExportImageTasksInput, fn func(*DescribeExportImageTasksOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeExportImageTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeExportImageTasksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*DescribeExportImageTasksOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
 }
 
 const opDescribeExportTasks = "DescribeExportTasks"
@@ -12834,6 +13975,138 @@ func (c *EC2) DescribeExportTasksWithContext(ctx aws.Context, input *DescribeExp
 	return out, req.Send()
 }
 
+const opDescribeFastSnapshotRestores = "DescribeFastSnapshotRestores"
+
+// DescribeFastSnapshotRestoresRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeFastSnapshotRestores operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeFastSnapshotRestores for more information on using the DescribeFastSnapshotRestores
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeFastSnapshotRestoresRequest method.
+//    req, resp := client.DescribeFastSnapshotRestoresRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFastSnapshotRestores
+func (c *EC2) DescribeFastSnapshotRestoresRequest(input *DescribeFastSnapshotRestoresInput) (req *request.Request, output *DescribeFastSnapshotRestoresOutput) {
+	op := &request.Operation{
+		Name:       opDescribeFastSnapshotRestores,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeFastSnapshotRestoresInput{}
+	}
+
+	output = &DescribeFastSnapshotRestoresOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeFastSnapshotRestores API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the state of fast snapshot restores for your snapshots.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeFastSnapshotRestores for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFastSnapshotRestores
+func (c *EC2) DescribeFastSnapshotRestores(input *DescribeFastSnapshotRestoresInput) (*DescribeFastSnapshotRestoresOutput, error) {
+	req, out := c.DescribeFastSnapshotRestoresRequest(input)
+	return out, req.Send()
+}
+
+// DescribeFastSnapshotRestoresWithContext is the same as DescribeFastSnapshotRestores with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeFastSnapshotRestores for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeFastSnapshotRestoresWithContext(ctx aws.Context, input *DescribeFastSnapshotRestoresInput, opts ...request.Option) (*DescribeFastSnapshotRestoresOutput, error) {
+	req, out := c.DescribeFastSnapshotRestoresRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeFastSnapshotRestoresPages iterates over the pages of a DescribeFastSnapshotRestores operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeFastSnapshotRestores method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeFastSnapshotRestores operation.
+//    pageNum := 0
+//    err := client.DescribeFastSnapshotRestoresPages(params,
+//        func(page *ec2.DescribeFastSnapshotRestoresOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *EC2) DescribeFastSnapshotRestoresPages(input *DescribeFastSnapshotRestoresInput, fn func(*DescribeFastSnapshotRestoresOutput, bool) bool) error {
+	return c.DescribeFastSnapshotRestoresPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeFastSnapshotRestoresPagesWithContext same as DescribeFastSnapshotRestoresPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeFastSnapshotRestoresPagesWithContext(ctx aws.Context, input *DescribeFastSnapshotRestoresInput, fn func(*DescribeFastSnapshotRestoresOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeFastSnapshotRestoresInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeFastSnapshotRestoresRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*DescribeFastSnapshotRestoresOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
+}
+
 const opDescribeFleetHistory = "DescribeFleetHistory"
 
 // DescribeFleetHistoryRequest generates a "aws/request.Request" representing the
@@ -12879,6 +14152,10 @@ func (c *EC2) DescribeFleetHistoryRequest(input *DescribeFleetHistoryInput) (req
 // DescribeFleetHistory API operation for Amazon Elastic Compute Cloud.
 //
 // Describes the events for the specified EC2 Fleet during the specified time.
+//
+// EC2 Fleet events are delayed by up to 30 seconds before they can be described.
+// This ensures that you can query by the last evaluated time and not miss a
+// recorded event. EC2 Fleet events are available for 48 hours.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -13032,7 +14309,7 @@ func (c *EC2) DescribeFleetsRequest(input *DescribeFleetsInput) (req *request.Re
 
 // DescribeFleets API operation for Amazon Elastic Compute Cloud.
 //
-// Describes the specified EC2 Fleets or all your EC2 Fleets.
+// Describes the specified EC2 Fleets or all of your EC2 Fleets.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -13105,10 +14382,12 @@ func (c *EC2) DescribeFleetsPagesWithContext(ctx aws.Context, input *DescribeFle
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeFleetsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeFleetsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13237,10 +14516,12 @@ func (c *EC2) DescribeFlowLogsPagesWithContext(ctx aws.Context, input *DescribeF
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeFlowLogsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeFlowLogsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13443,10 +14724,12 @@ func (c *EC2) DescribeFpgaImagesPagesWithContext(ctx aws.Context, input *Describ
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeFpgaImagesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeFpgaImagesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13502,8 +14785,8 @@ func (c *EC2) DescribeHostReservationOfferingsRequest(input *DescribeHostReserva
 //
 // Describes the Dedicated Host reservations that are available to purchase.
 //
-// The results describe all the Dedicated Host reservation offerings, including
-// offerings that may not match the instance family and Region of your Dedicated
+// The results describe all of the Dedicated Host reservation offerings, including
+// offerings that might not match the instance family and Region of your Dedicated
 // Hosts. When purchasing an offering, ensure that the instance family and Region
 // of the offering matches that of the Dedicated Hosts with which it is to be
 // associated. For more information about supported instance types, see Dedicated
@@ -13581,10 +14864,12 @@ func (c *EC2) DescribeHostReservationOfferingsPagesWithContext(ctx aws.Context, 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeHostReservationOfferingsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeHostReservationOfferingsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13711,10 +14996,12 @@ func (c *EC2) DescribeHostReservationsPagesWithContext(ctx aws.Context, input *D
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeHostReservationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeHostReservationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13845,10 +15132,12 @@ func (c *EC2) DescribeHostsPagesWithContext(ctx aws.Context, input *DescribeHost
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeHostsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeHostsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -13975,10 +15264,12 @@ func (c *EC2) DescribeIamInstanceProfileAssociationsPagesWithContext(ctx aws.Con
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeIamInstanceProfileAssociationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeIamInstanceProfileAssociationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -14447,10 +15738,12 @@ func (c *EC2) DescribeImportImageTasksPagesWithContext(ctx aws.Context, input *D
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeImportImageTasksOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeImportImageTasksOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -14577,10 +15870,12 @@ func (c *EC2) DescribeImportSnapshotTasksPagesWithContext(ctx aws.Context, input
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeImportSnapshotTasksOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeImportSnapshotTasksOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -14712,19 +16007,19 @@ func (c *EC2) DescribeInstanceCreditSpecificationsRequest(input *DescribeInstanc
 
 // DescribeInstanceCreditSpecifications API operation for Amazon Elastic Compute Cloud.
 //
-// Describes the credit option for CPU usage of the specified T2 or T3 instances.
-// The credit options are standard and unlimited.
+// Describes the credit option for CPU usage of the specified burstable performance
+// instances. The credit options are standard and unlimited.
 //
-// If you do not specify an instance ID, Amazon EC2 returns T2 and T3 instances
-// with the unlimited credit option, as well as instances that were previously
-// configured as T2 or T3 with the unlimited credit option. For example, if
-// you resize a T2 instance, while it is configured as unlimited, to an M4 instance,
-// Amazon EC2 returns the M4 instance.
+// If you do not specify an instance ID, Amazon EC2 returns burstable performance
+// instances with the unlimited credit option, as well as instances that were
+// previously configured as T2, T3, and T3a with the unlimited credit option.
+// For example, if you resize a T2 instance, while it is configured as unlimited,
+// to an M4 instance, Amazon EC2 returns the M4 instance.
 //
 // If you specify one or more instance IDs, Amazon EC2 returns the credit option
 // (standard or unlimited) of those instances. If you specify an instance ID
-// that is not valid, such as an instance that is not a T2 or T3 instance, an
-// error is returned.
+// that is not valid, such as an instance that is not a burstable performance
+// instance, an error is returned.
 //
 // Recently terminated instances might appear in the returned results. This
 // interval is usually less than one hour.
@@ -14808,10 +16103,12 @@ func (c *EC2) DescribeInstanceCreditSpecificationsPagesWithContext(ctx aws.Conte
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeInstanceCreditSpecificationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeInstanceCreditSpecificationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -14959,11 +16256,164 @@ func (c *EC2) DescribeInstanceStatusPagesWithContext(ctx aws.Context, input *Des
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeInstanceStatusOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeInstanceStatusOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
+}
+
+const opDescribeInstanceTypeOfferings = "DescribeInstanceTypeOfferings"
+
+// DescribeInstanceTypeOfferingsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeInstanceTypeOfferings operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeInstanceTypeOfferings for more information on using the DescribeInstanceTypeOfferings
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeInstanceTypeOfferingsRequest method.
+//    req, resp := client.DescribeInstanceTypeOfferingsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceTypeOfferings
+func (c *EC2) DescribeInstanceTypeOfferingsRequest(input *DescribeInstanceTypeOfferingsInput) (req *request.Request, output *DescribeInstanceTypeOfferingsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeInstanceTypeOfferings,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeInstanceTypeOfferingsInput{}
+	}
+
+	output = &DescribeInstanceTypeOfferingsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeInstanceTypeOfferings API operation for Amazon Elastic Compute Cloud.
+//
+// Returns a list of all instance types offered. The results can be filtered
+// by location (Region or Availability Zone). If no location is specified, the
+// instance types offered in the current Region are returned.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeInstanceTypeOfferings for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceTypeOfferings
+func (c *EC2) DescribeInstanceTypeOfferings(input *DescribeInstanceTypeOfferingsInput) (*DescribeInstanceTypeOfferingsOutput, error) {
+	req, out := c.DescribeInstanceTypeOfferingsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeInstanceTypeOfferingsWithContext is the same as DescribeInstanceTypeOfferings with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeInstanceTypeOfferings for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeInstanceTypeOfferingsWithContext(ctx aws.Context, input *DescribeInstanceTypeOfferingsInput, opts ...request.Option) (*DescribeInstanceTypeOfferingsOutput, error) {
+	req, out := c.DescribeInstanceTypeOfferingsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeInstanceTypes = "DescribeInstanceTypes"
+
+// DescribeInstanceTypesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeInstanceTypes operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeInstanceTypes for more information on using the DescribeInstanceTypes
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeInstanceTypesRequest method.
+//    req, resp := client.DescribeInstanceTypesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceTypes
+func (c *EC2) DescribeInstanceTypesRequest(input *DescribeInstanceTypesInput) (req *request.Request, output *DescribeInstanceTypesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeInstanceTypes,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeInstanceTypesInput{}
+	}
+
+	output = &DescribeInstanceTypesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeInstanceTypes API operation for Amazon Elastic Compute Cloud.
+//
+// Returns a list of all instance types offered in your current AWS Region.
+// The results can be filtered by the attributes of the instance types.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeInstanceTypes for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceTypes
+func (c *EC2) DescribeInstanceTypes(input *DescribeInstanceTypesInput) (*DescribeInstanceTypesOutput, error) {
+	req, out := c.DescribeInstanceTypesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeInstanceTypesWithContext is the same as DescribeInstanceTypes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeInstanceTypes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeInstanceTypesWithContext(ctx aws.Context, input *DescribeInstanceTypesInput, opts ...request.Option) (*DescribeInstanceTypesOutput, error) {
+	req, out := c.DescribeInstanceTypesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opDescribeInstances = "DescribeInstances"
@@ -15104,10 +16554,12 @@ func (c *EC2) DescribeInstancesPagesWithContext(ctx aws.Context, input *Describe
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeInstancesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeInstancesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -15234,10 +16686,12 @@ func (c *EC2) DescribeInternetGatewaysPagesWithContext(ctx aws.Context, input *D
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeInternetGatewaysOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeInternetGatewaysOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -15442,10 +16896,12 @@ func (c *EC2) DescribeLaunchTemplateVersionsPagesWithContext(ctx aws.Context, in
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeLaunchTemplateVersionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeLaunchTemplateVersionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -15572,11 +17028,461 @@ func (c *EC2) DescribeLaunchTemplatesPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeLaunchTemplatesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeLaunchTemplatesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
+}
+
+const opDescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations = "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations"
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations for more information on using the DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest method.
+//    req, resp := client.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations
+func (c *EC2) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(input *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) (req *request.Request, output *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput{}
+	}
+
+	output = &DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the associations between virtual interface groups and local gateway
+// route tables.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations
+func (c *EC2) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(input *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) (*DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsWithContext is the same as DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsWithContext(ctx aws.Context, input *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput, opts ...request.Option) (*DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLocalGatewayRouteTableVpcAssociations = "DescribeLocalGatewayRouteTableVpcAssociations"
+
+// DescribeLocalGatewayRouteTableVpcAssociationsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGatewayRouteTableVpcAssociations operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGatewayRouteTableVpcAssociations for more information on using the DescribeLocalGatewayRouteTableVpcAssociations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewayRouteTableVpcAssociationsRequest method.
+//    req, resp := client.DescribeLocalGatewayRouteTableVpcAssociationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTableVpcAssociations
+func (c *EC2) DescribeLocalGatewayRouteTableVpcAssociationsRequest(input *DescribeLocalGatewayRouteTableVpcAssociationsInput) (req *request.Request, output *DescribeLocalGatewayRouteTableVpcAssociationsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGatewayRouteTableVpcAssociations,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewayRouteTableVpcAssociationsInput{}
+	}
+
+	output = &DescribeLocalGatewayRouteTableVpcAssociationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGatewayRouteTableVpcAssociations API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the specified associations between VPCs and local gateway route
+// tables.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGatewayRouteTableVpcAssociations for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTableVpcAssociations
+func (c *EC2) DescribeLocalGatewayRouteTableVpcAssociations(input *DescribeLocalGatewayRouteTableVpcAssociationsInput) (*DescribeLocalGatewayRouteTableVpcAssociationsOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTableVpcAssociationsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewayRouteTableVpcAssociationsWithContext is the same as DescribeLocalGatewayRouteTableVpcAssociations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGatewayRouteTableVpcAssociations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewayRouteTableVpcAssociationsWithContext(ctx aws.Context, input *DescribeLocalGatewayRouteTableVpcAssociationsInput, opts ...request.Option) (*DescribeLocalGatewayRouteTableVpcAssociationsOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTableVpcAssociationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLocalGatewayRouteTables = "DescribeLocalGatewayRouteTables"
+
+// DescribeLocalGatewayRouteTablesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGatewayRouteTables operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGatewayRouteTables for more information on using the DescribeLocalGatewayRouteTables
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewayRouteTablesRequest method.
+//    req, resp := client.DescribeLocalGatewayRouteTablesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTables
+func (c *EC2) DescribeLocalGatewayRouteTablesRequest(input *DescribeLocalGatewayRouteTablesInput) (req *request.Request, output *DescribeLocalGatewayRouteTablesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGatewayRouteTables,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewayRouteTablesInput{}
+	}
+
+	output = &DescribeLocalGatewayRouteTablesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGatewayRouteTables API operation for Amazon Elastic Compute Cloud.
+//
+// Describes one or more local gateway route tables. By default, all local gateway
+// route tables are described. Alternatively, you can filter the results.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGatewayRouteTables for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayRouteTables
+func (c *EC2) DescribeLocalGatewayRouteTables(input *DescribeLocalGatewayRouteTablesInput) (*DescribeLocalGatewayRouteTablesOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTablesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewayRouteTablesWithContext is the same as DescribeLocalGatewayRouteTables with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGatewayRouteTables for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewayRouteTablesWithContext(ctx aws.Context, input *DescribeLocalGatewayRouteTablesInput, opts ...request.Option) (*DescribeLocalGatewayRouteTablesOutput, error) {
+	req, out := c.DescribeLocalGatewayRouteTablesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLocalGatewayVirtualInterfaceGroups = "DescribeLocalGatewayVirtualInterfaceGroups"
+
+// DescribeLocalGatewayVirtualInterfaceGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGatewayVirtualInterfaceGroups operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGatewayVirtualInterfaceGroups for more information on using the DescribeLocalGatewayVirtualInterfaceGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewayVirtualInterfaceGroupsRequest method.
+//    req, resp := client.DescribeLocalGatewayVirtualInterfaceGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayVirtualInterfaceGroups
+func (c *EC2) DescribeLocalGatewayVirtualInterfaceGroupsRequest(input *DescribeLocalGatewayVirtualInterfaceGroupsInput) (req *request.Request, output *DescribeLocalGatewayVirtualInterfaceGroupsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGatewayVirtualInterfaceGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewayVirtualInterfaceGroupsInput{}
+	}
+
+	output = &DescribeLocalGatewayVirtualInterfaceGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGatewayVirtualInterfaceGroups API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the specified local gateway virtual interface groups.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGatewayVirtualInterfaceGroups for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayVirtualInterfaceGroups
+func (c *EC2) DescribeLocalGatewayVirtualInterfaceGroups(input *DescribeLocalGatewayVirtualInterfaceGroupsInput) (*DescribeLocalGatewayVirtualInterfaceGroupsOutput, error) {
+	req, out := c.DescribeLocalGatewayVirtualInterfaceGroupsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewayVirtualInterfaceGroupsWithContext is the same as DescribeLocalGatewayVirtualInterfaceGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGatewayVirtualInterfaceGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewayVirtualInterfaceGroupsWithContext(ctx aws.Context, input *DescribeLocalGatewayVirtualInterfaceGroupsInput, opts ...request.Option) (*DescribeLocalGatewayVirtualInterfaceGroupsOutput, error) {
+	req, out := c.DescribeLocalGatewayVirtualInterfaceGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLocalGatewayVirtualInterfaces = "DescribeLocalGatewayVirtualInterfaces"
+
+// DescribeLocalGatewayVirtualInterfacesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGatewayVirtualInterfaces operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGatewayVirtualInterfaces for more information on using the DescribeLocalGatewayVirtualInterfaces
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewayVirtualInterfacesRequest method.
+//    req, resp := client.DescribeLocalGatewayVirtualInterfacesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayVirtualInterfaces
+func (c *EC2) DescribeLocalGatewayVirtualInterfacesRequest(input *DescribeLocalGatewayVirtualInterfacesInput) (req *request.Request, output *DescribeLocalGatewayVirtualInterfacesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGatewayVirtualInterfaces,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewayVirtualInterfacesInput{}
+	}
+
+	output = &DescribeLocalGatewayVirtualInterfacesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGatewayVirtualInterfaces API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the specified local gateway virtual interfaces.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGatewayVirtualInterfaces for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGatewayVirtualInterfaces
+func (c *EC2) DescribeLocalGatewayVirtualInterfaces(input *DescribeLocalGatewayVirtualInterfacesInput) (*DescribeLocalGatewayVirtualInterfacesOutput, error) {
+	req, out := c.DescribeLocalGatewayVirtualInterfacesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewayVirtualInterfacesWithContext is the same as DescribeLocalGatewayVirtualInterfaces with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGatewayVirtualInterfaces for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewayVirtualInterfacesWithContext(ctx aws.Context, input *DescribeLocalGatewayVirtualInterfacesInput, opts ...request.Option) (*DescribeLocalGatewayVirtualInterfacesOutput, error) {
+	req, out := c.DescribeLocalGatewayVirtualInterfacesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLocalGateways = "DescribeLocalGateways"
+
+// DescribeLocalGatewaysRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLocalGateways operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLocalGateways for more information on using the DescribeLocalGateways
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLocalGatewaysRequest method.
+//    req, resp := client.DescribeLocalGatewaysRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGateways
+func (c *EC2) DescribeLocalGatewaysRequest(input *DescribeLocalGatewaysInput) (req *request.Request, output *DescribeLocalGatewaysOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLocalGateways,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeLocalGatewaysInput{}
+	}
+
+	output = &DescribeLocalGatewaysOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLocalGateways API operation for Amazon Elastic Compute Cloud.
+//
+// Describes one or more local gateways. By default, all local gateways are
+// described. Alternatively, you can filter the results.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeLocalGateways for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeLocalGateways
+func (c *EC2) DescribeLocalGateways(input *DescribeLocalGatewaysInput) (*DescribeLocalGatewaysOutput, error) {
+	req, out := c.DescribeLocalGatewaysRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLocalGatewaysWithContext is the same as DescribeLocalGateways with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLocalGateways for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeLocalGatewaysWithContext(ctx aws.Context, input *DescribeLocalGatewaysInput, opts ...request.Option) (*DescribeLocalGatewaysOutput, error) {
+	req, out := c.DescribeLocalGatewaysRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opDescribeMovingAddresses = "DescribeMovingAddresses"
@@ -15704,10 +17610,12 @@ func (c *EC2) DescribeMovingAddressesPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeMovingAddressesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeMovingAddressesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -15834,10 +17742,12 @@ func (c *EC2) DescribeNatGatewaysPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeNatGatewaysOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeNatGatewaysOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -15967,10 +17877,12 @@ func (c *EC2) DescribeNetworkAclsPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeNetworkAclsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeNetworkAclsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -16172,10 +18084,12 @@ func (c *EC2) DescribeNetworkInterfacePermissionsPagesWithContext(ctx aws.Contex
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeNetworkInterfacePermissionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeNetworkInterfacePermissionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -16302,10 +18216,12 @@ func (c *EC2) DescribeNetworkInterfacesPagesWithContext(ctx aws.Context, input *
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeNetworkInterfacesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeNetworkInterfacesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -16513,10 +18429,12 @@ func (c *EC2) DescribePrefixListsPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribePrefixListsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribePrefixListsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -16657,10 +18575,12 @@ func (c *EC2) DescribePrincipalIdFormatPagesWithContext(ctx aws.Context, input *
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribePrincipalIdFormatOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribePrincipalIdFormatOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -16787,10 +18707,12 @@ func (c *EC2) DescribePublicIpv4PoolsPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribePublicIpv4PoolsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribePublicIpv4PoolsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17176,10 +19098,12 @@ func (c *EC2) DescribeReservedInstancesModificationsPagesWithContext(ctx aws.Con
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeReservedInstancesModificationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeReservedInstancesModificationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17317,10 +19241,12 @@ func (c *EC2) DescribeReservedInstancesOfferingsPagesWithContext(ctx aws.Context
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeReservedInstancesOfferingsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeReservedInstancesOfferingsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17455,10 +19381,12 @@ func (c *EC2) DescribeRouteTablesPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeRouteTablesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeRouteTablesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17593,10 +19521,12 @@ func (c *EC2) DescribeScheduledInstanceAvailabilityPagesWithContext(ctx aws.Cont
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeScheduledInstanceAvailabilityOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeScheduledInstanceAvailabilityOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17723,10 +19653,12 @@ func (c *EC2) DescribeScheduledInstancesPagesWithContext(ctx aws.Context, input 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeScheduledInstancesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeScheduledInstancesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -17935,10 +19867,12 @@ func (c *EC2) DescribeSecurityGroupsPagesWithContext(ctx aws.Context, input *Des
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSecurityGroupsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSecurityGroupsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -18190,10 +20124,12 @@ func (c *EC2) DescribeSnapshotsPagesWithContext(ctx aws.Context, input *Describe
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSnapshotsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSnapshotsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -18552,10 +20488,12 @@ func (c *EC2) DescribeSpotFleetRequestsPagesWithContext(ctx aws.Context, input *
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSpotFleetRequestsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSpotFleetRequestsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -18698,10 +20636,12 @@ func (c *EC2) DescribeSpotInstanceRequestsPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSpotInstanceRequestsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSpotInstanceRequestsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -18835,10 +20775,12 @@ func (c *EC2) DescribeSpotPriceHistoryPagesWithContext(ctx aws.Context, input *D
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSpotPriceHistoryOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSpotPriceHistoryOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -18968,10 +20910,12 @@ func (c *EC2) DescribeStaleSecurityGroupsPagesWithContext(ctx aws.Context, input
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeStaleSecurityGroupsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeStaleSecurityGroupsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19101,10 +21045,12 @@ func (c *EC2) DescribeSubnetsPagesWithContext(ctx aws.Context, input *DescribeSu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeSubnetsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeSubnetsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19234,10 +21180,12 @@ func (c *EC2) DescribeTagsPagesWithContext(ctx aws.Context, input *DescribeTagsI
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTagsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTagsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19364,10 +21312,12 @@ func (c *EC2) DescribeTrafficMirrorFiltersPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTrafficMirrorFiltersOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTrafficMirrorFiltersOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19495,10 +21445,12 @@ func (c *EC2) DescribeTrafficMirrorSessionsPagesWithContext(ctx aws.Context, inp
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTrafficMirrorSessionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTrafficMirrorSessionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19625,10 +21577,12 @@ func (c *EC2) DescribeTrafficMirrorTargetsPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTrafficMirrorTargetsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTrafficMirrorTargetsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -19758,11 +21712,161 @@ func (c *EC2) DescribeTransitGatewayAttachmentsPagesWithContext(ctx aws.Context,
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTransitGatewayAttachmentsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTransitGatewayAttachmentsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
+}
+
+const opDescribeTransitGatewayMulticastDomains = "DescribeTransitGatewayMulticastDomains"
+
+// DescribeTransitGatewayMulticastDomainsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeTransitGatewayMulticastDomains operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeTransitGatewayMulticastDomains for more information on using the DescribeTransitGatewayMulticastDomains
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeTransitGatewayMulticastDomainsRequest method.
+//    req, resp := client.DescribeTransitGatewayMulticastDomainsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeTransitGatewayMulticastDomains
+func (c *EC2) DescribeTransitGatewayMulticastDomainsRequest(input *DescribeTransitGatewayMulticastDomainsInput) (req *request.Request, output *DescribeTransitGatewayMulticastDomainsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeTransitGatewayMulticastDomains,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeTransitGatewayMulticastDomainsInput{}
+	}
+
+	output = &DescribeTransitGatewayMulticastDomainsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeTransitGatewayMulticastDomains API operation for Amazon Elastic Compute Cloud.
+//
+// Describes one or more transit gateway multicast domains.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeTransitGatewayMulticastDomains for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeTransitGatewayMulticastDomains
+func (c *EC2) DescribeTransitGatewayMulticastDomains(input *DescribeTransitGatewayMulticastDomainsInput) (*DescribeTransitGatewayMulticastDomainsOutput, error) {
+	req, out := c.DescribeTransitGatewayMulticastDomainsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeTransitGatewayMulticastDomainsWithContext is the same as DescribeTransitGatewayMulticastDomains with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeTransitGatewayMulticastDomains for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeTransitGatewayMulticastDomainsWithContext(ctx aws.Context, input *DescribeTransitGatewayMulticastDomainsInput, opts ...request.Option) (*DescribeTransitGatewayMulticastDomainsOutput, error) {
+	req, out := c.DescribeTransitGatewayMulticastDomainsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeTransitGatewayPeeringAttachments = "DescribeTransitGatewayPeeringAttachments"
+
+// DescribeTransitGatewayPeeringAttachmentsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeTransitGatewayPeeringAttachments operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeTransitGatewayPeeringAttachments for more information on using the DescribeTransitGatewayPeeringAttachments
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeTransitGatewayPeeringAttachmentsRequest method.
+//    req, resp := client.DescribeTransitGatewayPeeringAttachmentsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeTransitGatewayPeeringAttachments
+func (c *EC2) DescribeTransitGatewayPeeringAttachmentsRequest(input *DescribeTransitGatewayPeeringAttachmentsInput) (req *request.Request, output *DescribeTransitGatewayPeeringAttachmentsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeTransitGatewayPeeringAttachments,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeTransitGatewayPeeringAttachmentsInput{}
+	}
+
+	output = &DescribeTransitGatewayPeeringAttachmentsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeTransitGatewayPeeringAttachments API operation for Amazon Elastic Compute Cloud.
+//
+// Describes your transit gateway peering attachments.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeTransitGatewayPeeringAttachments for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeTransitGatewayPeeringAttachments
+func (c *EC2) DescribeTransitGatewayPeeringAttachments(input *DescribeTransitGatewayPeeringAttachmentsInput) (*DescribeTransitGatewayPeeringAttachmentsOutput, error) {
+	req, out := c.DescribeTransitGatewayPeeringAttachmentsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeTransitGatewayPeeringAttachmentsWithContext is the same as DescribeTransitGatewayPeeringAttachments with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeTransitGatewayPeeringAttachments for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeTransitGatewayPeeringAttachmentsWithContext(ctx aws.Context, input *DescribeTransitGatewayPeeringAttachmentsInput, opts ...request.Option) (*DescribeTransitGatewayPeeringAttachmentsOutput, error) {
+	req, out := c.DescribeTransitGatewayPeeringAttachmentsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opDescribeTransitGatewayRouteTables = "DescribeTransitGatewayRouteTables"
@@ -19889,10 +21993,12 @@ func (c *EC2) DescribeTransitGatewayRouteTablesPagesWithContext(ctx aws.Context,
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTransitGatewayRouteTablesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTransitGatewayRouteTablesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20020,10 +22126,12 @@ func (c *EC2) DescribeTransitGatewayVpcAttachmentsPagesWithContext(ctx aws.Conte
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTransitGatewayVpcAttachmentsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTransitGatewayVpcAttachmentsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20151,10 +22259,12 @@ func (c *EC2) DescribeTransitGatewaysPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTransitGatewaysOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTransitGatewaysOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20394,10 +22504,12 @@ func (c *EC2) DescribeVolumeStatusPagesWithContext(ctx aws.Context, input *Descr
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVolumeStatusOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVolumeStatusOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20534,10 +22646,12 @@ func (c *EC2) DescribeVolumesPagesWithContext(ctx aws.Context, input *DescribeVo
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVolumesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVolumesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20677,10 +22791,12 @@ func (c *EC2) DescribeVolumesModificationsPagesWithContext(ctx aws.Context, inpu
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVolumesModificationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVolumesModificationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -20962,10 +23078,12 @@ func (c *EC2) DescribeVpcClassicLinkDnsSupportPagesWithContext(ctx aws.Context, 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcClassicLinkDnsSupportOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcClassicLinkDnsSupportOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21093,10 +23211,12 @@ func (c *EC2) DescribeVpcEndpointConnectionNotificationsPagesWithContext(ctx aws
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcEndpointConnectionNotificationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcEndpointConnectionNotificationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21224,10 +23344,12 @@ func (c *EC2) DescribeVpcEndpointConnectionsPagesWithContext(ctx aws.Context, in
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcEndpointConnectionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcEndpointConnectionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21354,10 +23476,12 @@ func (c *EC2) DescribeVpcEndpointServiceConfigurationsPagesWithContext(ctx aws.C
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcEndpointServiceConfigurationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcEndpointServiceConfigurationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21485,10 +23609,12 @@ func (c *EC2) DescribeVpcEndpointServicePermissionsPagesWithContext(ctx aws.Cont
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcEndpointServicePermissionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcEndpointServicePermissionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21689,10 +23815,12 @@ func (c *EC2) DescribeVpcEndpointsPagesWithContext(ctx aws.Context, input *Descr
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcEndpointsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcEndpointsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21819,10 +23947,12 @@ func (c *EC2) DescribeVpcPeeringConnectionsPagesWithContext(ctx aws.Context, inp
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcPeeringConnectionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcPeeringConnectionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -21949,10 +24079,12 @@ func (c *EC2) DescribeVpcsPagesWithContext(ctx aws.Context, input *DescribeVpcsI
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeVpcsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeVpcsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -22585,6 +24717,81 @@ func (c *EC2) DisableEbsEncryptionByDefault(input *DisableEbsEncryptionByDefault
 // for more information on using Contexts.
 func (c *EC2) DisableEbsEncryptionByDefaultWithContext(ctx aws.Context, input *DisableEbsEncryptionByDefaultInput, opts ...request.Option) (*DisableEbsEncryptionByDefaultOutput, error) {
 	req, out := c.DisableEbsEncryptionByDefaultRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDisableFastSnapshotRestores = "DisableFastSnapshotRestores"
+
+// DisableFastSnapshotRestoresRequest generates a "aws/request.Request" representing the
+// client's request for the DisableFastSnapshotRestores operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DisableFastSnapshotRestores for more information on using the DisableFastSnapshotRestores
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DisableFastSnapshotRestoresRequest method.
+//    req, resp := client.DisableFastSnapshotRestoresRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DisableFastSnapshotRestores
+func (c *EC2) DisableFastSnapshotRestoresRequest(input *DisableFastSnapshotRestoresInput) (req *request.Request, output *DisableFastSnapshotRestoresOutput) {
+	op := &request.Operation{
+		Name:       opDisableFastSnapshotRestores,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DisableFastSnapshotRestoresInput{}
+	}
+
+	output = &DisableFastSnapshotRestoresOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DisableFastSnapshotRestores API operation for Amazon Elastic Compute Cloud.
+//
+// Disables fast snapshot restores for the specified snapshots in the specified
+// Availability Zones.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DisableFastSnapshotRestores for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DisableFastSnapshotRestores
+func (c *EC2) DisableFastSnapshotRestores(input *DisableFastSnapshotRestoresInput) (*DisableFastSnapshotRestoresOutput, error) {
+	req, out := c.DisableFastSnapshotRestoresRequest(input)
+	return out, req.Send()
+}
+
+// DisableFastSnapshotRestoresWithContext is the same as DisableFastSnapshotRestores with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DisableFastSnapshotRestores for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DisableFastSnapshotRestoresWithContext(ctx aws.Context, input *DisableFastSnapshotRestoresInput, opts ...request.Option) (*DisableFastSnapshotRestoresOutput, error) {
+	req, out := c.DisableFastSnapshotRestoresRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -23293,6 +25500,80 @@ func (c *EC2) DisassociateSubnetCidrBlockWithContext(ctx aws.Context, input *Dis
 	return out, req.Send()
 }
 
+const opDisassociateTransitGatewayMulticastDomain = "DisassociateTransitGatewayMulticastDomain"
+
+// DisassociateTransitGatewayMulticastDomainRequest generates a "aws/request.Request" representing the
+// client's request for the DisassociateTransitGatewayMulticastDomain operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DisassociateTransitGatewayMulticastDomain for more information on using the DisassociateTransitGatewayMulticastDomain
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DisassociateTransitGatewayMulticastDomainRequest method.
+//    req, resp := client.DisassociateTransitGatewayMulticastDomainRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DisassociateTransitGatewayMulticastDomain
+func (c *EC2) DisassociateTransitGatewayMulticastDomainRequest(input *DisassociateTransitGatewayMulticastDomainInput) (req *request.Request, output *DisassociateTransitGatewayMulticastDomainOutput) {
+	op := &request.Operation{
+		Name:       opDisassociateTransitGatewayMulticastDomain,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DisassociateTransitGatewayMulticastDomainInput{}
+	}
+
+	output = &DisassociateTransitGatewayMulticastDomainOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DisassociateTransitGatewayMulticastDomain API operation for Amazon Elastic Compute Cloud.
+//
+// Disassociates the specified subnets from the transit gateway multicast domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DisassociateTransitGatewayMulticastDomain for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DisassociateTransitGatewayMulticastDomain
+func (c *EC2) DisassociateTransitGatewayMulticastDomain(input *DisassociateTransitGatewayMulticastDomainInput) (*DisassociateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.DisassociateTransitGatewayMulticastDomainRequest(input)
+	return out, req.Send()
+}
+
+// DisassociateTransitGatewayMulticastDomainWithContext is the same as DisassociateTransitGatewayMulticastDomain with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DisassociateTransitGatewayMulticastDomain for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DisassociateTransitGatewayMulticastDomainWithContext(ctx aws.Context, input *DisassociateTransitGatewayMulticastDomainInput, opts ...request.Option) (*DisassociateTransitGatewayMulticastDomainOutput, error) {
+	req, out := c.DisassociateTransitGatewayMulticastDomainRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDisassociateTransitGatewayRouteTable = "DisassociateTransitGatewayRouteTable"
 
 // DisassociateTransitGatewayRouteTableRequest generates a "aws/request.Request" representing the
@@ -23532,6 +25813,85 @@ func (c *EC2) EnableEbsEncryptionByDefault(input *EnableEbsEncryptionByDefaultIn
 // for more information on using Contexts.
 func (c *EC2) EnableEbsEncryptionByDefaultWithContext(ctx aws.Context, input *EnableEbsEncryptionByDefaultInput, opts ...request.Option) (*EnableEbsEncryptionByDefaultOutput, error) {
 	req, out := c.EnableEbsEncryptionByDefaultRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opEnableFastSnapshotRestores = "EnableFastSnapshotRestores"
+
+// EnableFastSnapshotRestoresRequest generates a "aws/request.Request" representing the
+// client's request for the EnableFastSnapshotRestores operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See EnableFastSnapshotRestores for more information on using the EnableFastSnapshotRestores
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the EnableFastSnapshotRestoresRequest method.
+//    req, resp := client.EnableFastSnapshotRestoresRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/EnableFastSnapshotRestores
+func (c *EC2) EnableFastSnapshotRestoresRequest(input *EnableFastSnapshotRestoresInput) (req *request.Request, output *EnableFastSnapshotRestoresOutput) {
+	op := &request.Operation{
+		Name:       opEnableFastSnapshotRestores,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &EnableFastSnapshotRestoresInput{}
+	}
+
+	output = &EnableFastSnapshotRestoresOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// EnableFastSnapshotRestores API operation for Amazon Elastic Compute Cloud.
+//
+// Enables fast snapshot restores for the specified snapshots in the specified
+// Availability Zones.
+//
+// You get the full benefit of fast snapshot restores after they enter the enabled
+// state. To get the current state of fast snapshot restores, use DescribeFastSnapshotRestores.
+// To disable fast snapshot restores, use DisableFastSnapshotRestores.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation EnableFastSnapshotRestores for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/EnableFastSnapshotRestores
+func (c *EC2) EnableFastSnapshotRestores(input *EnableFastSnapshotRestoresInput) (*EnableFastSnapshotRestoresOutput, error) {
+	req, out := c.EnableFastSnapshotRestoresRequest(input)
+	return out, req.Send()
+}
+
+// EnableFastSnapshotRestoresWithContext is the same as EnableFastSnapshotRestores with the addition of
+// the ability to pass a context and additional request options.
+//
+// See EnableFastSnapshotRestores for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) EnableFastSnapshotRestoresWithContext(ctx aws.Context, input *EnableFastSnapshotRestoresInput, opts ...request.Option) (*EnableFastSnapshotRestoresOutput, error) {
+	req, out := c.EnableFastSnapshotRestoresRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -24306,6 +26666,80 @@ func (c *EC2) GetCapacityReservationUsageWithContext(ctx aws.Context, input *Get
 	return out, req.Send()
 }
 
+const opGetCoipPoolUsage = "GetCoipPoolUsage"
+
+// GetCoipPoolUsageRequest generates a "aws/request.Request" representing the
+// client's request for the GetCoipPoolUsage operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetCoipPoolUsage for more information on using the GetCoipPoolUsage
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCoipPoolUsageRequest method.
+//    req, resp := client.GetCoipPoolUsageRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetCoipPoolUsage
+func (c *EC2) GetCoipPoolUsageRequest(input *GetCoipPoolUsageInput) (req *request.Request, output *GetCoipPoolUsageOutput) {
+	op := &request.Operation{
+		Name:       opGetCoipPoolUsage,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetCoipPoolUsageInput{}
+	}
+
+	output = &GetCoipPoolUsageOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCoipPoolUsage API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the allocations from the specified customer-owned address pool.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation GetCoipPoolUsage for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetCoipPoolUsage
+func (c *EC2) GetCoipPoolUsage(input *GetCoipPoolUsageInput) (*GetCoipPoolUsageOutput, error) {
+	req, out := c.GetCoipPoolUsageRequest(input)
+	return out, req.Send()
+}
+
+// GetCoipPoolUsageWithContext is the same as GetCoipPoolUsage with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCoipPoolUsage for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) GetCoipPoolUsageWithContext(ctx aws.Context, input *GetCoipPoolUsageInput, opts ...request.Option) (*GetCoipPoolUsageOutput, error) {
+	req, out := c.GetCoipPoolUsageRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetConsoleOutput = "GetConsoleOutput"
 
 // GetConsoleOutputRequest generates a "aws/request.Request" representing the
@@ -24467,6 +26901,84 @@ func (c *EC2) GetConsoleScreenshot(input *GetConsoleScreenshotInput) (*GetConsol
 // for more information on using Contexts.
 func (c *EC2) GetConsoleScreenshotWithContext(ctx aws.Context, input *GetConsoleScreenshotInput, opts ...request.Option) (*GetConsoleScreenshotOutput, error) {
 	req, out := c.GetConsoleScreenshotRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetDefaultCreditSpecification = "GetDefaultCreditSpecification"
+
+// GetDefaultCreditSpecificationRequest generates a "aws/request.Request" representing the
+// client's request for the GetDefaultCreditSpecification operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetDefaultCreditSpecification for more information on using the GetDefaultCreditSpecification
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetDefaultCreditSpecificationRequest method.
+//    req, resp := client.GetDefaultCreditSpecificationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetDefaultCreditSpecification
+func (c *EC2) GetDefaultCreditSpecificationRequest(input *GetDefaultCreditSpecificationInput) (req *request.Request, output *GetDefaultCreditSpecificationOutput) {
+	op := &request.Operation{
+		Name:       opGetDefaultCreditSpecification,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetDefaultCreditSpecificationInput{}
+	}
+
+	output = &GetDefaultCreditSpecificationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetDefaultCreditSpecification API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the default credit option for CPU usage of a burstable performance
+// instance family.
+//
+// For more information, see Burstable Performance Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation GetDefaultCreditSpecification for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetDefaultCreditSpecification
+func (c *EC2) GetDefaultCreditSpecification(input *GetDefaultCreditSpecificationInput) (*GetDefaultCreditSpecificationOutput, error) {
+	req, out := c.GetDefaultCreditSpecificationRequest(input)
+	return out, req.Send()
+}
+
+// GetDefaultCreditSpecificationWithContext is the same as GetDefaultCreditSpecification with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetDefaultCreditSpecification for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) GetDefaultCreditSpecificationWithContext(ctx aws.Context, input *GetDefaultCreditSpecificationInput, opts ...request.Option) (*GetDefaultCreditSpecificationOutput, error) {
+	req, out := c.GetDefaultCreditSpecificationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -25075,11 +27587,88 @@ func (c *EC2) GetTransitGatewayAttachmentPropagationsPagesWithContext(ctx aws.Co
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*GetTransitGatewayAttachmentPropagationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*GetTransitGatewayAttachmentPropagationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
+}
+
+const opGetTransitGatewayMulticastDomainAssociations = "GetTransitGatewayMulticastDomainAssociations"
+
+// GetTransitGatewayMulticastDomainAssociationsRequest generates a "aws/request.Request" representing the
+// client's request for the GetTransitGatewayMulticastDomainAssociations operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetTransitGatewayMulticastDomainAssociations for more information on using the GetTransitGatewayMulticastDomainAssociations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetTransitGatewayMulticastDomainAssociationsRequest method.
+//    req, resp := client.GetTransitGatewayMulticastDomainAssociationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetTransitGatewayMulticastDomainAssociations
+func (c *EC2) GetTransitGatewayMulticastDomainAssociationsRequest(input *GetTransitGatewayMulticastDomainAssociationsInput) (req *request.Request, output *GetTransitGatewayMulticastDomainAssociationsOutput) {
+	op := &request.Operation{
+		Name:       opGetTransitGatewayMulticastDomainAssociations,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetTransitGatewayMulticastDomainAssociationsInput{}
+	}
+
+	output = &GetTransitGatewayMulticastDomainAssociationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetTransitGatewayMulticastDomainAssociations API operation for Amazon Elastic Compute Cloud.
+//
+// Gets information about the associations for the transit gateway multicast
+// domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation GetTransitGatewayMulticastDomainAssociations for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/GetTransitGatewayMulticastDomainAssociations
+func (c *EC2) GetTransitGatewayMulticastDomainAssociations(input *GetTransitGatewayMulticastDomainAssociationsInput) (*GetTransitGatewayMulticastDomainAssociationsOutput, error) {
+	req, out := c.GetTransitGatewayMulticastDomainAssociationsRequest(input)
+	return out, req.Send()
+}
+
+// GetTransitGatewayMulticastDomainAssociationsWithContext is the same as GetTransitGatewayMulticastDomainAssociations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetTransitGatewayMulticastDomainAssociations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) GetTransitGatewayMulticastDomainAssociationsWithContext(ctx aws.Context, input *GetTransitGatewayMulticastDomainAssociationsInput, opts ...request.Option) (*GetTransitGatewayMulticastDomainAssociationsOutput, error) {
+	req, out := c.GetTransitGatewayMulticastDomainAssociationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opGetTransitGatewayRouteTableAssociations = "GetTransitGatewayRouteTableAssociations"
@@ -25206,10 +27795,12 @@ func (c *EC2) GetTransitGatewayRouteTableAssociationsPagesWithContext(ctx aws.Co
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*GetTransitGatewayRouteTableAssociationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*GetTransitGatewayRouteTableAssociationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -25337,10 +27928,12 @@ func (c *EC2) GetTransitGatewayRouteTablePropagationsPagesWithContext(ctx aws.Co
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*GetTransitGatewayRouteTablePropagationsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*GetTransitGatewayRouteTablePropagationsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -25968,6 +28561,94 @@ func (c *EC2) ModifyClientVpnEndpointWithContext(ctx aws.Context, input *ModifyC
 	return out, req.Send()
 }
 
+const opModifyDefaultCreditSpecification = "ModifyDefaultCreditSpecification"
+
+// ModifyDefaultCreditSpecificationRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyDefaultCreditSpecification operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ModifyDefaultCreditSpecification for more information on using the ModifyDefaultCreditSpecification
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ModifyDefaultCreditSpecificationRequest method.
+//    req, resp := client.ModifyDefaultCreditSpecificationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyDefaultCreditSpecification
+func (c *EC2) ModifyDefaultCreditSpecificationRequest(input *ModifyDefaultCreditSpecificationInput) (req *request.Request, output *ModifyDefaultCreditSpecificationOutput) {
+	op := &request.Operation{
+		Name:       opModifyDefaultCreditSpecification,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyDefaultCreditSpecificationInput{}
+	}
+
+	output = &ModifyDefaultCreditSpecificationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyDefaultCreditSpecification API operation for Amazon Elastic Compute Cloud.
+//
+// Modifies the default credit option for CPU usage of burstable performance
+// instances. The default credit option is set at the account level per AWS
+// Region, and is specified per instance family. All new burstable performance
+// instances in the account launch using the default credit option.
+//
+// ModifyDefaultCreditSpecification is an asynchronous operation, which works
+// at an AWS Region level and modifies the credit option for each Availability
+// Zone. All zones in a Region are updated within five minutes. But if instances
+// are launched during this operation, they might not get the new credit option
+// until the zone is updated. To verify whether the update has occurred, you
+// can call GetDefaultCreditSpecification and check DefaultCreditSpecification
+// for updates.
+//
+// For more information, see Burstable Performance Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation ModifyDefaultCreditSpecification for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyDefaultCreditSpecification
+func (c *EC2) ModifyDefaultCreditSpecification(input *ModifyDefaultCreditSpecificationInput) (*ModifyDefaultCreditSpecificationOutput, error) {
+	req, out := c.ModifyDefaultCreditSpecificationRequest(input)
+	return out, req.Send()
+}
+
+// ModifyDefaultCreditSpecificationWithContext is the same as ModifyDefaultCreditSpecification with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyDefaultCreditSpecification for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) ModifyDefaultCreditSpecificationWithContext(ctx aws.Context, input *ModifyDefaultCreditSpecificationInput, opts ...request.Option) (*ModifyDefaultCreditSpecificationOutput, error) {
+	req, out := c.ModifyDefaultCreditSpecificationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opModifyEbsDefaultKmsKeyId = "ModifyEbsDefaultKmsKeyId"
 
 // ModifyEbsDefaultKmsKeyIdRequest generates a "aws/request.Request" representing the
@@ -26106,10 +28787,10 @@ func (c *EC2) ModifyFleetRequest(input *ModifyFleetInput) (req *request.Request,
 //
 // To scale up your EC2 Fleet, increase its target capacity. The EC2 Fleet launches
 // the additional Spot Instances according to the allocation strategy for the
-// EC2 Fleet request. If the allocation strategy is lowestPrice, the EC2 Fleet
+// EC2 Fleet request. If the allocation strategy is lowest-price, the EC2 Fleet
 // launches instances using the Spot Instance pool with the lowest price. If
 // the allocation strategy is diversified, the EC2 Fleet distributes the instances
-// across the Spot Instance pools. If the allocation strategy is capacityOptimized,
+// across the Spot Instance pools. If the allocation strategy is capacity-optimized,
 // EC2 Fleet launches instances from Spot Instance pools with optimal capacity
 // for the number of instances that are launching.
 //
@@ -26117,11 +28798,11 @@ func (c *EC2) ModifyFleetRequest(input *ModifyFleetInput) (req *request.Request,
 // Fleet cancels any open requests that exceed the new target capacity. You
 // can request that the EC2 Fleet terminate Spot Instances until the size of
 // the fleet no longer exceeds the new target capacity. If the allocation strategy
-// is lowestPrice, the EC2 Fleet terminates the instances with the highest price
-// per unit. If the allocation strategy is capacityOptimized, the EC2 Fleet
-// terminates the instances in the Spot Instance pools that have the least available
-// Spot Instance capacity. If the allocation strategy is diversified, the EC2
-// Fleet terminates instances across the Spot Instance pools. Alternatively,
+// is lowest-price, the EC2 Fleet terminates the instances with the highest
+// price per unit. If the allocation strategy is capacity-optimized, the EC2
+// Fleet terminates the instances in the Spot Instance pools that have the least
+// available Spot Instance capacity. If the allocation strategy is diversified,
+// the EC2 Fleet terminates instances across the Spot Instance pools. Alternatively,
 // you can request that the EC2 Fleet keep the fleet at its current size, but
 // not replace any Spot Instances that are interrupted or that you terminate
 // manually.
@@ -26282,6 +28963,10 @@ func (c *EC2) ModifyHostsRequest(input *ModifyHostsInput) (req *request.Request,
 // to provide a host ID to have the instance launch onto a specific host. If
 // no host ID is provided, the instance is launched onto a suitable host with
 // auto-placement enabled.
+//
+// You can also use this API action to modify a Dedicated Host to support either
+// multiple instance types in an instance family, or to support a specific instance
+// type only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -26796,8 +29481,8 @@ func (c *EC2) ModifyInstanceCreditSpecificationRequest(input *ModifyInstanceCred
 
 // ModifyInstanceCreditSpecification API operation for Amazon Elastic Compute Cloud.
 //
-// Modifies the credit option for CPU usage on a running or stopped T2 or T3
-// instance. The credit options are standard and unlimited.
+// Modifies the credit option for CPU usage on a running or stopped burstable
+// performance instance. The credit options are standard and unlimited.
 //
 // For more information, see Burstable Performance Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
 // in the Amazon Elastic Compute Cloud User Guide.
@@ -26899,6 +29584,86 @@ func (c *EC2) ModifyInstanceEventStartTime(input *ModifyInstanceEventStartTimeIn
 // for more information on using Contexts.
 func (c *EC2) ModifyInstanceEventStartTimeWithContext(ctx aws.Context, input *ModifyInstanceEventStartTimeInput, opts ...request.Option) (*ModifyInstanceEventStartTimeOutput, error) {
 	req, out := c.ModifyInstanceEventStartTimeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opModifyInstanceMetadataOptions = "ModifyInstanceMetadataOptions"
+
+// ModifyInstanceMetadataOptionsRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyInstanceMetadataOptions operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ModifyInstanceMetadataOptions for more information on using the ModifyInstanceMetadataOptions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ModifyInstanceMetadataOptionsRequest method.
+//    req, resp := client.ModifyInstanceMetadataOptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceMetadataOptions
+func (c *EC2) ModifyInstanceMetadataOptionsRequest(input *ModifyInstanceMetadataOptionsInput) (req *request.Request, output *ModifyInstanceMetadataOptionsOutput) {
+	op := &request.Operation{
+		Name:       opModifyInstanceMetadataOptions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyInstanceMetadataOptionsInput{}
+	}
+
+	output = &ModifyInstanceMetadataOptionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyInstanceMetadataOptions API operation for Amazon Elastic Compute Cloud.
+//
+// Modify the instance metadata parameters on a running or stopped instance.
+// When you modify the parameters on a stopped instance, they are applied when
+// the instance is started. When you modify the parameters on a running instance,
+// the API responds with a state of “pending”. After the parameter modifications
+// are successfully applied to the instance, the state of the modifications
+// changes from “pending” to “applied” in subsequent describe-instances
+// API calls. For more information, see Instance Metadata and User Data (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation ModifyInstanceMetadataOptions for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceMetadataOptions
+func (c *EC2) ModifyInstanceMetadataOptions(input *ModifyInstanceMetadataOptionsInput) (*ModifyInstanceMetadataOptionsOutput, error) {
+	req, out := c.ModifyInstanceMetadataOptionsRequest(input)
+	return out, req.Send()
+}
+
+// ModifyInstanceMetadataOptionsWithContext is the same as ModifyInstanceMetadataOptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyInstanceMetadataOptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) ModifyInstanceMetadataOptionsWithContext(ctx aws.Context, input *ModifyInstanceMetadataOptionsInput, opts ...request.Option) (*ModifyInstanceMetadataOptionsOutput, error) {
+	req, out := c.ModifyInstanceMetadataOptionsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -27550,7 +30315,7 @@ func (c *EC2) ModifyTrafficMirrorFilterNetworkServicesRequest(input *ModifyTraff
 // to mirror network services, use RemoveNetworkServices to remove the network
 // services from the Traffic Mirror filter.
 //
-// FFor information about filter rule properties, see Network Services (https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-considerations.html#traffic-mirroring-network-services)
+// For information about filter rule properties, see Network Services (https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-considerations.html)
 // in the Traffic Mirroring User Guide .
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -29203,6 +31968,9 @@ func (c *EC2) PurchaseReservedInstancesOfferingRequest(input *PurchaseReservedIn
 // offerings that match your specifications. After you've purchased a Reserved
 // Instance, you can check for your new Reserved Instance with DescribeReservedInstances.
 //
+// To queue a purchase for a future date and time, specify a purchase time.
+// If you do not specify a purchase time, the default is the current time.
+//
 // For more information, see Reserved Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts-on-demand-reserved-instances.html)
 // and Reserved Instance Marketplace (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ri-market-general.html)
 // in the Amazon Elastic Compute Cloud User Guide.
@@ -29464,16 +32232,24 @@ func (c *EC2) RegisterImageRequest(input *RegisterImageInput) (req *request.Requ
 // You can't register an image where a secondary (non-root) snapshot has AWS
 // Marketplace product codes.
 //
-// Some Linux distributions, such as Red Hat Enterprise Linux (RHEL) and SUSE
-// Linux Enterprise Server (SLES), use the EC2 billing product code associated
-// with an AMI to verify the subscription status for package updates. Creating
-// an AMI from an EBS snapshot does not maintain this billing code, and instances
-// launched from such an AMI are not able to connect to package update infrastructure.
-// If you purchase a Reserved Instance offering for one of these Linux distributions
-// and launch instances using an AMI that does not contain the required billing
-// code, your Reserved Instance is not applied to these instances.
+// Windows and some Linux distributions, such as Red Hat Enterprise Linux (RHEL)
+// and SUSE Linux Enterprise Server (SLES), use the EC2 billing product code
+// associated with an AMI to verify the subscription status for package updates.
+// To create a new AMI for operating systems that require a billing product
+// code, do the following:
 //
-// To create an AMI for operating systems that require a billing code, see CreateImage.
+// Launch an instance from an existing AMI with that billing product code.
+//
+// Customize the instance.
+//
+// Create a new AMI from the instance using CreateImage to preserve the billing
+// product code association.
+//
+// If you purchase a Reserved Instance to apply to an On-Demand Instance that
+// was launched from an AMI with a billing product code, make sure that the
+// Reserved Instance has the matching billing product code. If you purchase
+// a Reserved Instance without the matching billing product code, the Reserved
+// Instance will not be applied to the On-Demand Instance.
 //
 // If needed, you can deregister an AMI at any time. Any modifications you make
 // to an AMI backed by an instance store volume invalidates its registration.
@@ -29503,6 +32279,244 @@ func (c *EC2) RegisterImage(input *RegisterImageInput) (*RegisterImageOutput, er
 // for more information on using Contexts.
 func (c *EC2) RegisterImageWithContext(ctx aws.Context, input *RegisterImageInput, opts ...request.Option) (*RegisterImageOutput, error) {
 	req, out := c.RegisterImageRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRegisterTransitGatewayMulticastGroupMembers = "RegisterTransitGatewayMulticastGroupMembers"
+
+// RegisterTransitGatewayMulticastGroupMembersRequest generates a "aws/request.Request" representing the
+// client's request for the RegisterTransitGatewayMulticastGroupMembers operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RegisterTransitGatewayMulticastGroupMembers for more information on using the RegisterTransitGatewayMulticastGroupMembers
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RegisterTransitGatewayMulticastGroupMembersRequest method.
+//    req, resp := client.RegisterTransitGatewayMulticastGroupMembersRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RegisterTransitGatewayMulticastGroupMembers
+func (c *EC2) RegisterTransitGatewayMulticastGroupMembersRequest(input *RegisterTransitGatewayMulticastGroupMembersInput) (req *request.Request, output *RegisterTransitGatewayMulticastGroupMembersOutput) {
+	op := &request.Operation{
+		Name:       opRegisterTransitGatewayMulticastGroupMembers,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RegisterTransitGatewayMulticastGroupMembersInput{}
+	}
+
+	output = &RegisterTransitGatewayMulticastGroupMembersOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RegisterTransitGatewayMulticastGroupMembers API operation for Amazon Elastic Compute Cloud.
+//
+// Registers members (network interfaces) with the transit gateway multicast
+// group. A member is a network interface associated with a supported EC2 instance
+// that receives multicast traffic. For information about supported instances,
+// see Multicast Consideration (https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-limits.html#multicast-limits)
+// in Amazon VPC Transit Gateways.
+//
+// After you add the members, use SearchTransitGatewayMulticastGroups (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SearchTransitGatewayMulticastGroups.html)
+// to verify that the members were added to the transit gateway multicast group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation RegisterTransitGatewayMulticastGroupMembers for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RegisterTransitGatewayMulticastGroupMembers
+func (c *EC2) RegisterTransitGatewayMulticastGroupMembers(input *RegisterTransitGatewayMulticastGroupMembersInput) (*RegisterTransitGatewayMulticastGroupMembersOutput, error) {
+	req, out := c.RegisterTransitGatewayMulticastGroupMembersRequest(input)
+	return out, req.Send()
+}
+
+// RegisterTransitGatewayMulticastGroupMembersWithContext is the same as RegisterTransitGatewayMulticastGroupMembers with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RegisterTransitGatewayMulticastGroupMembers for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) RegisterTransitGatewayMulticastGroupMembersWithContext(ctx aws.Context, input *RegisterTransitGatewayMulticastGroupMembersInput, opts ...request.Option) (*RegisterTransitGatewayMulticastGroupMembersOutput, error) {
+	req, out := c.RegisterTransitGatewayMulticastGroupMembersRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRegisterTransitGatewayMulticastGroupSources = "RegisterTransitGatewayMulticastGroupSources"
+
+// RegisterTransitGatewayMulticastGroupSourcesRequest generates a "aws/request.Request" representing the
+// client's request for the RegisterTransitGatewayMulticastGroupSources operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RegisterTransitGatewayMulticastGroupSources for more information on using the RegisterTransitGatewayMulticastGroupSources
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RegisterTransitGatewayMulticastGroupSourcesRequest method.
+//    req, resp := client.RegisterTransitGatewayMulticastGroupSourcesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RegisterTransitGatewayMulticastGroupSources
+func (c *EC2) RegisterTransitGatewayMulticastGroupSourcesRequest(input *RegisterTransitGatewayMulticastGroupSourcesInput) (req *request.Request, output *RegisterTransitGatewayMulticastGroupSourcesOutput) {
+	op := &request.Operation{
+		Name:       opRegisterTransitGatewayMulticastGroupSources,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RegisterTransitGatewayMulticastGroupSourcesInput{}
+	}
+
+	output = &RegisterTransitGatewayMulticastGroupSourcesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RegisterTransitGatewayMulticastGroupSources API operation for Amazon Elastic Compute Cloud.
+//
+// Registers sources (network interfaces) with the specified transit gateway
+// multicast group.
+//
+// A multicast source is a network interface attached to a supported instance
+// that sends multicast traffic. For information about supported instances,
+// see Multicast Considerations (https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-limits.html#multicast-limits)
+// in Amazon VPC Transit Gateways.
+//
+// After you add the source, use SearchTransitGatewayMulticastGroups (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SearchTransitGatewayMulticastGroups.html)
+// to verify that the source was added to the multicast group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation RegisterTransitGatewayMulticastGroupSources for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RegisterTransitGatewayMulticastGroupSources
+func (c *EC2) RegisterTransitGatewayMulticastGroupSources(input *RegisterTransitGatewayMulticastGroupSourcesInput) (*RegisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	req, out := c.RegisterTransitGatewayMulticastGroupSourcesRequest(input)
+	return out, req.Send()
+}
+
+// RegisterTransitGatewayMulticastGroupSourcesWithContext is the same as RegisterTransitGatewayMulticastGroupSources with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RegisterTransitGatewayMulticastGroupSources for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) RegisterTransitGatewayMulticastGroupSourcesWithContext(ctx aws.Context, input *RegisterTransitGatewayMulticastGroupSourcesInput, opts ...request.Option) (*RegisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	req, out := c.RegisterTransitGatewayMulticastGroupSourcesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRejectTransitGatewayPeeringAttachment = "RejectTransitGatewayPeeringAttachment"
+
+// RejectTransitGatewayPeeringAttachmentRequest generates a "aws/request.Request" representing the
+// client's request for the RejectTransitGatewayPeeringAttachment operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RejectTransitGatewayPeeringAttachment for more information on using the RejectTransitGatewayPeeringAttachment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RejectTransitGatewayPeeringAttachmentRequest method.
+//    req, resp := client.RejectTransitGatewayPeeringAttachmentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RejectTransitGatewayPeeringAttachment
+func (c *EC2) RejectTransitGatewayPeeringAttachmentRequest(input *RejectTransitGatewayPeeringAttachmentInput) (req *request.Request, output *RejectTransitGatewayPeeringAttachmentOutput) {
+	op := &request.Operation{
+		Name:       opRejectTransitGatewayPeeringAttachment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RejectTransitGatewayPeeringAttachmentInput{}
+	}
+
+	output = &RejectTransitGatewayPeeringAttachmentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RejectTransitGatewayPeeringAttachment API operation for Amazon Elastic Compute Cloud.
+//
+// Rejects a transit gateway peering attachment request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation RejectTransitGatewayPeeringAttachment for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/RejectTransitGatewayPeeringAttachment
+func (c *EC2) RejectTransitGatewayPeeringAttachment(input *RejectTransitGatewayPeeringAttachmentInput) (*RejectTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.RejectTransitGatewayPeeringAttachmentRequest(input)
+	return out, req.Send()
+}
+
+// RejectTransitGatewayPeeringAttachmentWithContext is the same as RejectTransitGatewayPeeringAttachment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RejectTransitGatewayPeeringAttachment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) RejectTransitGatewayPeeringAttachmentWithContext(ctx aws.Context, input *RejectTransitGatewayPeeringAttachmentInput, opts ...request.Option) (*RejectTransitGatewayPeeringAttachmentOutput, error) {
+	req, out := c.RejectTransitGatewayPeeringAttachmentRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -30196,9 +33210,9 @@ func (c *EC2) ReplaceRouteRequest(input *ReplaceRouteInput) (req *request.Reques
 // ReplaceRoute API operation for Amazon Elastic Compute Cloud.
 //
 // Replaces an existing route within a route table in a VPC. You must provide
-// only one of the following: internet gateway or virtual private gateway, NAT
-// instance, NAT gateway, VPC peering connection, network interface, or egress-only
-// internet gateway.
+// only one of the following: internet gateway, virtual private gateway, NAT
+// instance, NAT gateway, VPC peering connection, network interface, egress-only
+// internet gateway, or transit gateway.
 //
 // For more information, see Route Tables (https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html)
 // in the Amazon Virtual Private Cloud User Guide.
@@ -30275,15 +33289,15 @@ func (c *EC2) ReplaceRouteTableAssociationRequest(input *ReplaceRouteTableAssoci
 
 // ReplaceRouteTableAssociation API operation for Amazon Elastic Compute Cloud.
 //
-// Changes the route table associated with a given subnet in a VPC. After the
-// operation completes, the subnet uses the routes in the new route table it's
-// associated with. For more information about route tables, see Route Tables
-// (https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html)
+// Changes the route table associated with a given subnet, internet gateway,
+// or virtual private gateway in a VPC. After the operation completes, the subnet
+// or gateway uses the routes in the new route table. For more information about
+// route tables, see Route Tables (https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
-// You can also use ReplaceRouteTableAssociation to change which table is the
-// main route table in the VPC. You just specify the main route table's association
-// ID and the route table to be the new main route table.
+// You can also use this operation to change which table is the main route table
+// in the VPC. Specify the main route table's association ID and the route table
+// ID of the new main route table.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -31652,6 +34666,155 @@ func (c *EC2) RunScheduledInstancesWithContext(ctx aws.Context, input *RunSchedu
 	return out, req.Send()
 }
 
+const opSearchLocalGatewayRoutes = "SearchLocalGatewayRoutes"
+
+// SearchLocalGatewayRoutesRequest generates a "aws/request.Request" representing the
+// client's request for the SearchLocalGatewayRoutes operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SearchLocalGatewayRoutes for more information on using the SearchLocalGatewayRoutes
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SearchLocalGatewayRoutesRequest method.
+//    req, resp := client.SearchLocalGatewayRoutesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SearchLocalGatewayRoutes
+func (c *EC2) SearchLocalGatewayRoutesRequest(input *SearchLocalGatewayRoutesInput) (req *request.Request, output *SearchLocalGatewayRoutesOutput) {
+	op := &request.Operation{
+		Name:       opSearchLocalGatewayRoutes,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &SearchLocalGatewayRoutesInput{}
+	}
+
+	output = &SearchLocalGatewayRoutesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// SearchLocalGatewayRoutes API operation for Amazon Elastic Compute Cloud.
+//
+// Searches for routes in the specified local gateway route table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation SearchLocalGatewayRoutes for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SearchLocalGatewayRoutes
+func (c *EC2) SearchLocalGatewayRoutes(input *SearchLocalGatewayRoutesInput) (*SearchLocalGatewayRoutesOutput, error) {
+	req, out := c.SearchLocalGatewayRoutesRequest(input)
+	return out, req.Send()
+}
+
+// SearchLocalGatewayRoutesWithContext is the same as SearchLocalGatewayRoutes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SearchLocalGatewayRoutes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) SearchLocalGatewayRoutesWithContext(ctx aws.Context, input *SearchLocalGatewayRoutesInput, opts ...request.Option) (*SearchLocalGatewayRoutesOutput, error) {
+	req, out := c.SearchLocalGatewayRoutesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opSearchTransitGatewayMulticastGroups = "SearchTransitGatewayMulticastGroups"
+
+// SearchTransitGatewayMulticastGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the SearchTransitGatewayMulticastGroups operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SearchTransitGatewayMulticastGroups for more information on using the SearchTransitGatewayMulticastGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SearchTransitGatewayMulticastGroupsRequest method.
+//    req, resp := client.SearchTransitGatewayMulticastGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SearchTransitGatewayMulticastGroups
+func (c *EC2) SearchTransitGatewayMulticastGroupsRequest(input *SearchTransitGatewayMulticastGroupsInput) (req *request.Request, output *SearchTransitGatewayMulticastGroupsOutput) {
+	op := &request.Operation{
+		Name:       opSearchTransitGatewayMulticastGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &SearchTransitGatewayMulticastGroupsInput{}
+	}
+
+	output = &SearchTransitGatewayMulticastGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// SearchTransitGatewayMulticastGroups API operation for Amazon Elastic Compute Cloud.
+//
+// Searches one or more transit gateway multicast groups and returns the group
+// membership information.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation SearchTransitGatewayMulticastGroups for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SearchTransitGatewayMulticastGroups
+func (c *EC2) SearchTransitGatewayMulticastGroups(input *SearchTransitGatewayMulticastGroupsInput) (*SearchTransitGatewayMulticastGroupsOutput, error) {
+	req, out := c.SearchTransitGatewayMulticastGroupsRequest(input)
+	return out, req.Send()
+}
+
+// SearchTransitGatewayMulticastGroupsWithContext is the same as SearchTransitGatewayMulticastGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SearchTransitGatewayMulticastGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) SearchTransitGatewayMulticastGroupsWithContext(ctx aws.Context, input *SearchTransitGatewayMulticastGroupsInput, opts ...request.Option) (*SearchTransitGatewayMulticastGroupsOutput, error) {
+	req, out := c.SearchTransitGatewayMulticastGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opSearchTransitGatewayRoutes = "SearchTransitGatewayRoutes"
 
 // SearchTransitGatewayRoutesRequest generates a "aws/request.Request" representing the
@@ -32767,6 +35930,79 @@ func (s *AcceptReservedInstancesExchangeQuoteOutput) SetExchangeId(v string) *Ac
 	return s
 }
 
+type AcceptTransitGatewayPeeringAttachmentInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the transit gateway attachment.
+	//
+	// TransitGatewayAttachmentId is a required field
+	TransitGatewayAttachmentId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AcceptTransitGatewayPeeringAttachmentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AcceptTransitGatewayPeeringAttachmentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AcceptTransitGatewayPeeringAttachmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AcceptTransitGatewayPeeringAttachmentInput"}
+	if s.TransitGatewayAttachmentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayAttachmentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AcceptTransitGatewayPeeringAttachmentInput) SetDryRun(v bool) *AcceptTransitGatewayPeeringAttachmentInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *AcceptTransitGatewayPeeringAttachmentInput) SetTransitGatewayAttachmentId(v string) *AcceptTransitGatewayPeeringAttachmentInput {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+type AcceptTransitGatewayPeeringAttachmentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The transit gateway peering attachment.
+	TransitGatewayPeeringAttachment *TransitGatewayPeeringAttachment `locationName:"transitGatewayPeeringAttachment" type:"structure"`
+}
+
+// String returns the string representation
+func (s AcceptTransitGatewayPeeringAttachmentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AcceptTransitGatewayPeeringAttachmentOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayPeeringAttachment sets the TransitGatewayPeeringAttachment field's value.
+func (s *AcceptTransitGatewayPeeringAttachmentOutput) SetTransitGatewayPeeringAttachment(v *TransitGatewayPeeringAttachment) *AcceptTransitGatewayPeeringAttachmentOutput {
+	s.TransitGatewayPeeringAttachment = v
+	return s
+}
+
 type AcceptTransitGatewayVpcAttachmentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -33107,12 +36343,21 @@ type Address struct {
 	// VPC.
 	AssociationId *string `locationName:"associationId" type:"string"`
 
+	// The customer-owned IP address.
+	CustomerOwnedIp *string `locationName:"customerOwnedIp" type:"string"`
+
+	// The ID of the customer-owned address pool.
+	CustomerOwnedIpv4Pool *string `locationName:"customerOwnedIpv4Pool" type:"string"`
+
 	// Indicates whether this Elastic IP address is for use with instances in EC2-Classic
 	// (standard) or instances in a VPC (vpc).
 	Domain *string `locationName:"domain" type:"string" enum:"DomainType"`
 
 	// The ID of the instance that the address is associated with (if any).
 	InstanceId *string `locationName:"instanceId" type:"string"`
+
+	// The name of the location from which the IP address is advertised.
+	NetworkBorderGroup *string `locationName:"networkBorderGroup" type:"string"`
 
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string"`
@@ -33155,6 +36400,18 @@ func (s *Address) SetAssociationId(v string) *Address {
 	return s
 }
 
+// SetCustomerOwnedIp sets the CustomerOwnedIp field's value.
+func (s *Address) SetCustomerOwnedIp(v string) *Address {
+	s.CustomerOwnedIp = &v
+	return s
+}
+
+// SetCustomerOwnedIpv4Pool sets the CustomerOwnedIpv4Pool field's value.
+func (s *Address) SetCustomerOwnedIpv4Pool(v string) *Address {
+	s.CustomerOwnedIpv4Pool = &v
+	return s
+}
+
 // SetDomain sets the Domain field's value.
 func (s *Address) SetDomain(v string) *Address {
 	s.Domain = &v
@@ -33164,6 +36421,12 @@ func (s *Address) SetDomain(v string) *Address {
 // SetInstanceId sets the InstanceId field's value.
 func (s *Address) SetInstanceId(v string) *Address {
 	s.InstanceId = &v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *Address) SetNetworkBorderGroup(v string) *Address {
+	s.NetworkBorderGroup = &v
 	return s
 }
 
@@ -33284,6 +36547,11 @@ type AllocateAddressInput struct {
 	// pool.
 	Address *string `type:"string"`
 
+	// The ID of a customer-owned address pool. Use this parameter to let Amazon
+	// EC2 select an address from the address pool. Alternatively, specify a specific
+	// address from the address pool.
+	CustomerOwnedIpv4Pool *string `type:"string"`
+
 	// Set to vpc to allocate the address for use with instances in a VPC.
 	//
 	// Default: The address is for use with instances in EC2-Classic.
@@ -33294,6 +36562,17 @@ type AllocateAddressInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
+
+	// The location from which the IP address is advertised. Use this parameter
+	// to limit the address to this location.
+	//
+	// Use DescribeVpcs (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html)
+	// to view the network border groups.
+	//
+	// You cannot use a network border group with EC2 Classic. If you attempt this
+	// operation on EC2 classic, you will receive an InvalidParameterCombination
+	// error. For more information, see Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
+	NetworkBorderGroup *string `type:"string"`
 
 	// The ID of an address pool that you own. Use this parameter to let Amazon
 	// EC2 select an address from the address pool. To specify a specific address
@@ -33317,6 +36596,12 @@ func (s *AllocateAddressInput) SetAddress(v string) *AllocateAddressInput {
 	return s
 }
 
+// SetCustomerOwnedIpv4Pool sets the CustomerOwnedIpv4Pool field's value.
+func (s *AllocateAddressInput) SetCustomerOwnedIpv4Pool(v string) *AllocateAddressInput {
+	s.CustomerOwnedIpv4Pool = &v
+	return s
+}
+
 // SetDomain sets the Domain field's value.
 func (s *AllocateAddressInput) SetDomain(v string) *AllocateAddressInput {
 	s.Domain = &v
@@ -33326,6 +36611,12 @@ func (s *AllocateAddressInput) SetDomain(v string) *AllocateAddressInput {
 // SetDryRun sets the DryRun field's value.
 func (s *AllocateAddressInput) SetDryRun(v bool) *AllocateAddressInput {
 	s.DryRun = &v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *AllocateAddressInput) SetNetworkBorderGroup(v string) *AllocateAddressInput {
+	s.NetworkBorderGroup = &v
 	return s
 }
 
@@ -33342,9 +36633,18 @@ type AllocateAddressOutput struct {
 	// IP address for use with instances in a VPC.
 	AllocationId *string `locationName:"allocationId" type:"string"`
 
+	// The customer-owned IP address.
+	CustomerOwnedIp *string `locationName:"customerOwnedIp" type:"string"`
+
+	// The ID of the customer-owned address pool.
+	CustomerOwnedIpv4Pool *string `locationName:"customerOwnedIpv4Pool" type:"string"`
+
 	// Indicates whether this Elastic IP address is for use with instances in EC2-Classic
 	// (standard) or instances in a VPC (vpc).
 	Domain *string `locationName:"domain" type:"string" enum:"DomainType"`
+
+	// The location from which the IP address is advertised.
+	NetworkBorderGroup *string `locationName:"networkBorderGroup" type:"string"`
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
@@ -33369,9 +36669,27 @@ func (s *AllocateAddressOutput) SetAllocationId(v string) *AllocateAddressOutput
 	return s
 }
 
+// SetCustomerOwnedIp sets the CustomerOwnedIp field's value.
+func (s *AllocateAddressOutput) SetCustomerOwnedIp(v string) *AllocateAddressOutput {
+	s.CustomerOwnedIp = &v
+	return s
+}
+
+// SetCustomerOwnedIpv4Pool sets the CustomerOwnedIpv4Pool field's value.
+func (s *AllocateAddressOutput) SetCustomerOwnedIpv4Pool(v string) *AllocateAddressOutput {
+	s.CustomerOwnedIpv4Pool = &v
+	return s
+}
+
 // SetDomain sets the Domain field's value.
 func (s *AllocateAddressOutput) SetDomain(v string) *AllocateAddressOutput {
 	s.Domain = &v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *AllocateAddressOutput) SetNetworkBorderGroup(v string) *AllocateAddressOutput {
+	s.NetworkBorderGroup = &v
 	return s
 }
 
@@ -33416,12 +36734,23 @@ type AllocateHostsInput struct {
 	// Default: off
 	HostRecovery *string `type:"string" enum:"HostRecovery"`
 
-	// Specifies the instance type for which to configure your Dedicated Hosts.
-	// When you specify the instance type, that is the only instance type that you
-	// can launch onto that host.
+	// Specifies the instance family to be supported by the Dedicated Hosts. If
+	// you specify an instance family, the Dedicated Hosts support multiple instance
+	// types within that instance family.
 	//
-	// InstanceType is a required field
-	InstanceType *string `locationName:"instanceType" type:"string" required:"true"`
+	// If you want the Dedicated Hosts to support a specific instance type only,
+	// omit this parameter and specify InstanceType instead. You cannot specify
+	// InstanceFamily and InstanceType in the same request.
+	InstanceFamily *string `type:"string"`
+
+	// Specifies the instance type to be supported by the Dedicated Hosts. If you
+	// specify an instance type, the Dedicated Hosts support instances of the specified
+	// instance type only.
+	//
+	// If you want the Dedicated Hosts to support multiple instance types in a specific
+	// instance family, omit this parameter and specify InstanceFamily instead.
+	// You cannot specify InstanceType and InstanceFamily in the same request.
+	InstanceType *string `locationName:"instanceType" type:"string"`
 
 	// The number of Dedicated Hosts to allocate to your account with these parameters.
 	//
@@ -33447,9 +36776,6 @@ func (s *AllocateHostsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "AllocateHostsInput"}
 	if s.AvailabilityZone == nil {
 		invalidParams.Add(request.NewErrParamRequired("AvailabilityZone"))
-	}
-	if s.InstanceType == nil {
-		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
 	}
 	if s.Quantity == nil {
 		invalidParams.Add(request.NewErrParamRequired("Quantity"))
@@ -33482,6 +36808,12 @@ func (s *AllocateHostsInput) SetClientToken(v string) *AllocateHostsInput {
 // SetHostRecovery sets the HostRecovery field's value.
 func (s *AllocateHostsInput) SetHostRecovery(v string) *AllocateHostsInput {
 	s.HostRecovery = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *AllocateHostsInput) SetInstanceFamily(v string) *AllocateHostsInput {
+	s.InstanceFamily = &v
 	return s
 }
 
@@ -34271,15 +37603,16 @@ type AssociateRouteTableInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
+	// The ID of the internet gateway or virtual private gateway.
+	GatewayId *string `type:"string"`
+
 	// The ID of the route table.
 	//
 	// RouteTableId is a required field
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
 
 	// The ID of the subnet.
-	//
-	// SubnetId is a required field
-	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
+	SubnetId *string `locationName:"subnetId" type:"string"`
 }
 
 // String returns the string representation
@@ -34298,9 +37631,6 @@ func (s *AssociateRouteTableInput) Validate() error {
 	if s.RouteTableId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
 	}
-	if s.SubnetId == nil {
-		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
-	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -34311,6 +37641,12 @@ func (s *AssociateRouteTableInput) Validate() error {
 // SetDryRun sets the DryRun field's value.
 func (s *AssociateRouteTableInput) SetDryRun(v bool) *AssociateRouteTableInput {
 	s.DryRun = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *AssociateRouteTableInput) SetGatewayId(v string) *AssociateRouteTableInput {
+	s.GatewayId = &v
 	return s
 }
 
@@ -34332,6 +37668,9 @@ type AssociateRouteTableOutput struct {
 	// The route table association ID. This ID is required for disassociating the
 	// route table.
 	AssociationId *string `locationName:"associationId" type:"string"`
+
+	// The state of the association.
+	AssociationState *RouteTableAssociationState `locationName:"associationState" type:"structure"`
 }
 
 // String returns the string representation
@@ -34347,6 +37686,12 @@ func (s AssociateRouteTableOutput) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *AssociateRouteTableOutput) SetAssociationId(v string) *AssociateRouteTableOutput {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationState sets the AssociationState field's value.
+func (s *AssociateRouteTableOutput) SetAssociationState(v *RouteTableAssociationState) *AssociateRouteTableOutput {
+	s.AssociationState = v
 	return s
 }
 
@@ -34431,6 +37776,83 @@ func (s *AssociateSubnetCidrBlockOutput) SetIpv6CidrBlockAssociation(v *SubnetIp
 // SetSubnetId sets the SubnetId field's value.
 func (s *AssociateSubnetCidrBlockOutput) SetSubnetId(v string) *AssociateSubnetCidrBlockOutput {
 	s.SubnetId = &v
+	return s
+}
+
+type AssociateTransitGatewayMulticastDomainInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IDs of the subnets to associate with the transit gateway multicast domain.
+	SubnetIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway attachment to associate with the transit gateway
+	// multicast domain.
+	TransitGatewayAttachmentId *string `type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s AssociateTransitGatewayMulticastDomainInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTransitGatewayMulticastDomainInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AssociateTransitGatewayMulticastDomainInput) SetDryRun(v bool) *AssociateTransitGatewayMulticastDomainInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *AssociateTransitGatewayMulticastDomainInput) SetSubnetIds(v []*string) *AssociateTransitGatewayMulticastDomainInput {
+	s.SubnetIds = v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *AssociateTransitGatewayMulticastDomainInput) SetTransitGatewayAttachmentId(v string) *AssociateTransitGatewayMulticastDomainInput {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *AssociateTransitGatewayMulticastDomainInput) SetTransitGatewayMulticastDomainId(v string) *AssociateTransitGatewayMulticastDomainInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type AssociateTransitGatewayMulticastDomainOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the transit gateway multicast domain associations.
+	Associations *TransitGatewayMulticastDomainAssociations `locationName:"associations" type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateTransitGatewayMulticastDomainOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTransitGatewayMulticastDomainOutput) GoString() string {
+	return s.String()
+}
+
+// SetAssociations sets the Associations field's value.
+func (s *AssociateTransitGatewayMulticastDomainOutput) SetAssociations(v *TransitGatewayMulticastDomainAssociations) *AssociateTransitGatewayMulticastDomainOutput {
+	s.Associations = v
 	return s
 }
 
@@ -34532,6 +37954,14 @@ type AssociateVpcCidrBlockInput struct {
 	// An IPv4 CIDR block to associate with the VPC.
 	CidrBlock *string `type:"string"`
 
+	// The name of the location from which we advertise the IPV6 CIDR block. Use
+	// this parameter to limit the CiDR block to this location.
+	//
+	// You must set AmazonProvidedIpv6CidrBlock to true to use this parameter.
+	//
+	// You can have one IPv6 CIDR block association per network border group.
+	Ipv6CidrBlockNetworkBorderGroup *string `type:"string"`
+
 	// The ID of the VPC.
 	//
 	// VpcId is a required field
@@ -34570,6 +38000,12 @@ func (s *AssociateVpcCidrBlockInput) SetAmazonProvidedIpv6CidrBlock(v bool) *Ass
 // SetCidrBlock sets the CidrBlock field's value.
 func (s *AssociateVpcCidrBlockInput) SetCidrBlock(v string) *AssociateVpcCidrBlockInput {
 	s.CidrBlock = &v
+	return s
+}
+
+// SetIpv6CidrBlockNetworkBorderGroup sets the Ipv6CidrBlockNetworkBorderGroup field's value.
+func (s *AssociateVpcCidrBlockInput) SetIpv6CidrBlockNetworkBorderGroup(v string) *AssociateVpcCidrBlockInput {
+	s.Ipv6CidrBlockNetworkBorderGroup = &v
 	return s
 }
 
@@ -34970,7 +38406,6 @@ func (s *AttachNetworkInterfaceOutput) SetAttachmentId(v string) *AttachNetworkI
 	return s
 }
 
-// Contains the parameters for AttachVolume.
 type AttachVolumeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -35673,23 +39108,37 @@ func (s AuthorizeSecurityGroupIngressOutput) GoString() string {
 	return s.String()
 }
 
-// Describes an Availability Zone.
+// Describes an Availability Zone or Local Zone.
 type AvailabilityZone struct {
 	_ struct{} `type:"structure"`
 
-	// Any messages about the Availability Zone.
+	// For Availability Zones, this parameter has the same value as the Region name.
+	//
+	// For Local Zones, the name of the associated group, for example us-west-2-lax-1.
+	GroupName *string `locationName:"groupName" type:"string"`
+
+	// Any messages about the Availability Zone or Local Zone.
 	Messages []*AvailabilityZoneMessage `locationName:"messageSet" locationNameList:"item" type:"list"`
+
+	// The name of the location from which the address is advertised.
+	NetworkBorderGroup *string `locationName:"networkBorderGroup" type:"string"`
+
+	// For Availability Zones, this parameter always has the value of opt-in-not-required.
+	//
+	// For Local Zones, this parameter is the opt in status. The possible values
+	// are opted-in, and not-opted-in.
+	OptInStatus *string `locationName:"optInStatus" type:"string" enum:"AvailabilityZoneOptInStatus"`
 
 	// The name of the Region.
 	RegionName *string `locationName:"regionName" type:"string"`
 
-	// The state of the Availability Zone.
+	// The state of the Availability Zone or Local Zone.
 	State *string `locationName:"zoneState" type:"string" enum:"AvailabilityZoneState"`
 
-	// The ID of the Availability Zone.
+	// The ID of the Availability Zone or Local Zone.
 	ZoneId *string `locationName:"zoneId" type:"string"`
 
-	// The name of the Availability Zone.
+	// The name of the Availability Zone or Local Zone.
 	ZoneName *string `locationName:"zoneName" type:"string"`
 }
 
@@ -35703,9 +39152,27 @@ func (s AvailabilityZone) GoString() string {
 	return s.String()
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *AvailabilityZone) SetGroupName(v string) *AvailabilityZone {
+	s.GroupName = &v
+	return s
+}
+
 // SetMessages sets the Messages field's value.
 func (s *AvailabilityZone) SetMessages(v []*AvailabilityZoneMessage) *AvailabilityZone {
 	s.Messages = v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *AvailabilityZone) SetNetworkBorderGroup(v string) *AvailabilityZone {
+	s.NetworkBorderGroup = &v
+	return s
+}
+
+// SetOptInStatus sets the OptInStatus field's value.
+func (s *AvailabilityZone) SetOptInStatus(v string) *AvailabilityZone {
+	s.OptInStatus = &v
 	return s
 }
 
@@ -35733,11 +39200,11 @@ func (s *AvailabilityZone) SetZoneName(v string) *AvailabilityZone {
 	return s
 }
 
-// Describes a message about an Availability Zone.
+// Describes a message about an Availability Zone or Local Zone.
 type AvailabilityZoneMessage struct {
 	_ struct{} `type:"structure"`
 
-	// The message about the Availability Zone.
+	// The message about the Availability Zone or Local Zone.
 	Message *string `locationName:"message" type:"string"`
 }
 
@@ -35757,14 +39224,19 @@ func (s *AvailabilityZoneMessage) SetMessage(v string) *AvailabilityZoneMessage 
 	return s
 }
 
-// The capacity information for instances launched onto the Dedicated Host.
+// The capacity information for instances that can be launched onto the Dedicated
+// Host.
 type AvailableCapacity struct {
 	_ struct{} `type:"structure"`
 
-	// The total number of instances supported by the Dedicated Host.
+	// The number of instances that can be launched onto the Dedicated Host depending
+	// on the host's available capacity. For Dedicated Hosts that support multiple
+	// instance types, this parameter represents the number of instances for each
+	// instance size that is supported on the host.
 	AvailableInstanceCapacity []*InstanceCapacity `locationName:"availableInstanceCapacity" locationNameList:"item" type:"list"`
 
-	// The number of vCPUs available on the Dedicated Host.
+	// The number of vCPUs available for launching instances onto the Dedicated
+	// Host.
 	AvailableVCpus *int64 `locationName:"availableVCpus" type:"integer"`
 }
 
@@ -37115,6 +40587,96 @@ func (s *CapacityReservation) SetTotalInstanceCount(v int64) *CapacityReservatio
 	return s
 }
 
+// Describes the strategy for using unused Capacity Reservations for fulfilling
+// On-Demand capacity.
+//
+// This strategy can only be used if the EC2 Fleet is of type instant.
+//
+// For more information about Capacity Reservations, see On-Demand Capacity
+// Reservations (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html)
+// in the Amazon Elastic Compute Cloud User Guide. For examples of using Capacity
+// Reservations in an EC2 Fleet, see EC2 Fleet Example Configurations (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-examples.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+type CapacityReservationOptions struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether to use unused Capacity Reservations for fulfilling On-Demand
+	// capacity.
+	//
+	// If you specify use-capacity-reservations-first, the fleet uses unused Capacity
+	// Reservations to fulfill On-Demand capacity up to the target On-Demand capacity.
+	// If multiple instance pools have unused Capacity Reservations, the On-Demand
+	// allocation strategy (lowest-price or prioritized) is applied. If the number
+	// of unused Capacity Reservations is less than the On-Demand target capacity,
+	// the remaining On-Demand target capacity is launched according to the On-Demand
+	// allocation strategy (lowest-price or prioritized).
+	//
+	// If you do not specify a value, the fleet fulfils the On-Demand capacity according
+	// to the chosen On-Demand allocation strategy.
+	UsageStrategy *string `locationName:"usageStrategy" type:"string" enum:"FleetCapacityReservationUsageStrategy"`
+}
+
+// String returns the string representation
+func (s CapacityReservationOptions) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CapacityReservationOptions) GoString() string {
+	return s.String()
+}
+
+// SetUsageStrategy sets the UsageStrategy field's value.
+func (s *CapacityReservationOptions) SetUsageStrategy(v string) *CapacityReservationOptions {
+	s.UsageStrategy = &v
+	return s
+}
+
+// Describes the strategy for using unused Capacity Reservations for fulfilling
+// On-Demand capacity.
+//
+// This strategy can only be used if the EC2 Fleet is of type instant.
+//
+// For more information about Capacity Reservations, see On-Demand Capacity
+// Reservations (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html)
+// in the Amazon Elastic Compute Cloud User Guide. For examples of using Capacity
+// Reservations in an EC2 Fleet, see EC2 Fleet Example Configurations (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-examples.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+type CapacityReservationOptionsRequest struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether to use unused Capacity Reservations for fulfilling On-Demand
+	// capacity.
+	//
+	// If you specify use-capacity-reservations-first, the fleet uses unused Capacity
+	// Reservations to fulfill On-Demand capacity up to the target On-Demand capacity.
+	// If multiple instance pools have unused Capacity Reservations, the On-Demand
+	// allocation strategy (lowest-price or prioritized) is applied. If the number
+	// of unused Capacity Reservations is less than the On-Demand target capacity,
+	// the remaining On-Demand target capacity is launched according to the On-Demand
+	// allocation strategy (lowest-price or prioritized).
+	//
+	// If you do not specify a value, the fleet fulfils the On-Demand capacity according
+	// to the chosen On-Demand allocation strategy.
+	UsageStrategy *string `type:"string" enum:"FleetCapacityReservationUsageStrategy"`
+}
+
+// String returns the string representation
+func (s CapacityReservationOptionsRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CapacityReservationOptionsRequest) GoString() string {
+	return s.String()
+}
+
+// SetUsageStrategy sets the UsageStrategy field's value.
+func (s *CapacityReservationOptionsRequest) SetUsageStrategy(v string) *CapacityReservationOptionsRequest {
+	s.UsageStrategy = &v
+	return s
+}
+
 // Describes an instance's Capacity Reservation targeting option. You can specify
 // only one parameter at a time. If you specify CapacityReservationPreference
 // and CapacityReservationTarget, the request fails.
@@ -38239,6 +41801,108 @@ func (s *ClientVpnRouteStatus) SetMessage(v string) *ClientVpnRouteStatus {
 	return s
 }
 
+// Describes address usage for a customer-owned address pool.
+type CoipAddressUsage struct {
+	_ struct{} `type:"structure"`
+
+	// The allocation ID of the address.
+	AllocationId *string `locationName:"allocationId" type:"string"`
+
+	// The AWS account ID.
+	AwsAccountId *string `locationName:"awsAccountId" type:"string"`
+
+	// The AWS service.
+	AwsService *string `locationName:"awsService" type:"string"`
+
+	// The customer-owned IP address.
+	CoIp *string `locationName:"coIp" type:"string"`
+}
+
+// String returns the string representation
+func (s CoipAddressUsage) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CoipAddressUsage) GoString() string {
+	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *CoipAddressUsage) SetAllocationId(v string) *CoipAddressUsage {
+	s.AllocationId = &v
+	return s
+}
+
+// SetAwsAccountId sets the AwsAccountId field's value.
+func (s *CoipAddressUsage) SetAwsAccountId(v string) *CoipAddressUsage {
+	s.AwsAccountId = &v
+	return s
+}
+
+// SetAwsService sets the AwsService field's value.
+func (s *CoipAddressUsage) SetAwsService(v string) *CoipAddressUsage {
+	s.AwsService = &v
+	return s
+}
+
+// SetCoIp sets the CoIp field's value.
+func (s *CoipAddressUsage) SetCoIp(v string) *CoipAddressUsage {
+	s.CoIp = &v
+	return s
+}
+
+// Describes a customer-owned address pool.
+type CoipPool struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+
+	// The address ranges of the address pool.
+	PoolCidrs []*string `locationName:"poolCidrSet" locationNameList:"item" type:"list"`
+
+	// The ID of the address pool.
+	PoolId *string `locationName:"poolId" type:"string"`
+
+	// The tags.
+	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s CoipPool) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CoipPool) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *CoipPool) SetLocalGatewayRouteTableId(v string) *CoipPool {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetPoolCidrs sets the PoolCidrs field's value.
+func (s *CoipPool) SetPoolCidrs(v []*string) *CoipPool {
+	s.PoolCidrs = v
+	return s
+}
+
+// SetPoolId sets the PoolId field's value.
+func (s *CoipPool) SetPoolId(v string) *CoipPool {
+	s.PoolId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CoipPool) SetTags(v []*Tag) *CoipPool {
+	s.Tags = v
+	return s
+}
+
 type ConfirmProductInstanceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -38870,7 +42534,6 @@ func (s *CopyImageOutput) SetImageId(v string) *CopyImageOutput {
 	return s
 }
 
-// Contains the parameters for CopySnapshot.
 type CopySnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -38945,6 +42608,9 @@ type CopySnapshotInput struct {
 	//
 	// SourceSnapshotId is a required field
 	SourceSnapshotId *string `type:"string" required:"true"`
+
+	// The tags to apply to the new snapshot.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation
@@ -39021,12 +42687,20 @@ func (s *CopySnapshotInput) SetSourceSnapshotId(v string) *CopySnapshotInput {
 	return s
 }
 
-// Contains the output of CopySnapshot.
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CopySnapshotInput) SetTagSpecifications(v []*TagSpecification) *CopySnapshotInput {
+	s.TagSpecifications = v
+	return s
+}
+
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The ID of the new snapshot.
 	SnapshotId *string `locationName:"snapshotId" type:"string"`
+
+	// Any tags applied to the new snapshot.
+	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation
@@ -39042,6 +42716,12 @@ func (s CopySnapshotOutput) GoString() string {
 // SetSnapshotId sets the SnapshotId field's value.
 func (s *CopySnapshotOutput) SetSnapshotId(v string) *CopySnapshotOutput {
 	s.SnapshotId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopySnapshotOutput) SetTags(v []*Tag) *CopySnapshotOutput {
+	s.Tags = v
 	return s
 }
 
@@ -39712,6 +43392,11 @@ type CreateCustomerGatewayInput struct {
 	// The Amazon Resource Name (ARN) for the customer gateway certificate.
 	CertificateArn *string `type:"string"`
 
+	// A name for the customer gateway device.
+	//
+	// Length Constraints: Up to 255 characters.
+	DeviceName *string `type:"string"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -39763,6 +43448,12 @@ func (s *CreateCustomerGatewayInput) SetBgpAsn(v int64) *CreateCustomerGatewayIn
 // SetCertificateArn sets the CertificateArn field's value.
 func (s *CreateCustomerGatewayInput) SetCertificateArn(v string) *CreateCustomerGatewayInput {
 	s.CertificateArn = &v
+	return s
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *CreateCustomerGatewayInput) SetDeviceName(v string) *CreateCustomerGatewayInput {
+	s.DeviceName = &v
 	return s
 }
 
@@ -40105,12 +43796,12 @@ type CreateFleetError struct {
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 
 	// The error message that describes why the instance could not be launched.
-	// For more information about error messages, see ee Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.html).
+	// For more information about error messages, see Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.html).
 	ErrorMessage *string `locationName:"errorMessage" type:"string"`
 
 	// The launch templates and overrides that were used for launching the instances.
-	// Any parameters that you specify in the Overrides override the same parameters
-	// in the launch template.
+	// The values that you specify in the Overrides replace the values in the launch
+	// template.
 	LaunchTemplateAndOverrides *LaunchTemplateAndOverridesResponse `locationName:"launchTemplateAndOverrides" type:"structure"`
 
 	// Indicates if the instance that could not be launched was a Spot Instance
@@ -40155,8 +43846,8 @@ func (s *CreateFleetError) SetLifecycle(v string) *CreateFleetError {
 type CreateFleetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Unique, case-sensitive identifier you provide to ensure the idempotency of
-	// the request. For more information, see Ensuring Idempotency (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
+	// Unique, case-sensitive identifier that you provide to ensure the idempotency
+	// of the request. For more information, see Ensuring Idempotency (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	ClientToken *string `type:"string"`
 
 	// Checks whether you have the required permissions for the action, without
@@ -40349,15 +44040,15 @@ type CreateFleetInstance struct {
 	InstanceType *string `locationName:"instanceType" type:"string" enum:"InstanceType"`
 
 	// The launch templates and overrides that were used for launching the instances.
-	// Any parameters that you specify in the Overrides override the same parameters
-	// in the launch template.
+	// The values that you specify in the Overrides replace the values in the launch
+	// template.
 	LaunchTemplateAndOverrides *LaunchTemplateAndOverridesResponse `locationName:"launchTemplateAndOverrides" type:"structure"`
 
 	// Indicates if the instance that was launched is a Spot Instance or On-Demand
 	// Instance.
 	Lifecycle *string `locationName:"lifecycle" type:"string" enum:"InstanceLifecycle"`
 
-	// The value is Windows for Windows instances; otherwise blank.
+	// The value is Windows for Windows instances. Otherwise, the value is blank.
 	Platform *string `locationName:"platform" type:"string" enum:"PlatformValues"`
 }
 
@@ -40470,7 +44161,9 @@ type CreateFlowLogsInput struct {
 	// for LogDestinationType.
 	//
 	// If LogDestinationType is not specified or cloud-watch-logs, specify the Amazon
-	// Resource Name (ARN) of the CloudWatch Logs log group.
+	// Resource Name (ARN) of the CloudWatch Logs log group. For example, to publish
+	// to a log group called my-logs, specify arn:aws:logs:us-east-1:123456789012:log-group:my-logs.
+	// Alternatively, use LogGroupName instead.
 	//
 	// If LogDestinationType is s3, specify the ARN of the Amazon S3 bucket. You
 	// can also specify a subfolder in the bucket. To specify a subfolder in the
@@ -40490,6 +44183,17 @@ type CreateFlowLogsInput struct {
 	//
 	// Default: cloud-watch-logs
 	LogDestinationType *string `type:"string" enum:"LogDestinationType"`
+
+	// The fields to include in the flow log record, in the order in which they
+	// should appear. For a list of available fields, see Flow Log Records (https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-log-records).
+	// If you omit this parameter, the flow log is created using the default format.
+	// If you specify this parameter, you must specify at least one field.
+	//
+	// Specify the fields using the ${field-id} format, separated by spaces. For
+	// the AWS CLI, use single quotation marks (' ') to surround the parameter value.
+	//
+	// Only applicable to flow logs that are published to an Amazon S3 bucket.
+	LogFormat *string `type:"string"`
 
 	// The name of a new or existing CloudWatch Logs log group where Amazon EC2
 	// publishes your flow logs.
@@ -40575,6 +44279,12 @@ func (s *CreateFlowLogsInput) SetLogDestination(v string) *CreateFlowLogsInput {
 // SetLogDestinationType sets the LogDestinationType field's value.
 func (s *CreateFlowLogsInput) SetLogDestinationType(v string) *CreateFlowLogsInput {
 	s.LogDestinationType = &v
+	return s
+}
+
+// SetLogFormat sets the LogFormat field's value.
+func (s *CreateFlowLogsInput) SetLogFormat(v string) *CreateFlowLogsInput {
+	s.LogFormat = &v
 	return s
 }
 
@@ -40671,6 +44381,9 @@ type CreateFpgaImageInput struct {
 
 	// A name for the AFI.
 	Name *string `type:"string"`
+
+	// The tags to apply to the FPGA image during creation.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation
@@ -40729,6 +44442,12 @@ func (s *CreateFpgaImageInput) SetLogsStorageLocation(v *StorageLocation) *Creat
 // SetName sets the Name field's value.
 func (s *CreateFpgaImageInput) SetName(v string) *CreateFpgaImageInput {
 	s.Name = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CreateFpgaImageInput) SetTagSpecifications(v []*TagSpecification) *CreateFpgaImageInput {
+	s.TagSpecifications = v
 	return s
 }
 
@@ -41085,7 +44804,7 @@ type CreateKeyPairOutput struct {
 	KeyFingerprint *string `locationName:"keyFingerprint" type:"string"`
 
 	// An unencrypted PEM encoded RSA private key.
-	KeyMaterial *string `locationName:"keyMaterial" type:"string"`
+	KeyMaterial *string `locationName:"keyMaterial" type:"string" sensitive:"true"`
 
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
@@ -41376,6 +45095,195 @@ func (s CreateLaunchTemplateVersionOutput) GoString() string {
 // SetLaunchTemplateVersion sets the LaunchTemplateVersion field's value.
 func (s *CreateLaunchTemplateVersionOutput) SetLaunchTemplateVersion(v *LaunchTemplateVersion) *CreateLaunchTemplateVersionOutput {
 	s.LaunchTemplateVersion = v
+	return s
+}
+
+type CreateLocalGatewayRouteInput struct {
+	_ struct{} `type:"structure"`
+
+	// The CIDR range used for destination matches. Routing decisions are based
+	// on the most specific match.
+	//
+	// DestinationCidrBlock is a required field
+	DestinationCidrBlock *string `type:"string" required:"true"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the local gateway route table.
+	//
+	// LocalGatewayRouteTableId is a required field
+	LocalGatewayRouteTableId *string `type:"string" required:"true"`
+
+	// The ID of the virtual interface group.
+	//
+	// LocalGatewayVirtualInterfaceGroupId is a required field
+	LocalGatewayVirtualInterfaceGroupId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateLocalGatewayRouteInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLocalGatewayRouteInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLocalGatewayRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLocalGatewayRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.LocalGatewayRouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayRouteTableId"))
+	}
+	if s.LocalGatewayVirtualInterfaceGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayVirtualInterfaceGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *CreateLocalGatewayRouteInput) SetDestinationCidrBlock(v string) *CreateLocalGatewayRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateLocalGatewayRouteInput) SetDryRun(v bool) *CreateLocalGatewayRouteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *CreateLocalGatewayRouteInput) SetLocalGatewayRouteTableId(v string) *CreateLocalGatewayRouteInput {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceGroupId sets the LocalGatewayVirtualInterfaceGroupId field's value.
+func (s *CreateLocalGatewayRouteInput) SetLocalGatewayVirtualInterfaceGroupId(v string) *CreateLocalGatewayRouteInput {
+	s.LocalGatewayVirtualInterfaceGroupId = &v
+	return s
+}
+
+type CreateLocalGatewayRouteOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the route.
+	Route *LocalGatewayRoute `locationName:"route" type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLocalGatewayRouteOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLocalGatewayRouteOutput) GoString() string {
+	return s.String()
+}
+
+// SetRoute sets the Route field's value.
+func (s *CreateLocalGatewayRouteOutput) SetRoute(v *LocalGatewayRoute) *CreateLocalGatewayRouteOutput {
+	s.Route = v
+	return s
+}
+
+type CreateLocalGatewayRouteTableVpcAssociationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the local gateway route table.
+	//
+	// LocalGatewayRouteTableId is a required field
+	LocalGatewayRouteTableId *string `type:"string" required:"true"`
+
+	// The ID of the VPC.
+	//
+	// VpcId is a required field
+	VpcId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateLocalGatewayRouteTableVpcAssociationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLocalGatewayRouteTableVpcAssociationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLocalGatewayRouteTableVpcAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLocalGatewayRouteTableVpcAssociationInput"}
+	if s.LocalGatewayRouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayRouteTableId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateLocalGatewayRouteTableVpcAssociationInput) SetDryRun(v bool) *CreateLocalGatewayRouteTableVpcAssociationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *CreateLocalGatewayRouteTableVpcAssociationInput) SetLocalGatewayRouteTableId(v string) *CreateLocalGatewayRouteTableVpcAssociationInput {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateLocalGatewayRouteTableVpcAssociationInput) SetVpcId(v string) *CreateLocalGatewayRouteTableVpcAssociationInput {
+	s.VpcId = &v
+	return s
+}
+
+type CreateLocalGatewayRouteTableVpcAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the association.
+	LocalGatewayRouteTableVpcAssociation *LocalGatewayRouteTableVpcAssociation `locationName:"localGatewayRouteTableVpcAssociation" type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLocalGatewayRouteTableVpcAssociationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLocalGatewayRouteTableVpcAssociationOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTableVpcAssociation sets the LocalGatewayRouteTableVpcAssociation field's value.
+func (s *CreateLocalGatewayRouteTableVpcAssociationOutput) SetLocalGatewayRouteTableVpcAssociation(v *LocalGatewayRouteTableVpcAssociation) *CreateLocalGatewayRouteTableVpcAssociationOutput {
+	s.LocalGatewayRouteTableVpcAssociation = v
 	return s
 }
 
@@ -42202,6 +46110,9 @@ type CreateRouteInput struct {
 	// an instance ID unless exactly one network interface is attached.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
+	// The ID of the local gateway.
+	LocalGatewayId *string `type:"string"`
+
 	// [IPv4 traffic only] The ID of a NAT gateway.
 	NatGatewayId *string `locationName:"natGatewayId" type:"string"`
 
@@ -42276,6 +46187,12 @@ func (s *CreateRouteInput) SetGatewayId(v string) *CreateRouteInput {
 // SetInstanceId sets the InstanceId field's value.
 func (s *CreateRouteInput) SetInstanceId(v string) *CreateRouteInput {
 	s.InstanceId = &v
+	return s
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *CreateRouteInput) SetLocalGatewayId(v string) *CreateRouteInput {
+	s.LocalGatewayId = &v
 	return s
 }
 
@@ -42513,7 +46430,6 @@ func (s *CreateSecurityGroupOutput) SetGroupId(v string) *CreateSecurityGroupOut
 	return s
 }
 
-// Contains the parameters for CreateSnapshot.
 type CreateSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -42591,9 +46507,10 @@ type CreateSnapshotsInput struct {
 	// A description propagated to every snapshot specified by the instance.
 	Description *string `type:"string"`
 
-	// Checks whether you have the required permissions for the action without actually
-	// making the request. Provides an error response. If you have the required
-	// permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
 	DryRun *bool `type:"boolean"`
 
 	// The instance to specify which volumes should be included in the snapshots.
@@ -42768,13 +46685,18 @@ func (s *CreateSpotDatafeedSubscriptionOutput) SetSpotDatafeedSubscription(v *Sp
 type CreateSubnetInput struct {
 	_ struct{} `type:"structure"`
 
-	// The Availability Zone for the subnet.
+	// The Availability Zone or Local Zone for the subnet.
 	//
 	// Default: AWS selects one for you. If you create more than one subnet in your
-	// VPC, we may not necessarily select a different zone for each subnet.
+	// VPC, we do not necessarily select a different zone for each subnet.
+	//
+	// To create a subnet in a Local Zone, set this value to the Local Zone ID,
+	// for example us-west-2-lax-1a. For information about the Regions that support
+	// Local Zones, see Available Regions (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)
+	// in the Amazon Elastic Compute Cloud User Guide.
 	AvailabilityZone *string `type:"string"`
 
-	// The AZ ID of the subnet.
+	// The AZ ID or the Local Zone ID of the subnet.
 	AvailabilityZoneId *string `type:"string"`
 
 	// The IPv4 network range for the subnet, in CIDR notation. For example, 10.0.0.0/24.
@@ -42791,6 +46713,9 @@ type CreateSubnetInput struct {
 	// The IPv6 network range for the subnet, in CIDR notation. The subnet size
 	// must use a /64 prefix length.
 	Ipv6CidrBlock *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `type:"string"`
 
 	// The ID of the VPC.
 	//
@@ -42851,6 +46776,12 @@ func (s *CreateSubnetInput) SetDryRun(v bool) *CreateSubnetInput {
 // SetIpv6CidrBlock sets the Ipv6CidrBlock field's value.
 func (s *CreateSubnetInput) SetIpv6CidrBlock(v string) *CreateSubnetInput {
 	s.Ipv6CidrBlock = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *CreateSubnetInput) SetOutpostArn(v string) *CreateSubnetInput {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -43281,9 +47212,8 @@ type CreateTrafficMirrorSessionInput struct {
 	// The number of bytes in each packet to mirror. These are bytes after the VXLAN
 	// header. Do not specify this parameter when you want to mirror the entire
 	// packet. To mirror a subset of the packet, set this to the length (in bytes)
-	// that you want to mirror. For example, if you set this value to 1network0,
-	// then the first 100 bytes that meet the filter criteria are copied to the
-	// target.
+	// that you want to mirror. For example, if you set this value to 100, then
+	// the first 100 bytes that meet the filter criteria are copied to the target.
 	//
 	// If you do not want to mirror the entire packet, use the PacketLength parameter
 	// to specify the number of bytes in each packet to mirror.
@@ -43602,6 +47532,88 @@ func (s *CreateTransitGatewayInput) SetTagSpecifications(v []*TagSpecification) 
 	return s
 }
 
+type CreateTransitGatewayMulticastDomainInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The tags for the transit gateway multicast domain.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway.
+	//
+	// TransitGatewayId is a required field
+	TransitGatewayId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTransitGatewayMulticastDomainInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransitGatewayMulticastDomainInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTransitGatewayMulticastDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTransitGatewayMulticastDomainInput"}
+	if s.TransitGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateTransitGatewayMulticastDomainInput) SetDryRun(v bool) *CreateTransitGatewayMulticastDomainInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CreateTransitGatewayMulticastDomainInput) SetTagSpecifications(v []*TagSpecification) *CreateTransitGatewayMulticastDomainInput {
+	s.TagSpecifications = v
+	return s
+}
+
+// SetTransitGatewayId sets the TransitGatewayId field's value.
+func (s *CreateTransitGatewayMulticastDomainInput) SetTransitGatewayId(v string) *CreateTransitGatewayMulticastDomainInput {
+	s.TransitGatewayId = &v
+	return s
+}
+
+type CreateTransitGatewayMulticastDomainOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the transit gateway multicast domain.
+	TransitGatewayMulticastDomain *TransitGatewayMulticastDomain `locationName:"transitGatewayMulticastDomain" type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTransitGatewayMulticastDomainOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransitGatewayMulticastDomainOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayMulticastDomain sets the TransitGatewayMulticastDomain field's value.
+func (s *CreateTransitGatewayMulticastDomainOutput) SetTransitGatewayMulticastDomain(v *TransitGatewayMulticastDomain) *CreateTransitGatewayMulticastDomainOutput {
+	s.TransitGatewayMulticastDomain = v
+	return s
+}
+
 type CreateTransitGatewayOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -43622,6 +47634,130 @@ func (s CreateTransitGatewayOutput) GoString() string {
 // SetTransitGateway sets the TransitGateway field's value.
 func (s *CreateTransitGatewayOutput) SetTransitGateway(v *TransitGateway) *CreateTransitGatewayOutput {
 	s.TransitGateway = v
+	return s
+}
+
+type CreateTransitGatewayPeeringAttachmentInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The AWS account ID of the owner of the peer transit gateway.
+	//
+	// PeerAccountId is a required field
+	PeerAccountId *string `type:"string" required:"true"`
+
+	// The Region where the peer transit gateway is located.
+	//
+	// PeerRegion is a required field
+	PeerRegion *string `type:"string" required:"true"`
+
+	// The ID of the peer transit gateway with which to create the peering attachment.
+	//
+	// PeerTransitGatewayId is a required field
+	PeerTransitGatewayId *string `type:"string" required:"true"`
+
+	// The tags to apply to the transit gateway peering attachment.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway.
+	//
+	// TransitGatewayId is a required field
+	TransitGatewayId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTransitGatewayPeeringAttachmentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransitGatewayPeeringAttachmentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTransitGatewayPeeringAttachmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTransitGatewayPeeringAttachmentInput"}
+	if s.PeerAccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PeerAccountId"))
+	}
+	if s.PeerRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("PeerRegion"))
+	}
+	if s.PeerTransitGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PeerTransitGatewayId"))
+	}
+	if s.TransitGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetDryRun(v bool) *CreateTransitGatewayPeeringAttachmentInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPeerAccountId sets the PeerAccountId field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetPeerAccountId(v string) *CreateTransitGatewayPeeringAttachmentInput {
+	s.PeerAccountId = &v
+	return s
+}
+
+// SetPeerRegion sets the PeerRegion field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetPeerRegion(v string) *CreateTransitGatewayPeeringAttachmentInput {
+	s.PeerRegion = &v
+	return s
+}
+
+// SetPeerTransitGatewayId sets the PeerTransitGatewayId field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetPeerTransitGatewayId(v string) *CreateTransitGatewayPeeringAttachmentInput {
+	s.PeerTransitGatewayId = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetTagSpecifications(v []*TagSpecification) *CreateTransitGatewayPeeringAttachmentInput {
+	s.TagSpecifications = v
+	return s
+}
+
+// SetTransitGatewayId sets the TransitGatewayId field's value.
+func (s *CreateTransitGatewayPeeringAttachmentInput) SetTransitGatewayId(v string) *CreateTransitGatewayPeeringAttachmentInput {
+	s.TransitGatewayId = &v
+	return s
+}
+
+type CreateTransitGatewayPeeringAttachmentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The transit gateway peering attachment.
+	TransitGatewayPeeringAttachment *TransitGatewayPeeringAttachment `locationName:"transitGatewayPeeringAttachment" type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTransitGatewayPeeringAttachmentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransitGatewayPeeringAttachmentOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayPeeringAttachment sets the TransitGatewayPeeringAttachment field's value.
+func (s *CreateTransitGatewayPeeringAttachmentOutput) SetTransitGatewayPeeringAttachment(v *TransitGatewayPeeringAttachment) *CreateTransitGatewayPeeringAttachmentOutput {
+	s.TransitGatewayPeeringAttachment = v
 	return s
 }
 
@@ -43968,7 +48104,6 @@ func (s *CreateTransitGatewayVpcAttachmentRequestOptions) SetIpv6Support(v strin
 	return s
 }
 
-// Contains the parameters for CreateVolume.
 type CreateVolumeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -44023,6 +48158,9 @@ type CreateVolumeInput struct {
 	// alias, or ARN that is not valid, the action can appear to complete, but eventually
 	// fails.
 	KmsKeyId *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `type:"string"`
 
 	// The size of the volume, in GiBs.
 	//
@@ -44102,6 +48240,12 @@ func (s *CreateVolumeInput) SetIops(v int64) *CreateVolumeInput {
 // SetKmsKeyId sets the KmsKeyId field's value.
 func (s *CreateVolumeInput) SetKmsKeyId(v string) *CreateVolumeInput {
 	s.KmsKeyId = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *CreateVolumeInput) SetOutpostArn(v string) *CreateVolumeInput {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -44638,6 +48782,12 @@ type CreateVpcInput struct {
 	//
 	// Default: default
 	InstanceTenancy *string `locationName:"instanceTenancy" type:"string" enum:"Tenancy"`
+
+	// The name of the location from which we advertise the IPV6 CIDR block. Use
+	// this parameter to limit the address to this location.
+	//
+	// You must set AmazonProvidedIpv6CidrBlock to true to use this parameter.
+	Ipv6CidrBlockNetworkBorderGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -44684,6 +48834,12 @@ func (s *CreateVpcInput) SetDryRun(v bool) *CreateVpcInput {
 // SetInstanceTenancy sets the InstanceTenancy field's value.
 func (s *CreateVpcInput) SetInstanceTenancy(v string) *CreateVpcInput {
 	s.InstanceTenancy = &v
+	return s
+}
+
+// SetIpv6CidrBlockNetworkBorderGroup sets the Ipv6CidrBlockNetworkBorderGroup field's value.
+func (s *CreateVpcInput) SetIpv6CidrBlockNetworkBorderGroup(v string) *CreateVpcInput {
+	s.Ipv6CidrBlockNetworkBorderGroup = &v
 	return s
 }
 
@@ -45162,6 +49318,9 @@ type CustomerGateway struct {
 	// The ID of the customer gateway.
 	CustomerGatewayId *string `locationName:"customerGatewayId" type:"string"`
 
+	// The name of customer gateway device.
+	DeviceName *string `locationName:"deviceName" type:"string"`
+
 	// The Internet-routable IP address of the customer gateway's outside interface.
 	IpAddress *string `locationName:"ipAddress" type:"string"`
 
@@ -45201,6 +49360,12 @@ func (s *CustomerGateway) SetCertificateArn(v string) *CustomerGateway {
 // SetCustomerGatewayId sets the CustomerGatewayId field's value.
 func (s *CustomerGateway) SetCustomerGatewayId(v string) *CustomerGateway {
 	s.CustomerGatewayId = &v
+	return s
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *CustomerGateway) SetDeviceName(v string) *CustomerGateway {
+	s.DeviceName = &v
 	return s
 }
 
@@ -46360,6 +50525,166 @@ func (s *DeleteLaunchTemplateVersionsResponseSuccessItem) SetVersionNumber(v int
 	return s
 }
 
+type DeleteLocalGatewayRouteInput struct {
+	_ struct{} `type:"structure"`
+
+	// The CIDR range for the route. This must match the CIDR for the route exactly.
+	//
+	// DestinationCidrBlock is a required field
+	DestinationCidrBlock *string `type:"string" required:"true"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the local gateway route table.
+	//
+	// LocalGatewayRouteTableId is a required field
+	LocalGatewayRouteTableId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteLocalGatewayRouteInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLocalGatewayRouteInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLocalGatewayRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLocalGatewayRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.LocalGatewayRouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayRouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *DeleteLocalGatewayRouteInput) SetDestinationCidrBlock(v string) *DeleteLocalGatewayRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteLocalGatewayRouteInput) SetDryRun(v bool) *DeleteLocalGatewayRouteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *DeleteLocalGatewayRouteInput) SetLocalGatewayRouteTableId(v string) *DeleteLocalGatewayRouteInput {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+type DeleteLocalGatewayRouteOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the route.
+	Route *LocalGatewayRoute `locationName:"route" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLocalGatewayRouteOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLocalGatewayRouteOutput) GoString() string {
+	return s.String()
+}
+
+// SetRoute sets the Route field's value.
+func (s *DeleteLocalGatewayRouteOutput) SetRoute(v *LocalGatewayRoute) *DeleteLocalGatewayRouteOutput {
+	s.Route = v
+	return s
+}
+
+type DeleteLocalGatewayRouteTableVpcAssociationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the association.
+	//
+	// LocalGatewayRouteTableVpcAssociationId is a required field
+	LocalGatewayRouteTableVpcAssociationId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteLocalGatewayRouteTableVpcAssociationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLocalGatewayRouteTableVpcAssociationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLocalGatewayRouteTableVpcAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLocalGatewayRouteTableVpcAssociationInput"}
+	if s.LocalGatewayRouteTableVpcAssociationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayRouteTableVpcAssociationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteLocalGatewayRouteTableVpcAssociationInput) SetDryRun(v bool) *DeleteLocalGatewayRouteTableVpcAssociationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableVpcAssociationId sets the LocalGatewayRouteTableVpcAssociationId field's value.
+func (s *DeleteLocalGatewayRouteTableVpcAssociationInput) SetLocalGatewayRouteTableVpcAssociationId(v string) *DeleteLocalGatewayRouteTableVpcAssociationInput {
+	s.LocalGatewayRouteTableVpcAssociationId = &v
+	return s
+}
+
+type DeleteLocalGatewayRouteTableVpcAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the association.
+	LocalGatewayRouteTableVpcAssociation *LocalGatewayRouteTableVpcAssociation `locationName:"localGatewayRouteTableVpcAssociation" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLocalGatewayRouteTableVpcAssociationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLocalGatewayRouteTableVpcAssociationOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTableVpcAssociation sets the LocalGatewayRouteTableVpcAssociation field's value.
+func (s *DeleteLocalGatewayRouteTableVpcAssociationOutput) SetLocalGatewayRouteTableVpcAssociation(v *LocalGatewayRouteTableVpcAssociation) *DeleteLocalGatewayRouteTableVpcAssociationOutput {
+	s.LocalGatewayRouteTableVpcAssociation = v
+	return s
+}
+
 type DeleteNatGatewayInput struct {
 	_ struct{} `type:"structure"`
 
@@ -46791,6 +51116,125 @@ func (s DeletePlacementGroupOutput) GoString() string {
 	return s.String()
 }
 
+// Describes the error for a Reserved Instance whose queued purchase could not
+// be deleted.
+type DeleteQueuedReservedInstancesError struct {
+	_ struct{} `type:"structure"`
+
+	// The error code.
+	Code *string `locationName:"code" type:"string" enum:"DeleteQueuedReservedInstancesErrorCode"`
+
+	// The error message.
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s DeleteQueuedReservedInstancesError) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteQueuedReservedInstancesError) GoString() string {
+	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *DeleteQueuedReservedInstancesError) SetCode(v string) *DeleteQueuedReservedInstancesError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *DeleteQueuedReservedInstancesError) SetMessage(v string) *DeleteQueuedReservedInstancesError {
+	s.Message = &v
+	return s
+}
+
+type DeleteQueuedReservedInstancesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IDs of the Reserved Instances.
+	//
+	// ReservedInstancesIds is a required field
+	ReservedInstancesIds []*string `locationName:"ReservedInstancesId" locationNameList:"item" min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteQueuedReservedInstancesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteQueuedReservedInstancesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteQueuedReservedInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteQueuedReservedInstancesInput"}
+	if s.ReservedInstancesIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedInstancesIds"))
+	}
+	if s.ReservedInstancesIds != nil && len(s.ReservedInstancesIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ReservedInstancesIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteQueuedReservedInstancesInput) SetDryRun(v bool) *DeleteQueuedReservedInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetReservedInstancesIds sets the ReservedInstancesIds field's value.
+func (s *DeleteQueuedReservedInstancesInput) SetReservedInstancesIds(v []*string) *DeleteQueuedReservedInstancesInput {
+	s.ReservedInstancesIds = v
+	return s
+}
+
+type DeleteQueuedReservedInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the queued purchases that could not be deleted.
+	FailedQueuedPurchaseDeletions []*FailedQueuedPurchaseDeletion `locationName:"failedQueuedPurchaseDeletionSet" locationNameList:"item" type:"list"`
+
+	// Information about the queued purchases that were successfully deleted.
+	SuccessfulQueuedPurchaseDeletions []*SuccessfulQueuedPurchaseDeletion `locationName:"successfulQueuedPurchaseDeletionSet" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DeleteQueuedReservedInstancesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteQueuedReservedInstancesOutput) GoString() string {
+	return s.String()
+}
+
+// SetFailedQueuedPurchaseDeletions sets the FailedQueuedPurchaseDeletions field's value.
+func (s *DeleteQueuedReservedInstancesOutput) SetFailedQueuedPurchaseDeletions(v []*FailedQueuedPurchaseDeletion) *DeleteQueuedReservedInstancesOutput {
+	s.FailedQueuedPurchaseDeletions = v
+	return s
+}
+
+// SetSuccessfulQueuedPurchaseDeletions sets the SuccessfulQueuedPurchaseDeletions field's value.
+func (s *DeleteQueuedReservedInstancesOutput) SetSuccessfulQueuedPurchaseDeletions(v []*SuccessfulQueuedPurchaseDeletion) *DeleteQueuedReservedInstancesOutput {
+	s.SuccessfulQueuedPurchaseDeletions = v
+	return s
+}
+
 type DeleteRouteInput struct {
 	_ struct{} `type:"structure"`
 
@@ -46998,7 +51442,6 @@ func (s DeleteSecurityGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteSnapshot.
 type DeleteSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -47593,6 +52036,79 @@ func (s *DeleteTransitGatewayInput) SetTransitGatewayId(v string) *DeleteTransit
 	return s
 }
 
+type DeleteTransitGatewayMulticastDomainInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the transit gateway multicast domain.
+	//
+	// TransitGatewayMulticastDomainId is a required field
+	TransitGatewayMulticastDomainId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteTransitGatewayMulticastDomainInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTransitGatewayMulticastDomainInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTransitGatewayMulticastDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTransitGatewayMulticastDomainInput"}
+	if s.TransitGatewayMulticastDomainId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayMulticastDomainId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteTransitGatewayMulticastDomainInput) SetDryRun(v bool) *DeleteTransitGatewayMulticastDomainInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *DeleteTransitGatewayMulticastDomainInput) SetTransitGatewayMulticastDomainId(v string) *DeleteTransitGatewayMulticastDomainInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type DeleteTransitGatewayMulticastDomainOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the deleted transit gateway multicast domain.
+	TransitGatewayMulticastDomain *TransitGatewayMulticastDomain `locationName:"transitGatewayMulticastDomain" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTransitGatewayMulticastDomainOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTransitGatewayMulticastDomainOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayMulticastDomain sets the TransitGatewayMulticastDomain field's value.
+func (s *DeleteTransitGatewayMulticastDomainOutput) SetTransitGatewayMulticastDomain(v *TransitGatewayMulticastDomain) *DeleteTransitGatewayMulticastDomainOutput {
+	s.TransitGatewayMulticastDomain = v
+	return s
+}
+
 type DeleteTransitGatewayOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -47613,6 +52129,79 @@ func (s DeleteTransitGatewayOutput) GoString() string {
 // SetTransitGateway sets the TransitGateway field's value.
 func (s *DeleteTransitGatewayOutput) SetTransitGateway(v *TransitGateway) *DeleteTransitGatewayOutput {
 	s.TransitGateway = v
+	return s
+}
+
+type DeleteTransitGatewayPeeringAttachmentInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the transit gateway peering attachment.
+	//
+	// TransitGatewayAttachmentId is a required field
+	TransitGatewayAttachmentId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteTransitGatewayPeeringAttachmentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTransitGatewayPeeringAttachmentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTransitGatewayPeeringAttachmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTransitGatewayPeeringAttachmentInput"}
+	if s.TransitGatewayAttachmentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayAttachmentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteTransitGatewayPeeringAttachmentInput) SetDryRun(v bool) *DeleteTransitGatewayPeeringAttachmentInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *DeleteTransitGatewayPeeringAttachmentInput) SetTransitGatewayAttachmentId(v string) *DeleteTransitGatewayPeeringAttachmentInput {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+type DeleteTransitGatewayPeeringAttachmentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The transit gateway peering attachment.
+	TransitGatewayPeeringAttachment *TransitGatewayPeeringAttachment `locationName:"transitGatewayPeeringAttachment" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTransitGatewayPeeringAttachmentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTransitGatewayPeeringAttachmentOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayPeeringAttachment sets the TransitGatewayPeeringAttachment field's value.
+func (s *DeleteTransitGatewayPeeringAttachmentOutput) SetTransitGatewayPeeringAttachment(v *TransitGatewayPeeringAttachment) *DeleteTransitGatewayPeeringAttachmentOutput {
+	s.TransitGatewayPeeringAttachment = v
 	return s
 }
 
@@ -47849,7 +52438,6 @@ func (s *DeleteTransitGatewayVpcAttachmentOutput) SetTransitGatewayVpcAttachment
 	return s
 }
 
-// Contains the parameters for DeleteVolume.
 type DeleteVolumeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -48608,6 +53196,158 @@ func (s DeregisterImageOutput) GoString() string {
 	return s.String()
 }
 
+type DeregisterTransitGatewayMulticastGroupMembersInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `type:"string"`
+
+	// The IDs of the group members' network interfaces.
+	NetworkInterfaceIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupMembersInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupMembersInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeregisterTransitGatewayMulticastGroupMembersInput) SetDryRun(v bool) *DeregisterTransitGatewayMulticastGroupMembersInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *DeregisterTransitGatewayMulticastGroupMembersInput) SetGroupIpAddress(v string) *DeregisterTransitGatewayMulticastGroupMembersInput {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceIds sets the NetworkInterfaceIds field's value.
+func (s *DeregisterTransitGatewayMulticastGroupMembersInput) SetNetworkInterfaceIds(v []*string) *DeregisterTransitGatewayMulticastGroupMembersInput {
+	s.NetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *DeregisterTransitGatewayMulticastGroupMembersInput) SetTransitGatewayMulticastDomainId(v string) *DeregisterTransitGatewayMulticastGroupMembersInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type DeregisterTransitGatewayMulticastGroupMembersOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the deregistered members.
+	DeregisteredMulticastGroupMembers *TransitGatewayMulticastDeregisteredGroupMembers `locationName:"deregisteredMulticastGroupMembers" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupMembersOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupMembersOutput) GoString() string {
+	return s.String()
+}
+
+// SetDeregisteredMulticastGroupMembers sets the DeregisteredMulticastGroupMembers field's value.
+func (s *DeregisterTransitGatewayMulticastGroupMembersOutput) SetDeregisteredMulticastGroupMembers(v *TransitGatewayMulticastDeregisteredGroupMembers) *DeregisterTransitGatewayMulticastGroupMembersOutput {
+	s.DeregisteredMulticastGroupMembers = v
+	return s
+}
+
+type DeregisterTransitGatewayMulticastGroupSourcesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `type:"string"`
+
+	// The IDs of the group sources' network interfaces.
+	NetworkInterfaceIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupSourcesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupSourcesInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeregisterTransitGatewayMulticastGroupSourcesInput) SetDryRun(v bool) *DeregisterTransitGatewayMulticastGroupSourcesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *DeregisterTransitGatewayMulticastGroupSourcesInput) SetGroupIpAddress(v string) *DeregisterTransitGatewayMulticastGroupSourcesInput {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceIds sets the NetworkInterfaceIds field's value.
+func (s *DeregisterTransitGatewayMulticastGroupSourcesInput) SetNetworkInterfaceIds(v []*string) *DeregisterTransitGatewayMulticastGroupSourcesInput {
+	s.NetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *DeregisterTransitGatewayMulticastGroupSourcesInput) SetTransitGatewayMulticastDomainId(v string) *DeregisterTransitGatewayMulticastGroupSourcesInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type DeregisterTransitGatewayMulticastGroupSourcesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the deregistered group sources.
+	DeregisteredMulticastGroupSources *TransitGatewayMulticastDeregisteredGroupSources `locationName:"deregisteredMulticastGroupSources" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupSourcesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTransitGatewayMulticastGroupSourcesOutput) GoString() string {
+	return s.String()
+}
+
+// SetDeregisteredMulticastGroupSources sets the DeregisteredMulticastGroupSources field's value.
+func (s *DeregisterTransitGatewayMulticastGroupSourcesOutput) SetDeregisteredMulticastGroupSources(v *TransitGatewayMulticastDeregisteredGroupSources) *DeregisterTransitGatewayMulticastGroupSourcesOutput {
+	s.DeregisteredMulticastGroupSources = v
+	return s
+}
+
 type DescribeAccountAttributesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -48837,6 +53577,13 @@ func (s *DescribeAggregateIdFormatOutput) SetUseLongIdsAggregated(v bool) *Descr
 type DescribeAvailabilityZonesInput struct {
 	_ struct{} `type:"structure"`
 
+	// Include all Availability Zones and Local Zones regardless of your opt in
+	// status.
+	//
+	// If you do not use this parameter, the results include only the zones for
+	// the Regions where you have chosen the option to opt in.
+	AllAvailabilityZones *bool `type:"boolean"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -48845,23 +53592,31 @@ type DescribeAvailabilityZonesInput struct {
 
 	// The filters.
 	//
-	//    * message - Information about the Availability Zone.
+	//    * group-name - For Availability Zones, use the Region name. For Local
+	//    Zones, use the name of the group associated with the Local Zone (for example,
+	//    us-west-2-lax-1).
 	//
-	//    * region-name - The name of the Region for the Availability Zone (for
-	//    example, us-east-1).
+	//    * message - The Availability Zone or Local Zone message.
 	//
-	//    * state - The state of the Availability Zone (available | information
-	//    | impaired | unavailable).
+	//    * opt-in-status - The opt in status (opted-in, and not-opted-in | opt-in-not-required).
 	//
-	//    * zone-id - The ID of the Availability Zone (for example, use1-az1).
+	//    * region-name - The name of the Region for the Availability Zone or Local
+	//    Zone (for example, us-east-1).
 	//
-	//    * zone-name - The name of the Availability Zone (for example, us-east-1a).
+	//    * state - The state of the Availability Zone or Local Zone (available
+	//    | information | impaired | unavailable).
+	//
+	//    * zone-id - The ID of the Availability Zone (for example, use1-az1) or
+	//    the Local Zone (for example, use usw2-lax1-az1).
+	//
+	//    * zone-name - The name of the Availability Zone (for example, us-east-1a)
+	//    or the Local Zone (for example, use us-west-2-lax-1a).
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	// The IDs of the Availability Zones.
+	// The IDs of the Availability Zones and Local Zones.
 	ZoneIds []*string `locationName:"ZoneId" locationNameList:"ZoneId" type:"list"`
 
-	// The names of the Availability Zones.
+	// The names of the Availability Zones and Local Zones.
 	ZoneNames []*string `locationName:"ZoneName" locationNameList:"ZoneName" type:"list"`
 }
 
@@ -48873,6 +53628,12 @@ func (s DescribeAvailabilityZonesInput) String() string {
 // GoString returns the string representation
 func (s DescribeAvailabilityZonesInput) GoString() string {
 	return s.String()
+}
+
+// SetAllAvailabilityZones sets the AllAvailabilityZones field's value.
+func (s *DescribeAvailabilityZonesInput) SetAllAvailabilityZones(v bool) *DescribeAvailabilityZonesInput {
+	s.AllAvailabilityZones = &v
+	return s
 }
 
 // SetDryRun sets the DryRun field's value.
@@ -48902,7 +53663,7 @@ func (s *DescribeAvailabilityZonesInput) SetZoneNames(v []*string) *DescribeAvai
 type DescribeAvailabilityZonesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Information about the Availability Zones.
+	// Information about the Availability Zones and Local Zones.
 	AvailabilityZones []*AvailabilityZone `locationName:"availabilityZoneInfo" locationNameList:"item" type:"list"`
 }
 
@@ -49927,6 +54688,119 @@ func (s *DescribeClientVpnTargetNetworksOutput) SetNextToken(v string) *Describe
 	return s
 }
 
+type DescribeCoipPoolsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The filters. The following are the possible values:
+	//
+	//    * coip-pool.pool-id
+	//
+	//    * coip-pool.local-gateway-route-table-id
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// The IDs of the address pools.
+	PoolIds []*string `locationName:"PoolId" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeCoipPoolsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCoipPoolsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCoipPoolsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCoipPoolsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeCoipPoolsInput) SetDryRun(v bool) *DescribeCoipPoolsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeCoipPoolsInput) SetFilters(v []*Filter) *DescribeCoipPoolsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeCoipPoolsInput) SetMaxResults(v int64) *DescribeCoipPoolsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCoipPoolsInput) SetNextToken(v string) *DescribeCoipPoolsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPoolIds sets the PoolIds field's value.
+func (s *DescribeCoipPoolsInput) SetPoolIds(v []*string) *DescribeCoipPoolsInput {
+	s.PoolIds = v
+	return s
+}
+
+type DescribeCoipPoolsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the address pools.
+	CoipPools []*CoipPool `locationName:"coipPoolSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeCoipPoolsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCoipPoolsOutput) GoString() string {
+	return s.String()
+}
+
+// SetCoipPools sets the CoipPools field's value.
+func (s *DescribeCoipPoolsOutput) SetCoipPools(v []*CoipPool) *DescribeCoipPoolsOutput {
+	s.CoipPools = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCoipPoolsOutput) SetNextToken(v string) *DescribeCoipPoolsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeConversionTasksInput struct {
 	_ struct{} `type:"structure"`
 
@@ -50599,6 +55473,222 @@ func (s *DescribeExportTasksOutput) SetExportTasks(v []*ExportTask) *DescribeExp
 	return s
 }
 
+// Describes fast snapshot restores for a snapshot.
+type DescribeFastSnapshotRestoreSuccessItem struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The time at which fast snapshot restores entered the disabled state.
+	DisabledTime *time.Time `locationName:"disabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the disabling state.
+	DisablingTime *time.Time `locationName:"disablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabled state.
+	EnabledTime *time.Time `locationName:"enabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabling state.
+	EnablingTime *time.Time `locationName:"enablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the optimizing state.
+	OptimizingTime *time.Time `locationName:"optimizingTime" type:"timestamp"`
+
+	// The alias of the snapshot owner.
+	OwnerAlias *string `locationName:"ownerAlias" type:"string"`
+
+	// The ID of the AWS account that owns the snapshot.
+	OwnerId *string `locationName:"ownerId" type:"string"`
+
+	// The ID of the snapshot.
+	SnapshotId *string `locationName:"snapshotId" type:"string"`
+
+	// The state of fast snapshot restores.
+	State *string `locationName:"state" type:"string" enum:"FastSnapshotRestoreStateCode"`
+
+	// The reason for the state transition. The possible values are as follows:
+	//
+	//    * Client.UserInitiated - The state successfully transitioned to enabling
+	//    or disabling.
+	//
+	//    * Client.UserInitiated - Lifecycle state transition - The state successfully
+	//    transitioned to optimizing, enabled, or disabled.
+	StateTransitionReason *string `locationName:"stateTransitionReason" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeFastSnapshotRestoreSuccessItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFastSnapshotRestoreSuccessItem) GoString() string {
+	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetAvailabilityZone(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDisabledTime sets the DisabledTime field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetDisabledTime(v time.Time) *DescribeFastSnapshotRestoreSuccessItem {
+	s.DisabledTime = &v
+	return s
+}
+
+// SetDisablingTime sets the DisablingTime field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetDisablingTime(v time.Time) *DescribeFastSnapshotRestoreSuccessItem {
+	s.DisablingTime = &v
+	return s
+}
+
+// SetEnabledTime sets the EnabledTime field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetEnabledTime(v time.Time) *DescribeFastSnapshotRestoreSuccessItem {
+	s.EnabledTime = &v
+	return s
+}
+
+// SetEnablingTime sets the EnablingTime field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetEnablingTime(v time.Time) *DescribeFastSnapshotRestoreSuccessItem {
+	s.EnablingTime = &v
+	return s
+}
+
+// SetOptimizingTime sets the OptimizingTime field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetOptimizingTime(v time.Time) *DescribeFastSnapshotRestoreSuccessItem {
+	s.OptimizingTime = &v
+	return s
+}
+
+// SetOwnerAlias sets the OwnerAlias field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetOwnerAlias(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.OwnerAlias = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetOwnerId(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.OwnerId = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetSnapshotId(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetState(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.State = &v
+	return s
+}
+
+// SetStateTransitionReason sets the StateTransitionReason field's value.
+func (s *DescribeFastSnapshotRestoreSuccessItem) SetStateTransitionReason(v string) *DescribeFastSnapshotRestoreSuccessItem {
+	s.StateTransitionReason = &v
+	return s
+}
+
+type DescribeFastSnapshotRestoresInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The filters. The possible values are:
+	//
+	//    * availability-zone: The Availability Zone of the snapshot.
+	//
+	//    * owner-id: The ID of the AWS account that owns the snapshot.
+	//
+	//    * snapshot-id: The ID of the snapshot.
+	//
+	//    * state: The state of fast snapshot restores for the snapshot (enabling
+	//    | optimizing | enabled | disabling | disabled).
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeFastSnapshotRestoresInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFastSnapshotRestoresInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeFastSnapshotRestoresInput) SetDryRun(v bool) *DescribeFastSnapshotRestoresInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeFastSnapshotRestoresInput) SetFilters(v []*Filter) *DescribeFastSnapshotRestoresInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeFastSnapshotRestoresInput) SetMaxResults(v int64) *DescribeFastSnapshotRestoresInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFastSnapshotRestoresInput) SetNextToken(v string) *DescribeFastSnapshotRestoresInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeFastSnapshotRestoresOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the state of fast snapshot restores.
+	FastSnapshotRestores []*DescribeFastSnapshotRestoreSuccessItem `locationName:"fastSnapshotRestoreSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeFastSnapshotRestoresOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFastSnapshotRestoresOutput) GoString() string {
+	return s.String()
+}
+
+// SetFastSnapshotRestores sets the FastSnapshotRestores field's value.
+func (s *DescribeFastSnapshotRestoresOutput) SetFastSnapshotRestores(v []*DescribeFastSnapshotRestoreSuccessItem) *DescribeFastSnapshotRestoresOutput {
+	s.FastSnapshotRestores = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFastSnapshotRestoresOutput) SetNextToken(v string) *DescribeFastSnapshotRestoresOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Describes the instances that could not be launched by the fleet.
 type DescribeFleetError struct {
 	_ struct{} `type:"structure"`
@@ -50608,12 +55698,12 @@ type DescribeFleetError struct {
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 
 	// The error message that describes why the instance could not be launched.
-	// For more information about error messages, see ee Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.html).
+	// For more information about error messages, see Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.html).
 	ErrorMessage *string `locationName:"errorMessage" type:"string"`
 
 	// The launch templates and overrides that were used for launching the instances.
-	// Any parameters that you specify in the Overrides override the same parameters
-	// in the launch template.
+	// The values that you specify in the Overrides replace the values in the launch
+	// template.
 	LaunchTemplateAndOverrides *LaunchTemplateAndOverridesResponse `locationName:"launchTemplateAndOverrides" type:"structure"`
 
 	// Indicates if the instance that could not be launched was a Spot Instance
@@ -51023,15 +56113,15 @@ type DescribeFleetsInstances struct {
 	InstanceType *string `locationName:"instanceType" type:"string" enum:"InstanceType"`
 
 	// The launch templates and overrides that were used for launching the instances.
-	// Any parameters that you specify in the Overrides override the same parameters
-	// in the launch template.
+	// The values that you specify in the Overrides replace the values in the launch
+	// template.
 	LaunchTemplateAndOverrides *LaunchTemplateAndOverridesResponse `locationName:"launchTemplateAndOverrides" type:"structure"`
 
 	// Indicates if the instance that was launched is a Spot Instance or On-Demand
 	// Instance.
 	Lifecycle *string `locationName:"lifecycle" type:"string" enum:"InstanceLifecycle"`
 
-	// The value is Windows for Windows instances; otherwise blank.
+	// The value is Windows for Windows instances. Otherwise, the value is blank.
 	Platform *string `locationName:"platform" type:"string" enum:"PlatformValues"`
 }
 
@@ -53039,6 +58129,305 @@ func (s *DescribeInstanceStatusOutput) SetNextToken(v string) *DescribeInstanceS
 	return s
 }
 
+type DescribeInstanceTypeOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters. Filter names and values are case-sensitive.
+	//
+	//    * location - This depends on the location type. For example, if the location
+	//    type is region (default), the location is the Region code (for example,
+	//    us-east-2.)
+	//
+	//    * instance-type - The instance type.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The location type.
+	LocationType *string `type:"string" enum:"LocationType"`
+
+	// The maximum number of results to return for the request in a single page.
+	// The remaining results can be seen by sending another request with the next
+	// token value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token to retrieve the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceTypeOfferingsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceTypeOfferingsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstanceTypeOfferingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstanceTypeOfferingsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstanceTypeOfferingsInput) SetDryRun(v bool) *DescribeInstanceTypeOfferingsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInstanceTypeOfferingsInput) SetFilters(v []*Filter) *DescribeInstanceTypeOfferingsInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocationType sets the LocationType field's value.
+func (s *DescribeInstanceTypeOfferingsInput) SetLocationType(v string) *DescribeInstanceTypeOfferingsInput {
+	s.LocationType = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstanceTypeOfferingsInput) SetMaxResults(v int64) *DescribeInstanceTypeOfferingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceTypeOfferingsInput) SetNextToken(v string) *DescribeInstanceTypeOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeInstanceTypeOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The instance types offered.
+	InstanceTypeOfferings []*InstanceTypeOffering `locationName:"instanceTypeOfferingSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceTypeOfferingsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceTypeOfferingsOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceTypeOfferings sets the InstanceTypeOfferings field's value.
+func (s *DescribeInstanceTypeOfferingsOutput) SetInstanceTypeOfferings(v []*InstanceTypeOffering) *DescribeInstanceTypeOfferingsOutput {
+	s.InstanceTypeOfferings = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceTypeOfferingsOutput) SetNextToken(v string) *DescribeInstanceTypeOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeInstanceTypesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters. Filter names and values are case-sensitive.
+	//
+	//    * auto-recovery-supported - Indicates whether auto recovery is supported.
+	//    (true | false)
+	//
+	//    * bare-metal - Indicates whether it is a bare metal instance type. (true
+	//    | false)
+	//
+	//    * burstable-performance-supported - Indicates whether it is a burstable
+	//    performance instance type. (true | false)
+	//
+	//    * current-generation - Indicates whether this instance type is the latest
+	//    generation instance type of an instance family. (true | false)
+	//
+	//    * ebs-info.ebs-optimized-support - Indicates whether the instance type
+	//    is EBS-optimized. (true | false)
+	//
+	//    * ebs-info.encryption-support - Indicates whether EBS encryption is supported.
+	//    (true | false)
+	//
+	//    * free-tier-eligible - Indicates whether the instance type is eligible
+	//    to use in the free tier. (true | false)
+	//
+	//    * hibernation-supported - Indicates whether On-Demand hibernation is supported.
+	//    (true | false)
+	//
+	//    * hypervisor - The hypervisor used. (nitro | xen)
+	//
+	//    * instance-storage-info.disk.count - The number of local disks.
+	//
+	//    * instance-storage-info.disk.size-in-gb - The storage size of each instance
+	//    storage disk, in GB.
+	//
+	//    * instance-storage-info.disk.type - The storage technology for the local
+	//    instance storage disks. (hdd | ssd)
+	//
+	//    * instance-storage-info.total-size-in-gb - The total amount of storage
+	//    available from all local instance storage, in GB.
+	//
+	//    * instance-storage-supported - Indicates whether the instance type has
+	//    local instance storage. (true | false)
+	//
+	//    * memory-info.size-in-mib - The memory size.
+	//
+	//    * network-info.ena-support - Indicates whether Elastic Network Adapter
+	//    (ENA) is supported or required. (required | supported | unsupported)
+	//
+	//    * network-info.ipv4-addresses-per-interface - The maximum number of private
+	//    IPv4 addresses per network interface.
+	//
+	//    * network-info.ipv6-addresses-per-interface - The maximum number of private
+	//    IPv6 addresses per network interface.
+	//
+	//    * network-info.ipv6-supported - Indicates whether the instance type supports
+	//    IPv6. (true | false)
+	//
+	//    * network-info.maximum-network-interfaces - The maximum number of network
+	//    interfaces per instance.
+	//
+	//    * network-info.network-performance - Describes the network performance.
+	//
+	//    * processor-info.sustained-clock-speed-in-ghz - The CPU clock speed, in
+	//    GHz.
+	//
+	//    * vcpu-info.default-cores - The default number of cores for the instance
+	//    type.
+	//
+	//    * vcpu-info.default-threads-per-core - The default number of threads per
+	//    cores for the instance type.
+	//
+	//    * vcpu-info.default-vcpus - The default number of vCPUs for the instance
+	//    type.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The instance types. For more information, see Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+	// in the Amazon Elastic Compute Cloud User Guide.
+	InstanceTypes []*string `locationName:"InstanceType" type:"list"`
+
+	// The maximum number of results to return for the request in a single page.
+	// The remaining results can be seen by sending another request with the next
+	// token value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token to retrieve the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceTypesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceTypesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstanceTypesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstanceTypesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstanceTypesInput) SetDryRun(v bool) *DescribeInstanceTypesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInstanceTypesInput) SetFilters(v []*Filter) *DescribeInstanceTypesInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceTypes sets the InstanceTypes field's value.
+func (s *DescribeInstanceTypesInput) SetInstanceTypes(v []*string) *DescribeInstanceTypesInput {
+	s.InstanceTypes = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstanceTypesInput) SetMaxResults(v int64) *DescribeInstanceTypesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceTypesInput) SetNextToken(v string) *DescribeInstanceTypesInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeInstanceTypesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The instance type. For more information, see Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+	// in the Amazon Elastic Compute Cloud User Guide.
+	InstanceTypes []*InstanceTypeInfo `locationName:"instanceTypeSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceTypesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceTypesOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceTypes sets the InstanceTypes field's value.
+func (s *DescribeInstanceTypesOutput) SetInstanceTypes(v []*InstanceTypeInfo) *DescribeInstanceTypesOutput {
+	s.InstanceTypes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceTypesOutput) SetNextToken(v string) *DescribeInstanceTypesOutput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeInstancesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -53126,6 +58515,15 @@ type DescribeInstancesInput struct {
 	//    for the instance in the launch group (for example, 0, 1, 2, and so on).
 	//
 	//    * launch-time - The time when the instance was launched.
+	//
+	//    * metadata-options.http-tokens - The metadata request authorization state
+	//    (optional | required)
+	//
+	//    * metadata-options.http-put-response-hop-limit - The http metadata request
+	//    put response hop limit (integer, possible values 1 to 64)
+	//
+	//    * metadata-options.http-endpoint - Enable or disable metadata access on
+	//    http endpoint (enabled | disabled)
 	//
 	//    * monitoring-state - Indicates whether detailed monitoring is enabled
 	//    (disabled | enabled).
@@ -53873,6 +59271,660 @@ func (s *DescribeLaunchTemplatesOutput) SetLaunchTemplates(v []*LaunchTemplate) 
 
 // SetNextToken sets the NextToken field's value.
 func (s *DescribeLaunchTemplatesOutput) SetNextToken(v string) *DescribeLaunchTemplatesOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the associations.
+	LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds []*string `locationName:"LocalGatewayRouteTableVirtualInterfaceGroupAssociationId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) SetDryRun(v bool) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) SetFilters(v []*Filter) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayRouteTableVirtualInterfaceGroupAssociationIds sets the LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) SetLocalGatewayRouteTableVirtualInterfaceGroupAssociationIds(v []*string) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput {
+	s.LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) SetMaxResults(v int64) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) SetNextToken(v string) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the associations.
+	LocalGatewayRouteTableVirtualInterfaceGroupAssociations []*LocalGatewayRouteTableVirtualInterfaceGroupAssociation `locationName:"localGatewayRouteTableVirtualInterfaceGroupAssociationSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTableVirtualInterfaceGroupAssociations sets the LocalGatewayRouteTableVirtualInterfaceGroupAssociations field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) SetLocalGatewayRouteTableVirtualInterfaceGroupAssociations(v []*LocalGatewayRouteTableVirtualInterfaceGroupAssociation) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput {
+	s.LocalGatewayRouteTableVirtualInterfaceGroupAssociations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) SetNextToken(v string) *DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTableVpcAssociationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the associations.
+	LocalGatewayRouteTableVpcAssociationIds []*string `locationName:"LocalGatewayRouteTableVpcAssociationId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTableVpcAssociationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTableVpcAssociationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewayRouteTableVpcAssociationsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) SetDryRun(v bool) *DescribeLocalGatewayRouteTableVpcAssociationsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) SetFilters(v []*Filter) *DescribeLocalGatewayRouteTableVpcAssociationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayRouteTableVpcAssociationIds sets the LocalGatewayRouteTableVpcAssociationIds field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) SetLocalGatewayRouteTableVpcAssociationIds(v []*string) *DescribeLocalGatewayRouteTableVpcAssociationsInput {
+	s.LocalGatewayRouteTableVpcAssociationIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) SetMaxResults(v int64) *DescribeLocalGatewayRouteTableVpcAssociationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsInput) SetNextToken(v string) *DescribeLocalGatewayRouteTableVpcAssociationsInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTableVpcAssociationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the associations.
+	LocalGatewayRouteTableVpcAssociations []*LocalGatewayRouteTableVpcAssociation `locationName:"localGatewayRouteTableVpcAssociationSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTableVpcAssociationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTableVpcAssociationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTableVpcAssociations sets the LocalGatewayRouteTableVpcAssociations field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsOutput) SetLocalGatewayRouteTableVpcAssociations(v []*LocalGatewayRouteTableVpcAssociation) *DescribeLocalGatewayRouteTableVpcAssociationsOutput {
+	s.LocalGatewayRouteTableVpcAssociations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTableVpcAssociationsOutput) SetNextToken(v string) *DescribeLocalGatewayRouteTableVpcAssociationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTablesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the local gateway route tables.
+	LocalGatewayRouteTableIds []*string `locationName:"LocalGatewayRouteTableId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTablesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTablesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewayRouteTablesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewayRouteTablesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewayRouteTablesInput) SetDryRun(v bool) *DescribeLocalGatewayRouteTablesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewayRouteTablesInput) SetFilters(v []*Filter) *DescribeLocalGatewayRouteTablesInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayRouteTableIds sets the LocalGatewayRouteTableIds field's value.
+func (s *DescribeLocalGatewayRouteTablesInput) SetLocalGatewayRouteTableIds(v []*string) *DescribeLocalGatewayRouteTablesInput {
+	s.LocalGatewayRouteTableIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewayRouteTablesInput) SetMaxResults(v int64) *DescribeLocalGatewayRouteTablesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTablesInput) SetNextToken(v string) *DescribeLocalGatewayRouteTablesInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayRouteTablesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the local gateway route tables.
+	LocalGatewayRouteTables []*LocalGatewayRouteTable `locationName:"localGatewayRouteTableSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayRouteTablesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayRouteTablesOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayRouteTables sets the LocalGatewayRouteTables field's value.
+func (s *DescribeLocalGatewayRouteTablesOutput) SetLocalGatewayRouteTables(v []*LocalGatewayRouteTable) *DescribeLocalGatewayRouteTablesOutput {
+	s.LocalGatewayRouteTables = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayRouteTablesOutput) SetNextToken(v string) *DescribeLocalGatewayRouteTablesOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayVirtualInterfaceGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the virtual interface groups.
+	LocalGatewayVirtualInterfaceGroupIds []*string `locationName:"LocalGatewayVirtualInterfaceGroupId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayVirtualInterfaceGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayVirtualInterfaceGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewayVirtualInterfaceGroupsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) SetDryRun(v bool) *DescribeLocalGatewayVirtualInterfaceGroupsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) SetFilters(v []*Filter) *DescribeLocalGatewayVirtualInterfaceGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceGroupIds sets the LocalGatewayVirtualInterfaceGroupIds field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) SetLocalGatewayVirtualInterfaceGroupIds(v []*string) *DescribeLocalGatewayVirtualInterfaceGroupsInput {
+	s.LocalGatewayVirtualInterfaceGroupIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) SetMaxResults(v int64) *DescribeLocalGatewayVirtualInterfaceGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsInput) SetNextToken(v string) *DescribeLocalGatewayVirtualInterfaceGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayVirtualInterfaceGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The virtual interface groups.
+	LocalGatewayVirtualInterfaceGroups []*LocalGatewayVirtualInterfaceGroup `locationName:"localGatewayVirtualInterfaceGroupSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayVirtualInterfaceGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayVirtualInterfaceGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayVirtualInterfaceGroups sets the LocalGatewayVirtualInterfaceGroups field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsOutput) SetLocalGatewayVirtualInterfaceGroups(v []*LocalGatewayVirtualInterfaceGroup) *DescribeLocalGatewayVirtualInterfaceGroupsOutput {
+	s.LocalGatewayVirtualInterfaceGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayVirtualInterfaceGroupsOutput) SetNextToken(v string) *DescribeLocalGatewayVirtualInterfaceGroupsOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayVirtualInterfacesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the virtual interfaces.
+	LocalGatewayVirtualInterfaceIds []*string `locationName:"LocalGatewayVirtualInterfaceId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayVirtualInterfacesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayVirtualInterfacesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewayVirtualInterfacesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) SetDryRun(v bool) *DescribeLocalGatewayVirtualInterfacesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) SetFilters(v []*Filter) *DescribeLocalGatewayVirtualInterfacesInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceIds sets the LocalGatewayVirtualInterfaceIds field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) SetLocalGatewayVirtualInterfaceIds(v []*string) *DescribeLocalGatewayVirtualInterfacesInput {
+	s.LocalGatewayVirtualInterfaceIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) SetMaxResults(v int64) *DescribeLocalGatewayVirtualInterfacesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesInput) SetNextToken(v string) *DescribeLocalGatewayVirtualInterfacesInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewayVirtualInterfacesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the virtual interfaces.
+	LocalGatewayVirtualInterfaces []*LocalGatewayVirtualInterface `locationName:"localGatewayVirtualInterfaceSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewayVirtualInterfacesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewayVirtualInterfacesOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayVirtualInterfaces sets the LocalGatewayVirtualInterfaces field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesOutput) SetLocalGatewayVirtualInterfaces(v []*LocalGatewayVirtualInterface) *DescribeLocalGatewayVirtualInterfacesOutput {
+	s.LocalGatewayVirtualInterfaces = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewayVirtualInterfacesOutput) SetNextToken(v string) *DescribeLocalGatewayVirtualInterfacesOutput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewaysInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The IDs of the local gateways.
+	LocalGatewayIds []*string `locationName:"LocalGatewayId" locationNameList:"item" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewaysInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewaysInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLocalGatewaysInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLocalGatewaysInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeLocalGatewaysInput) SetDryRun(v bool) *DescribeLocalGatewaysInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeLocalGatewaysInput) SetFilters(v []*Filter) *DescribeLocalGatewaysInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayIds sets the LocalGatewayIds field's value.
+func (s *DescribeLocalGatewaysInput) SetLocalGatewayIds(v []*string) *DescribeLocalGatewaysInput {
+	s.LocalGatewayIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeLocalGatewaysInput) SetMaxResults(v int64) *DescribeLocalGatewaysInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewaysInput) SetNextToken(v string) *DescribeLocalGatewaysInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeLocalGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the local gateways.
+	LocalGateways []*LocalGateway `locationName:"localGatewaySet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeLocalGatewaysOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocalGatewaysOutput) GoString() string {
+	return s.String()
+}
+
+// SetLocalGateways sets the LocalGateways field's value.
+func (s *DescribeLocalGatewaysOutput) SetLocalGateways(v []*LocalGateway) *DescribeLocalGatewaysOutput {
+	s.LocalGateways = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLocalGatewaysOutput) SetNextToken(v string) *DescribeLocalGatewaysOutput {
 	s.NextToken = &v
 	return s
 }
@@ -56472,7 +62524,6 @@ func (s *DescribeSecurityGroupsOutput) SetSecurityGroups(v []*SecurityGroup) *De
 	return s
 }
 
-// Contains the parameters for DescribeSnapshotAttribute.
 type DescribeSnapshotAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -56537,7 +62588,6 @@ func (s *DescribeSnapshotAttributeInput) SetSnapshotId(v string) *DescribeSnapsh
 	return s
 }
 
-// Contains the output of DescribeSnapshotAttribute.
 type DescribeSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -58385,6 +64435,232 @@ func (s *DescribeTransitGatewayAttachmentsOutput) SetTransitGatewayAttachments(v
 	return s
 }
 
+type DescribeTransitGatewayMulticastDomainsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters. The possible values are:
+	//
+	//    * state - The state of the transit gateway multicast domain. Valid values
+	//    are pending | available | deleting | deleted.
+	//
+	//    * transit-gateway-id - The ID of the transit gateway.
+	//
+	//    * transit-gateway-multicast-domain-id - The ID of the transit gateway
+	//    multicast domain.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainIds []*string `locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeTransitGatewayMulticastDomainsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransitGatewayMulticastDomainsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTransitGatewayMulticastDomainsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTransitGatewayMulticastDomainsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeTransitGatewayMulticastDomainsInput) SetDryRun(v bool) *DescribeTransitGatewayMulticastDomainsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeTransitGatewayMulticastDomainsInput) SetFilters(v []*Filter) *DescribeTransitGatewayMulticastDomainsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeTransitGatewayMulticastDomainsInput) SetMaxResults(v int64) *DescribeTransitGatewayMulticastDomainsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTransitGatewayMulticastDomainsInput) SetNextToken(v string) *DescribeTransitGatewayMulticastDomainsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainIds sets the TransitGatewayMulticastDomainIds field's value.
+func (s *DescribeTransitGatewayMulticastDomainsInput) SetTransitGatewayMulticastDomainIds(v []*string) *DescribeTransitGatewayMulticastDomainsInput {
+	s.TransitGatewayMulticastDomainIds = v
+	return s
+}
+
+type DescribeTransitGatewayMulticastDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// Information about the transit gateway multicast domains.
+	TransitGatewayMulticastDomains []*TransitGatewayMulticastDomain `locationName:"transitGatewayMulticastDomains" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeTransitGatewayMulticastDomainsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransitGatewayMulticastDomainsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTransitGatewayMulticastDomainsOutput) SetNextToken(v string) *DescribeTransitGatewayMulticastDomainsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomains sets the TransitGatewayMulticastDomains field's value.
+func (s *DescribeTransitGatewayMulticastDomainsOutput) SetTransitGatewayMulticastDomains(v []*TransitGatewayMulticastDomain) *DescribeTransitGatewayMulticastDomainsOutput {
+	s.TransitGatewayMulticastDomains = v
+	return s
+}
+
+type DescribeTransitGatewayPeeringAttachmentsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// One or more IDs of the transit gateway peering attachments.
+	TransitGatewayAttachmentIds []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeTransitGatewayPeeringAttachmentsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransitGatewayPeeringAttachmentsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTransitGatewayPeeringAttachmentsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) SetDryRun(v bool) *DescribeTransitGatewayPeeringAttachmentsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) SetFilters(v []*Filter) *DescribeTransitGatewayPeeringAttachmentsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) SetMaxResults(v int64) *DescribeTransitGatewayPeeringAttachmentsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) SetNextToken(v string) *DescribeTransitGatewayPeeringAttachmentsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayAttachmentIds sets the TransitGatewayAttachmentIds field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsInput) SetTransitGatewayAttachmentIds(v []*string) *DescribeTransitGatewayPeeringAttachmentsInput {
+	s.TransitGatewayAttachmentIds = v
+	return s
+}
+
+type DescribeTransitGatewayPeeringAttachmentsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The transit gateway peering attachments.
+	TransitGatewayPeeringAttachments []*TransitGatewayPeeringAttachment `locationName:"transitGatewayPeeringAttachments" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeTransitGatewayPeeringAttachmentsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransitGatewayPeeringAttachmentsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsOutput) SetNextToken(v string) *DescribeTransitGatewayPeeringAttachmentsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayPeeringAttachments sets the TransitGatewayPeeringAttachments field's value.
+func (s *DescribeTransitGatewayPeeringAttachmentsOutput) SetTransitGatewayPeeringAttachments(v []*TransitGatewayPeeringAttachment) *DescribeTransitGatewayPeeringAttachmentsOutput {
+	s.TransitGatewayPeeringAttachments = v
+	return s
+}
+
 type DescribeTransitGatewayRouteTablesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -58771,7 +65047,6 @@ func (s *DescribeTransitGatewaysOutput) SetTransitGateways(v []*TransitGateway) 
 	return s
 }
 
-// Contains the parameters for DescribeVolumeAttribute.
 type DescribeVolumeAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -58836,7 +65111,6 @@ func (s *DescribeVolumeAttributeInput) SetVolumeId(v string) *DescribeVolumeAttr
 	return s
 }
 
-// Contains the output of DescribeVolumeAttribute.
 type DescribeVolumeAttributeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -60126,8 +66400,8 @@ type DescribeVpcEndpointsInput struct {
 	//
 	//    * vpc-endpoint-id: The ID of the endpoint.
 	//
-	//    * vpc-endpoint-state: The state of the endpoint. (pending | available
-	//    | deleting | deleted)
+	//    * vpc-endpoint-state - The state of the endpoint (pendingAcceptance |
+	//    pending | available | deleting | deleted | rejected | failed).
 	//
 	//    * tag:<key> - The key/value combination of a tag assigned to the resource.
 	//    Use the tag key in the filter name and the tag value as the filter value.
@@ -60577,6 +66851,9 @@ type DescribeVpnConnectionsInput struct {
 	//
 	//    * vpn-gateway-id - The ID of a virtual private gateway associated with
 	//    the VPN connection.
+	//
+	//    * transit-gateway-id - The ID of a transit gateway associated with the
+	//    VPN connection.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
 	// One or more VPN connection IDs.
@@ -60989,7 +67266,6 @@ func (s DetachNetworkInterfaceOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DetachVolume.
 type DetachVolumeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -61330,6 +67606,325 @@ func (s DisableEbsEncryptionByDefaultOutput) GoString() string {
 // SetEbsEncryptionByDefault sets the EbsEncryptionByDefault field's value.
 func (s *DisableEbsEncryptionByDefaultOutput) SetEbsEncryptionByDefault(v bool) *DisableEbsEncryptionByDefaultOutput {
 	s.EbsEncryptionByDefault = &v
+	return s
+}
+
+// Contains information about the errors that occurred when disabling fast snapshot
+// restores.
+type DisableFastSnapshotRestoreErrorItem struct {
+	_ struct{} `type:"structure"`
+
+	// The errors.
+	FastSnapshotRestoreStateErrors []*DisableFastSnapshotRestoreStateErrorItem `locationName:"fastSnapshotRestoreStateErrorSet" locationNameList:"item" type:"list"`
+
+	// The ID of the snapshot.
+	SnapshotId *string `locationName:"snapshotId" type:"string"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoreErrorItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoreErrorItem) GoString() string {
+	return s.String()
+}
+
+// SetFastSnapshotRestoreStateErrors sets the FastSnapshotRestoreStateErrors field's value.
+func (s *DisableFastSnapshotRestoreErrorItem) SetFastSnapshotRestoreStateErrors(v []*DisableFastSnapshotRestoreStateErrorItem) *DisableFastSnapshotRestoreErrorItem {
+	s.FastSnapshotRestoreStateErrors = v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DisableFastSnapshotRestoreErrorItem) SetSnapshotId(v string) *DisableFastSnapshotRestoreErrorItem {
+	s.SnapshotId = &v
+	return s
+}
+
+// Describes an error that occurred when disabling fast snapshot restores.
+type DisableFastSnapshotRestoreStateError struct {
+	_ struct{} `type:"structure"`
+
+	// The error code.
+	Code *string `locationName:"code" type:"string"`
+
+	// The error message.
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoreStateError) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoreStateError) GoString() string {
+	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *DisableFastSnapshotRestoreStateError) SetCode(v string) *DisableFastSnapshotRestoreStateError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *DisableFastSnapshotRestoreStateError) SetMessage(v string) *DisableFastSnapshotRestoreStateError {
+	s.Message = &v
+	return s
+}
+
+// Contains information about an error that occurred when disabling fast snapshot
+// restores.
+type DisableFastSnapshotRestoreStateErrorItem struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The error.
+	Error *DisableFastSnapshotRestoreStateError `locationName:"error" type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoreStateErrorItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoreStateErrorItem) GoString() string {
+	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DisableFastSnapshotRestoreStateErrorItem) SetAvailabilityZone(v string) *DisableFastSnapshotRestoreStateErrorItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetError sets the Error field's value.
+func (s *DisableFastSnapshotRestoreStateErrorItem) SetError(v *DisableFastSnapshotRestoreStateError) *DisableFastSnapshotRestoreStateErrorItem {
+	s.Error = v
+	return s
+}
+
+// Describes fast snapshot restores that were successfully disabled.
+type DisableFastSnapshotRestoreSuccessItem struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The time at which fast snapshot restores entered the disabled state.
+	DisabledTime *time.Time `locationName:"disabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the disabling state.
+	DisablingTime *time.Time `locationName:"disablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabled state.
+	EnabledTime *time.Time `locationName:"enabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabling state.
+	EnablingTime *time.Time `locationName:"enablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the optimizing state.
+	OptimizingTime *time.Time `locationName:"optimizingTime" type:"timestamp"`
+
+	// The alias of the snapshot owner.
+	OwnerAlias *string `locationName:"ownerAlias" type:"string"`
+
+	// The ID of the AWS account that owns the snapshot.
+	OwnerId *string `locationName:"ownerId" type:"string"`
+
+	// The ID of the snapshot.
+	SnapshotId *string `locationName:"snapshotId" type:"string"`
+
+	// The state of fast snapshot restores for the snapshot.
+	State *string `locationName:"state" type:"string" enum:"FastSnapshotRestoreStateCode"`
+
+	// The reason for the state transition. The possible values are as follows:
+	//
+	//    * Client.UserInitiated - The state successfully transitioned to enabling
+	//    or disabling.
+	//
+	//    * Client.UserInitiated - Lifecycle state transition - The state successfully
+	//    transitioned to optimizing, enabled, or disabled.
+	StateTransitionReason *string `locationName:"stateTransitionReason" type:"string"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoreSuccessItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoreSuccessItem) GoString() string {
+	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetAvailabilityZone(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDisabledTime sets the DisabledTime field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetDisabledTime(v time.Time) *DisableFastSnapshotRestoreSuccessItem {
+	s.DisabledTime = &v
+	return s
+}
+
+// SetDisablingTime sets the DisablingTime field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetDisablingTime(v time.Time) *DisableFastSnapshotRestoreSuccessItem {
+	s.DisablingTime = &v
+	return s
+}
+
+// SetEnabledTime sets the EnabledTime field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetEnabledTime(v time.Time) *DisableFastSnapshotRestoreSuccessItem {
+	s.EnabledTime = &v
+	return s
+}
+
+// SetEnablingTime sets the EnablingTime field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetEnablingTime(v time.Time) *DisableFastSnapshotRestoreSuccessItem {
+	s.EnablingTime = &v
+	return s
+}
+
+// SetOptimizingTime sets the OptimizingTime field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetOptimizingTime(v time.Time) *DisableFastSnapshotRestoreSuccessItem {
+	s.OptimizingTime = &v
+	return s
+}
+
+// SetOwnerAlias sets the OwnerAlias field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetOwnerAlias(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.OwnerAlias = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetOwnerId(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.OwnerId = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetSnapshotId(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetState(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.State = &v
+	return s
+}
+
+// SetStateTransitionReason sets the StateTransitionReason field's value.
+func (s *DisableFastSnapshotRestoreSuccessItem) SetStateTransitionReason(v string) *DisableFastSnapshotRestoreSuccessItem {
+	s.StateTransitionReason = &v
+	return s
+}
+
+type DisableFastSnapshotRestoresInput struct {
+	_ struct{} `type:"structure"`
+
+	// One or more Availability Zones. For example, us-east-2a.
+	//
+	// AvailabilityZones is a required field
+	AvailabilityZones []*string `locationName:"AvailabilityZone" locationNameList:"AvailabilityZone" type:"list" required:"true"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IDs of one or more snapshots. For example, snap-1234567890abcdef0.
+	//
+	// SourceSnapshotIds is a required field
+	SourceSnapshotIds []*string `locationName:"SourceSnapshotId" locationNameList:"SnapshotId" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoresInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoresInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableFastSnapshotRestoresInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableFastSnapshotRestoresInput"}
+	if s.AvailabilityZones == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZones"))
+	}
+	if s.SourceSnapshotIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceSnapshotIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DisableFastSnapshotRestoresInput) SetAvailabilityZones(v []*string) *DisableFastSnapshotRestoresInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DisableFastSnapshotRestoresInput) SetDryRun(v bool) *DisableFastSnapshotRestoresInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSourceSnapshotIds sets the SourceSnapshotIds field's value.
+func (s *DisableFastSnapshotRestoresInput) SetSourceSnapshotIds(v []*string) *DisableFastSnapshotRestoresInput {
+	s.SourceSnapshotIds = v
+	return s
+}
+
+type DisableFastSnapshotRestoresOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the snapshots for which fast snapshot restores were successfully
+	// disabled.
+	Successful []*DisableFastSnapshotRestoreSuccessItem `locationName:"successful" locationNameList:"item" type:"list"`
+
+	// Information about the snapshots for which fast snapshot restores could not
+	// be disabled.
+	Unsuccessful []*DisableFastSnapshotRestoreErrorItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s DisableFastSnapshotRestoresOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisableFastSnapshotRestoresOutput) GoString() string {
+	return s.String()
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *DisableFastSnapshotRestoresOutput) SetSuccessful(v []*DisableFastSnapshotRestoreSuccessItem) *DisableFastSnapshotRestoresOutput {
+	s.Successful = v
+	return s
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *DisableFastSnapshotRestoresOutput) SetUnsuccessful(v []*DisableFastSnapshotRestoreErrorItem) *DisableFastSnapshotRestoresOutput {
+	s.Unsuccessful = v
 	return s
 }
 
@@ -61956,6 +68551,82 @@ func (s *DisassociateSubnetCidrBlockOutput) SetSubnetId(v string) *DisassociateS
 	return s
 }
 
+type DisassociateTransitGatewayMulticastDomainInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IDs of the subnets;
+	SubnetIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the attachment.
+	TransitGatewayAttachmentId *string `type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DisassociateTransitGatewayMulticastDomainInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateTransitGatewayMulticastDomainInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DisassociateTransitGatewayMulticastDomainInput) SetDryRun(v bool) *DisassociateTransitGatewayMulticastDomainInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DisassociateTransitGatewayMulticastDomainInput) SetSubnetIds(v []*string) *DisassociateTransitGatewayMulticastDomainInput {
+	s.SubnetIds = v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *DisassociateTransitGatewayMulticastDomainInput) SetTransitGatewayAttachmentId(v string) *DisassociateTransitGatewayMulticastDomainInput {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *DisassociateTransitGatewayMulticastDomainInput) SetTransitGatewayMulticastDomainId(v string) *DisassociateTransitGatewayMulticastDomainInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type DisassociateTransitGatewayMulticastDomainOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the association.
+	Associations *TransitGatewayMulticastDomainAssociations `locationName:"associations" type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateTransitGatewayMulticastDomainOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateTransitGatewayMulticastDomainOutput) GoString() string {
+	return s.String()
+}
+
+// SetAssociations sets the Associations field's value.
+func (s *DisassociateTransitGatewayMulticastDomainOutput) SetAssociations(v *TransitGatewayMulticastDomainAssociations) *DisassociateTransitGatewayMulticastDomainOutput {
+	s.Associations = v
+	return s
+}
+
 type DisassociateTransitGatewayRouteTableInput struct {
 	_ struct{} `type:"structure"`
 
@@ -62349,6 +69020,48 @@ func (s *DiskImageVolumeDescription) SetSize(v int64) *DiskImageVolumeDescriptio
 	return s
 }
 
+// Describes the disk.
+type DiskInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The number of disks with this configuration.
+	Count *int64 `locationName:"count" type:"integer"`
+
+	// The size of the disk in GB.
+	SizeInGB *int64 `locationName:"sizeInGB" type:"long"`
+
+	// The type of disk.
+	Type *string `locationName:"type" type:"string" enum:"DiskType"`
+}
+
+// String returns the string representation
+func (s DiskInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DiskInfo) GoString() string {
+	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *DiskInfo) SetCount(v int64) *DiskInfo {
+	s.Count = &v
+	return s
+}
+
+// SetSizeInGB sets the SizeInGB field's value.
+func (s *DiskInfo) SetSizeInGB(v int64) *DiskInfo {
+	s.SizeInGB = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *DiskInfo) SetType(v string) *DiskInfo {
+	s.Type = &v
+	return s
+}
+
 // Describes a DNS entry.
 type DnsEntry struct {
 	_ struct{} `type:"structure"`
@@ -62422,7 +69135,10 @@ func (s *DnsServersOptionsModifyStructure) SetEnabled(v bool) *DnsServersOptions
 type EbsBlockDevice struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates whether the EBS volume is deleted on instance termination.
+	// Indicates whether the EBS volume is deleted on instance termination. For
+	// more information, see Preserving Amazon EBS Volumes on Instance Termination
+	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#preserving-volumes-on-termination)
+	// in the Amazon Elastic Compute Cloud User Guide.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
 
 	// Indicates whether the encryption state of an EBS volume is changed while
@@ -62480,8 +69196,9 @@ type EbsBlockDevice struct {
 	// size.
 	VolumeSize *int64 `locationName:"volumeSize" type:"integer"`
 
-	// The volume type. If you set the type to io1, you must also specify the IOPS
-	// that the volume supports.
+	// The volume type. If you set the type to io1, you must also specify the Iops
+	// parameter. If you set the type to gp2, st1, sc1, or standard, you must omit
+	// the Iops parameter.
 	//
 	// Default: gp2
 	VolumeType *string `locationName:"volumeType" type:"string" enum:"VolumeType"`
@@ -62536,6 +69253,41 @@ func (s *EbsBlockDevice) SetVolumeSize(v int64) *EbsBlockDevice {
 // SetVolumeType sets the VolumeType field's value.
 func (s *EbsBlockDevice) SetVolumeType(v string) *EbsBlockDevice {
 	s.VolumeType = &v
+	return s
+}
+
+// Describes the Amazon EBS features supported by the instance type.
+type EbsInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates that the instance type is Amazon EBS-optimized. For more information,
+	// see Amazon EBS-Optimized Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html)
+	// in Amazon EC2 User Guide for Linux Instances.
+	EbsOptimizedSupport *string `locationName:"ebsOptimizedSupport" type:"string" enum:"EbsOptimizedSupport"`
+
+	// Indicates whether Amazon EBS encryption is supported.
+	EncryptionSupport *string `locationName:"encryptionSupport" type:"string" enum:"EbsEncryptionSupport"`
+}
+
+// String returns the string representation
+func (s EbsInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EbsInfo) GoString() string {
+	return s.String()
+}
+
+// SetEbsOptimizedSupport sets the EbsOptimizedSupport field's value.
+func (s *EbsInfo) SetEbsOptimizedSupport(v string) *EbsInfo {
+	s.EbsOptimizedSupport = &v
+	return s
+}
+
+// SetEncryptionSupport sets the EncryptionSupport field's value.
+func (s *EbsInfo) SetEncryptionSupport(v string) *EbsInfo {
+	s.EncryptionSupport = &v
 	return s
 }
 
@@ -62817,6 +69569,9 @@ type ElasticGpus struct {
 
 	// The ID of the instance to which the Elastic Graphics accelerator is attached.
 	InstanceId *string `locationName:"instanceId" type:"string"`
+
+	// The tags assigned to the Elastic Graphics accelerator.
+	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation
@@ -62865,12 +69620,23 @@ func (s *ElasticGpus) SetInstanceId(v string) *ElasticGpus {
 	return s
 }
 
+// SetTags sets the Tags field's value.
+func (s *ElasticGpus) SetTags(v []*Tag) *ElasticGpus {
+	s.Tags = v
+	return s
+}
+
 // Describes an elastic inference accelerator.
 type ElasticInferenceAccelerator struct {
 	_ struct{} `type:"structure"`
 
-	// The type of elastic inference accelerator. The possible values are eia1.small,
-	// eia1.medium, and eia1.large.
+	// The number of elastic inference accelerators of given type to be attached
+	// to the instance. Only positive values allowed. If not specified defaults
+	// to 1.
+	Count *int64 `min:"1" type:"integer"`
+
+	// The type of elastic inference accelerator. The possible values are eia1.medium,
+	// eia1.large, and eia1.xlarge.
 	//
 	// Type is a required field
 	Type *string `type:"string" required:"true"`
@@ -62889,6 +69655,9 @@ func (s ElasticInferenceAccelerator) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ElasticInferenceAccelerator) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ElasticInferenceAccelerator"}
+	if s.Count != nil && *s.Count < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Count", 1))
+	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
 	}
@@ -62897,6 +69666,12 @@ func (s *ElasticInferenceAccelerator) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCount sets the Count field's value.
+func (s *ElasticInferenceAccelerator) SetCount(v int64) *ElasticInferenceAccelerator {
+	s.Count = &v
+	return s
 }
 
 // SetType sets the Type field's value.
@@ -63003,6 +69778,326 @@ func (s EnableEbsEncryptionByDefaultOutput) GoString() string {
 // SetEbsEncryptionByDefault sets the EbsEncryptionByDefault field's value.
 func (s *EnableEbsEncryptionByDefaultOutput) SetEbsEncryptionByDefault(v bool) *EnableEbsEncryptionByDefaultOutput {
 	s.EbsEncryptionByDefault = &v
+	return s
+}
+
+// Contains information about the errors that occurred when enabling fast snapshot
+// restores.
+type EnableFastSnapshotRestoreErrorItem struct {
+	_ struct{} `type:"structure"`
+
+	// The errors.
+	FastSnapshotRestoreStateErrors []*EnableFastSnapshotRestoreStateErrorItem `locationName:"fastSnapshotRestoreStateErrorSet" locationNameList:"item" type:"list"`
+
+	// The ID of the snapshot.
+	SnapshotId *string `locationName:"snapshotId" type:"string"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoreErrorItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoreErrorItem) GoString() string {
+	return s.String()
+}
+
+// SetFastSnapshotRestoreStateErrors sets the FastSnapshotRestoreStateErrors field's value.
+func (s *EnableFastSnapshotRestoreErrorItem) SetFastSnapshotRestoreStateErrors(v []*EnableFastSnapshotRestoreStateErrorItem) *EnableFastSnapshotRestoreErrorItem {
+	s.FastSnapshotRestoreStateErrors = v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *EnableFastSnapshotRestoreErrorItem) SetSnapshotId(v string) *EnableFastSnapshotRestoreErrorItem {
+	s.SnapshotId = &v
+	return s
+}
+
+// Describes an error that occurred when enabling fast snapshot restores.
+type EnableFastSnapshotRestoreStateError struct {
+	_ struct{} `type:"structure"`
+
+	// The error code.
+	Code *string `locationName:"code" type:"string"`
+
+	// The error message.
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoreStateError) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoreStateError) GoString() string {
+	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *EnableFastSnapshotRestoreStateError) SetCode(v string) *EnableFastSnapshotRestoreStateError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *EnableFastSnapshotRestoreStateError) SetMessage(v string) *EnableFastSnapshotRestoreStateError {
+	s.Message = &v
+	return s
+}
+
+// Contains information about an error that occurred when enabling fast snapshot
+// restores.
+type EnableFastSnapshotRestoreStateErrorItem struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The error.
+	Error *EnableFastSnapshotRestoreStateError `locationName:"error" type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoreStateErrorItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoreStateErrorItem) GoString() string {
+	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *EnableFastSnapshotRestoreStateErrorItem) SetAvailabilityZone(v string) *EnableFastSnapshotRestoreStateErrorItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetError sets the Error field's value.
+func (s *EnableFastSnapshotRestoreStateErrorItem) SetError(v *EnableFastSnapshotRestoreStateError) *EnableFastSnapshotRestoreStateErrorItem {
+	s.Error = v
+	return s
+}
+
+// Describes fast snapshot restores that were successfully enabled.
+type EnableFastSnapshotRestoreSuccessItem struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The time at which fast snapshot restores entered the disabled state.
+	DisabledTime *time.Time `locationName:"disabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the disabling state.
+	DisablingTime *time.Time `locationName:"disablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabled state.
+	EnabledTime *time.Time `locationName:"enabledTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the enabling state.
+	EnablingTime *time.Time `locationName:"enablingTime" type:"timestamp"`
+
+	// The time at which fast snapshot restores entered the optimizing state.
+	OptimizingTime *time.Time `locationName:"optimizingTime" type:"timestamp"`
+
+	// The alias of the snapshot owner.
+	OwnerAlias *string `locationName:"ownerAlias" type:"string"`
+
+	// The ID of the AWS account that owns the snapshot.
+	OwnerId *string `locationName:"ownerId" type:"string"`
+
+	// The ID of the snapshot.
+	SnapshotId *string `locationName:"snapshotId" type:"string"`
+
+	// The state of fast snapshot restores.
+	State *string `locationName:"state" type:"string" enum:"FastSnapshotRestoreStateCode"`
+
+	// The reason for the state transition. The possible values are as follows:
+	//
+	//    * Client.UserInitiated - The state successfully transitioned to enabling
+	//    or disabling.
+	//
+	//    * Client.UserInitiated - Lifecycle state transition - The state successfully
+	//    transitioned to optimizing, enabled, or disabled.
+	StateTransitionReason *string `locationName:"stateTransitionReason" type:"string"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoreSuccessItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoreSuccessItem) GoString() string {
+	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetAvailabilityZone(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDisabledTime sets the DisabledTime field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetDisabledTime(v time.Time) *EnableFastSnapshotRestoreSuccessItem {
+	s.DisabledTime = &v
+	return s
+}
+
+// SetDisablingTime sets the DisablingTime field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetDisablingTime(v time.Time) *EnableFastSnapshotRestoreSuccessItem {
+	s.DisablingTime = &v
+	return s
+}
+
+// SetEnabledTime sets the EnabledTime field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetEnabledTime(v time.Time) *EnableFastSnapshotRestoreSuccessItem {
+	s.EnabledTime = &v
+	return s
+}
+
+// SetEnablingTime sets the EnablingTime field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetEnablingTime(v time.Time) *EnableFastSnapshotRestoreSuccessItem {
+	s.EnablingTime = &v
+	return s
+}
+
+// SetOptimizingTime sets the OptimizingTime field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetOptimizingTime(v time.Time) *EnableFastSnapshotRestoreSuccessItem {
+	s.OptimizingTime = &v
+	return s
+}
+
+// SetOwnerAlias sets the OwnerAlias field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetOwnerAlias(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.OwnerAlias = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetOwnerId(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.OwnerId = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetSnapshotId(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetState(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.State = &v
+	return s
+}
+
+// SetStateTransitionReason sets the StateTransitionReason field's value.
+func (s *EnableFastSnapshotRestoreSuccessItem) SetStateTransitionReason(v string) *EnableFastSnapshotRestoreSuccessItem {
+	s.StateTransitionReason = &v
+	return s
+}
+
+type EnableFastSnapshotRestoresInput struct {
+	_ struct{} `type:"structure"`
+
+	// One or more Availability Zones. For example, us-east-2a.
+	//
+	// AvailabilityZones is a required field
+	AvailabilityZones []*string `locationName:"AvailabilityZone" locationNameList:"AvailabilityZone" type:"list" required:"true"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IDs of one or more snapshots. For example, snap-1234567890abcdef0. You
+	// can specify a snapshot that was shared with you from another AWS account.
+	//
+	// SourceSnapshotIds is a required field
+	SourceSnapshotIds []*string `locationName:"SourceSnapshotId" locationNameList:"SnapshotId" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoresInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoresInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableFastSnapshotRestoresInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableFastSnapshotRestoresInput"}
+	if s.AvailabilityZones == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZones"))
+	}
+	if s.SourceSnapshotIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceSnapshotIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *EnableFastSnapshotRestoresInput) SetAvailabilityZones(v []*string) *EnableFastSnapshotRestoresInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *EnableFastSnapshotRestoresInput) SetDryRun(v bool) *EnableFastSnapshotRestoresInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSourceSnapshotIds sets the SourceSnapshotIds field's value.
+func (s *EnableFastSnapshotRestoresInput) SetSourceSnapshotIds(v []*string) *EnableFastSnapshotRestoresInput {
+	s.SourceSnapshotIds = v
+	return s
+}
+
+type EnableFastSnapshotRestoresOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the snapshots for which fast snapshot restores were successfully
+	// enabled.
+	Successful []*EnableFastSnapshotRestoreSuccessItem `locationName:"successful" locationNameList:"item" type:"list"`
+
+	// Information about the snapshots for which fast snapshot restores could not
+	// be enabled.
+	Unsuccessful []*EnableFastSnapshotRestoreErrorItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s EnableFastSnapshotRestoresOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EnableFastSnapshotRestoresOutput) GoString() string {
+	return s.String()
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *EnableFastSnapshotRestoresOutput) SetSuccessful(v []*EnableFastSnapshotRestoreSuccessItem) *EnableFastSnapshotRestoresOutput {
+	s.Successful = v
+	return s
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *EnableFastSnapshotRestoresOutput) SetUnsuccessful(v []*EnableFastSnapshotRestoreErrorItem) *EnableFastSnapshotRestoresOutput {
+	s.Unsuccessful = v
 	return s
 }
 
@@ -63163,7 +70258,6 @@ func (s EnableVgwRoutePropagationOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for EnableVolumeIO.
 type EnableVolumeIOInput struct {
 	_ struct{} `type:"structure"`
 
@@ -64275,6 +71369,39 @@ func (s *ExportTransitGatewayRoutesOutput) SetS3Location(v string) *ExportTransi
 	return s
 }
 
+// Describes a Reserved Instance whose queued purchase was not deleted.
+type FailedQueuedPurchaseDeletion struct {
+	_ struct{} `type:"structure"`
+
+	// The error.
+	Error *DeleteQueuedReservedInstancesError `locationName:"error" type:"structure"`
+
+	// The ID of the Reserved Instance.
+	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
+}
+
+// String returns the string representation
+func (s FailedQueuedPurchaseDeletion) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FailedQueuedPurchaseDeletion) GoString() string {
+	return s.String()
+}
+
+// SetError sets the Error field's value.
+func (s *FailedQueuedPurchaseDeletion) SetError(v *DeleteQueuedReservedInstancesError) *FailedQueuedPurchaseDeletion {
+	s.Error = v
+	return s
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *FailedQueuedPurchaseDeletion) SetReservedInstancesId(v string) *FailedQueuedPurchaseDeletion {
+	s.ReservedInstancesId = &v
+	return s
+}
+
 // A filter name and value pair that is used to return a more specific list
 // of results from a describe operation. Filters can be used to match a set
 // of resources by specific criteria, such as tags, attributes, or IDs. The
@@ -64343,8 +71470,8 @@ type FleetData struct {
 	// is pending_termination while instances are terminating.
 	ActivityStatus *string `locationName:"activityStatus" type:"string" enum:"FleetActivityStatus"`
 
-	// Unique, case-sensitive identifier you provide to ensure the idempotency of
-	// the request. For more information, see Ensuring Idempotency (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
+	// Unique, case-sensitive identifier that you provide to ensure the idempotency
+	// of the request. For more information, see Ensuring Idempotency (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	//
 	// Constraints: Maximum 64 ASCII characters
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -64407,11 +71534,11 @@ type FleetData struct {
 	// The type of request. Indicates whether the EC2 Fleet only requests the target
 	// capacity, or also attempts to maintain it. If you request a certain target
 	// capacity, EC2 Fleet only places the required requests; it does not attempt
-	// to replenish instances if capacity is diminished, and does not submit requests
-	// in alternative capacity pools if capacity is unavailable. To maintain a certain
-	// target capacity, EC2 Fleet places the required requests to meet this target
-	// capacity. It also automatically replenishes any interrupted Spot Instances.
-	// Default: maintain.
+	// to replenish instances if capacity is diminished, and it does not submit
+	// requests in alternative capacity pools if capacity is unavailable. To maintain
+	// a certain target capacity, EC2 Fleet places the required requests to meet
+	// this target capacity. It also automatically replenishes any interrupted Spot
+	// Instances. Default: maintain.
 	Type *string `locationName:"type" type:"string" enum:"FleetType"`
 
 	// The start date and time of the request, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
@@ -64957,6 +72084,9 @@ type FlowLog struct {
 	// Flow log data can be published to CloudWatch Logs or Amazon S3.
 	LogDestinationType *string `locationName:"logDestinationType" type:"string" enum:"LogDestinationType"`
 
+	// The format of the flow log record.
+	LogFormat *string `locationName:"logFormat" type:"string"`
+
 	// The name of the flow log group.
 	LogGroupName *string `locationName:"logGroupName" type:"string"`
 
@@ -65025,6 +72155,12 @@ func (s *FlowLog) SetLogDestinationType(v string) *FlowLog {
 	return s
 }
 
+// SetLogFormat sets the LogFormat field's value.
+func (s *FlowLog) SetLogFormat(v string) *FlowLog {
+	s.LogFormat = &v
+	return s
+}
+
 // SetLogGroupName sets the LogGroupName field's value.
 func (s *FlowLog) SetLogGroupName(v string) *FlowLog {
 	s.LogGroupName = &v
@@ -65040,6 +72176,81 @@ func (s *FlowLog) SetResourceId(v string) *FlowLog {
 // SetTrafficType sets the TrafficType field's value.
 func (s *FlowLog) SetTrafficType(v string) *FlowLog {
 	s.TrafficType = &v
+	return s
+}
+
+// Describes the FPGA accelerator for the instance type.
+type FpgaDeviceInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The count of FPGA accelerators for the instance type.
+	Count *int64 `locationName:"count" type:"integer"`
+
+	// The manufacturer of the FPGA accelerator.
+	Manufacturer *string `locationName:"manufacturer" type:"string"`
+
+	// Describes the memory for the FPGA accelerator for the instance type.
+	MemoryInfo *FpgaDeviceMemoryInfo `locationName:"memoryInfo" type:"structure"`
+
+	// The name of the FPGA accelerator.
+	Name *string `locationName:"name" type:"string"`
+}
+
+// String returns the string representation
+func (s FpgaDeviceInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FpgaDeviceInfo) GoString() string {
+	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *FpgaDeviceInfo) SetCount(v int64) *FpgaDeviceInfo {
+	s.Count = &v
+	return s
+}
+
+// SetManufacturer sets the Manufacturer field's value.
+func (s *FpgaDeviceInfo) SetManufacturer(v string) *FpgaDeviceInfo {
+	s.Manufacturer = &v
+	return s
+}
+
+// SetMemoryInfo sets the MemoryInfo field's value.
+func (s *FpgaDeviceInfo) SetMemoryInfo(v *FpgaDeviceMemoryInfo) *FpgaDeviceInfo {
+	s.MemoryInfo = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *FpgaDeviceInfo) SetName(v string) *FpgaDeviceInfo {
+	s.Name = &v
+	return s
+}
+
+// Describes the memory for the FPGA accelerator for the instance type.
+type FpgaDeviceMemoryInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The size (in MiB) for the memory available to the FPGA accelerator.
+	SizeInMiB *int64 `locationName:"sizeInMiB" type:"integer"`
+}
+
+// String returns the string representation
+func (s FpgaDeviceMemoryInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FpgaDeviceMemoryInfo) GoString() string {
+	return s.String()
+}
+
+// SetSizeInMiB sets the SizeInMiB field's value.
+func (s *FpgaDeviceMemoryInfo) SetSizeInMiB(v int64) *FpgaDeviceMemoryInfo {
+	s.SizeInMiB = &v
 	return s
 }
 
@@ -65295,6 +72506,39 @@ func (s *FpgaImageState) SetMessage(v string) *FpgaImageState {
 	return s
 }
 
+// Describes the FPGAs for the instance type.
+type FpgaInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the FPGAs for the instance type.
+	Fpgas []*FpgaDeviceInfo `locationName:"fpgas" locationNameList:"item" type:"list"`
+
+	// The total memory of all FPGA accelerators for the instance type.
+	TotalFpgaMemoryInMiB *int64 `locationName:"totalFpgaMemoryInMiB" type:"integer"`
+}
+
+// String returns the string representation
+func (s FpgaInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FpgaInfo) GoString() string {
+	return s.String()
+}
+
+// SetFpgas sets the Fpgas field's value.
+func (s *FpgaInfo) SetFpgas(v []*FpgaDeviceInfo) *FpgaInfo {
+	s.Fpgas = v
+	return s
+}
+
+// SetTotalFpgaMemoryInMiB sets the TotalFpgaMemoryInMiB field's value.
+func (s *FpgaInfo) SetTotalFpgaMemoryInMiB(v int64) *FpgaInfo {
+	s.TotalFpgaMemoryInMiB = &v
+	return s
+}
+
 type GetCapacityReservationUsageInput struct {
 	_ struct{} `type:"structure"`
 
@@ -65464,6 +72708,136 @@ func (s *GetCapacityReservationUsageOutput) SetState(v string) *GetCapacityReser
 // SetTotalInstanceCount sets the TotalInstanceCount field's value.
 func (s *GetCapacityReservationUsageOutput) SetTotalInstanceCount(v int64) *GetCapacityReservationUsageOutput {
 	s.TotalInstanceCount = &v
+	return s
+}
+
+type GetCoipPoolUsageInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The filters. The following are the possible values:
+	//
+	//    * coip-address-usage.allocation-id
+	//
+	//    * coip-address-usage.aws-account-id
+	//
+	//    * coip-address-usage.aws-service
+	//
+	//    * coip-address-usage.co-ip
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// The ID of the address pool.
+	//
+	// PoolId is a required field
+	PoolId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCoipPoolUsageInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCoipPoolUsageInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCoipPoolUsageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCoipPoolUsageInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+	if s.PoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PoolId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *GetCoipPoolUsageInput) SetDryRun(v bool) *GetCoipPoolUsageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *GetCoipPoolUsageInput) SetFilters(v []*Filter) *GetCoipPoolUsageInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetCoipPoolUsageInput) SetMaxResults(v int64) *GetCoipPoolUsageInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetCoipPoolUsageInput) SetNextToken(v string) *GetCoipPoolUsageInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPoolId sets the PoolId field's value.
+func (s *GetCoipPoolUsageInput) SetPoolId(v string) *GetCoipPoolUsageInput {
+	s.PoolId = &v
+	return s
+}
+
+type GetCoipPoolUsageOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the address usage.
+	CoipAddressUsages []*CoipAddressUsage `locationName:"coipAddressUsageSet" locationNameList:"item" type:"list"`
+
+	// The ID of the customer-owned address pool.
+	CoipPoolId *string `locationName:"coipPoolId" type:"string"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+}
+
+// String returns the string representation
+func (s GetCoipPoolUsageOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCoipPoolUsageOutput) GoString() string {
+	return s.String()
+}
+
+// SetCoipAddressUsages sets the CoipAddressUsages field's value.
+func (s *GetCoipPoolUsageOutput) SetCoipAddressUsages(v []*CoipAddressUsage) *GetCoipPoolUsageOutput {
+	s.CoipAddressUsages = v
+	return s
+}
+
+// SetCoipPoolId sets the CoipPoolId field's value.
+func (s *GetCoipPoolUsageOutput) SetCoipPoolId(v string) *GetCoipPoolUsageOutput {
+	s.CoipPoolId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *GetCoipPoolUsageOutput) SetLocalGatewayRouteTableId(v string) *GetCoipPoolUsageOutput {
+	s.LocalGatewayRouteTableId = &v
 	return s
 }
 
@@ -65659,6 +73033,79 @@ func (s *GetConsoleScreenshotOutput) SetImageData(v string) *GetConsoleScreensho
 // SetInstanceId sets the InstanceId field's value.
 func (s *GetConsoleScreenshotOutput) SetInstanceId(v string) *GetConsoleScreenshotOutput {
 	s.InstanceId = &v
+	return s
+}
+
+type GetDefaultCreditSpecificationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The instance family.
+	//
+	// InstanceFamily is a required field
+	InstanceFamily *string `type:"string" required:"true" enum:"UnlimitedSupportedInstanceFamily"`
+}
+
+// String returns the string representation
+func (s GetDefaultCreditSpecificationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetDefaultCreditSpecificationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDefaultCreditSpecificationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDefaultCreditSpecificationInput"}
+	if s.InstanceFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceFamily"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *GetDefaultCreditSpecificationInput) SetDryRun(v bool) *GetDefaultCreditSpecificationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *GetDefaultCreditSpecificationInput) SetInstanceFamily(v string) *GetDefaultCreditSpecificationInput {
+	s.InstanceFamily = &v
+	return s
+}
+
+type GetDefaultCreditSpecificationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The default credit option for CPU usage of the instance family.
+	InstanceFamilyCreditSpecification *InstanceFamilyCreditSpecification `locationName:"instanceFamilyCreditSpecification" type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDefaultCreditSpecificationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetDefaultCreditSpecificationOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceFamilyCreditSpecification sets the InstanceFamilyCreditSpecification field's value.
+func (s *GetDefaultCreditSpecificationOutput) SetInstanceFamilyCreditSpecification(v *InstanceFamilyCreditSpecification) *GetDefaultCreditSpecificationOutput {
+	s.InstanceFamilyCreditSpecification = v
 	return s
 }
 
@@ -66313,6 +73760,126 @@ func (s *GetTransitGatewayAttachmentPropagationsOutput) SetTransitGatewayAttachm
 	return s
 }
 
+type GetTransitGatewayMulticastDomainAssociationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters. The possible values are:
+	//
+	//    * resource-id - The ID of the resource.
+	//
+	//    * resource-type - The type of resource. The valid value is: vpc.
+	//
+	//    * state - The state of the subnet association. Valid values are associated
+	//    | associating | disassociated | disassociating.
+	//
+	//    * subnet-id - The ID of the subnet.
+	//
+	//    * transit-gateway-attachment-id - The id of the transit gateway attachment.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GetTransitGatewayMulticastDomainAssociationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetTransitGatewayMulticastDomainAssociationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTransitGatewayMulticastDomainAssociationsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) SetDryRun(v bool) *GetTransitGatewayMulticastDomainAssociationsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) SetFilters(v []*Filter) *GetTransitGatewayMulticastDomainAssociationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) SetMaxResults(v int64) *GetTransitGatewayMulticastDomainAssociationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) SetNextToken(v string) *GetTransitGatewayMulticastDomainAssociationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsInput) SetTransitGatewayMulticastDomainId(v string) *GetTransitGatewayMulticastDomainAssociationsInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type GetTransitGatewayMulticastDomainAssociationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the multicast domain associations.
+	MulticastDomainAssociations []*TransitGatewayMulticastDomainAssociation `locationName:"multicastDomainAssociations" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetTransitGatewayMulticastDomainAssociationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetTransitGatewayMulticastDomainAssociationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetMulticastDomainAssociations sets the MulticastDomainAssociations field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsOutput) SetMulticastDomainAssociations(v []*TransitGatewayMulticastDomainAssociation) *GetTransitGatewayMulticastDomainAssociationsOutput {
+	s.MulticastDomainAssociations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetTransitGatewayMulticastDomainAssociationsOutput) SetNextToken(v string) *GetTransitGatewayMulticastDomainAssociationsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type GetTransitGatewayRouteTableAssociationsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -66553,6 +74120,114 @@ func (s *GetTransitGatewayRouteTablePropagationsOutput) SetTransitGatewayRouteTa
 	return s
 }
 
+// Describes the GPU accelerators for the instance type.
+type GpuDeviceInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The number of GPUs for the instance type.
+	Count *int64 `locationName:"count" type:"integer"`
+
+	// The manufacturer of the GPU accelerator.
+	Manufacturer *string `locationName:"manufacturer" type:"string"`
+
+	// Describes the memory available to the GPU accelerator.
+	MemoryInfo *GpuDeviceMemoryInfo `locationName:"memoryInfo" type:"structure"`
+
+	// The name of the GPU accelerator.
+	Name *string `locationName:"name" type:"string"`
+}
+
+// String returns the string representation
+func (s GpuDeviceInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GpuDeviceInfo) GoString() string {
+	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *GpuDeviceInfo) SetCount(v int64) *GpuDeviceInfo {
+	s.Count = &v
+	return s
+}
+
+// SetManufacturer sets the Manufacturer field's value.
+func (s *GpuDeviceInfo) SetManufacturer(v string) *GpuDeviceInfo {
+	s.Manufacturer = &v
+	return s
+}
+
+// SetMemoryInfo sets the MemoryInfo field's value.
+func (s *GpuDeviceInfo) SetMemoryInfo(v *GpuDeviceMemoryInfo) *GpuDeviceInfo {
+	s.MemoryInfo = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GpuDeviceInfo) SetName(v string) *GpuDeviceInfo {
+	s.Name = &v
+	return s
+}
+
+// Describes the memory available to the GPU accelerator.
+type GpuDeviceMemoryInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The size (in MiB) for the memory available to the GPU accelerator.
+	SizeInMiB *int64 `locationName:"sizeInMiB" type:"integer"`
+}
+
+// String returns the string representation
+func (s GpuDeviceMemoryInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GpuDeviceMemoryInfo) GoString() string {
+	return s.String()
+}
+
+// SetSizeInMiB sets the SizeInMiB field's value.
+func (s *GpuDeviceMemoryInfo) SetSizeInMiB(v int64) *GpuDeviceMemoryInfo {
+	s.SizeInMiB = &v
+	return s
+}
+
+// Describes the GPU accelerators for the instance type.
+type GpuInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the GPU accelerators for the instance type.
+	Gpus []*GpuDeviceInfo `locationName:"gpus" locationNameList:"item" type:"list"`
+
+	// The total size of the memory for the GPU accelerators for the instance type.
+	TotalGpuMemoryInMiB *int64 `locationName:"totalGpuMemoryInMiB" type:"integer"`
+}
+
+// String returns the string representation
+func (s GpuInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GpuInfo) GoString() string {
+	return s.String()
+}
+
+// SetGpus sets the Gpus field's value.
+func (s *GpuInfo) SetGpus(v []*GpuDeviceInfo) *GpuInfo {
+	s.Gpus = v
+	return s
+}
+
+// SetTotalGpuMemoryInMiB sets the TotalGpuMemoryInMiB field's value.
+func (s *GpuInfo) SetTotalGpuMemoryInMiB(v int64) *GpuInfo {
+	s.TotalGpuMemoryInMiB = &v
+	return s
+}
+
 // Describes a security group.
 type GroupIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -66588,8 +74263,7 @@ func (s *GroupIdentifier) SetGroupName(v string) *GroupIdentifier {
 
 // Indicates whether your instance is configured for hibernation. This parameter
 // is valid only if the instance meets the hibernation prerequisites (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html#hibernating-prerequisites).
-// Hibernation is currently supported only for Amazon Linux. For more information,
-// see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
+// For more information, see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 type HibernationOptions struct {
 	_ struct{} `type:"structure"`
@@ -66617,8 +74291,7 @@ func (s *HibernationOptions) SetConfigured(v bool) *HibernationOptions {
 
 // Indicates whether your instance is configured for hibernation. This parameter
 // is valid only if the instance meets the hibernation prerequisites (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html#hibernating-prerequisites).
-// Hibernation is currently supported only for Amazon Linux. For more information,
-// see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
+// For more information, see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 type HibernationOptionsRequest struct {
 	_ struct{} `type:"structure"`
@@ -66745,13 +74418,23 @@ type Host struct {
 	// The time that the Dedicated Host was allocated.
 	AllocationTime *time.Time `locationName:"allocationTime" type:"timestamp"`
 
+	// Indicates whether the Dedicated Host supports multiple instance types of
+	// the same instance family, or a specific instance type only. one indicates
+	// that the Dedicated Host supports multiple instance types in the instance
+	// family. off indicates that the Dedicated Host supports a single instance
+	// type only.
+	AllowsMultipleInstanceTypes *string `locationName:"allowsMultipleInstanceTypes" type:"string" enum:"AllowsMultipleInstanceTypes"`
+
 	// Whether auto-placement is on or off.
 	AutoPlacement *string `locationName:"autoPlacement" type:"string" enum:"AutoPlacement"`
 
 	// The Availability Zone of the Dedicated Host.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
-	// The number of new instances that can be launched onto the Dedicated Host.
+	// The ID of the Availability Zone in which the Dedicated Host is allocated.
+	AvailabilityZoneId *string `locationName:"availabilityZoneId" type:"string"`
+
+	// Information about the instances running on the Dedicated Host.
 	AvailableCapacity *AvailableCapacity `locationName:"availableCapacity" type:"structure"`
 
 	// Unique, case-sensitive identifier that you provide to ensure the idempotency
@@ -66774,6 +74457,13 @@ type Host struct {
 
 	// The IDs and instance type that are currently running on the Dedicated Host.
 	Instances []*HostInstance `locationName:"instances" locationNameList:"item" type:"list"`
+
+	// Indicates whether the Dedicated Host is in a host resource group. If memberOfServiceLinkedResourceGroup
+	// is true, the host is in a host resource group; otherwise, it is not.
+	MemberOfServiceLinkedResourceGroup *bool `locationName:"memberOfServiceLinkedResourceGroup" type:"boolean"`
+
+	// The ID of the AWS account that owns the Dedicated Host.
+	OwnerId *string `locationName:"ownerId" type:"string"`
 
 	// The time that the Dedicated Host was released.
 	ReleaseTime *time.Time `locationName:"releaseTime" type:"timestamp"`
@@ -66801,6 +74491,12 @@ func (s *Host) SetAllocationTime(v time.Time) *Host {
 	return s
 }
 
+// SetAllowsMultipleInstanceTypes sets the AllowsMultipleInstanceTypes field's value.
+func (s *Host) SetAllowsMultipleInstanceTypes(v string) *Host {
+	s.AllowsMultipleInstanceTypes = &v
+	return s
+}
+
 // SetAutoPlacement sets the AutoPlacement field's value.
 func (s *Host) SetAutoPlacement(v string) *Host {
 	s.AutoPlacement = &v
@@ -66810,6 +74506,12 @@ func (s *Host) SetAutoPlacement(v string) *Host {
 // SetAvailabilityZone sets the AvailabilityZone field's value.
 func (s *Host) SetAvailabilityZone(v string) *Host {
 	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAvailabilityZoneId sets the AvailabilityZoneId field's value.
+func (s *Host) SetAvailabilityZoneId(v string) *Host {
+	s.AvailabilityZoneId = &v
 	return s
 }
 
@@ -66855,6 +74557,18 @@ func (s *Host) SetInstances(v []*HostInstance) *Host {
 	return s
 }
 
+// SetMemberOfServiceLinkedResourceGroup sets the MemberOfServiceLinkedResourceGroup field's value.
+func (s *Host) SetMemberOfServiceLinkedResourceGroup(v bool) *Host {
+	s.MemberOfServiceLinkedResourceGroup = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *Host) SetOwnerId(v string) *Host {
+	s.OwnerId = &v
+	return s
+}
+
 // SetReleaseTime sets the ReleaseTime field's value.
 func (s *Host) SetReleaseTime(v time.Time) *Host {
 	s.ReleaseTime = &v
@@ -66877,11 +74591,14 @@ func (s *Host) SetTags(v []*Tag) *Host {
 type HostInstance struct {
 	_ struct{} `type:"structure"`
 
-	// the IDs of instances that are running on the Dedicated Host.
+	// The ID of instance that is running on the Dedicated Host.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
-	// The instance type size (for example, m3.medium) of the running instance.
+	// The instance type (for example, m3.medium) of the running instance.
 	InstanceType *string `locationName:"instanceType" type:"string"`
+
+	// The ID of the AWS account that owns the instance.
+	OwnerId *string `locationName:"ownerId" type:"string"`
 }
 
 // String returns the string representation
@@ -66903,6 +74620,12 @@ func (s *HostInstance) SetInstanceId(v string) *HostInstance {
 // SetInstanceType sets the InstanceType field's value.
 func (s *HostInstance) SetInstanceType(v string) *HostInstance {
 	s.InstanceType = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *HostInstance) SetOwnerId(v string) *HostInstance {
+	s.OwnerId = &v
 	return s
 }
 
@@ -66984,20 +74707,24 @@ func (s *HostOffering) SetUpfrontPrice(v string) *HostOffering {
 	return s
 }
 
-// Describes properties of a Dedicated Host.
+// Describes the properties of a Dedicated Host.
 type HostProperties struct {
 	_ struct{} `type:"structure"`
 
 	// The number of cores on the Dedicated Host.
 	Cores *int64 `locationName:"cores" type:"integer"`
 
-	// The instance type size that the Dedicated Host supports (for example, m3.medium).
+	// The instance family supported by the Dedicated Host. For example, m5.
+	InstanceFamily *string `locationName:"instanceFamily" type:"string"`
+
+	// The instance type supported by the Dedicated Host. For example, m5.large.
+	// If the host supports multiple instance types, no instanceType is returned.
 	InstanceType *string `locationName:"instanceType" type:"string"`
 
 	// The number of sockets on the Dedicated Host.
 	Sockets *int64 `locationName:"sockets" type:"integer"`
 
-	// The number of vCPUs on the Dedicated Host.
+	// The total number of vCPUs on the Dedicated Host.
 	TotalVCpus *int64 `locationName:"totalVCpus" type:"integer"`
 }
 
@@ -67014,6 +74741,12 @@ func (s HostProperties) GoString() string {
 // SetCores sets the Cores field's value.
 func (s *HostProperties) SetCores(v int64) *HostProperties {
 	s.Cores = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *HostProperties) SetInstanceFamily(v string) *HostProperties {
+	s.InstanceFamily = &v
 	return s
 }
 
@@ -67900,6 +75633,9 @@ type ImportImageInput struct {
 	// The specified CMK must exist in the Region that the AMI is being copied to.
 	KmsKeyId *string `type:"string"`
 
+	// The ARNs of the license configurations.
+	LicenseSpecifications []*ImportImageLicenseConfigurationRequest `locationNameList:"item" type:"list"`
+
 	// The license type to be used for the Amazon Machine Image (AMI) after importing.
 	//
 	// By default, we detect the source-system operating system (OS) and apply the
@@ -67986,6 +75722,12 @@ func (s *ImportImageInput) SetKmsKeyId(v string) *ImportImageInput {
 	return s
 }
 
+// SetLicenseSpecifications sets the LicenseSpecifications field's value.
+func (s *ImportImageInput) SetLicenseSpecifications(v []*ImportImageLicenseConfigurationRequest) *ImportImageInput {
+	s.LicenseSpecifications = v
+	return s
+}
+
 // SetLicenseType sets the LicenseType field's value.
 func (s *ImportImageInput) SetLicenseType(v string) *ImportImageInput {
 	s.LicenseType = &v
@@ -68001,6 +75743,54 @@ func (s *ImportImageInput) SetPlatform(v string) *ImportImageInput {
 // SetRoleName sets the RoleName field's value.
 func (s *ImportImageInput) SetRoleName(v string) *ImportImageInput {
 	s.RoleName = &v
+	return s
+}
+
+// The request information of license configurations.
+type ImportImageLicenseConfigurationRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of a license configuration.
+	LicenseConfigurationArn *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ImportImageLicenseConfigurationRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImportImageLicenseConfigurationRequest) GoString() string {
+	return s.String()
+}
+
+// SetLicenseConfigurationArn sets the LicenseConfigurationArn field's value.
+func (s *ImportImageLicenseConfigurationRequest) SetLicenseConfigurationArn(v string) *ImportImageLicenseConfigurationRequest {
+	s.LicenseConfigurationArn = &v
+	return s
+}
+
+// The response information of license configurations.
+type ImportImageLicenseConfigurationResponse struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of a license configuration.
+	LicenseConfigurationArn *string `locationName:"licenseConfigurationArn" type:"string"`
+}
+
+// String returns the string representation
+func (s ImportImageLicenseConfigurationResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImportImageLicenseConfigurationResponse) GoString() string {
+	return s.String()
+}
+
+// SetLicenseConfigurationArn sets the LicenseConfigurationArn field's value.
+func (s *ImportImageLicenseConfigurationResponse) SetLicenseConfigurationArn(v string) *ImportImageLicenseConfigurationResponse {
+	s.LicenseConfigurationArn = &v
 	return s
 }
 
@@ -68028,6 +75818,9 @@ type ImportImageOutput struct {
 	// The identifier for the AWS Key Management Service (AWS KMS) customer master
 	// key (CMK) that was used to create the encrypted AMI.
 	KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
+
+	// The ARNs of the license configurations.
+	LicenseSpecifications []*ImportImageLicenseConfigurationResponse `locationName:"licenseSpecifications" locationNameList:"item" type:"list"`
 
 	// The license type of the virtual machine.
 	LicenseType *string `locationName:"licenseType" type:"string"`
@@ -68100,6 +75893,12 @@ func (s *ImportImageOutput) SetKmsKeyId(v string) *ImportImageOutput {
 	return s
 }
 
+// SetLicenseSpecifications sets the LicenseSpecifications field's value.
+func (s *ImportImageOutput) SetLicenseSpecifications(v []*ImportImageLicenseConfigurationResponse) *ImportImageOutput {
+	s.LicenseSpecifications = v
+	return s
+}
+
 // SetLicenseType sets the LicenseType field's value.
 func (s *ImportImageOutput) SetLicenseType(v string) *ImportImageOutput {
 	s.LicenseType = &v
@@ -68165,6 +75964,9 @@ type ImportImageTask struct {
 	// The identifier for the AWS Key Management Service (AWS KMS) customer master
 	// key (CMK) that was used to create the encrypted image.
 	KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
+
+	// The ARNs of the license configurations associated to the import image task.
+	LicenseSpecifications []*ImportImageLicenseConfigurationResponse `locationName:"licenseSpecifications" locationNameList:"item" type:"list"`
 
 	// The license type of the virtual machine.
 	LicenseType *string `locationName:"licenseType" type:"string"`
@@ -68234,6 +76036,12 @@ func (s *ImportImageTask) SetImportTaskId(v string) *ImportImageTask {
 // SetKmsKeyId sets the KmsKeyId field's value.
 func (s *ImportImageTask) SetKmsKeyId(v string) *ImportImageTask {
 	s.KmsKeyId = &v
+	return s
+}
+
+// SetLicenseSpecifications sets the LicenseSpecifications field's value.
+func (s *ImportImageTask) SetLicenseSpecifications(v []*ImportImageLicenseConfigurationResponse) *ImportImageTask {
+	s.LicenseSpecifications = v
 	return s
 }
 
@@ -68398,7 +76206,7 @@ type ImportInstanceLaunchSpecification struct {
 	SubnetId *string `locationName:"subnetId" type:"string"`
 
 	// The Base64-encoded user data to make available to the instance.
-	UserData *UserData `locationName:"userData" type:"structure"`
+	UserData *UserData `locationName:"userData" type:"structure" sensitive:"true"`
 }
 
 // String returns the string representation
@@ -69111,6 +76919,72 @@ func (s *ImportVolumeTaskDetails) SetVolume(v *DiskImageVolumeDescription) *Impo
 	return s
 }
 
+// Describes the Inference accelerators for the instance type.
+type InferenceAcceleratorInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the Inference accelerators for the instance type.
+	Accelerators []*InferenceDeviceInfo `locationName:"accelerators" type:"list"`
+}
+
+// String returns the string representation
+func (s InferenceAcceleratorInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InferenceAcceleratorInfo) GoString() string {
+	return s.String()
+}
+
+// SetAccelerators sets the Accelerators field's value.
+func (s *InferenceAcceleratorInfo) SetAccelerators(v []*InferenceDeviceInfo) *InferenceAcceleratorInfo {
+	s.Accelerators = v
+	return s
+}
+
+// Describes the Inference accelerators for the instance type.
+type InferenceDeviceInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The number of Inference accelerators for the instance type.
+	Count *int64 `locationName:"count" type:"integer"`
+
+	// The manufacturer of the Inference accelerator.
+	Manufacturer *string `locationName:"manufacturer" type:"string"`
+
+	// The name of the Inference accelerator.
+	Name *string `locationName:"name" type:"string"`
+}
+
+// String returns the string representation
+func (s InferenceDeviceInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InferenceDeviceInfo) GoString() string {
+	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *InferenceDeviceInfo) SetCount(v int64) *InferenceDeviceInfo {
+	s.Count = &v
+	return s
+}
+
+// SetManufacturer sets the Manufacturer field's value.
+func (s *InferenceDeviceInfo) SetManufacturer(v string) *InferenceDeviceInfo {
+	s.Manufacturer = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InferenceDeviceInfo) SetName(v string) *InferenceDeviceInfo {
+	s.Name = &v
+	return s
+}
+
 // Describes an instance.
 type Instance struct {
 	_ struct{} `type:"structure"`
@@ -69187,11 +77061,17 @@ type Instance struct {
 	// The license configurations.
 	Licenses []*LicenseConfiguration `locationName:"licenseSet" locationNameList:"item" type:"list"`
 
+	// The metadata options for the instance.
+	MetadataOptions *InstanceMetadataOptionsResponse `locationName:"metadataOptions" type:"structure"`
+
 	// The monitoring for the instance.
 	Monitoring *Monitoring `locationName:"monitoring" type:"structure"`
 
 	// [EC2-VPC] The network interfaces for the instance.
 	NetworkInterfaces []*InstanceNetworkInterface `locationName:"networkInterfaceSet" locationNameList:"item" type:"list"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
 
 	// The location where the instance launched, if applicable.
 	Placement *Placement `locationName:"placement" type:"structure"`
@@ -69415,6 +77295,12 @@ func (s *Instance) SetLicenses(v []*LicenseConfiguration) *Instance {
 	return s
 }
 
+// SetMetadataOptions sets the MetadataOptions field's value.
+func (s *Instance) SetMetadataOptions(v *InstanceMetadataOptionsResponse) *Instance {
+	s.MetadataOptions = v
+	return s
+}
+
 // SetMonitoring sets the Monitoring field's value.
 func (s *Instance) SetMonitoring(v *Monitoring) *Instance {
 	s.Monitoring = v
@@ -69424,6 +77310,12 @@ func (s *Instance) SetMonitoring(v *Monitoring) *Instance {
 // SetNetworkInterfaces sets the NetworkInterfaces field's value.
 func (s *Instance) SetNetworkInterfaces(v []*InstanceNetworkInterface) *Instance {
 	s.NetworkInterfaces = v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *Instance) SetOutpostArn(v string) *Instance {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -69639,17 +77531,20 @@ func (s *InstanceBlockDeviceMappingSpecification) SetVirtualName(v string) *Inst
 	return s
 }
 
-// Information about the instance type that the Dedicated Host supports.
+// Information about the number of instances that can be launched onto the Dedicated
+// Host.
 type InstanceCapacity struct {
 	_ struct{} `type:"structure"`
 
-	// The number of instances that can still be launched onto the Dedicated Host.
+	// The number of instances that can be launched onto the Dedicated Host based
+	// on the host's available capacity.
 	AvailableCapacity *int64 `locationName:"availableCapacity" type:"integer"`
 
-	// The instance type size supported by the Dedicated Host.
+	// The instance type supported by the Dedicated Host.
 	InstanceType *string `locationName:"instanceType" type:"string"`
 
-	// The total number of instances that can be launched onto the Dedicated Host.
+	// The total number of instances that can be launched onto the Dedicated Host
+	// if there are no instances running on it.
 	TotalCapacity *int64 `locationName:"totalCapacity" type:"integer"`
 }
 
@@ -69714,7 +77609,7 @@ func (s *InstanceCount) SetState(v string) *InstanceCount {
 	return s
 }
 
-// Describes the credit option for CPU usage of a T2 or T3 instance.
+// Describes the credit option for CPU usage of a burstable performance instance.
 type InstanceCreditSpecification struct {
 	_ struct{} `type:"structure"`
 
@@ -69748,7 +77643,7 @@ func (s *InstanceCreditSpecification) SetInstanceId(v string) *InstanceCreditSpe
 	return s
 }
 
-// Describes the credit option for CPU usage of a T2 or T3 instance.
+// Describes the credit option for CPU usage of a burstable performance instance.
 type InstanceCreditSpecificationRequest struct {
 	_ struct{} `type:"structure"`
 
@@ -69812,6 +77707,41 @@ func (s *InstanceExportDetails) SetInstanceId(v string) *InstanceExportDetails {
 // SetTargetEnvironment sets the TargetEnvironment field's value.
 func (s *InstanceExportDetails) SetTargetEnvironment(v string) *InstanceExportDetails {
 	s.TargetEnvironment = &v
+	return s
+}
+
+// Describes the default credit option for CPU usage of a burstable performance
+// instance family.
+type InstanceFamilyCreditSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// The default credit option for CPU usage of the instance family. Valid values
+	// are standard and unlimited.
+	CpuCredits *string `locationName:"cpuCredits" type:"string"`
+
+	// The instance family.
+	InstanceFamily *string `locationName:"instanceFamily" type:"string" enum:"UnlimitedSupportedInstanceFamily"`
+}
+
+// String returns the string representation
+func (s InstanceFamilyCreditSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceFamilyCreditSpecification) GoString() string {
+	return s.String()
+}
+
+// SetCpuCredits sets the CpuCredits field's value.
+func (s *InstanceFamilyCreditSpecification) SetCpuCredits(v string) *InstanceFamilyCreditSpecification {
+	s.CpuCredits = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *InstanceFamilyCreditSpecification) SetInstanceFamily(v string) *InstanceFamilyCreditSpecification {
+	s.InstanceFamily = &v
 	return s
 }
 
@@ -69893,6 +77823,146 @@ func (s *InstanceMarketOptionsRequest) SetMarketType(v string) *InstanceMarketOp
 // SetSpotOptions sets the SpotOptions field's value.
 func (s *InstanceMarketOptionsRequest) SetSpotOptions(v *SpotMarketOptions) *InstanceMarketOptionsRequest {
 	s.SpotOptions = v
+	return s
+}
+
+// The metadata options for the instance.
+type InstanceMetadataOptionsRequest struct {
+	_ struct{} `type:"structure"`
+
+	// This parameter enables or disables the HTTP metadata endpoint on your instances.
+	// If the parameter is not specified, the default state is enabled.
+	//
+	// If you specify a value of disabled, you will not be able to access your instance
+	// metadata.
+	HttpEndpoint *string `type:"string" enum:"InstanceMetadataEndpointState"`
+
+	// The desired HTTP PUT response hop limit for instance metadata requests. The
+	// larger the number, the further instance metadata requests can travel.
+	//
+	// Default: 1
+	//
+	// Possible values: Integers from 1 to 64
+	HttpPutResponseHopLimit *int64 `type:"integer"`
+
+	// The state of token usage for your instance metadata requests. If the parameter
+	// is not specified in the request, the default state is optional.
+	//
+	// If the state is optional, you can choose to retrieve instance metadata with
+	// or without a signed token header on your request. If you retrieve the IAM
+	// role credentials without a token, the version 1.0 role credentials are returned.
+	// If you retrieve the IAM role credentials using a valid signed token, the
+	// version 2.0 role credentials are returned.
+	//
+	// If the state is required, you must send a signed token header with any instance
+	// metadata retrieval requests. In this state, retrieving the IAM role credentials
+	// always returns the version 2.0 credentials; the version 1.0 credentials are
+	// not available.
+	HttpTokens *string `type:"string" enum:"HttpTokensState"`
+}
+
+// String returns the string representation
+func (s InstanceMetadataOptionsRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceMetadataOptionsRequest) GoString() string {
+	return s.String()
+}
+
+// SetHttpEndpoint sets the HttpEndpoint field's value.
+func (s *InstanceMetadataOptionsRequest) SetHttpEndpoint(v string) *InstanceMetadataOptionsRequest {
+	s.HttpEndpoint = &v
+	return s
+}
+
+// SetHttpPutResponseHopLimit sets the HttpPutResponseHopLimit field's value.
+func (s *InstanceMetadataOptionsRequest) SetHttpPutResponseHopLimit(v int64) *InstanceMetadataOptionsRequest {
+	s.HttpPutResponseHopLimit = &v
+	return s
+}
+
+// SetHttpTokens sets the HttpTokens field's value.
+func (s *InstanceMetadataOptionsRequest) SetHttpTokens(v string) *InstanceMetadataOptionsRequest {
+	s.HttpTokens = &v
+	return s
+}
+
+// The metadata options for the instance.
+type InstanceMetadataOptionsResponse struct {
+	_ struct{} `type:"structure"`
+
+	// This parameter enables or disables the HTTP metadata endpoint on your instances.
+	// If the parameter is not specified, the default state is enabled.
+	//
+	// If you specify a value of disabled, you will not be able to access your instance
+	// metadata.
+	HttpEndpoint *string `locationName:"httpEndpoint" type:"string" enum:"InstanceMetadataEndpointState"`
+
+	// The desired HTTP PUT response hop limit for instance metadata requests. The
+	// larger the number, the further instance metadata requests can travel.
+	//
+	// Default: 1
+	//
+	// Possible values: Integers from 1 to 64
+	HttpPutResponseHopLimit *int64 `locationName:"httpPutResponseHopLimit" type:"integer"`
+
+	// The state of token usage for your instance metadata requests. If the parameter
+	// is not specified in the request, the default state is optional.
+	//
+	// If the state is optional, you can choose to retrieve instance metadata with
+	// or without a signed token header on your request. If you retrieve the IAM
+	// role credentials without a token, the version 1.0 role credentials are returned.
+	// If you retrieve the IAM role credentials using a valid signed token, the
+	// version 2.0 role credentials are returned.
+	//
+	// If the state is required, you must send a signed token header with any instance
+	// metadata retrieval requests. In this state, retrieving the IAM role credential
+	// always returns the version 2.0 credentials; the version 1.0 credentials are
+	// not available.
+	HttpTokens *string `locationName:"httpTokens" type:"string" enum:"HttpTokensState"`
+
+	// The state of the metadata option changes.
+	//
+	// pending - The metadata options are being updated and the instance is not
+	// ready to process metadata traffic with the new selection.
+	//
+	// applied - The metadata options have been successfully applied on the instance.
+	State *string `locationName:"state" type:"string" enum:"InstanceMetadataOptionsState"`
+}
+
+// String returns the string representation
+func (s InstanceMetadataOptionsResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceMetadataOptionsResponse) GoString() string {
+	return s.String()
+}
+
+// SetHttpEndpoint sets the HttpEndpoint field's value.
+func (s *InstanceMetadataOptionsResponse) SetHttpEndpoint(v string) *InstanceMetadataOptionsResponse {
+	s.HttpEndpoint = &v
+	return s
+}
+
+// SetHttpPutResponseHopLimit sets the HttpPutResponseHopLimit field's value.
+func (s *InstanceMetadataOptionsResponse) SetHttpPutResponseHopLimit(v int64) *InstanceMetadataOptionsResponse {
+	s.HttpPutResponseHopLimit = &v
+	return s
+}
+
+// SetHttpTokens sets the HttpTokens field's value.
+func (s *InstanceMetadataOptionsResponse) SetHttpTokens(v string) *InstanceMetadataOptionsResponse {
+	s.HttpTokens = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *InstanceMetadataOptionsResponse) SetState(v string) *InstanceMetadataOptionsResponse {
+	s.State = &v
 	return s
 }
 
@@ -70568,6 +78638,9 @@ type InstanceStatus struct {
 	// such as impaired reachability.
 	InstanceStatus *InstanceStatusSummary `locationName:"instanceStatus" type:"structure"`
 
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
+
 	// Reports impaired functionality that stems from issues related to the systems
 	// that support an instance, such as hardware failures and network connectivity
 	// problems.
@@ -70611,6 +78684,12 @@ func (s *InstanceStatus) SetInstanceState(v *InstanceState) *InstanceStatus {
 // SetInstanceStatus sets the InstanceStatus field's value.
 func (s *InstanceStatus) SetInstanceStatus(v *InstanceStatusSummary) *InstanceStatus {
 	s.InstanceStatus = v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *InstanceStatus) SetOutpostArn(v string) *InstanceStatus {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -70766,6 +78845,298 @@ func (s *InstanceStatusSummary) SetDetails(v []*InstanceStatusDetails) *Instance
 // SetStatus sets the Status field's value.
 func (s *InstanceStatusSummary) SetStatus(v string) *InstanceStatusSummary {
 	s.Status = &v
+	return s
+}
+
+// Describes the disks that are available for the instance type.
+type InstanceStorageInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Array describing the disks that are available for the instance type.
+	Disks []*DiskInfo `locationName:"disks" locationNameList:"item" type:"list"`
+
+	// The total size of the disks, in GB.
+	TotalSizeInGB *int64 `locationName:"totalSizeInGB" type:"long"`
+}
+
+// String returns the string representation
+func (s InstanceStorageInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStorageInfo) GoString() string {
+	return s.String()
+}
+
+// SetDisks sets the Disks field's value.
+func (s *InstanceStorageInfo) SetDisks(v []*DiskInfo) *InstanceStorageInfo {
+	s.Disks = v
+	return s
+}
+
+// SetTotalSizeInGB sets the TotalSizeInGB field's value.
+func (s *InstanceStorageInfo) SetTotalSizeInGB(v int64) *InstanceStorageInfo {
+	s.TotalSizeInGB = &v
+	return s
+}
+
+// Describes the instance type.
+type InstanceTypeInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether auto recovery is supported.
+	AutoRecoverySupported *bool `locationName:"autoRecoverySupported" type:"boolean"`
+
+	// Indicates whether the instance is bare metal.
+	BareMetal *bool `locationName:"bareMetal" type:"boolean"`
+
+	// Indicates whether the instance type is a burstable performance instance type.
+	BurstablePerformanceSupported *bool `locationName:"burstablePerformanceSupported" type:"boolean"`
+
+	// Indicates whether the instance type is a current generation.
+	CurrentGeneration *bool `locationName:"currentGeneration" type:"boolean"`
+
+	// Indicates whether Dedicated Hosts are supported on the instance type.
+	DedicatedHostsSupported *bool `locationName:"dedicatedHostsSupported" type:"boolean"`
+
+	// Describes the Amazon EBS settings for the instance type.
+	EbsInfo *EbsInfo `locationName:"ebsInfo" type:"structure"`
+
+	// Describes the FPGA accelerator settings for the instance type.
+	FpgaInfo *FpgaInfo `locationName:"fpgaInfo" type:"structure"`
+
+	// Indicates whether the instance type is eligible for the free tier.
+	FreeTierEligible *bool `locationName:"freeTierEligible" type:"boolean"`
+
+	// Describes the GPU accelerator settings for the instance type.
+	GpuInfo *GpuInfo `locationName:"gpuInfo" type:"structure"`
+
+	// Indicates whether On-Demand hibernation is supported.
+	HibernationSupported *bool `locationName:"hibernationSupported" type:"boolean"`
+
+	// Indicates the hypervisor used for the instance type.
+	Hypervisor *string `locationName:"hypervisor" type:"string" enum:"InstanceTypeHypervisor"`
+
+	// Describes the Inference accelerator settings for the instance type.
+	InferenceAcceleratorInfo *InferenceAcceleratorInfo `locationName:"inferenceAcceleratorInfo" type:"structure"`
+
+	// Describes the disks for the instance type.
+	InstanceStorageInfo *InstanceStorageInfo `locationName:"instanceStorageInfo" type:"structure"`
+
+	// Indicates whether instance storage is supported.
+	InstanceStorageSupported *bool `locationName:"instanceStorageSupported" type:"boolean"`
+
+	// The instance type. For more information, see Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+	// in the Amazon Elastic Compute Cloud User Guide.
+	InstanceType *string `locationName:"instanceType" type:"string" enum:"InstanceType"`
+
+	// Describes the memory for the instance type.
+	MemoryInfo *MemoryInfo `locationName:"memoryInfo" type:"structure"`
+
+	// Describes the network settings for the instance type.
+	NetworkInfo *NetworkInfo `locationName:"networkInfo" type:"structure"`
+
+	// Describes the placement group settings for the instance type.
+	PlacementGroupInfo *PlacementGroupInfo `locationName:"placementGroupInfo" type:"structure"`
+
+	// Describes the processor.
+	ProcessorInfo *ProcessorInfo `locationName:"processorInfo" type:"structure"`
+
+	// Indicates the supported root device types.
+	SupportedRootDeviceTypes []*string `locationName:"supportedRootDeviceTypes" locationNameList:"item" type:"list"`
+
+	// Indicates whether the instance type is offered for spot or On-Demand.
+	SupportedUsageClasses []*string `locationName:"supportedUsageClasses" locationNameList:"item" type:"list"`
+
+	// Describes the vCPU configurations for the instance type.
+	VCpuInfo *VCpuInfo `locationName:"vCpuInfo" type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceTypeInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceTypeInfo) GoString() string {
+	return s.String()
+}
+
+// SetAutoRecoverySupported sets the AutoRecoverySupported field's value.
+func (s *InstanceTypeInfo) SetAutoRecoverySupported(v bool) *InstanceTypeInfo {
+	s.AutoRecoverySupported = &v
+	return s
+}
+
+// SetBareMetal sets the BareMetal field's value.
+func (s *InstanceTypeInfo) SetBareMetal(v bool) *InstanceTypeInfo {
+	s.BareMetal = &v
+	return s
+}
+
+// SetBurstablePerformanceSupported sets the BurstablePerformanceSupported field's value.
+func (s *InstanceTypeInfo) SetBurstablePerformanceSupported(v bool) *InstanceTypeInfo {
+	s.BurstablePerformanceSupported = &v
+	return s
+}
+
+// SetCurrentGeneration sets the CurrentGeneration field's value.
+func (s *InstanceTypeInfo) SetCurrentGeneration(v bool) *InstanceTypeInfo {
+	s.CurrentGeneration = &v
+	return s
+}
+
+// SetDedicatedHostsSupported sets the DedicatedHostsSupported field's value.
+func (s *InstanceTypeInfo) SetDedicatedHostsSupported(v bool) *InstanceTypeInfo {
+	s.DedicatedHostsSupported = &v
+	return s
+}
+
+// SetEbsInfo sets the EbsInfo field's value.
+func (s *InstanceTypeInfo) SetEbsInfo(v *EbsInfo) *InstanceTypeInfo {
+	s.EbsInfo = v
+	return s
+}
+
+// SetFpgaInfo sets the FpgaInfo field's value.
+func (s *InstanceTypeInfo) SetFpgaInfo(v *FpgaInfo) *InstanceTypeInfo {
+	s.FpgaInfo = v
+	return s
+}
+
+// SetFreeTierEligible sets the FreeTierEligible field's value.
+func (s *InstanceTypeInfo) SetFreeTierEligible(v bool) *InstanceTypeInfo {
+	s.FreeTierEligible = &v
+	return s
+}
+
+// SetGpuInfo sets the GpuInfo field's value.
+func (s *InstanceTypeInfo) SetGpuInfo(v *GpuInfo) *InstanceTypeInfo {
+	s.GpuInfo = v
+	return s
+}
+
+// SetHibernationSupported sets the HibernationSupported field's value.
+func (s *InstanceTypeInfo) SetHibernationSupported(v bool) *InstanceTypeInfo {
+	s.HibernationSupported = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *InstanceTypeInfo) SetHypervisor(v string) *InstanceTypeInfo {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetInferenceAcceleratorInfo sets the InferenceAcceleratorInfo field's value.
+func (s *InstanceTypeInfo) SetInferenceAcceleratorInfo(v *InferenceAcceleratorInfo) *InstanceTypeInfo {
+	s.InferenceAcceleratorInfo = v
+	return s
+}
+
+// SetInstanceStorageInfo sets the InstanceStorageInfo field's value.
+func (s *InstanceTypeInfo) SetInstanceStorageInfo(v *InstanceStorageInfo) *InstanceTypeInfo {
+	s.InstanceStorageInfo = v
+	return s
+}
+
+// SetInstanceStorageSupported sets the InstanceStorageSupported field's value.
+func (s *InstanceTypeInfo) SetInstanceStorageSupported(v bool) *InstanceTypeInfo {
+	s.InstanceStorageSupported = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceTypeInfo) SetInstanceType(v string) *InstanceTypeInfo {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMemoryInfo sets the MemoryInfo field's value.
+func (s *InstanceTypeInfo) SetMemoryInfo(v *MemoryInfo) *InstanceTypeInfo {
+	s.MemoryInfo = v
+	return s
+}
+
+// SetNetworkInfo sets the NetworkInfo field's value.
+func (s *InstanceTypeInfo) SetNetworkInfo(v *NetworkInfo) *InstanceTypeInfo {
+	s.NetworkInfo = v
+	return s
+}
+
+// SetPlacementGroupInfo sets the PlacementGroupInfo field's value.
+func (s *InstanceTypeInfo) SetPlacementGroupInfo(v *PlacementGroupInfo) *InstanceTypeInfo {
+	s.PlacementGroupInfo = v
+	return s
+}
+
+// SetProcessorInfo sets the ProcessorInfo field's value.
+func (s *InstanceTypeInfo) SetProcessorInfo(v *ProcessorInfo) *InstanceTypeInfo {
+	s.ProcessorInfo = v
+	return s
+}
+
+// SetSupportedRootDeviceTypes sets the SupportedRootDeviceTypes field's value.
+func (s *InstanceTypeInfo) SetSupportedRootDeviceTypes(v []*string) *InstanceTypeInfo {
+	s.SupportedRootDeviceTypes = v
+	return s
+}
+
+// SetSupportedUsageClasses sets the SupportedUsageClasses field's value.
+func (s *InstanceTypeInfo) SetSupportedUsageClasses(v []*string) *InstanceTypeInfo {
+	s.SupportedUsageClasses = v
+	return s
+}
+
+// SetVCpuInfo sets the VCpuInfo field's value.
+func (s *InstanceTypeInfo) SetVCpuInfo(v *VCpuInfo) *InstanceTypeInfo {
+	s.VCpuInfo = v
+	return s
+}
+
+// The instance types offered.
+type InstanceTypeOffering struct {
+	_ struct{} `type:"structure"`
+
+	// The instance type. For more information, see Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+	// in the Amazon Elastic Compute Cloud User Guide.
+	InstanceType *string `locationName:"instanceType" type:"string" enum:"InstanceType"`
+
+	// The identifier for the location. This depends on the location type. For example,
+	// if the location type is region, the location is the Region code (for example,
+	// us-east-2.)
+	Location *string `locationName:"location" type:"string"`
+
+	// The location type.
+	LocationType *string `locationName:"locationType" type:"string" enum:"LocationType"`
+}
+
+// String returns the string representation
+func (s InstanceTypeOffering) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceTypeOffering) GoString() string {
+	return s.String()
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceTypeOffering) SetInstanceType(v string) *InstanceTypeOffering {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *InstanceTypeOffering) SetLocation(v string) *InstanceTypeOffering {
+	s.Location = &v
+	return s
+}
+
+// SetLocationType sets the LocationType field's value.
+func (s *InstanceTypeOffering) SetLocationType(v string) *InstanceTypeOffering {
+	s.LocationType = &v
 	return s
 }
 
@@ -71939,6 +80310,11 @@ func (s *LaunchTemplateEbsBlockDeviceRequest) SetVolumeType(v string) *LaunchTem
 type LaunchTemplateElasticInferenceAccelerator struct {
 	_ struct{} `type:"structure"`
 
+	// The number of elastic inference accelerators of given type to be attached
+	// to the instance. Only positive values allowed. If not specified defaults
+	// to 1.
+	Count *int64 `min:"1" type:"integer"`
+
 	// The type of elastic inference accelerator. The possible values are eia1.medium,
 	// eia1.large, and eia1.xlarge.
 	//
@@ -71959,6 +80335,9 @@ func (s LaunchTemplateElasticInferenceAccelerator) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *LaunchTemplateElasticInferenceAccelerator) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "LaunchTemplateElasticInferenceAccelerator"}
+	if s.Count != nil && *s.Count < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Count", 1))
+	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
 	}
@@ -71967,6 +80346,12 @@ func (s *LaunchTemplateElasticInferenceAccelerator) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCount sets the Count field's value.
+func (s *LaunchTemplateElasticInferenceAccelerator) SetCount(v int64) *LaunchTemplateElasticInferenceAccelerator {
+	s.Count = &v
+	return s
 }
 
 // SetType sets the Type field's value.
@@ -71978,6 +80363,11 @@ func (s *LaunchTemplateElasticInferenceAccelerator) SetType(v string) *LaunchTem
 // Describes an elastic inference accelerator.
 type LaunchTemplateElasticInferenceAcceleratorResponse struct {
 	_ struct{} `type:"structure"`
+
+	// The number of elastic inference accelerators of given type to be attached
+	// to the instance. Only positive values allowed. If not specified defaults
+	// to 1.
+	Count *int64 `locationName:"count" type:"integer"`
 
 	// The type of elastic inference accelerator. The possible values are eia1.medium,
 	// eia1.large, and eia1.xlarge.
@@ -71992,6 +80382,12 @@ func (s LaunchTemplateElasticInferenceAcceleratorResponse) String() string {
 // GoString returns the string representation
 func (s LaunchTemplateElasticInferenceAcceleratorResponse) GoString() string {
 	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *LaunchTemplateElasticInferenceAcceleratorResponse) SetCount(v int64) *LaunchTemplateElasticInferenceAcceleratorResponse {
+	s.Count = &v
+	return s
 }
 
 // SetType sets the Type field's value.
@@ -72027,7 +80423,6 @@ func (s *LaunchTemplateHibernationOptions) SetConfigured(v bool) *LaunchTemplate
 
 // Indicates whether the instance is configured for hibernation. This parameter
 // is valid only if the instance meets the hibernation prerequisites (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html#hibernating-prerequisites).
-// Hibernation is currently supported only for Amazon Linux.
 type LaunchTemplateHibernationOptionsRequest struct {
 	_ struct{} `type:"structure"`
 
@@ -72597,6 +80992,9 @@ type LaunchTemplatePlacement struct {
 	// The ID of the Dedicated Host for the instance.
 	HostId *string `locationName:"hostId" type:"string"`
 
+	// The ARN of the host resource group in which to launch the instances.
+	HostResourceGroupArn *string `locationName:"hostResourceGroupArn" type:"string"`
+
 	// Reserved for future use.
 	SpreadDomain *string `locationName:"spreadDomain" type:"string"`
 
@@ -72639,6 +81037,12 @@ func (s *LaunchTemplatePlacement) SetHostId(v string) *LaunchTemplatePlacement {
 	return s
 }
 
+// SetHostResourceGroupArn sets the HostResourceGroupArn field's value.
+func (s *LaunchTemplatePlacement) SetHostResourceGroupArn(v string) *LaunchTemplatePlacement {
+	s.HostResourceGroupArn = &v
+	return s
+}
+
 // SetSpreadDomain sets the SpreadDomain field's value.
 func (s *LaunchTemplatePlacement) SetSpreadDomain(v string) *LaunchTemplatePlacement {
 	s.SpreadDomain = &v
@@ -72666,6 +81070,11 @@ type LaunchTemplatePlacementRequest struct {
 
 	// The ID of the Dedicated Host for the instance.
 	HostId *string `type:"string"`
+
+	// The ARN of the host resource group in which to launch the instances. If you
+	// specify a host resource group ARN, omit the Tenancy parameter or set it to
+	// host.
+	HostResourceGroupArn *string `type:"string"`
 
 	// Reserved for future use.
 	SpreadDomain *string `type:"string"`
@@ -72706,6 +81115,12 @@ func (s *LaunchTemplatePlacementRequest) SetGroupName(v string) *LaunchTemplateP
 // SetHostId sets the HostId field's value.
 func (s *LaunchTemplatePlacementRequest) SetHostId(v string) *LaunchTemplatePlacementRequest {
 	s.HostId = &v
+	return s
+}
+
+// SetHostResourceGroupArn sets the HostResourceGroupArn field's value.
+func (s *LaunchTemplatePlacementRequest) SetHostResourceGroupArn(v string) *LaunchTemplatePlacementRequest {
+	s.HostResourceGroupArn = &v
 	return s
 }
 
@@ -73303,6 +81718,434 @@ func (s *LoadPermissionRequest) SetUserId(v string) *LoadPermissionRequest {
 	return s
 }
 
+// Describes a local gateway.
+type LocalGateway struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
+
+	// The ID of the AWS account ID that owns the local gateway.
+	OwnerId *string `locationName:"ownerId" type:"string"`
+
+	// The state of the local gateway.
+	State *string `locationName:"state" type:"string"`
+}
+
+// String returns the string representation
+func (s LocalGateway) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGateway) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGateway) SetLocalGatewayId(v string) *LocalGateway {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *LocalGateway) SetOutpostArn(v string) *LocalGateway {
+	s.OutpostArn = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *LocalGateway) SetOwnerId(v string) *LocalGateway {
+	s.OwnerId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LocalGateway) SetState(v string) *LocalGateway {
+	s.State = &v
+	return s
+}
+
+// Describes a route for a local gateway route table.
+type LocalGatewayRoute struct {
+	_ struct{} `type:"structure"`
+
+	// The CIDR block used for destination matches.
+	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+
+	// The ID of the virtual interface group.
+	LocalGatewayVirtualInterfaceGroupId *string `locationName:"localGatewayVirtualInterfaceGroupId" type:"string"`
+
+	// The state of the route.
+	State *string `locationName:"state" type:"string" enum:"LocalGatewayRouteState"`
+
+	// The route type.
+	Type *string `locationName:"type" type:"string" enum:"LocalGatewayRouteType"`
+}
+
+// String returns the string representation
+func (s LocalGatewayRoute) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayRoute) GoString() string {
+	return s.String()
+}
+
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *LocalGatewayRoute) SetDestinationCidrBlock(v string) *LocalGatewayRoute {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *LocalGatewayRoute) SetLocalGatewayRouteTableId(v string) *LocalGatewayRoute {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceGroupId sets the LocalGatewayVirtualInterfaceGroupId field's value.
+func (s *LocalGatewayRoute) SetLocalGatewayVirtualInterfaceGroupId(v string) *LocalGatewayRoute {
+	s.LocalGatewayVirtualInterfaceGroupId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LocalGatewayRoute) SetState(v string) *LocalGatewayRoute {
+	s.State = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *LocalGatewayRoute) SetType(v string) *LocalGatewayRoute {
+	s.Type = &v
+	return s
+}
+
+// Describes a local gateway route table.
+type LocalGatewayRouteTable struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
+
+	// The state of the local gateway route table.
+	State *string `locationName:"state" type:"string"`
+}
+
+// String returns the string representation
+func (s LocalGatewayRouteTable) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayRouteTable) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGatewayRouteTable) SetLocalGatewayId(v string) *LocalGatewayRouteTable {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *LocalGatewayRouteTable) SetLocalGatewayRouteTableId(v string) *LocalGatewayRouteTable {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *LocalGatewayRouteTable) SetOutpostArn(v string) *LocalGatewayRouteTable {
+	s.OutpostArn = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LocalGatewayRouteTable) SetState(v string) *LocalGatewayRouteTable {
+	s.State = &v
+	return s
+}
+
+// Describes an association between a local gateway route table and a virtual
+// interface group.
+type LocalGatewayRouteTableVirtualInterfaceGroupAssociation struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+
+	// The ID of the association.
+	LocalGatewayRouteTableVirtualInterfaceGroupAssociationId *string `locationName:"localGatewayRouteTableVirtualInterfaceGroupAssociationId" type:"string"`
+
+	// The ID of the virtual interface group.
+	LocalGatewayVirtualInterfaceGroupId *string `locationName:"localGatewayVirtualInterfaceGroupId" type:"string"`
+
+	// The state of the association.
+	State *string `locationName:"state" type:"string"`
+}
+
+// String returns the string representation
+func (s LocalGatewayRouteTableVirtualInterfaceGroupAssociation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayRouteTableVirtualInterfaceGroupAssociation) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGatewayRouteTableVirtualInterfaceGroupAssociation) SetLocalGatewayId(v string) *LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *LocalGatewayRouteTableVirtualInterfaceGroupAssociation) SetLocalGatewayRouteTableId(v string) *LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableVirtualInterfaceGroupAssociationId sets the LocalGatewayRouteTableVirtualInterfaceGroupAssociationId field's value.
+func (s *LocalGatewayRouteTableVirtualInterfaceGroupAssociation) SetLocalGatewayRouteTableVirtualInterfaceGroupAssociationId(v string) *LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
+	s.LocalGatewayRouteTableVirtualInterfaceGroupAssociationId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceGroupId sets the LocalGatewayVirtualInterfaceGroupId field's value.
+func (s *LocalGatewayRouteTableVirtualInterfaceGroupAssociation) SetLocalGatewayVirtualInterfaceGroupId(v string) *LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
+	s.LocalGatewayVirtualInterfaceGroupId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LocalGatewayRouteTableVirtualInterfaceGroupAssociation) SetState(v string) *LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
+	s.State = &v
+	return s
+}
+
+// Describes an association between a local gateway route table and a VPC.
+type LocalGatewayRouteTableVpcAssociation struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The ID of the local gateway route table.
+	LocalGatewayRouteTableId *string `locationName:"localGatewayRouteTableId" type:"string"`
+
+	// The ID of the association.
+	LocalGatewayRouteTableVpcAssociationId *string `locationName:"localGatewayRouteTableVpcAssociationId" type:"string"`
+
+	// The state of the association.
+	State *string `locationName:"state" type:"string"`
+
+	// The ID of the VPC.
+	VpcId *string `locationName:"vpcId" type:"string"`
+}
+
+// String returns the string representation
+func (s LocalGatewayRouteTableVpcAssociation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayRouteTableVpcAssociation) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGatewayRouteTableVpcAssociation) SetLocalGatewayId(v string) *LocalGatewayRouteTableVpcAssociation {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *LocalGatewayRouteTableVpcAssociation) SetLocalGatewayRouteTableId(v string) *LocalGatewayRouteTableVpcAssociation {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetLocalGatewayRouteTableVpcAssociationId sets the LocalGatewayRouteTableVpcAssociationId field's value.
+func (s *LocalGatewayRouteTableVpcAssociation) SetLocalGatewayRouteTableVpcAssociationId(v string) *LocalGatewayRouteTableVpcAssociation {
+	s.LocalGatewayRouteTableVpcAssociationId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LocalGatewayRouteTableVpcAssociation) SetState(v string) *LocalGatewayRouteTableVpcAssociation {
+	s.State = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *LocalGatewayRouteTableVpcAssociation) SetVpcId(v string) *LocalGatewayRouteTableVpcAssociation {
+	s.VpcId = &v
+	return s
+}
+
+// Describes a local gateway virtual interface.
+type LocalGatewayVirtualInterface struct {
+	_ struct{} `type:"structure"`
+
+	// The local address.
+	LocalAddress *string `locationName:"localAddress" type:"string"`
+
+	// The Border Gateway Protocol (BGP) Autonomous System Number (ASN) of the local
+	// gateway.
+	LocalBgpAsn *int64 `locationName:"localBgpAsn" type:"integer"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The ID of the virtual interface.
+	LocalGatewayVirtualInterfaceId *string `locationName:"localGatewayVirtualInterfaceId" type:"string"`
+
+	// The peer address.
+	PeerAddress *string `locationName:"peerAddress" type:"string"`
+
+	// The peer BGP ASN.
+	PeerBgpAsn *int64 `locationName:"peerBgpAsn" type:"integer"`
+
+	// The ID of the VLAN.
+	Vlan *int64 `locationName:"vlan" type:"integer"`
+}
+
+// String returns the string representation
+func (s LocalGatewayVirtualInterface) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayVirtualInterface) GoString() string {
+	return s.String()
+}
+
+// SetLocalAddress sets the LocalAddress field's value.
+func (s *LocalGatewayVirtualInterface) SetLocalAddress(v string) *LocalGatewayVirtualInterface {
+	s.LocalAddress = &v
+	return s
+}
+
+// SetLocalBgpAsn sets the LocalBgpAsn field's value.
+func (s *LocalGatewayVirtualInterface) SetLocalBgpAsn(v int64) *LocalGatewayVirtualInterface {
+	s.LocalBgpAsn = &v
+	return s
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGatewayVirtualInterface) SetLocalGatewayId(v string) *LocalGatewayVirtualInterface {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceId sets the LocalGatewayVirtualInterfaceId field's value.
+func (s *LocalGatewayVirtualInterface) SetLocalGatewayVirtualInterfaceId(v string) *LocalGatewayVirtualInterface {
+	s.LocalGatewayVirtualInterfaceId = &v
+	return s
+}
+
+// SetPeerAddress sets the PeerAddress field's value.
+func (s *LocalGatewayVirtualInterface) SetPeerAddress(v string) *LocalGatewayVirtualInterface {
+	s.PeerAddress = &v
+	return s
+}
+
+// SetPeerBgpAsn sets the PeerBgpAsn field's value.
+func (s *LocalGatewayVirtualInterface) SetPeerBgpAsn(v int64) *LocalGatewayVirtualInterface {
+	s.PeerBgpAsn = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *LocalGatewayVirtualInterface) SetVlan(v int64) *LocalGatewayVirtualInterface {
+	s.Vlan = &v
+	return s
+}
+
+// Describes a local gateway virtual interface group.
+type LocalGatewayVirtualInterfaceGroup struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
+	// The ID of the virtual interface group.
+	LocalGatewayVirtualInterfaceGroupId *string `locationName:"localGatewayVirtualInterfaceGroupId" type:"string"`
+
+	// The IDs of the virtual interfaces.
+	LocalGatewayVirtualInterfaceIds []*string `locationName:"localGatewayVirtualInterfaceIdSet" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s LocalGatewayVirtualInterfaceGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalGatewayVirtualInterfaceGroup) GoString() string {
+	return s.String()
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *LocalGatewayVirtualInterfaceGroup) SetLocalGatewayId(v string) *LocalGatewayVirtualInterfaceGroup {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceGroupId sets the LocalGatewayVirtualInterfaceGroupId field's value.
+func (s *LocalGatewayVirtualInterfaceGroup) SetLocalGatewayVirtualInterfaceGroupId(v string) *LocalGatewayVirtualInterfaceGroup {
+	s.LocalGatewayVirtualInterfaceGroupId = &v
+	return s
+}
+
+// SetLocalGatewayVirtualInterfaceIds sets the LocalGatewayVirtualInterfaceIds field's value.
+func (s *LocalGatewayVirtualInterfaceGroup) SetLocalGatewayVirtualInterfaceIds(v []*string) *LocalGatewayVirtualInterfaceGroup {
+	s.LocalGatewayVirtualInterfaceIds = v
+	return s
+}
+
+// Describes the memory for the instance type.
+type MemoryInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Size of the memory, in MiB.
+	SizeInMiB *int64 `locationName:"sizeInMiB" type:"long"`
+}
+
+// String returns the string representation
+func (s MemoryInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MemoryInfo) GoString() string {
+	return s.String()
+}
+
+// SetSizeInMiB sets the SizeInMiB field's value.
+func (s *MemoryInfo) SetSizeInMiB(v int64) *MemoryInfo {
+	s.SizeInMiB = &v
+	return s
+}
+
 type ModifyCapacityReservationInput struct {
 	_ struct{} `type:"structure"`
 
@@ -73552,6 +82395,95 @@ func (s ModifyClientVpnEndpointOutput) GoString() string {
 // SetReturn sets the Return field's value.
 func (s *ModifyClientVpnEndpointOutput) SetReturn(v bool) *ModifyClientVpnEndpointOutput {
 	s.Return = &v
+	return s
+}
+
+type ModifyDefaultCreditSpecificationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The credit option for CPU usage of the instance family.
+	//
+	// Valid Values: standard | unlimited
+	//
+	// CpuCredits is a required field
+	CpuCredits *string `type:"string" required:"true"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The instance family.
+	//
+	// InstanceFamily is a required field
+	InstanceFamily *string `type:"string" required:"true" enum:"UnlimitedSupportedInstanceFamily"`
+}
+
+// String returns the string representation
+func (s ModifyDefaultCreditSpecificationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDefaultCreditSpecificationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDefaultCreditSpecificationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDefaultCreditSpecificationInput"}
+	if s.CpuCredits == nil {
+		invalidParams.Add(request.NewErrParamRequired("CpuCredits"))
+	}
+	if s.InstanceFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceFamily"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCpuCredits sets the CpuCredits field's value.
+func (s *ModifyDefaultCreditSpecificationInput) SetCpuCredits(v string) *ModifyDefaultCreditSpecificationInput {
+	s.CpuCredits = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyDefaultCreditSpecificationInput) SetDryRun(v bool) *ModifyDefaultCreditSpecificationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *ModifyDefaultCreditSpecificationInput) SetInstanceFamily(v string) *ModifyDefaultCreditSpecificationInput {
+	s.InstanceFamily = &v
+	return s
+}
+
+type ModifyDefaultCreditSpecificationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The default credit option for CPU usage of the instance family.
+	InstanceFamilyCreditSpecification *InstanceFamilyCreditSpecification `locationName:"instanceFamilyCreditSpecification" type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyDefaultCreditSpecificationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDefaultCreditSpecificationOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceFamilyCreditSpecification sets the InstanceFamilyCreditSpecification field's value.
+func (s *ModifyDefaultCreditSpecificationOutput) SetInstanceFamilyCreditSpecification(v *InstanceFamilyCreditSpecification) *ModifyDefaultCreditSpecificationOutput {
+	s.InstanceFamilyCreditSpecification = v
 	return s
 }
 
@@ -73911,6 +82843,24 @@ type ModifyHostsInput struct {
 	// For more information, see Host Recovery (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-recovery.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	HostRecovery *string `type:"string" enum:"HostRecovery"`
+
+	// Specifies the instance family to be supported by the Dedicated Host. Specify
+	// this parameter to modify a Dedicated Host to support multiple instance types
+	// within its current instance family.
+	//
+	// If you want to modify a Dedicated Host to support a specific instance type
+	// only, omit this parameter and specify InstanceType instead. You cannot specify
+	// InstanceFamily and InstanceType in the same request.
+	InstanceFamily *string `type:"string"`
+
+	// Specifies the instance type to be supported by the Dedicated Host. Specify
+	// this parameter to modify a Dedicated Host to support only a specific instance
+	// type.
+	//
+	// If you want to modify a Dedicated Host to support multiple instance types
+	// in its current instance family, omit this parameter and specify InstanceFamily
+	// instead. You cannot specify InstanceType and InstanceFamily in the same request.
+	InstanceType *string `type:"string"`
 }
 
 // String returns the string representation
@@ -73951,6 +82901,18 @@ func (s *ModifyHostsInput) SetHostIds(v []*string) *ModifyHostsInput {
 // SetHostRecovery sets the HostRecovery field's value.
 func (s *ModifyHostsInput) SetHostRecovery(v string) *ModifyHostsInput {
 	s.HostRecovery = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *ModifyHostsInput) SetInstanceFamily(v string) *ModifyHostsInput {
+	s.InstanceFamily = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ModifyHostsInput) SetInstanceType(v string) *ModifyHostsInput {
+	s.InstanceType = &v
 	return s
 }
 
@@ -74808,6 +83770,135 @@ func (s *ModifyInstanceEventStartTimeOutput) SetEvent(v *InstanceStatusEvent) *M
 	return s
 }
 
+type ModifyInstanceMetadataOptionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// This parameter enables or disables the HTTP metadata endpoint on your instances.
+	// If the parameter is not specified, the existing state is maintained.
+	//
+	// If you specify a value of disabled, you will not be able to access your instance
+	// metadata.
+	HttpEndpoint *string `type:"string" enum:"InstanceMetadataEndpointState"`
+
+	// The desired HTTP PUT response hop limit for instance metadata requests. The
+	// larger the number, the further instance metadata requests can travel. If
+	// no parameter is specified, the existing state is maintained.
+	//
+	// Possible values: Integers from 1 to 64
+	HttpPutResponseHopLimit *int64 `type:"integer"`
+
+	// The state of token usage for your instance metadata requests. If the parameter
+	// is not specified in the request, the default state is optional.
+	//
+	// If the state is optional, you can choose to retrieve instance metadata with
+	// or without a signed token header on your request. If you retrieve the IAM
+	// role credentials without a token, the version 1.0 role credentials are returned.
+	// If you retrieve the IAM role credentials using a valid signed token, the
+	// version 2.0 role credentials are returned.
+	//
+	// If the state is required, you must send a signed token header with any instance
+	// metadata retrieval requests. In this state, retrieving the IAM role credential
+	// always returns the version 2.0 credentials; the version 1.0 credentials are
+	// not available.
+	HttpTokens *string `type:"string" enum:"HttpTokensState"`
+
+	// The ID of the instance.
+	//
+	// InstanceId is a required field
+	InstanceId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceMetadataOptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceMetadataOptionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyInstanceMetadataOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyInstanceMetadataOptionsInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyInstanceMetadataOptionsInput) SetDryRun(v bool) *ModifyInstanceMetadataOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetHttpEndpoint sets the HttpEndpoint field's value.
+func (s *ModifyInstanceMetadataOptionsInput) SetHttpEndpoint(v string) *ModifyInstanceMetadataOptionsInput {
+	s.HttpEndpoint = &v
+	return s
+}
+
+// SetHttpPutResponseHopLimit sets the HttpPutResponseHopLimit field's value.
+func (s *ModifyInstanceMetadataOptionsInput) SetHttpPutResponseHopLimit(v int64) *ModifyInstanceMetadataOptionsInput {
+	s.HttpPutResponseHopLimit = &v
+	return s
+}
+
+// SetHttpTokens sets the HttpTokens field's value.
+func (s *ModifyInstanceMetadataOptionsInput) SetHttpTokens(v string) *ModifyInstanceMetadataOptionsInput {
+	s.HttpTokens = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ModifyInstanceMetadataOptionsInput) SetInstanceId(v string) *ModifyInstanceMetadataOptionsInput {
+	s.InstanceId = &v
+	return s
+}
+
+type ModifyInstanceMetadataOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the instance.
+	InstanceId *string `locationName:"instanceId" type:"string"`
+
+	// The metadata options for the instance.
+	InstanceMetadataOptions *InstanceMetadataOptionsResponse `locationName:"instanceMetadataOptions" type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceMetadataOptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceMetadataOptionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ModifyInstanceMetadataOptionsOutput) SetInstanceId(v string) *ModifyInstanceMetadataOptionsOutput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceMetadataOptions sets the InstanceMetadataOptions field's value.
+func (s *ModifyInstanceMetadataOptionsOutput) SetInstanceMetadataOptions(v *InstanceMetadataOptionsResponse) *ModifyInstanceMetadataOptionsOutput {
+	s.InstanceMetadataOptions = v
+	return s
+}
+
 type ModifyInstancePlacementInput struct {
 	_ struct{} `type:"structure"`
 
@@ -74824,6 +83915,9 @@ type ModifyInstancePlacementInput struct {
 
 	// The ID of the Dedicated Host with which to associate the instance.
 	HostId *string `locationName:"hostId" type:"string"`
+
+	// The ARN of the host resource group in which to place the instance.
+	HostResourceGroupArn *string `type:"string"`
 
 	// The ID of the instance that you are modifying.
 	//
@@ -74875,6 +83969,12 @@ func (s *ModifyInstancePlacementInput) SetGroupName(v string) *ModifyInstancePla
 // SetHostId sets the HostId field's value.
 func (s *ModifyInstancePlacementInput) SetHostId(v string) *ModifyInstancePlacementInput {
 	s.HostId = &v
+	return s
+}
+
+// SetHostResourceGroupArn sets the HostResourceGroupArn field's value.
+func (s *ModifyInstancePlacementInput) SetHostResourceGroupArn(v string) *ModifyInstancePlacementInput {
+	s.HostResourceGroupArn = &v
 	return s
 }
 
@@ -75218,7 +84318,6 @@ func (s *ModifyReservedInstancesOutput) SetReservedInstancesModificationId(v str
 	return s
 }
 
-// Contains the parameters for ModifySnapshotAttribute.
 type ModifySnapshotAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -76040,7 +85139,6 @@ func (s *ModifyTransitGatewayVpcAttachmentRequestOptions) SetIpv6Support(v strin
 	return s
 }
 
-// Contains the parameters for ModifyVolumeAttribute.
 type ModifyVolumeAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -78081,6 +87179,75 @@ func (s *NetworkAclEntry) SetRuleNumber(v int64) *NetworkAclEntry {
 	return s
 }
 
+// Describes the networking features of the instance type.
+type NetworkInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether Elastic Network Adapter (ENA) is supported.
+	EnaSupport *string `locationName:"enaSupport" type:"string" enum:"EnaSupport"`
+
+	// The maximum number of IPv4 addresses per network interface.
+	Ipv4AddressesPerInterface *int64 `locationName:"ipv4AddressesPerInterface" type:"integer"`
+
+	// The maximum number of IPv6 addresses per network interface.
+	Ipv6AddressesPerInterface *int64 `locationName:"ipv6AddressesPerInterface" type:"integer"`
+
+	// Indicates whether IPv6 is supported.
+	Ipv6Supported *bool `locationName:"ipv6Supported" type:"boolean"`
+
+	// The maximum number of network interfaces for the instance type.
+	MaximumNetworkInterfaces *int64 `locationName:"maximumNetworkInterfaces" type:"integer"`
+
+	// Describes the network performance.
+	NetworkPerformance *string `locationName:"networkPerformance" type:"string"`
+}
+
+// String returns the string representation
+func (s NetworkInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInfo) GoString() string {
+	return s.String()
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *NetworkInfo) SetEnaSupport(v string) *NetworkInfo {
+	s.EnaSupport = &v
+	return s
+}
+
+// SetIpv4AddressesPerInterface sets the Ipv4AddressesPerInterface field's value.
+func (s *NetworkInfo) SetIpv4AddressesPerInterface(v int64) *NetworkInfo {
+	s.Ipv4AddressesPerInterface = &v
+	return s
+}
+
+// SetIpv6AddressesPerInterface sets the Ipv6AddressesPerInterface field's value.
+func (s *NetworkInfo) SetIpv6AddressesPerInterface(v int64) *NetworkInfo {
+	s.Ipv6AddressesPerInterface = &v
+	return s
+}
+
+// SetIpv6Supported sets the Ipv6Supported field's value.
+func (s *NetworkInfo) SetIpv6Supported(v bool) *NetworkInfo {
+	s.Ipv6Supported = &v
+	return s
+}
+
+// SetMaximumNetworkInterfaces sets the MaximumNetworkInterfaces field's value.
+func (s *NetworkInfo) SetMaximumNetworkInterfaces(v int64) *NetworkInfo {
+	s.MaximumNetworkInterfaces = &v
+	return s
+}
+
+// SetNetworkPerformance sets the NetworkPerformance field's value.
+func (s *NetworkInfo) SetNetworkPerformance(v string) *NetworkInfo {
+	s.NetworkPerformance = &v
+	return s
+}
+
 // Describes a network interface.
 type NetworkInterface struct {
 	_ struct{} `type:"structure"`
@@ -78112,6 +87279,9 @@ type NetworkInterface struct {
 
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
 
 	// The AWS account ID of the owner of the network interface.
 	OwnerId *string `locationName:"ownerId" type:"string"`
@@ -78209,6 +87379,12 @@ func (s *NetworkInterface) SetMacAddress(v string) *NetworkInterface {
 // SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
 func (s *NetworkInterface) SetNetworkInterfaceId(v string) *NetworkInterface {
 	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *NetworkInterface) SetOutpostArn(v string) *NetworkInterface {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -78670,6 +87846,10 @@ type OnDemandOptions struct {
 	// Fleet defaults to lowest-price.
 	AllocationStrategy *string `locationName:"allocationStrategy" type:"string" enum:"FleetOnDemandAllocationStrategy"`
 
+	// The strategy for using unused Capacity Reservations for fulfilling On-Demand
+	// capacity. Only available for fleets of type instant.
+	CapacityReservationOptions *CapacityReservationOptions `locationName:"capacityReservationOptions" type:"structure"`
+
 	// The maximum amount per hour for On-Demand Instances that you're willing to
 	// pay.
 	MaxTotalPrice *string `locationName:"maxTotalPrice" type:"string"`
@@ -78700,6 +87880,12 @@ func (s OnDemandOptions) GoString() string {
 // SetAllocationStrategy sets the AllocationStrategy field's value.
 func (s *OnDemandOptions) SetAllocationStrategy(v string) *OnDemandOptions {
 	s.AllocationStrategy = &v
+	return s
+}
+
+// SetCapacityReservationOptions sets the CapacityReservationOptions field's value.
+func (s *OnDemandOptions) SetCapacityReservationOptions(v *CapacityReservationOptions) *OnDemandOptions {
+	s.CapacityReservationOptions = v
 	return s
 }
 
@@ -78739,6 +87925,10 @@ type OnDemandOptionsRequest struct {
 	// Fleet defaults to lowest-price.
 	AllocationStrategy *string `type:"string" enum:"FleetOnDemandAllocationStrategy"`
 
+	// The strategy for using unused Capacity Reservations for fulfilling On-Demand
+	// capacity. Only available for fleets of type instant.
+	CapacityReservationOptions *CapacityReservationOptionsRequest `type:"structure"`
+
 	// The maximum amount per hour for On-Demand Instances that you're willing to
 	// pay.
 	MaxTotalPrice *string `type:"string"`
@@ -78769,6 +87959,12 @@ func (s OnDemandOptionsRequest) GoString() string {
 // SetAllocationStrategy sets the AllocationStrategy field's value.
 func (s *OnDemandOptionsRequest) SetAllocationStrategy(v string) *OnDemandOptionsRequest {
 	s.AllocationStrategy = &v
+	return s
+}
+
+// SetCapacityReservationOptions sets the CapacityReservationOptions field's value.
+func (s *OnDemandOptionsRequest) SetCapacityReservationOptions(v *CapacityReservationOptionsRequest) *OnDemandOptionsRequest {
+	s.CapacityReservationOptions = v
 	return s
 }
 
@@ -78845,6 +88041,39 @@ func (s *PciId) SetSubsystemVendorId(v string) *PciId {
 // SetVendorId sets the VendorId field's value.
 func (s *PciId) SetVendorId(v string) *PciId {
 	s.VendorId = &v
+	return s
+}
+
+// The status of the transit gateway peering attachment.
+type PeeringAttachmentStatus struct {
+	_ struct{} `type:"structure"`
+
+	// The status code.
+	Code *string `locationName:"code" type:"string"`
+
+	// The status message, if applicable.
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s PeeringAttachmentStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PeeringAttachmentStatus) GoString() string {
+	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *PeeringAttachmentStatus) SetCode(v string) *PeeringAttachmentStatus {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *PeeringAttachmentStatus) SetMessage(v string) *PeeringAttachmentStatus {
+	s.Message = &v
 	return s
 }
 
@@ -78935,6 +88164,48 @@ func (s *PeeringConnectionOptionsRequest) SetAllowEgressFromLocalClassicLinkToRe
 // SetAllowEgressFromLocalVpcToRemoteClassicLink sets the AllowEgressFromLocalVpcToRemoteClassicLink field's value.
 func (s *PeeringConnectionOptionsRequest) SetAllowEgressFromLocalVpcToRemoteClassicLink(v bool) *PeeringConnectionOptionsRequest {
 	s.AllowEgressFromLocalVpcToRemoteClassicLink = &v
+	return s
+}
+
+// Information about the transit gateway in the peering attachment.
+type PeeringTgwInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The AWS account ID of the owner of the transit gateway.
+	OwnerId *string `locationName:"ownerId" type:"string"`
+
+	// The Region of the transit gateway.
+	Region *string `locationName:"region" type:"string"`
+
+	// The ID of the transit gateway.
+	TransitGatewayId *string `locationName:"transitGatewayId" type:"string"`
+}
+
+// String returns the string representation
+func (s PeeringTgwInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PeeringTgwInfo) GoString() string {
+	return s.String()
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *PeeringTgwInfo) SetOwnerId(v string) *PeeringTgwInfo {
+	s.OwnerId = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *PeeringTgwInfo) SetRegion(v string) *PeeringTgwInfo {
+	s.Region = &v
+	return s
+}
+
+// SetTransitGatewayId sets the TransitGatewayId field's value.
+func (s *PeeringTgwInfo) SetTransitGatewayId(v string) *PeeringTgwInfo {
+	s.TransitGatewayId = &v
 	return s
 }
 
@@ -79249,6 +88520,11 @@ type Placement struct {
 	// is not supported for the ImportInstance command.
 	HostId *string `locationName:"hostId" type:"string"`
 
+	// The ARN of the host resource group in which to launch the instances. If you
+	// specify a host resource group ARN, omit the Tenancy parameter or set it to
+	// host.
+	HostResourceGroupArn *string `locationName:"hostResourceGroupArn" type:"string"`
+
 	// The number of the partition the instance is in. Valid only if the placement
 	// group strategy is set to partition.
 	PartitionNumber *int64 `locationName:"partitionNumber" type:"integer"`
@@ -79293,6 +88569,12 @@ func (s *Placement) SetGroupName(v string) *Placement {
 // SetHostId sets the HostId field's value.
 func (s *Placement) SetHostId(v string) *Placement {
 	s.HostId = &v
+	return s
+}
+
+// SetHostResourceGroupArn sets the HostResourceGroupArn field's value.
+func (s *Placement) SetHostResourceGroupArn(v string) *Placement {
+	s.HostResourceGroupArn = &v
 	return s
 }
 
@@ -79365,11 +88647,35 @@ func (s *PlacementGroup) SetStrategy(v string) *PlacementGroup {
 	return s
 }
 
+// Describes the placement group support of the instance type.
+type PlacementGroupInfo struct {
+	_ struct{} `type:"structure"`
+
+	// A list of supported placement groups types.
+	SupportedStrategies []*string `locationName:"supportedStrategies" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s PlacementGroupInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PlacementGroupInfo) GoString() string {
+	return s.String()
+}
+
+// SetSupportedStrategies sets the SupportedStrategies field's value.
+func (s *PlacementGroupInfo) SetSupportedStrategies(v []*string) *PlacementGroupInfo {
+	s.SupportedStrategies = v
+	return s
+}
+
 // Describes the placement of an instance.
 type PlacementResponse struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the placement group the instance is in.
+	// The name of the placement group that the instance is in.
 	GroupName *string `locationName:"groupName" type:"string"`
 }
 
@@ -79704,6 +89010,39 @@ func (s *PrivateIpAddressSpecification) SetPrimary(v bool) *PrivateIpAddressSpec
 // SetPrivateIpAddress sets the PrivateIpAddress field's value.
 func (s *PrivateIpAddressSpecification) SetPrivateIpAddress(v string) *PrivateIpAddressSpecification {
 	s.PrivateIpAddress = &v
+	return s
+}
+
+// Describes the processor used by the instance type.
+type ProcessorInfo struct {
+	_ struct{} `type:"structure"`
+
+	// A list of architectures supported by the instance type.
+	SupportedArchitectures []*string `locationName:"supportedArchitectures" locationNameList:"item" type:"list"`
+
+	// The speed of the processor, in GHz.
+	SustainedClockSpeedInGhz *float64 `locationName:"sustainedClockSpeedInGhz" type:"double"`
+}
+
+// String returns the string representation
+func (s ProcessorInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ProcessorInfo) GoString() string {
+	return s.String()
+}
+
+// SetSupportedArchitectures sets the SupportedArchitectures field's value.
+func (s *ProcessorInfo) SetSupportedArchitectures(v []*string) *ProcessorInfo {
+	s.SupportedArchitectures = v
+	return s
+}
+
+// SetSustainedClockSpeedInGhz sets the SustainedClockSpeedInGhz field's value.
+func (s *ProcessorInfo) SetSustainedClockSpeedInGhz(v float64) *ProcessorInfo {
+	s.SustainedClockSpeedInGhz = &v
 	return s
 }
 
@@ -80355,6 +89694,10 @@ type PurchaseReservedInstancesOfferingInput struct {
 	// prices.
 	LimitPrice *ReservedInstanceLimitPrice `locationName:"limitPrice" type:"structure"`
 
+	// The time at which to purchase the Reserved Instance, in UTC format (for example,
+	// YYYY-MM-DDTHH:MM:SSZ).
+	PurchaseTime *time.Time `type:"timestamp"`
+
 	// The ID of the Reserved Instance offering to purchase.
 	//
 	// ReservedInstancesOfferingId is a required field
@@ -80402,6 +89745,12 @@ func (s *PurchaseReservedInstancesOfferingInput) SetInstanceCount(v int64) *Purc
 // SetLimitPrice sets the LimitPrice field's value.
 func (s *PurchaseReservedInstancesOfferingInput) SetLimitPrice(v *ReservedInstanceLimitPrice) *PurchaseReservedInstancesOfferingInput {
 	s.LimitPrice = v
+	return s
+}
+
+// SetPurchaseTime sets the PurchaseTime field's value.
+func (s *PurchaseReservedInstancesOfferingInput) SetPurchaseTime(v time.Time) *PurchaseReservedInstancesOfferingInput {
+	s.PurchaseTime = &v
 	return s
 }
 
@@ -80872,6 +90221,233 @@ func (s *RegisterImageOutput) SetImageId(v string) *RegisterImageOutput {
 	return s
 }
 
+type RegisterTransitGatewayMulticastGroupMembersInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `type:"string"`
+
+	// The group members' network interface IDs to register with the transit gateway
+	// multicast group.
+	NetworkInterfaceIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s RegisterTransitGatewayMulticastGroupMembersInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTransitGatewayMulticastGroupMembersInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RegisterTransitGatewayMulticastGroupMembersInput) SetDryRun(v bool) *RegisterTransitGatewayMulticastGroupMembersInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *RegisterTransitGatewayMulticastGroupMembersInput) SetGroupIpAddress(v string) *RegisterTransitGatewayMulticastGroupMembersInput {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceIds sets the NetworkInterfaceIds field's value.
+func (s *RegisterTransitGatewayMulticastGroupMembersInput) SetNetworkInterfaceIds(v []*string) *RegisterTransitGatewayMulticastGroupMembersInput {
+	s.NetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *RegisterTransitGatewayMulticastGroupMembersInput) SetTransitGatewayMulticastDomainId(v string) *RegisterTransitGatewayMulticastGroupMembersInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type RegisterTransitGatewayMulticastGroupMembersOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the registered transit gateway multicast group members.
+	RegisteredMulticastGroupMembers *TransitGatewayMulticastRegisteredGroupMembers `locationName:"registeredMulticastGroupMembers" type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterTransitGatewayMulticastGroupMembersOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTransitGatewayMulticastGroupMembersOutput) GoString() string {
+	return s.String()
+}
+
+// SetRegisteredMulticastGroupMembers sets the RegisteredMulticastGroupMembers field's value.
+func (s *RegisterTransitGatewayMulticastGroupMembersOutput) SetRegisteredMulticastGroupMembers(v *TransitGatewayMulticastRegisteredGroupMembers) *RegisterTransitGatewayMulticastGroupMembersOutput {
+	s.RegisteredMulticastGroupMembers = v
+	return s
+}
+
+type RegisterTransitGatewayMulticastGroupSourcesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `type:"string"`
+
+	// The group sources' network interface IDs to register with the transit gateway
+	// multicast group.
+	NetworkInterfaceIds []*string `locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s RegisterTransitGatewayMulticastGroupSourcesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTransitGatewayMulticastGroupSourcesInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RegisterTransitGatewayMulticastGroupSourcesInput) SetDryRun(v bool) *RegisterTransitGatewayMulticastGroupSourcesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *RegisterTransitGatewayMulticastGroupSourcesInput) SetGroupIpAddress(v string) *RegisterTransitGatewayMulticastGroupSourcesInput {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceIds sets the NetworkInterfaceIds field's value.
+func (s *RegisterTransitGatewayMulticastGroupSourcesInput) SetNetworkInterfaceIds(v []*string) *RegisterTransitGatewayMulticastGroupSourcesInput {
+	s.NetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *RegisterTransitGatewayMulticastGroupSourcesInput) SetTransitGatewayMulticastDomainId(v string) *RegisterTransitGatewayMulticastGroupSourcesInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type RegisterTransitGatewayMulticastGroupSourcesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the transit gateway multicast group sources.
+	RegisteredMulticastGroupSources *TransitGatewayMulticastRegisteredGroupSources `locationName:"registeredMulticastGroupSources" type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterTransitGatewayMulticastGroupSourcesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTransitGatewayMulticastGroupSourcesOutput) GoString() string {
+	return s.String()
+}
+
+// SetRegisteredMulticastGroupSources sets the RegisteredMulticastGroupSources field's value.
+func (s *RegisterTransitGatewayMulticastGroupSourcesOutput) SetRegisteredMulticastGroupSources(v *TransitGatewayMulticastRegisteredGroupSources) *RegisterTransitGatewayMulticastGroupSourcesOutput {
+	s.RegisteredMulticastGroupSources = v
+	return s
+}
+
+type RejectTransitGatewayPeeringAttachmentInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the transit gateway peering attachment.
+	//
+	// TransitGatewayAttachmentId is a required field
+	TransitGatewayAttachmentId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RejectTransitGatewayPeeringAttachmentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RejectTransitGatewayPeeringAttachmentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RejectTransitGatewayPeeringAttachmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RejectTransitGatewayPeeringAttachmentInput"}
+	if s.TransitGatewayAttachmentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitGatewayAttachmentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RejectTransitGatewayPeeringAttachmentInput) SetDryRun(v bool) *RejectTransitGatewayPeeringAttachmentInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *RejectTransitGatewayPeeringAttachmentInput) SetTransitGatewayAttachmentId(v string) *RejectTransitGatewayPeeringAttachmentInput {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+type RejectTransitGatewayPeeringAttachmentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The transit gateway peering attachment.
+	TransitGatewayPeeringAttachment *TransitGatewayPeeringAttachment `locationName:"transitGatewayPeeringAttachment" type:"structure"`
+}
+
+// String returns the string representation
+func (s RejectTransitGatewayPeeringAttachmentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RejectTransitGatewayPeeringAttachmentOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransitGatewayPeeringAttachment sets the TransitGatewayPeeringAttachment field's value.
+func (s *RejectTransitGatewayPeeringAttachmentOutput) SetTransitGatewayPeeringAttachment(v *TransitGatewayPeeringAttachment) *RejectTransitGatewayPeeringAttachmentOutput {
+	s.TransitGatewayPeeringAttachment = v
+	return s
+}
+
 type RejectTransitGatewayVpcAttachmentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -81117,6 +90693,16 @@ type ReleaseAddressInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
+	// The location that the IP address is released from.
+	//
+	// If you provide an incorrect network border group, you will receive an InvalidAddress.NotFound
+	// error. For more information, see Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
+	//
+	// You cannot use a network border group with EC2 Classic. If you attempt this
+	// operation on EC2 classic, you will receive an InvalidParameterCombination
+	// error. For more information, see Error Codes (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
+	NetworkBorderGroup *string `type:"string"`
+
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIp *string `type:"string"`
 }
@@ -81140,6 +90726,12 @@ func (s *ReleaseAddressInput) SetAllocationId(v string) *ReleaseAddressInput {
 // SetDryRun sets the DryRun field's value.
 func (s *ReleaseAddressInput) SetDryRun(v bool) *ReleaseAddressInput {
 	s.DryRun = &v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *ReleaseAddressInput) SetNetworkBorderGroup(v string) *ReleaseAddressInput {
+	s.NetworkBorderGroup = &v
 	return s
 }
 
@@ -81589,6 +91181,12 @@ type ReplaceRouteInput struct {
 	// The ID of a NAT instance in your VPC.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
+	// The ID of the local gateway.
+	LocalGatewayId *string `type:"string"`
+
+	// Specifies whether to reset the local route to its default target (local).
+	LocalTarget *bool `type:"boolean"`
+
 	// [IPv4 traffic only] The ID of a NAT gateway.
 	NatGatewayId *string `locationName:"natGatewayId" type:"string"`
 
@@ -81663,6 +91261,18 @@ func (s *ReplaceRouteInput) SetGatewayId(v string) *ReplaceRouteInput {
 // SetInstanceId sets the InstanceId field's value.
 func (s *ReplaceRouteInput) SetInstanceId(v string) *ReplaceRouteInput {
 	s.InstanceId = &v
+	return s
+}
+
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *ReplaceRouteInput) SetLocalGatewayId(v string) *ReplaceRouteInput {
+	s.LocalGatewayId = &v
+	return s
+}
+
+// SetLocalTarget sets the LocalTarget field's value.
+func (s *ReplaceRouteInput) SetLocalTarget(v bool) *ReplaceRouteInput {
+	s.LocalTarget = &v
 	return s
 }
 
@@ -81777,6 +91387,9 @@ func (s *ReplaceRouteTableAssociationInput) SetRouteTableId(v string) *ReplaceRo
 type ReplaceRouteTableAssociationOutput struct {
 	_ struct{} `type:"structure"`
 
+	// The state of the association.
+	AssociationState *RouteTableAssociationState `locationName:"associationState" type:"structure"`
+
 	// The ID of the new association.
 	NewAssociationId *string `locationName:"newAssociationId" type:"string"`
 }
@@ -81789,6 +91402,12 @@ func (s ReplaceRouteTableAssociationOutput) String() string {
 // GoString returns the string representation
 func (s ReplaceRouteTableAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationState sets the AssociationState field's value.
+func (s *ReplaceRouteTableAssociationOutput) SetAssociationState(v *RouteTableAssociationState) *ReplaceRouteTableAssociationOutput {
+	s.AssociationState = v
+	return s
 }
 
 // SetNewAssociationId sets the NewAssociationId field's value.
@@ -82093,8 +91712,7 @@ type RequestLaunchTemplateData struct {
 
 	// Indicates whether an instance is enabled for hibernation. This parameter
 	// is valid only if the instance meets the hibernation prerequisites (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html#hibernating-prerequisites).
-	// Hibernation is currently supported only for Amazon Linux. For more information,
-	// see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
+	// For more information, see Hibernate Your Instance (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	HibernationOptions *LaunchTemplateHibernationOptionsRequest `type:"structure"`
 
@@ -82530,6 +92148,10 @@ type RequestSpotInstancesInput struct {
 	// launch, the request expires, or the request is canceled. If the request is
 	// persistent, the request becomes active at this date and time and remains
 	// active until it expires or is canceled.
+	//
+	// The specified start date and time cannot be equal to the current date and
+	// time. You must specify a start date and time that occurs after the current
+	// date and time.
 	ValidFrom *time.Time `locationName:"validFrom" type:"timestamp"`
 
 	// The end date of the request. If this is a one-time request, the request remains
@@ -84054,7 +93676,6 @@ func (s ResetNetworkInterfaceAttributeOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for ResetSnapshotAttribute.
 type ResetSnapshotAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -84897,6 +94518,9 @@ type Route struct {
 	// The AWS account ID of the owner of the instance.
 	InstanceOwnerId *string `locationName:"instanceOwnerId" type:"string"`
 
+	// The ID of the local gateway.
+	LocalGatewayId *string `locationName:"localGatewayId" type:"string"`
+
 	// The ID of a NAT gateway.
 	NatGatewayId *string `locationName:"natGatewayId" type:"string"`
 
@@ -84977,6 +94601,12 @@ func (s *Route) SetInstanceOwnerId(v string) *Route {
 	return s
 }
 
+// SetLocalGatewayId sets the LocalGatewayId field's value.
+func (s *Route) SetLocalGatewayId(v string) *Route {
+	s.LocalGatewayId = &v
+	return s
+}
+
 // SetNatGatewayId sets the NatGatewayId field's value.
 func (s *Route) SetNatGatewayId(v string) *Route {
 	s.NatGatewayId = &v
@@ -85017,7 +94647,7 @@ func (s *Route) SetVpcPeeringConnectionId(v string) *Route {
 type RouteTable struct {
 	_ struct{} `type:"structure"`
 
-	// The associations between the route table and one or more subnets.
+	// The associations between the route table and one or more subnets or a gateway.
 	Associations []*RouteTableAssociation `locationName:"associationSet" locationNameList:"item" type:"list"`
 
 	// The ID of the AWS account that owns the route table.
@@ -85091,14 +94721,20 @@ func (s *RouteTable) SetVpcId(v string) *RouteTable {
 	return s
 }
 
-// Describes an association between a route table and a subnet.
+// Describes an association between a route table and a subnet or gateway.
 type RouteTableAssociation struct {
 	_ struct{} `type:"structure"`
+
+	// The state of the association.
+	AssociationState *RouteTableAssociationState `locationName:"associationState" type:"structure"`
+
+	// The ID of the internet gateway or virtual private gateway.
+	GatewayId *string `locationName:"gatewayId" type:"string"`
 
 	// Indicates whether this is the main route table.
 	Main *bool `locationName:"main" type:"boolean"`
 
-	// The ID of the association between a route table and a subnet.
+	// The ID of the association.
 	RouteTableAssociationId *string `locationName:"routeTableAssociationId" type:"string"`
 
 	// The ID of the route table.
@@ -85116,6 +94752,18 @@ func (s RouteTableAssociation) String() string {
 // GoString returns the string representation
 func (s RouteTableAssociation) GoString() string {
 	return s.String()
+}
+
+// SetAssociationState sets the AssociationState field's value.
+func (s *RouteTableAssociation) SetAssociationState(v *RouteTableAssociationState) *RouteTableAssociation {
+	s.AssociationState = v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *RouteTableAssociation) SetGatewayId(v string) *RouteTableAssociation {
+	s.GatewayId = &v
+	return s
 }
 
 // SetMain sets the Main field's value.
@@ -85139,6 +94787,40 @@ func (s *RouteTableAssociation) SetRouteTableId(v string) *RouteTableAssociation
 // SetSubnetId sets the SubnetId field's value.
 func (s *RouteTableAssociation) SetSubnetId(v string) *RouteTableAssociation {
 	s.SubnetId = &v
+	return s
+}
+
+// Describes the state of an association between a route table and a subnet
+// or gateway.
+type RouteTableAssociationState struct {
+	_ struct{} `type:"structure"`
+
+	// The state of the association.
+	State *string `locationName:"state" type:"string" enum:"RouteTableAssociationStateCode"`
+
+	// The status message, if applicable.
+	StatusMessage *string `locationName:"statusMessage" type:"string"`
+}
+
+// String returns the string representation
+func (s RouteTableAssociationState) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RouteTableAssociationState) GoString() string {
+	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *RouteTableAssociationState) SetState(v string) *RouteTableAssociationState {
+	s.State = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *RouteTableAssociationState) SetStatusMessage(v string) *RouteTableAssociationState {
+	s.StatusMessage = &v
 	return s
 }
 
@@ -85168,13 +94850,13 @@ type RunInstancesInput struct {
 	// in the Amazon Elastic Compute Cloud User Guide.
 	CpuOptions *CpuOptionsRequest `type:"structure"`
 
-	// The credit option for CPU usage of the T2 or T3 instance. Valid values are
-	// standard and unlimited. To change this attribute after launch, use ModifyInstanceCreditSpecification
-	// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceCreditSpecification.html).
+	// The credit option for CPU usage of the burstable performance instance. Valid
+	// values are standard and unlimited. To change this attribute after launch,
+	// use ModifyInstanceCreditSpecification (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceCreditSpecification.html).
 	// For more information, see Burstable Performance Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Default: standard (T2 instances) or unlimited (T3 instances)
+	// Default: standard (T2 instances) or unlimited (T3/T3a instances)
 	CreditSpecification *CreditSpecificationRequest `type:"structure"`
 
 	// If you set this parameter to true, you can't terminate the instance using
@@ -85294,6 +94976,10 @@ type RunInstancesInput struct {
 	//
 	// MaxCount is a required field
 	MaxCount *int64 `type:"integer" required:"true"`
+
+	// The metadata options for the instance. For more information, see Instance
+	// Metadata and User Data (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+	MetadataOptions *InstanceMetadataOptionsRequest `type:"structure"`
 
 	// The minimum number of instances to launch. If you specify a minimum that
 	// is more instances than Amazon EC2 can launch in the target Availability Zone,
@@ -85574,6 +95260,12 @@ func (s *RunInstancesInput) SetLicenseSpecifications(v []*LicenseConfigurationRe
 // SetMaxCount sets the MaxCount field's value.
 func (s *RunInstancesInput) SetMaxCount(v int64) *RunInstancesInput {
 	s.MaxCount = &v
+	return s
+}
+
+// SetMetadataOptions sets the MetadataOptions field's value.
+func (s *RunInstancesInput) SetMetadataOptions(v *InstanceMetadataOptionsRequest) *RunInstancesInput {
+	s.MetadataOptions = v
 	return s
 }
 
@@ -86870,6 +96562,255 @@ func (s *ScheduledInstancesPrivateIpAddressConfig) SetPrimary(v bool) *Scheduled
 // SetPrivateIpAddress sets the PrivateIpAddress field's value.
 func (s *ScheduledInstancesPrivateIpAddressConfig) SetPrivateIpAddress(v string) *ScheduledInstancesPrivateIpAddressConfig {
 	s.PrivateIpAddress = &v
+	return s
+}
+
+type SearchLocalGatewayRoutesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	//
+	// Filters is a required field
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list" required:"true"`
+
+	// The ID of the local gateway route table.
+	//
+	// LocalGatewayRouteTableId is a required field
+	LocalGatewayRouteTableId *string `type:"string" required:"true"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s SearchLocalGatewayRoutesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchLocalGatewayRoutesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SearchLocalGatewayRoutesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SearchLocalGatewayRoutesInput"}
+	if s.Filters == nil {
+		invalidParams.Add(request.NewErrParamRequired("Filters"))
+	}
+	if s.LocalGatewayRouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalGatewayRouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *SearchLocalGatewayRoutesInput) SetDryRun(v bool) *SearchLocalGatewayRoutesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *SearchLocalGatewayRoutesInput) SetFilters(v []*Filter) *SearchLocalGatewayRoutesInput {
+	s.Filters = v
+	return s
+}
+
+// SetLocalGatewayRouteTableId sets the LocalGatewayRouteTableId field's value.
+func (s *SearchLocalGatewayRoutesInput) SetLocalGatewayRouteTableId(v string) *SearchLocalGatewayRoutesInput {
+	s.LocalGatewayRouteTableId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *SearchLocalGatewayRoutesInput) SetMaxResults(v int64) *SearchLocalGatewayRoutesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchLocalGatewayRoutesInput) SetNextToken(v string) *SearchLocalGatewayRoutesInput {
+	s.NextToken = &v
+	return s
+}
+
+type SearchLocalGatewayRoutesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// Information about the routes.
+	Routes []*LocalGatewayRoute `locationName:"routeSet" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s SearchLocalGatewayRoutesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchLocalGatewayRoutesOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchLocalGatewayRoutesOutput) SetNextToken(v string) *SearchLocalGatewayRoutesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRoutes sets the Routes field's value.
+func (s *SearchLocalGatewayRoutesOutput) SetRoutes(v []*LocalGatewayRoute) *SearchLocalGatewayRoutesOutput {
+	s.Routes = v
+	return s
+}
+
+type SearchTransitGatewayMulticastGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters. The possible values are:
+	//
+	//    * group-ip-address - The IP address of the transit gateway multicast group.
+	//
+	//    * is-group-member - The resource is a group member. Valid values are true
+	//    | false.
+	//
+	//    * is-group-source - The resource is a group source. Valid values are true
+	//    | false.
+	//
+	//    * member-type - The member type. Valid values are igmp | static.
+	//
+	//    * resource-id - The ID of the resource.
+	//
+	//    * resource-type - The type of resource. Valid values are vpc | vpn | direct-connect-gateway
+	//    | tgw-peering.
+	//
+	//    * source-type - The source type. Valid values are igmp | static.
+	//
+	//    * state - The state of the subnet association. Valid values are associated
+	//    | associated | disassociated | disassociating.
+	//
+	//    * subnet-id - The ID of the subnet.
+	//
+	//    * transit-gateway-attachment-id - The id of the transit gateway attachment.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// The maximum number of results to return with a single call. To retrieve the
+	// remaining results, make another call with the returned nextToken value.
+	MaxResults *int64 `min:"5" type:"integer"`
+
+	// The token for the next page of results.
+	NextToken *string `type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s SearchTransitGatewayMulticastGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchTransitGatewayMulticastGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SearchTransitGatewayMulticastGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SearchTransitGatewayMulticastGroupsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *SearchTransitGatewayMulticastGroupsInput) SetDryRun(v bool) *SearchTransitGatewayMulticastGroupsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *SearchTransitGatewayMulticastGroupsInput) SetFilters(v []*Filter) *SearchTransitGatewayMulticastGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *SearchTransitGatewayMulticastGroupsInput) SetMaxResults(v int64) *SearchTransitGatewayMulticastGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchTransitGatewayMulticastGroupsInput) SetNextToken(v string) *SearchTransitGatewayMulticastGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *SearchTransitGatewayMulticastGroupsInput) SetTransitGatewayMulticastDomainId(v string) *SearchTransitGatewayMulticastGroupsInput {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+type SearchTransitGatewayMulticastGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the transit gateway multicast group.
+	MulticastGroups []*TransitGatewayMulticastGroup `locationName:"multicastGroups" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s SearchTransitGatewayMulticastGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchTransitGatewayMulticastGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetMulticastGroups sets the MulticastGroups field's value.
+func (s *SearchTransitGatewayMulticastGroupsOutput) SetMulticastGroups(v []*TransitGatewayMulticastGroup) *SearchTransitGatewayMulticastGroupsOutput {
+	s.MulticastGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchTransitGatewayMulticastGroupsOutput) SetNextToken(v string) *SearchTransitGatewayMulticastGroupsOutput {
+	s.NextToken = &v
 	return s
 }
 
@@ -89182,14 +99123,14 @@ type SpotOptions struct {
 	// Indicates how to allocate the target Spot Instance capacity across the Spot
 	// Instance pools specified by the EC2 Fleet.
 	//
-	// If the allocation strategy is lowestPrice, EC2 Fleet launches instances from
-	// the Spot Instance pools with the lowest price. This is the default allocation
+	// If the allocation strategy is lowest-price, EC2 Fleet launches instances
+	// from the Spot Instance pools with the lowest price. This is the default allocation
 	// strategy.
 	//
 	// If the allocation strategy is diversified, EC2 Fleet launches instances from
-	// all the Spot Instance pools that you specify.
+	// all of the Spot Instance pools that you specify.
 	//
-	// If the allocation strategy is capacityOptimized, EC2 Fleet launches instances
+	// If the allocation strategy is capacity-optimized, EC2 Fleet launches instances
 	// from Spot Instance pools with optimal capacity for the number of instances
 	// that are launching.
 	AllocationStrategy *string `locationName:"allocationStrategy" type:"string" enum:"SpotAllocationStrategy"`
@@ -89198,7 +99139,7 @@ type SpotOptions struct {
 	InstanceInterruptionBehavior *string `locationName:"instanceInterruptionBehavior" type:"string" enum:"SpotInstanceInterruptionBehavior"`
 
 	// The number of Spot pools across which to allocate your target Spot capacity.
-	// Valid only when AllocationStrategy is set to lowestPrice. EC2 Fleet selects
+	// Valid only when AllocationStrategy is set to lowest-price. EC2 Fleet selects
 	// the cheapest Spot pools and evenly allocates your target Spot capacity across
 	// the number of Spot pools that you specify.
 	InstancePoolsToUseCount *int64 `locationName:"instancePoolsToUseCount" type:"integer"`
@@ -89278,14 +99219,14 @@ type SpotOptionsRequest struct {
 	// Indicates how to allocate the target Spot Instance capacity across the Spot
 	// Instance pools specified by the EC2 Fleet.
 	//
-	// If the allocation strategy is lowestPrice, EC2 Fleet launches instances from
-	// the Spot Instance pools with the lowest price. This is the default allocation
+	// If the allocation strategy is lowest-price, EC2 Fleet launches instances
+	// from the Spot Instance pools with the lowest price. This is the default allocation
 	// strategy.
 	//
 	// If the allocation strategy is diversified, EC2 Fleet launches instances from
-	// all the Spot Instance pools that you specify.
+	// all of the Spot Instance pools that you specify.
 	//
-	// If the allocation strategy is capacityOptimized, EC2 Fleet launches instances
+	// If the allocation strategy is capacity-optimized, EC2 Fleet launches instances
 	// from Spot Instance pools with optimal capacity for the number of instances
 	// that are launching.
 	AllocationStrategy *string `type:"string" enum:"SpotAllocationStrategy"`
@@ -89960,6 +99901,9 @@ type Subnet struct {
 	// address.
 	MapPublicIpOnLaunch *bool `locationName:"mapPublicIpOnLaunch" type:"boolean"`
 
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
+
 	// The ID of the AWS account that owns the subnet.
 	OwnerId *string `locationName:"ownerId" type:"string"`
 
@@ -90037,6 +99981,12 @@ func (s *Subnet) SetMapPublicIpOnLaunch(v bool) *Subnet {
 	return s
 }
 
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *Subnet) SetOutpostArn(v string) *Subnet {
+	s.OutpostArn = &v
+	return s
+}
+
 // SetOwnerId sets the OwnerId field's value.
 func (s *Subnet) SetOwnerId(v string) *Subnet {
 	s.OwnerId = &v
@@ -90070,6 +100020,39 @@ func (s *Subnet) SetTags(v []*Tag) *Subnet {
 // SetVpcId sets the VpcId field's value.
 func (s *Subnet) SetVpcId(v string) *Subnet {
 	s.VpcId = &v
+	return s
+}
+
+// Describes the subnet association with the transit gateway multicast domain.
+type SubnetAssociation struct {
+	_ struct{} `type:"structure"`
+
+	// The state of the subnet association.
+	State *string `locationName:"state" type:"string" enum:"TransitGatewayMulitcastDomainAssociationState"`
+
+	// The ID of the subnet.
+	SubnetId *string `locationName:"subnetId" type:"string"`
+}
+
+// String returns the string representation
+func (s SubnetAssociation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SubnetAssociation) GoString() string {
+	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *SubnetAssociation) SetState(v string) *SubnetAssociation {
+	s.State = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *SubnetAssociation) SetSubnetId(v string) *SubnetAssociation {
+	s.SubnetId = &v
 	return s
 }
 
@@ -90148,8 +100131,8 @@ func (s *SubnetIpv6CidrBlockAssociation) SetIpv6CidrBlockState(v *SubnetCidrBloc
 	return s
 }
 
-// Describes the T2 or T3 instance whose credit option for CPU usage was successfully
-// modified.
+// Describes the burstable performance instance whose credit option for CPU
+// usage was successfully modified.
 type SuccessfulInstanceCreditSpecificationItem struct {
 	_ struct{} `type:"structure"`
 
@@ -90170,6 +100153,30 @@ func (s SuccessfulInstanceCreditSpecificationItem) GoString() string {
 // SetInstanceId sets the InstanceId field's value.
 func (s *SuccessfulInstanceCreditSpecificationItem) SetInstanceId(v string) *SuccessfulInstanceCreditSpecificationItem {
 	s.InstanceId = &v
+	return s
+}
+
+// Describes a Reserved Instance whose queued purchase was successfully deleted.
+type SuccessfulQueuedPurchaseDeletion struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the Reserved Instance.
+	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
+}
+
+// String returns the string representation
+func (s SuccessfulQueuedPurchaseDeletion) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SuccessfulQueuedPurchaseDeletion) GoString() string {
+	return s.String()
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *SuccessfulQueuedPurchaseDeletion) SetReservedInstancesId(v string) *SuccessfulQueuedPurchaseDeletion {
+	s.ReservedInstancesId = &v
 	return s
 }
 
@@ -90269,10 +100276,11 @@ type TagSpecification struct {
 
 	// The type of resource to tag. Currently, the resource types that support tagging
 	// on creation are: capacity-reservation | client-vpn-endpoint | dedicated-host
-	// | fleet | instance | launch-template | snapshot | transit-gateway | transit-gateway-attachment
+	// | fleet | fpga-image | instance | launch-template | snapshot | traffic-mirror-filter
+	// | traffic-mirror-session | traffic-mirror-target | transit-gateway | transit-gateway-attachment
 	// | transit-gateway-route-table | volume.
 	//
-	// To tag a resource after it has been created, see CreateTags.
+	// To tag a resource after it has been created, see CreateTags (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html).
 	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
 
 	// The tags to apply to the resource.
@@ -90308,13 +100316,13 @@ func (s *TagSpecification) SetTags(v []*Tag) *TagSpecification {
 // later.
 //
 // You can use the On-Demand Instance MaxTotalPrice parameter, the Spot Instance
-// MaxTotalPrice, or both to ensure your fleet cost does not exceed your budget.
-// If you set a maximum price per hour for the On-Demand Instances and Spot
-// Instances in your request, EC2 Fleet will launch instances until it reaches
-// the maximum amount you're willing to pay. When the maximum amount you're
-// willing to pay is reached, the fleet stops launching instances even if it
-// hasn’t met the target capacity. The MaxTotalPrice parameters are located
-// in and
+// MaxTotalPrice, or both to ensure that your fleet cost does not exceed your
+// budget. If you set a maximum price per hour for the On-Demand Instances and
+// Spot Instances in your request, EC2 Fleet will launch instances until it
+// reaches the maximum amount that you're willing to pay. When the maximum amount
+// you're willing to pay is reached, the fleet stops launching instances even
+// if it hasn’t met the target capacity. The MaxTotalPrice parameters are
+// located in and
 type TargetCapacitySpecification struct {
 	_ struct{} `type:"structure"`
 
@@ -90377,9 +100385,9 @@ func (s *TargetCapacitySpecification) SetTotalTargetCapacity(v int64) *TargetCap
 // MaxTotalPrice parameter, or both parameters to ensure that your fleet cost
 // does not exceed your budget. If you set a maximum price per hour for the
 // On-Demand Instances and Spot Instances in your request, EC2 Fleet will launch
-// instances until it reaches the maximum amount you're willing to pay. When
-// the maximum amount you're willing to pay is reached, the fleet stops launching
-// instances even if it hasn’t met the target capacity. The MaxTotalPrice
+// instances until it reaches the maximum amount that you're willing to pay.
+// When the maximum amount you're willing to pay is reached, the fleet stops
+// launching instances even if it hasn’t met the target capacity. The MaxTotalPrice
 // parameters are located in and .
 type TargetCapacitySpecificationRequest struct {
 	_ struct{} `type:"structure"`
@@ -91690,6 +101698,451 @@ func (s *TransitGatewayAttachmentPropagation) SetTransitGatewayRouteTableId(v st
 	return s
 }
 
+// Describes the deregistered transit gateway multicast group members.
+type TransitGatewayMulticastDeregisteredGroupMembers struct {
+	_ struct{} `type:"structure"`
+
+	// The network interface IDs of the deregistered members.
+	DeregisteredNetworkInterfaceIds []*string `locationName:"deregisteredNetworkInterfaceIds" locationNameList:"item" type:"list"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `locationName:"groupIpAddress" type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastDeregisteredGroupMembers) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastDeregisteredGroupMembers) GoString() string {
+	return s.String()
+}
+
+// SetDeregisteredNetworkInterfaceIds sets the DeregisteredNetworkInterfaceIds field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupMembers) SetDeregisteredNetworkInterfaceIds(v []*string) *TransitGatewayMulticastDeregisteredGroupMembers {
+	s.DeregisteredNetworkInterfaceIds = v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupMembers) SetGroupIpAddress(v string) *TransitGatewayMulticastDeregisteredGroupMembers {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupMembers) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastDeregisteredGroupMembers {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+// Describes the deregistered transit gateway multicast group sources.
+type TransitGatewayMulticastDeregisteredGroupSources struct {
+	_ struct{} `type:"structure"`
+
+	// The network interface IDs of the non-registered members.
+	DeregisteredNetworkInterfaceIds []*string `locationName:"deregisteredNetworkInterfaceIds" locationNameList:"item" type:"list"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `locationName:"groupIpAddress" type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastDeregisteredGroupSources) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastDeregisteredGroupSources) GoString() string {
+	return s.String()
+}
+
+// SetDeregisteredNetworkInterfaceIds sets the DeregisteredNetworkInterfaceIds field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupSources) SetDeregisteredNetworkInterfaceIds(v []*string) *TransitGatewayMulticastDeregisteredGroupSources {
+	s.DeregisteredNetworkInterfaceIds = v
+	return s
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupSources) SetGroupIpAddress(v string) *TransitGatewayMulticastDeregisteredGroupSources {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastDeregisteredGroupSources) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastDeregisteredGroupSources {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+// Describes the transit gateway multicast domain.
+type TransitGatewayMulticastDomain struct {
+	_ struct{} `type:"structure"`
+
+	// The time the transit gateway multicast domain was created.
+	CreationTime *time.Time `locationName:"creationTime" type:"timestamp"`
+
+	// The state of the transit gateway multicast domain.
+	State *string `locationName:"state" type:"string" enum:"TransitGatewayMulticastDomainState"`
+
+	// The tags for the transit gateway multicast domain.
+	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway.
+	TransitGatewayId *string `locationName:"transitGatewayId" type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastDomain) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastDomain) GoString() string {
+	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *TransitGatewayMulticastDomain) SetCreationTime(v time.Time) *TransitGatewayMulticastDomain {
+	s.CreationTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *TransitGatewayMulticastDomain) SetState(v string) *TransitGatewayMulticastDomain {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TransitGatewayMulticastDomain) SetTags(v []*Tag) *TransitGatewayMulticastDomain {
+	s.Tags = v
+	return s
+}
+
+// SetTransitGatewayId sets the TransitGatewayId field's value.
+func (s *TransitGatewayMulticastDomain) SetTransitGatewayId(v string) *TransitGatewayMulticastDomain {
+	s.TransitGatewayId = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastDomain) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastDomain {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+// Describes the resources associated with the transit gateway multicast domain.
+type TransitGatewayMulticastDomainAssociation struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the resource.
+	ResourceId *string `locationName:"resourceId" type:"string"`
+
+	// The type of resource, for example a VPC attachment.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"TransitGatewayAttachmentResourceType"`
+
+	// The subnet associated with the transit gateway multicast domain.
+	Subnet *SubnetAssociation `locationName:"subnet" type:"structure"`
+
+	// The ID of the transit gateway attachment.
+	TransitGatewayAttachmentId *string `locationName:"transitGatewayAttachmentId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastDomainAssociation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastDomainAssociation) GoString() string {
+	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TransitGatewayMulticastDomainAssociation) SetResourceId(v string) *TransitGatewayMulticastDomainAssociation {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TransitGatewayMulticastDomainAssociation) SetResourceType(v string) *TransitGatewayMulticastDomainAssociation {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSubnet sets the Subnet field's value.
+func (s *TransitGatewayMulticastDomainAssociation) SetSubnet(v *SubnetAssociation) *TransitGatewayMulticastDomainAssociation {
+	s.Subnet = v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *TransitGatewayMulticastDomainAssociation) SetTransitGatewayAttachmentId(v string) *TransitGatewayMulticastDomainAssociation {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+// Describes the multicast domain associations.
+type TransitGatewayMulticastDomainAssociations struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the resource.
+	ResourceId *string `locationName:"resourceId" type:"string"`
+
+	// The type of resource, for example a VPC attachment.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"TransitGatewayAttachmentResourceType"`
+
+	// The subnets associated with the multicast domain.
+	Subnets []*SubnetAssociation `locationName:"subnets" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway attachment.
+	TransitGatewayAttachmentId *string `locationName:"transitGatewayAttachmentId" type:"string"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastDomainAssociations) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastDomainAssociations) GoString() string {
+	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TransitGatewayMulticastDomainAssociations) SetResourceId(v string) *TransitGatewayMulticastDomainAssociations {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TransitGatewayMulticastDomainAssociations) SetResourceType(v string) *TransitGatewayMulticastDomainAssociations {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *TransitGatewayMulticastDomainAssociations) SetSubnets(v []*SubnetAssociation) *TransitGatewayMulticastDomainAssociations {
+	s.Subnets = v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *TransitGatewayMulticastDomainAssociations) SetTransitGatewayAttachmentId(v string) *TransitGatewayMulticastDomainAssociations {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastDomainAssociations) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastDomainAssociations {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+// Describes the transit gateway multicast group resources.
+type TransitGatewayMulticastGroup struct {
+	_ struct{} `type:"structure"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `locationName:"groupIpAddress" type:"string"`
+
+	// Indicates that the resource is a transit gateway multicast group member.
+	GroupMember *bool `locationName:"groupMember" type:"boolean"`
+
+	// Indicates that the resource is a transit gateway multicast group member.
+	GroupSource *bool `locationName:"groupSource" type:"boolean"`
+
+	// The member type (for example, static).
+	MemberType *string `locationName:"memberType" type:"string" enum:"MembershipType"`
+
+	// The ID of the transit gateway attachment.
+	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string"`
+
+	// The ID of the resource.
+	ResourceId *string `locationName:"resourceId" type:"string"`
+
+	// The type of resource, for example a VPC attachment.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"TransitGatewayAttachmentResourceType"`
+
+	// The source type.
+	SourceType *string `locationName:"sourceType" type:"string" enum:"MembershipType"`
+
+	// The ID of the subnet.
+	SubnetId *string `locationName:"subnetId" type:"string"`
+
+	// The ID of the transit gateway attachment.
+	TransitGatewayAttachmentId *string `locationName:"transitGatewayAttachmentId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastGroup) GoString() string {
+	return s.String()
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *TransitGatewayMulticastGroup) SetGroupIpAddress(v string) *TransitGatewayMulticastGroup {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetGroupMember sets the GroupMember field's value.
+func (s *TransitGatewayMulticastGroup) SetGroupMember(v bool) *TransitGatewayMulticastGroup {
+	s.GroupMember = &v
+	return s
+}
+
+// SetGroupSource sets the GroupSource field's value.
+func (s *TransitGatewayMulticastGroup) SetGroupSource(v bool) *TransitGatewayMulticastGroup {
+	s.GroupSource = &v
+	return s
+}
+
+// SetMemberType sets the MemberType field's value.
+func (s *TransitGatewayMulticastGroup) SetMemberType(v string) *TransitGatewayMulticastGroup {
+	s.MemberType = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *TransitGatewayMulticastGroup) SetNetworkInterfaceId(v string) *TransitGatewayMulticastGroup {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TransitGatewayMulticastGroup) SetResourceId(v string) *TransitGatewayMulticastGroup {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TransitGatewayMulticastGroup) SetResourceType(v string) *TransitGatewayMulticastGroup {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *TransitGatewayMulticastGroup) SetSourceType(v string) *TransitGatewayMulticastGroup {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *TransitGatewayMulticastGroup) SetSubnetId(v string) *TransitGatewayMulticastGroup {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *TransitGatewayMulticastGroup) SetTransitGatewayAttachmentId(v string) *TransitGatewayMulticastGroup {
+	s.TransitGatewayAttachmentId = &v
+	return s
+}
+
+// Describes the registered transit gateway multicast group members.
+type TransitGatewayMulticastRegisteredGroupMembers struct {
+	_ struct{} `type:"structure"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `locationName:"groupIpAddress" type:"string"`
+
+	// The ID of the registered network interfaces.
+	RegisteredNetworkInterfaceIds []*string `locationName:"registeredNetworkInterfaceIds" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastRegisteredGroupMembers) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastRegisteredGroupMembers) GoString() string {
+	return s.String()
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *TransitGatewayMulticastRegisteredGroupMembers) SetGroupIpAddress(v string) *TransitGatewayMulticastRegisteredGroupMembers {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetRegisteredNetworkInterfaceIds sets the RegisteredNetworkInterfaceIds field's value.
+func (s *TransitGatewayMulticastRegisteredGroupMembers) SetRegisteredNetworkInterfaceIds(v []*string) *TransitGatewayMulticastRegisteredGroupMembers {
+	s.RegisteredNetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastRegisteredGroupMembers) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastRegisteredGroupMembers {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
+// Describes the members registered with the transit gateway multicast group.
+type TransitGatewayMulticastRegisteredGroupSources struct {
+	_ struct{} `type:"structure"`
+
+	// The IP address assigned to the transit gateway multicast group.
+	GroupIpAddress *string `locationName:"groupIpAddress" type:"string"`
+
+	// The IDs of the network interfaces members registered with the transit gateway
+	// multicast group.
+	RegisteredNetworkInterfaceIds []*string `locationName:"registeredNetworkInterfaceIds" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway multicast domain.
+	TransitGatewayMulticastDomainId *string `locationName:"transitGatewayMulticastDomainId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayMulticastRegisteredGroupSources) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayMulticastRegisteredGroupSources) GoString() string {
+	return s.String()
+}
+
+// SetGroupIpAddress sets the GroupIpAddress field's value.
+func (s *TransitGatewayMulticastRegisteredGroupSources) SetGroupIpAddress(v string) *TransitGatewayMulticastRegisteredGroupSources {
+	s.GroupIpAddress = &v
+	return s
+}
+
+// SetRegisteredNetworkInterfaceIds sets the RegisteredNetworkInterfaceIds field's value.
+func (s *TransitGatewayMulticastRegisteredGroupSources) SetRegisteredNetworkInterfaceIds(v []*string) *TransitGatewayMulticastRegisteredGroupSources {
+	s.RegisteredNetworkInterfaceIds = v
+	return s
+}
+
+// SetTransitGatewayMulticastDomainId sets the TransitGatewayMulticastDomainId field's value.
+func (s *TransitGatewayMulticastRegisteredGroupSources) SetTransitGatewayMulticastDomainId(v string) *TransitGatewayMulticastRegisteredGroupSources {
+	s.TransitGatewayMulticastDomainId = &v
+	return s
+}
+
 // Describes the options for a transit gateway.
 type TransitGatewayOptions struct {
 	_ struct{} `type:"structure"`
@@ -91715,6 +102168,9 @@ type TransitGatewayOptions struct {
 
 	// Indicates whether DNS support is enabled.
 	DnsSupport *string `locationName:"dnsSupport" type:"string" enum:"DnsSupportValue"`
+
+	// Indicates whether multicast is enabled on the transit gateway
+	MulticastSupport *string `locationName:"multicastSupport" type:"string" enum:"MulticastSupportValue"`
 
 	// The ID of the default propagation route table.
 	PropagationDefaultRouteTableId *string `locationName:"propagationDefaultRouteTableId" type:"string"`
@@ -91769,6 +102225,12 @@ func (s *TransitGatewayOptions) SetDnsSupport(v string) *TransitGatewayOptions {
 	return s
 }
 
+// SetMulticastSupport sets the MulticastSupport field's value.
+func (s *TransitGatewayOptions) SetMulticastSupport(v string) *TransitGatewayOptions {
+	s.MulticastSupport = &v
+	return s
+}
+
 // SetPropagationDefaultRouteTableId sets the PropagationDefaultRouteTableId field's value.
 func (s *TransitGatewayOptions) SetPropagationDefaultRouteTableId(v string) *TransitGatewayOptions {
 	s.PropagationDefaultRouteTableId = &v
@@ -91778,6 +102240,84 @@ func (s *TransitGatewayOptions) SetPropagationDefaultRouteTableId(v string) *Tra
 // SetVpnEcmpSupport sets the VpnEcmpSupport field's value.
 func (s *TransitGatewayOptions) SetVpnEcmpSupport(v string) *TransitGatewayOptions {
 	s.VpnEcmpSupport = &v
+	return s
+}
+
+// Describes the transit gateway peering attachment.
+type TransitGatewayPeeringAttachment struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the accepter transit gateway.
+	AccepterTgwInfo *PeeringTgwInfo `locationName:"accepterTgwInfo" type:"structure"`
+
+	// The time the transit gateway peering attachment was created.
+	CreationTime *time.Time `locationName:"creationTime" type:"timestamp"`
+
+	// Information about the requester transit gateway.
+	RequesterTgwInfo *PeeringTgwInfo `locationName:"requesterTgwInfo" type:"structure"`
+
+	// The state of the transit gateway peering attachment.
+	State *string `locationName:"state" type:"string" enum:"TransitGatewayAttachmentState"`
+
+	// The status of the transit gateway peering attachment.
+	Status *PeeringAttachmentStatus `locationName:"status" type:"structure"`
+
+	// The tags for the transit gateway peering attachment.
+	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
+
+	// The ID of the transit gateway peering attachment.
+	TransitGatewayAttachmentId *string `locationName:"transitGatewayAttachmentId" type:"string"`
+}
+
+// String returns the string representation
+func (s TransitGatewayPeeringAttachment) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransitGatewayPeeringAttachment) GoString() string {
+	return s.String()
+}
+
+// SetAccepterTgwInfo sets the AccepterTgwInfo field's value.
+func (s *TransitGatewayPeeringAttachment) SetAccepterTgwInfo(v *PeeringTgwInfo) *TransitGatewayPeeringAttachment {
+	s.AccepterTgwInfo = v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *TransitGatewayPeeringAttachment) SetCreationTime(v time.Time) *TransitGatewayPeeringAttachment {
+	s.CreationTime = &v
+	return s
+}
+
+// SetRequesterTgwInfo sets the RequesterTgwInfo field's value.
+func (s *TransitGatewayPeeringAttachment) SetRequesterTgwInfo(v *PeeringTgwInfo) *TransitGatewayPeeringAttachment {
+	s.RequesterTgwInfo = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *TransitGatewayPeeringAttachment) SetState(v string) *TransitGatewayPeeringAttachment {
+	s.State = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TransitGatewayPeeringAttachment) SetStatus(v *PeeringAttachmentStatus) *TransitGatewayPeeringAttachment {
+	s.Status = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TransitGatewayPeeringAttachment) SetTags(v []*Tag) *TransitGatewayPeeringAttachment {
+	s.Tags = v
+	return s
+}
+
+// SetTransitGatewayAttachmentId sets the TransitGatewayAttachmentId field's value.
+func (s *TransitGatewayPeeringAttachment) SetTransitGatewayAttachmentId(v string) *TransitGatewayPeeringAttachment {
+	s.TransitGatewayAttachmentId = &v
 	return s
 }
 
@@ -91865,6 +102405,9 @@ type TransitGatewayRequestOptions struct {
 	// Enable or disable DNS support.
 	DnsSupport *string `type:"string" enum:"DnsSupportValue"`
 
+	// Indicates whether multicast is enabled on the transit gateway
+	MulticastSupport *string `type:"string" enum:"MulticastSupportValue"`
+
 	// Enable or disable Equal Cost Multipath Protocol support.
 	VpnEcmpSupport *string `type:"string" enum:"VpnEcmpSupportValue"`
 }
@@ -91906,6 +102449,12 @@ func (s *TransitGatewayRequestOptions) SetDefaultRouteTablePropagation(v string)
 // SetDnsSupport sets the DnsSupport field's value.
 func (s *TransitGatewayRequestOptions) SetDnsSupport(v string) *TransitGatewayRequestOptions {
 	s.DnsSupport = &v
+	return s
+}
+
+// SetMulticastSupport sets the MulticastSupport field's value.
+func (s *TransitGatewayRequestOptions) SetMulticastSupport(v string) *TransitGatewayRequestOptions {
+	s.MulticastSupport = &v
 	return s
 }
 
@@ -92708,13 +103257,13 @@ func (s *UnmonitorInstancesOutput) SetInstanceMonitorings(v []*InstanceMonitorin
 	return s
 }
 
-// Describes the T2 or T3 instance whose credit option for CPU usage was not
-// modified.
+// Describes the burstable performance instance whose credit option for CPU
+// usage was not modified.
 type UnsuccessfulInstanceCreditSpecificationItem struct {
 	_ struct{} `type:"structure"`
 
-	// The applicable error for the T2 or T3 instance whose credit option for CPU
-	// usage was not modified.
+	// The applicable error for the burstable performance instance whose credit
+	// option for CPU usage was not modified.
 	Error *UnsuccessfulInstanceCreditSpecificationItemError `locationName:"error" type:"structure"`
 
 	// The ID of the instance.
@@ -92743,8 +103292,8 @@ func (s *UnsuccessfulInstanceCreditSpecificationItem) SetInstanceId(v string) *U
 	return s
 }
 
-// Information about the error for the T2 or T3 instance whose credit option
-// for CPU usage was not modified.
+// Information about the error for the burstable performance instance whose
+// credit option for CPU usage was not modified.
 type UnsuccessfulInstanceCreditSpecificationItemError struct {
 	_ struct{} `type:"structure"`
 
@@ -93100,7 +103649,7 @@ func (s *UserBucketDetails) SetS3Key(v string) *UserBucketDetails {
 
 // Describes the user data for an instance.
 type UserData struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" sensitive:"true"`
 
 	// The user data. If you are using an AWS SDK or command line tool, Base64-encoding
 	// is performed for you, and you can load the text from a file. Otherwise, you
@@ -93218,6 +103767,68 @@ func (s *UserIdGroupPair) SetVpcPeeringConnectionId(v string) *UserIdGroupPair {
 	return s
 }
 
+// Describes the vCPU configurations for the instance type.
+type VCpuInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The default number of cores for the instance type.
+	DefaultCores *int64 `locationName:"defaultCores" type:"integer"`
+
+	// The default number of threads per core for the instance type.
+	DefaultThreadsPerCore *int64 `locationName:"defaultThreadsPerCore" type:"integer"`
+
+	// The default number of vCPUs for the instance type.
+	DefaultVCpus *int64 `locationName:"defaultVCpus" type:"integer"`
+
+	// List of the valid number of cores that can be configured for the instance
+	// type.
+	ValidCores []*int64 `locationName:"validCores" locationNameList:"item" type:"list"`
+
+	// List of the valid number of threads per core that can be configured for the
+	// instance type.
+	ValidThreadsPerCore []*int64 `locationName:"validThreadsPerCore" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s VCpuInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s VCpuInfo) GoString() string {
+	return s.String()
+}
+
+// SetDefaultCores sets the DefaultCores field's value.
+func (s *VCpuInfo) SetDefaultCores(v int64) *VCpuInfo {
+	s.DefaultCores = &v
+	return s
+}
+
+// SetDefaultThreadsPerCore sets the DefaultThreadsPerCore field's value.
+func (s *VCpuInfo) SetDefaultThreadsPerCore(v int64) *VCpuInfo {
+	s.DefaultThreadsPerCore = &v
+	return s
+}
+
+// SetDefaultVCpus sets the DefaultVCpus field's value.
+func (s *VCpuInfo) SetDefaultVCpus(v int64) *VCpuInfo {
+	s.DefaultVCpus = &v
+	return s
+}
+
+// SetValidCores sets the ValidCores field's value.
+func (s *VCpuInfo) SetValidCores(v []*int64) *VCpuInfo {
+	s.ValidCores = v
+	return s
+}
+
+// SetValidThreadsPerCore sets the ValidThreadsPerCore field's value.
+func (s *VCpuInfo) SetValidThreadsPerCore(v []*int64) *VCpuInfo {
+	s.ValidThreadsPerCore = v
+	return s
+}
+
 // Describes telemetry for a VPN tunnel.
 type VgwTelemetry struct {
 	_ struct{} `type:"structure"`
@@ -93304,6 +103915,9 @@ type Volume struct {
 	// Indicates whether the volume is encrypted.
 	Encrypted *bool `locationName:"encrypted" type:"boolean"`
 
+	// Indicates whether the volume was created using fast snapshot restore.
+	FastRestored *bool `locationName:"fastRestored" type:"boolean"`
+
 	// The number of I/O operations per second (IOPS) that the volume supports.
 	// For Provisioned IOPS SSD volumes, this represents the number of IOPS that
 	// are provisioned for the volume. For General Purpose SSD volumes, this represents
@@ -93325,6 +103939,9 @@ type Volume struct {
 	// customer master key (CMK) that was used to protect the volume encryption
 	// key for the volume.
 	KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
 
 	// The size of the volume, in GiBs.
 	Size *int64 `locationName:"size" type:"integer"`
@@ -93381,6 +103998,12 @@ func (s *Volume) SetEncrypted(v bool) *Volume {
 	return s
 }
 
+// SetFastRestored sets the FastRestored field's value.
+func (s *Volume) SetFastRestored(v bool) *Volume {
+	s.FastRestored = &v
+	return s
+}
+
 // SetIops sets the Iops field's value.
 func (s *Volume) SetIops(v int64) *Volume {
 	s.Iops = &v
@@ -93390,6 +104013,12 @@ func (s *Volume) SetIops(v int64) *Volume {
 // SetKmsKeyId sets the KmsKeyId field's value.
 func (s *Volume) SetKmsKeyId(v string) *Volume {
 	s.KmsKeyId = &v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *Volume) SetOutpostArn(v string) *Volume {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -93853,6 +104482,9 @@ type VolumeStatusItem struct {
 	// A list of events associated with the volume.
 	Events []*VolumeStatusEvent `locationName:"eventsSet" locationNameList:"item" type:"list"`
 
+	// The Amazon Resource Name (ARN) of the Outpost.
+	OutpostArn *string `locationName:"outpostArn" type:"string"`
+
 	// The volume ID.
 	VolumeId *string `locationName:"volumeId" type:"string"`
 
@@ -93885,6 +104517,12 @@ func (s *VolumeStatusItem) SetAvailabilityZone(v string) *VolumeStatusItem {
 // SetEvents sets the Events field's value.
 func (s *VolumeStatusItem) SetEvents(v []*VolumeStatusEvent) *VolumeStatusItem {
 	s.Events = v
+	return s
+}
+
+// SetOutpostArn sets the OutpostArn field's value.
+func (s *VolumeStatusItem) SetOutpostArn(v string) *VolumeStatusItem {
+	s.OutpostArn = &v
 	return s
 }
 
@@ -94407,6 +105045,9 @@ type VpcIpv6CidrBlockAssociation struct {
 
 	// Information about the state of the CIDR block.
 	Ipv6CidrBlockState *VpcCidrBlockState `locationName:"ipv6CidrBlockState" type:"structure"`
+
+	// The name of the location from which we advertise the IPV6 CIDR block.
+	NetworkBorderGroup *string `locationName:"networkBorderGroup" type:"string"`
 }
 
 // String returns the string representation
@@ -94434,6 +105075,12 @@ func (s *VpcIpv6CidrBlockAssociation) SetIpv6CidrBlock(v string) *VpcIpv6CidrBlo
 // SetIpv6CidrBlockState sets the Ipv6CidrBlockState field's value.
 func (s *VpcIpv6CidrBlockAssociation) SetIpv6CidrBlockState(v *VpcCidrBlockState) *VpcIpv6CidrBlockAssociation {
 	s.Ipv6CidrBlockState = v
+	return s
+}
+
+// SetNetworkBorderGroup sets the NetworkBorderGroup field's value.
+func (s *VpcIpv6CidrBlockAssociation) SetNetworkBorderGroup(v string) *VpcIpv6CidrBlockAssociation {
+	s.NetworkBorderGroup = &v
 	return s
 }
 
@@ -94796,6 +105443,9 @@ func (s *VpnConnection) SetVpnGatewayId(v string) *VpnConnection {
 type VpnConnectionOptions struct {
 	_ struct{} `type:"structure"`
 
+	// Indicates whether acceleration is enabled for the VPN connection.
+	EnableAcceleration *bool `locationName:"enableAcceleration" type:"boolean"`
+
 	// Indicates whether the VPN connection uses static routes only. Static routes
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
@@ -94814,6 +105464,12 @@ func (s VpnConnectionOptions) GoString() string {
 	return s.String()
 }
 
+// SetEnableAcceleration sets the EnableAcceleration field's value.
+func (s *VpnConnectionOptions) SetEnableAcceleration(v bool) *VpnConnectionOptions {
+	s.EnableAcceleration = &v
+	return s
+}
+
 // SetStaticRoutesOnly sets the StaticRoutesOnly field's value.
 func (s *VpnConnectionOptions) SetStaticRoutesOnly(v bool) *VpnConnectionOptions {
 	s.StaticRoutesOnly = &v
@@ -94829,6 +105485,11 @@ func (s *VpnConnectionOptions) SetTunnelOptions(v []*TunnelOption) *VpnConnectio
 // Describes VPN connection options.
 type VpnConnectionOptionsSpecification struct {
 	_ struct{} `type:"structure"`
+
+	// Indicate whether to enable acceleration for the VPN connection.
+	//
+	// Default: false
+	EnableAcceleration *bool `type:"boolean"`
 
 	// Indicate whether the VPN connection uses static routes only. If you are creating
 	// a VPN connection for a device that does not support BGP, you must specify
@@ -94849,6 +105510,12 @@ func (s VpnConnectionOptionsSpecification) String() string {
 // GoString returns the string representation
 func (s VpnConnectionOptionsSpecification) GoString() string {
 	return s.String()
+}
+
+// SetEnableAcceleration sets the EnableAcceleration field's value.
+func (s *VpnConnectionOptionsSpecification) SetEnableAcceleration(v bool) *VpnConnectionOptionsSpecification {
+	s.EnableAcceleration = &v
+	return s
 }
 
 // SetStaticRoutesOnly sets the StaticRoutesOnly field's value.
@@ -95341,6 +106008,25 @@ const (
 )
 
 const (
+	// AllowsMultipleInstanceTypesOn is a AllowsMultipleInstanceTypes enum value
+	AllowsMultipleInstanceTypesOn = "on"
+
+	// AllowsMultipleInstanceTypesOff is a AllowsMultipleInstanceTypes enum value
+	AllowsMultipleInstanceTypesOff = "off"
+)
+
+const (
+	// ArchitectureTypeI386 is a ArchitectureType enum value
+	ArchitectureTypeI386 = "i386"
+
+	// ArchitectureTypeX8664 is a ArchitectureType enum value
+	ArchitectureTypeX8664 = "x86_64"
+
+	// ArchitectureTypeArm64 is a ArchitectureType enum value
+	ArchitectureTypeArm64 = "arm64"
+)
+
+const (
 	// ArchitectureValuesI386 is a ArchitectureValues enum value
 	ArchitectureValuesI386 = "i386"
 
@@ -95401,6 +106087,17 @@ const (
 
 	// AutoPlacementOff is a AutoPlacement enum value
 	AutoPlacementOff = "off"
+)
+
+const (
+	// AvailabilityZoneOptInStatusOptInNotRequired is a AvailabilityZoneOptInStatus enum value
+	AvailabilityZoneOptInStatusOptInNotRequired = "opt-in-not-required"
+
+	// AvailabilityZoneOptInStatusOptedIn is a AvailabilityZoneOptInStatus enum value
+	AvailabilityZoneOptInStatusOptedIn = "opted-in"
+
+	// AvailabilityZoneOptInStatusNotOptedIn is a AvailabilityZoneOptInStatus enum value
+	AvailabilityZoneOptInStatusNotOptedIn = "not-opted-in"
 )
 
 const (
@@ -95746,6 +106443,17 @@ const (
 )
 
 const (
+	// DeleteQueuedReservedInstancesErrorCodeReservedInstancesIdInvalid is a DeleteQueuedReservedInstancesErrorCode enum value
+	DeleteQueuedReservedInstancesErrorCodeReservedInstancesIdInvalid = "reserved-instances-id-invalid"
+
+	// DeleteQueuedReservedInstancesErrorCodeReservedInstancesNotInQueuedState is a DeleteQueuedReservedInstancesErrorCode enum value
+	DeleteQueuedReservedInstancesErrorCodeReservedInstancesNotInQueuedState = "reserved-instances-not-in-queued-state"
+
+	// DeleteQueuedReservedInstancesErrorCodeUnexpectedError is a DeleteQueuedReservedInstancesErrorCode enum value
+	DeleteQueuedReservedInstancesErrorCodeUnexpectedError = "unexpected-error"
+)
+
+const (
 	// DeviceTypeEbs is a DeviceType enum value
 	DeviceTypeEbs = "ebs"
 
@@ -95765,6 +106473,14 @@ const (
 )
 
 const (
+	// DiskTypeHdd is a DiskType enum value
+	DiskTypeHdd = "hdd"
+
+	// DiskTypeSsd is a DiskType enum value
+	DiskTypeSsd = "ssd"
+)
+
+const (
 	// DnsSupportValueEnable is a DnsSupportValue enum value
 	DnsSupportValueEnable = "enable"
 
@@ -95781,6 +106497,25 @@ const (
 )
 
 const (
+	// EbsEncryptionSupportUnsupported is a EbsEncryptionSupport enum value
+	EbsEncryptionSupportUnsupported = "unsupported"
+
+	// EbsEncryptionSupportSupported is a EbsEncryptionSupport enum value
+	EbsEncryptionSupportSupported = "supported"
+)
+
+const (
+	// EbsOptimizedSupportUnsupported is a EbsOptimizedSupport enum value
+	EbsOptimizedSupportUnsupported = "unsupported"
+
+	// EbsOptimizedSupportSupported is a EbsOptimizedSupport enum value
+	EbsOptimizedSupportSupported = "supported"
+
+	// EbsOptimizedSupportDefault is a EbsOptimizedSupport enum value
+	EbsOptimizedSupportDefault = "default"
+)
+
+const (
 	// ElasticGpuStateAttached is a ElasticGpuState enum value
 	ElasticGpuStateAttached = "ATTACHED"
 )
@@ -95791,6 +106526,17 @@ const (
 
 	// ElasticGpuStatusImpaired is a ElasticGpuStatus enum value
 	ElasticGpuStatusImpaired = "IMPAIRED"
+)
+
+const (
+	// EnaSupportUnsupported is a EnaSupport enum value
+	EnaSupportUnsupported = "unsupported"
+
+	// EnaSupportSupported is a EnaSupport enum value
+	EnaSupportSupported = "supported"
+
+	// EnaSupportRequired is a EnaSupport enum value
+	EnaSupportRequired = "required"
 )
 
 const (
@@ -95866,17 +106612,39 @@ const (
 )
 
 const (
+	// FastSnapshotRestoreStateCodeEnabling is a FastSnapshotRestoreStateCode enum value
+	FastSnapshotRestoreStateCodeEnabling = "enabling"
+
+	// FastSnapshotRestoreStateCodeOptimizing is a FastSnapshotRestoreStateCode enum value
+	FastSnapshotRestoreStateCodeOptimizing = "optimizing"
+
+	// FastSnapshotRestoreStateCodeEnabled is a FastSnapshotRestoreStateCode enum value
+	FastSnapshotRestoreStateCodeEnabled = "enabled"
+
+	// FastSnapshotRestoreStateCodeDisabling is a FastSnapshotRestoreStateCode enum value
+	FastSnapshotRestoreStateCodeDisabling = "disabling"
+
+	// FastSnapshotRestoreStateCodeDisabled is a FastSnapshotRestoreStateCode enum value
+	FastSnapshotRestoreStateCodeDisabled = "disabled"
+)
+
+const (
 	// FleetActivityStatusError is a FleetActivityStatus enum value
 	FleetActivityStatusError = "error"
 
 	// FleetActivityStatusPendingFulfillment is a FleetActivityStatus enum value
-	FleetActivityStatusPendingFulfillment = "pending-fulfillment"
+	FleetActivityStatusPendingFulfillment = "pending_fulfillment"
 
 	// FleetActivityStatusPendingTermination is a FleetActivityStatus enum value
-	FleetActivityStatusPendingTermination = "pending-termination"
+	FleetActivityStatusPendingTermination = "pending_termination"
 
 	// FleetActivityStatusFulfilled is a FleetActivityStatus enum value
 	FleetActivityStatusFulfilled = "fulfilled"
+)
+
+const (
+	// FleetCapacityReservationUsageStrategyUseCapacityReservationsFirst is a FleetCapacityReservationUsageStrategy enum value
+	FleetCapacityReservationUsageStrategyUseCapacityReservationsFirst = "use-capacity-reservations-first"
 )
 
 const (
@@ -95920,10 +106688,10 @@ const (
 	FleetStateCodeFailed = "failed"
 
 	// FleetStateCodeDeletedRunning is a FleetStateCode enum value
-	FleetStateCodeDeletedRunning = "deleted-running"
+	FleetStateCodeDeletedRunning = "deleted_running"
 
 	// FleetStateCodeDeletedTerminating is a FleetStateCode enum value
-	FleetStateCodeDeletedTerminating = "deleted-terminating"
+	FleetStateCodeDeletedTerminating = "deleted_terminating"
 
 	// FleetStateCodeModifying is a FleetStateCode enum value
 	FleetStateCodeModifying = "modifying"
@@ -95998,6 +106766,14 @@ const (
 
 	// HostTenancyHost is a HostTenancy enum value
 	HostTenancyHost = "host"
+)
+
+const (
+	// HttpTokensStateOptional is a HttpTokensState enum value
+	HttpTokensStateOptional = "optional"
+
+	// HttpTokensStateRequired is a HttpTokensState enum value
+	HttpTokensStateRequired = "required"
 )
 
 const (
@@ -96164,6 +106940,22 @@ const (
 
 	// InstanceMatchCriteriaTargeted is a InstanceMatchCriteria enum value
 	InstanceMatchCriteriaTargeted = "targeted"
+)
+
+const (
+	// InstanceMetadataEndpointStateDisabled is a InstanceMetadataEndpointState enum value
+	InstanceMetadataEndpointStateDisabled = "disabled"
+
+	// InstanceMetadataEndpointStateEnabled is a InstanceMetadataEndpointState enum value
+	InstanceMetadataEndpointStateEnabled = "enabled"
+)
+
+const (
+	// InstanceMetadataOptionsStatePending is a InstanceMetadataOptionsState enum value
+	InstanceMetadataOptionsStatePending = "pending"
+
+	// InstanceMetadataOptionsStateApplied is a InstanceMetadataOptionsState enum value
+	InstanceMetadataOptionsStateApplied = "applied"
 )
 
 const (
@@ -96607,8 +107399,17 @@ const (
 	// InstanceTypeC5d9xlarge is a InstanceType enum value
 	InstanceTypeC5d9xlarge = "c5d.9xlarge"
 
+	// InstanceTypeC5d12xlarge is a InstanceType enum value
+	InstanceTypeC5d12xlarge = "c5d.12xlarge"
+
 	// InstanceTypeC5d18xlarge is a InstanceType enum value
 	InstanceTypeC5d18xlarge = "c5d.18xlarge"
+
+	// InstanceTypeC5d24xlarge is a InstanceType enum value
+	InstanceTypeC5d24xlarge = "c5d.24xlarge"
+
+	// InstanceTypeC5dMetal is a InstanceType enum value
+	InstanceTypeC5dMetal = "c5d.metal"
 
 	// InstanceTypeC5nLarge is a InstanceType enum value
 	InstanceTypeC5nLarge = "c5n.large"
@@ -96651,6 +107452,24 @@ const (
 
 	// InstanceTypeG3sXlarge is a InstanceType enum value
 	InstanceTypeG3sXlarge = "g3s.xlarge"
+
+	// InstanceTypeG4dnXlarge is a InstanceType enum value
+	InstanceTypeG4dnXlarge = "g4dn.xlarge"
+
+	// InstanceTypeG4dn2xlarge is a InstanceType enum value
+	InstanceTypeG4dn2xlarge = "g4dn.2xlarge"
+
+	// InstanceTypeG4dn4xlarge is a InstanceType enum value
+	InstanceTypeG4dn4xlarge = "g4dn.4xlarge"
+
+	// InstanceTypeG4dn8xlarge is a InstanceType enum value
+	InstanceTypeG4dn8xlarge = "g4dn.8xlarge"
+
+	// InstanceTypeG4dn12xlarge is a InstanceType enum value
+	InstanceTypeG4dn12xlarge = "g4dn.12xlarge"
+
+	// InstanceTypeG4dn16xlarge is a InstanceType enum value
+	InstanceTypeG4dn16xlarge = "g4dn.16xlarge"
 
 	// InstanceTypeCg14xlarge is a InstanceType enum value
 	InstanceTypeCg14xlarge = "cg1.4xlarge"
@@ -96841,6 +107660,12 @@ const (
 	// InstanceTypeU12tb1Metal is a InstanceType enum value
 	InstanceTypeU12tb1Metal = "u-12tb1.metal"
 
+	// InstanceTypeU18tb1Metal is a InstanceType enum value
+	InstanceTypeU18tb1Metal = "u-18tb1.metal"
+
+	// InstanceTypeU24tb1Metal is a InstanceType enum value
+	InstanceTypeU24tb1Metal = "u-24tb1.metal"
+
 	// InstanceTypeA1Medium is a InstanceType enum value
 	InstanceTypeA1Medium = "a1.medium"
 
@@ -96855,6 +107680,125 @@ const (
 
 	// InstanceTypeA14xlarge is a InstanceType enum value
 	InstanceTypeA14xlarge = "a1.4xlarge"
+
+	// InstanceTypeA1Metal is a InstanceType enum value
+	InstanceTypeA1Metal = "a1.metal"
+
+	// InstanceTypeM5dnLarge is a InstanceType enum value
+	InstanceTypeM5dnLarge = "m5dn.large"
+
+	// InstanceTypeM5dnXlarge is a InstanceType enum value
+	InstanceTypeM5dnXlarge = "m5dn.xlarge"
+
+	// InstanceTypeM5dn2xlarge is a InstanceType enum value
+	InstanceTypeM5dn2xlarge = "m5dn.2xlarge"
+
+	// InstanceTypeM5dn4xlarge is a InstanceType enum value
+	InstanceTypeM5dn4xlarge = "m5dn.4xlarge"
+
+	// InstanceTypeM5dn8xlarge is a InstanceType enum value
+	InstanceTypeM5dn8xlarge = "m5dn.8xlarge"
+
+	// InstanceTypeM5dn12xlarge is a InstanceType enum value
+	InstanceTypeM5dn12xlarge = "m5dn.12xlarge"
+
+	// InstanceTypeM5dn16xlarge is a InstanceType enum value
+	InstanceTypeM5dn16xlarge = "m5dn.16xlarge"
+
+	// InstanceTypeM5dn24xlarge is a InstanceType enum value
+	InstanceTypeM5dn24xlarge = "m5dn.24xlarge"
+
+	// InstanceTypeM5nLarge is a InstanceType enum value
+	InstanceTypeM5nLarge = "m5n.large"
+
+	// InstanceTypeM5nXlarge is a InstanceType enum value
+	InstanceTypeM5nXlarge = "m5n.xlarge"
+
+	// InstanceTypeM5n2xlarge is a InstanceType enum value
+	InstanceTypeM5n2xlarge = "m5n.2xlarge"
+
+	// InstanceTypeM5n4xlarge is a InstanceType enum value
+	InstanceTypeM5n4xlarge = "m5n.4xlarge"
+
+	// InstanceTypeM5n8xlarge is a InstanceType enum value
+	InstanceTypeM5n8xlarge = "m5n.8xlarge"
+
+	// InstanceTypeM5n12xlarge is a InstanceType enum value
+	InstanceTypeM5n12xlarge = "m5n.12xlarge"
+
+	// InstanceTypeM5n16xlarge is a InstanceType enum value
+	InstanceTypeM5n16xlarge = "m5n.16xlarge"
+
+	// InstanceTypeM5n24xlarge is a InstanceType enum value
+	InstanceTypeM5n24xlarge = "m5n.24xlarge"
+
+	// InstanceTypeR5dnLarge is a InstanceType enum value
+	InstanceTypeR5dnLarge = "r5dn.large"
+
+	// InstanceTypeR5dnXlarge is a InstanceType enum value
+	InstanceTypeR5dnXlarge = "r5dn.xlarge"
+
+	// InstanceTypeR5dn2xlarge is a InstanceType enum value
+	InstanceTypeR5dn2xlarge = "r5dn.2xlarge"
+
+	// InstanceTypeR5dn4xlarge is a InstanceType enum value
+	InstanceTypeR5dn4xlarge = "r5dn.4xlarge"
+
+	// InstanceTypeR5dn8xlarge is a InstanceType enum value
+	InstanceTypeR5dn8xlarge = "r5dn.8xlarge"
+
+	// InstanceTypeR5dn12xlarge is a InstanceType enum value
+	InstanceTypeR5dn12xlarge = "r5dn.12xlarge"
+
+	// InstanceTypeR5dn16xlarge is a InstanceType enum value
+	InstanceTypeR5dn16xlarge = "r5dn.16xlarge"
+
+	// InstanceTypeR5dn24xlarge is a InstanceType enum value
+	InstanceTypeR5dn24xlarge = "r5dn.24xlarge"
+
+	// InstanceTypeR5nLarge is a InstanceType enum value
+	InstanceTypeR5nLarge = "r5n.large"
+
+	// InstanceTypeR5nXlarge is a InstanceType enum value
+	InstanceTypeR5nXlarge = "r5n.xlarge"
+
+	// InstanceTypeR5n2xlarge is a InstanceType enum value
+	InstanceTypeR5n2xlarge = "r5n.2xlarge"
+
+	// InstanceTypeR5n4xlarge is a InstanceType enum value
+	InstanceTypeR5n4xlarge = "r5n.4xlarge"
+
+	// InstanceTypeR5n8xlarge is a InstanceType enum value
+	InstanceTypeR5n8xlarge = "r5n.8xlarge"
+
+	// InstanceTypeR5n12xlarge is a InstanceType enum value
+	InstanceTypeR5n12xlarge = "r5n.12xlarge"
+
+	// InstanceTypeR5n16xlarge is a InstanceType enum value
+	InstanceTypeR5n16xlarge = "r5n.16xlarge"
+
+	// InstanceTypeR5n24xlarge is a InstanceType enum value
+	InstanceTypeR5n24xlarge = "r5n.24xlarge"
+
+	// InstanceTypeInf1Xlarge is a InstanceType enum value
+	InstanceTypeInf1Xlarge = "inf1.xlarge"
+
+	// InstanceTypeInf12xlarge is a InstanceType enum value
+	InstanceTypeInf12xlarge = "inf1.2xlarge"
+
+	// InstanceTypeInf16xlarge is a InstanceType enum value
+	InstanceTypeInf16xlarge = "inf1.6xlarge"
+
+	// InstanceTypeInf124xlarge is a InstanceType enum value
+	InstanceTypeInf124xlarge = "inf1.24xlarge"
+)
+
+const (
+	// InstanceTypeHypervisorNitro is a InstanceTypeHypervisor enum value
+	InstanceTypeHypervisorNitro = "nitro"
+
+	// InstanceTypeHypervisorXen is a InstanceTypeHypervisor enum value
+	InstanceTypeHypervisorXen = "xen"
 )
 
 const (
@@ -96922,6 +107866,42 @@ const (
 )
 
 const (
+	// LocalGatewayRouteStatePending is a LocalGatewayRouteState enum value
+	LocalGatewayRouteStatePending = "pending"
+
+	// LocalGatewayRouteStateActive is a LocalGatewayRouteState enum value
+	LocalGatewayRouteStateActive = "active"
+
+	// LocalGatewayRouteStateBlackhole is a LocalGatewayRouteState enum value
+	LocalGatewayRouteStateBlackhole = "blackhole"
+
+	// LocalGatewayRouteStateDeleting is a LocalGatewayRouteState enum value
+	LocalGatewayRouteStateDeleting = "deleting"
+
+	// LocalGatewayRouteStateDeleted is a LocalGatewayRouteState enum value
+	LocalGatewayRouteStateDeleted = "deleted"
+)
+
+const (
+	// LocalGatewayRouteTypeStatic is a LocalGatewayRouteType enum value
+	LocalGatewayRouteTypeStatic = "static"
+
+	// LocalGatewayRouteTypePropagated is a LocalGatewayRouteType enum value
+	LocalGatewayRouteTypePropagated = "propagated"
+)
+
+const (
+	// LocationTypeRegion is a LocationType enum value
+	LocationTypeRegion = "region"
+
+	// LocationTypeAvailabilityZone is a LocationType enum value
+	LocationTypeAvailabilityZone = "availability-zone"
+
+	// LocationTypeAvailabilityZoneId is a LocationType enum value
+	LocationTypeAvailabilityZoneId = "availability-zone-id"
+)
+
+const (
 	// LogDestinationTypeCloudWatchLogs is a LogDestinationType enum value
 	LogDestinationTypeCloudWatchLogs = "cloud-watch-logs"
 
@@ -96932,6 +107912,14 @@ const (
 const (
 	// MarketTypeSpot is a MarketType enum value
 	MarketTypeSpot = "spot"
+)
+
+const (
+	// MembershipTypeStatic is a MembershipType enum value
+	MembershipTypeStatic = "static"
+
+	// MembershipTypeIgmp is a MembershipType enum value
+	MembershipTypeIgmp = "igmp"
 )
 
 const (
@@ -96954,6 +107942,14 @@ const (
 
 	// MoveStatusRestoringToClassic is a MoveStatus enum value
 	MoveStatusRestoringToClassic = "restoringToClassic"
+)
+
+const (
+	// MulticastSupportValueEnable is a MulticastSupportValue enum value
+	MulticastSupportValueEnable = "enable"
+
+	// MulticastSupportValueDisable is a MulticastSupportValue enum value
+	MulticastSupportValueDisable = "disable"
 )
 
 const (
@@ -97109,6 +108105,17 @@ const (
 )
 
 const (
+	// PlacementGroupStrategyCluster is a PlacementGroupStrategy enum value
+	PlacementGroupStrategyCluster = "cluster"
+
+	// PlacementGroupStrategyPartition is a PlacementGroupStrategy enum value
+	PlacementGroupStrategyPartition = "partition"
+
+	// PlacementGroupStrategySpread is a PlacementGroupStrategy enum value
+	PlacementGroupStrategySpread = "spread"
+)
+
+const (
 	// PlacementStrategyCluster is a PlacementStrategy enum value
 	PlacementStrategyCluster = "cluster"
 
@@ -97234,6 +108241,12 @@ const (
 
 	// ReservedInstanceStateRetired is a ReservedInstanceState enum value
 	ReservedInstanceStateRetired = "retired"
+
+	// ReservedInstanceStateQueued is a ReservedInstanceState enum value
+	ReservedInstanceStateQueued = "queued"
+
+	// ReservedInstanceStateQueuedDeleted is a ReservedInstanceState enum value
+	ReservedInstanceStateQueuedDeleted = "queued-deleted"
 )
 
 const (
@@ -97304,6 +108317,9 @@ const (
 	// ResourceTypeSnapshot is a ResourceType enum value
 	ResourceTypeSnapshot = "snapshot"
 
+	// ResourceTypeSpotFleetRequest is a ResourceType enum value
+	ResourceTypeSpotFleetRequest = "spot-fleet-request"
+
 	// ResourceTypeSpotInstancesRequest is a ResourceType enum value
 	ResourceTypeSpotInstancesRequest = "spot-instances-request"
 
@@ -97325,6 +108341,9 @@ const (
 	// ResourceTypeTransitGatewayAttachment is a ResourceType enum value
 	ResourceTypeTransitGatewayAttachment = "transit-gateway-attachment"
 
+	// ResourceTypeTransitGatewayMulticastDomain is a ResourceType enum value
+	ResourceTypeTransitGatewayMulticastDomain = "transit-gateway-multicast-domain"
+
 	// ResourceTypeTransitGatewayRouteTable is a ResourceType enum value
 	ResourceTypeTransitGatewayRouteTable = "transit-gateway-route-table"
 
@@ -97345,6 +108364,14 @@ const (
 )
 
 const (
+	// RootDeviceTypeEbs is a RootDeviceType enum value
+	RootDeviceTypeEbs = "ebs"
+
+	// RootDeviceTypeInstanceStore is a RootDeviceType enum value
+	RootDeviceTypeInstanceStore = "instance-store"
+)
+
+const (
 	// RouteOriginCreateRouteTable is a RouteOrigin enum value
 	RouteOriginCreateRouteTable = "CreateRouteTable"
 
@@ -97361,6 +108388,23 @@ const (
 
 	// RouteStateBlackhole is a RouteState enum value
 	RouteStateBlackhole = "blackhole"
+)
+
+const (
+	// RouteTableAssociationStateCodeAssociating is a RouteTableAssociationStateCode enum value
+	RouteTableAssociationStateCodeAssociating = "associating"
+
+	// RouteTableAssociationStateCodeAssociated is a RouteTableAssociationStateCode enum value
+	RouteTableAssociationStateCodeAssociated = "associated"
+
+	// RouteTableAssociationStateCodeDisassociating is a RouteTableAssociationStateCode enum value
+	RouteTableAssociationStateCodeDisassociating = "disassociating"
+
+	// RouteTableAssociationStateCodeDisassociated is a RouteTableAssociationStateCode enum value
+	RouteTableAssociationStateCodeDisassociated = "disassociated"
+
+	// RouteTableAssociationStateCodeFailed is a RouteTableAssociationStateCode enum value
+	RouteTableAssociationStateCodeFailed = "failed"
 )
 
 const (
@@ -97678,9 +108722,15 @@ const (
 
 	// TransitGatewayAttachmentResourceTypeDirectConnectGateway is a TransitGatewayAttachmentResourceType enum value
 	TransitGatewayAttachmentResourceTypeDirectConnectGateway = "direct-connect-gateway"
+
+	// TransitGatewayAttachmentResourceTypeTgwPeering is a TransitGatewayAttachmentResourceType enum value
+	TransitGatewayAttachmentResourceTypeTgwPeering = "tgw-peering"
 )
 
 const (
+	// TransitGatewayAttachmentStateInitiating is a TransitGatewayAttachmentState enum value
+	TransitGatewayAttachmentStateInitiating = "initiating"
+
 	// TransitGatewayAttachmentStatePendingAcceptance is a TransitGatewayAttachmentState enum value
 	TransitGatewayAttachmentStatePendingAcceptance = "pendingAcceptance"
 
@@ -97713,6 +108763,34 @@ const (
 
 	// TransitGatewayAttachmentStateFailing is a TransitGatewayAttachmentState enum value
 	TransitGatewayAttachmentStateFailing = "failing"
+)
+
+const (
+	// TransitGatewayMulitcastDomainAssociationStateAssociating is a TransitGatewayMulitcastDomainAssociationState enum value
+	TransitGatewayMulitcastDomainAssociationStateAssociating = "associating"
+
+	// TransitGatewayMulitcastDomainAssociationStateAssociated is a TransitGatewayMulitcastDomainAssociationState enum value
+	TransitGatewayMulitcastDomainAssociationStateAssociated = "associated"
+
+	// TransitGatewayMulitcastDomainAssociationStateDisassociating is a TransitGatewayMulitcastDomainAssociationState enum value
+	TransitGatewayMulitcastDomainAssociationStateDisassociating = "disassociating"
+
+	// TransitGatewayMulitcastDomainAssociationStateDisassociated is a TransitGatewayMulitcastDomainAssociationState enum value
+	TransitGatewayMulitcastDomainAssociationStateDisassociated = "disassociated"
+)
+
+const (
+	// TransitGatewayMulticastDomainStatePending is a TransitGatewayMulticastDomainState enum value
+	TransitGatewayMulticastDomainStatePending = "pending"
+
+	// TransitGatewayMulticastDomainStateAvailable is a TransitGatewayMulticastDomainState enum value
+	TransitGatewayMulticastDomainStateAvailable = "available"
+
+	// TransitGatewayMulticastDomainStateDeleting is a TransitGatewayMulticastDomainState enum value
+	TransitGatewayMulticastDomainStateDeleting = "deleting"
+
+	// TransitGatewayMulticastDomainStateDeleted is a TransitGatewayMulticastDomainState enum value
+	TransitGatewayMulticastDomainStateDeleted = "deleted"
 )
 
 const (
@@ -97794,6 +108872,17 @@ const (
 )
 
 const (
+	// UnlimitedSupportedInstanceFamilyT2 is a UnlimitedSupportedInstanceFamily enum value
+	UnlimitedSupportedInstanceFamilyT2 = "t2"
+
+	// UnlimitedSupportedInstanceFamilyT3 is a UnlimitedSupportedInstanceFamily enum value
+	UnlimitedSupportedInstanceFamilyT3 = "t3"
+
+	// UnlimitedSupportedInstanceFamilyT3a is a UnlimitedSupportedInstanceFamily enum value
+	UnlimitedSupportedInstanceFamilyT3a = "t3a"
+)
+
+const (
 	// UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
 	UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed = "InvalidInstanceID.Malformed"
 
@@ -97805,6 +108894,14 @@ const (
 
 	// UnsuccessfulInstanceCreditSpecificationErrorCodeInstanceCreditSpecificationNotSupported is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
 	UnsuccessfulInstanceCreditSpecificationErrorCodeInstanceCreditSpecificationNotSupported = "InstanceCreditSpecification.NotSupported"
+)
+
+const (
+	// UsageClassTypeSpot is a UsageClassType enum value
+	UsageClassTypeSpot = "spot"
+
+	// UsageClassTypeOnDemand is a UsageClassType enum value
+	UsageClassTypeOnDemand = "on-demand"
 )
 
 const (

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
@@ -8,64 +8,31 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/internal/sdkrand"
 )
 
-type retryer struct {
-	client.DefaultRetryer
-}
+const (
+	// customRetryerMinRetryDelay sets min retry delay
+	customRetryerMinRetryDelay = 1 * time.Second
 
-func (d retryer) RetryRules(r *request.Request) time.Duration {
-	switch r.Operation.Name {
-	case opModifyNetworkInterfaceAttribute:
-		fallthrough
-	case opAssignPrivateIpAddresses:
-		return customRetryRule(r)
-	default:
-		return d.DefaultRetryer.RetryRules(r)
-	}
-}
-
-func customRetryRule(r *request.Request) time.Duration {
-	retryTimes := []time.Duration{
-		time.Second,
-		3 * time.Second,
-		5 * time.Second,
-	}
-
-	count := r.RetryCount
-	if count >= len(retryTimes) {
-		count = len(retryTimes) - 1
-	}
-
-	minTime := int64(retryTimes[count])
-	return time.Duration(sdkrand.SeededRand.Int63n(minTime) + minTime)
-}
-
-func setCustomRetryer(c *client.Client) {
-	maxRetries := aws.IntValue(c.Config.MaxRetries)
-	if c.Config.MaxRetries == nil || maxRetries == aws.UseServiceDefaultRetries {
-		maxRetries = 3
-	}
-
-	c.Retryer = retryer{
-		DefaultRetryer: client.DefaultRetryer{
-			NumMaxRetries: maxRetries,
-		},
-	}
-}
+	// customRetryerMaxRetryDelay sets max retry delay
+	customRetryerMaxRetryDelay = 8 * time.Second
+)
 
 func init() {
-	initClient = func(c *client.Client) {
-		if c.Config.Retryer == nil {
-			// Only override the retryer with a custom one if the config
-			// does not already contain a retryer
-			setCustomRetryer(c)
-		}
-	}
 	initRequest = func(r *request.Request) {
 		if r.Operation.Name == opCopySnapshot { // fill the PresignedURL parameter
 			r.Handlers.Build.PushFront(fillPresignedURL)
+		}
+
+		// only set the retryer on request if config doesn't have a retryer
+		if r.Config.Retryer == nil && (r.Operation.Name == opModifyNetworkInterfaceAttribute || r.Operation.Name == opAssignPrivateIpAddresses) {
+			r.Retryer = client.DefaultRetryer{
+				NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
+				MinRetryDelay:    customRetryerMinRetryDelay,
+				MinThrottleDelay: customRetryerMinRetryDelay,
+				MaxRetryDelay:    customRetryerMaxRetryDelay,
+				MaxThrottleDelay: customRetryerMaxRetryDelay,
+			}
 		}
 	}
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ec2"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "EC2"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EC2"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EC2 client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a EC2 client from just a session.
 //     svc := ec2.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := ec2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *EC2 {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *EC2 {
 	svc := &EC2{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-11-15",
 			},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
@@ -952,6 +952,57 @@ func (c *EC2) WaitUntilPasswordDataAvailableWithContext(ctx aws.Context, input *
 	return w.WaitWithContext(ctx)
 }
 
+// WaitUntilSecurityGroupExists uses the Amazon EC2 API operation
+// DescribeSecurityGroups to wait for a condition to be met before returning.
+// If the condition is not met within the max attempt window, an error will
+// be returned.
+func (c *EC2) WaitUntilSecurityGroupExists(input *DescribeSecurityGroupsInput) error {
+	return c.WaitUntilSecurityGroupExistsWithContext(aws.BackgroundContext(), input)
+}
+
+// WaitUntilSecurityGroupExistsWithContext is an extended version of WaitUntilSecurityGroupExists.
+// With the support for passing in a context and options to configure the
+// Waiter and the underlying request options.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) WaitUntilSecurityGroupExistsWithContext(ctx aws.Context, input *DescribeSecurityGroupsInput, opts ...request.WaiterOption) error {
+	w := request.Waiter{
+		Name:        "WaitUntilSecurityGroupExists",
+		MaxAttempts: 6,
+		Delay:       request.ConstantWaiterDelay(5 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:   request.SuccessWaiterState,
+				Matcher: request.PathWaiterMatch, Argument: "length(SecurityGroups[].GroupId) > `0`",
+				Expected: true,
+			},
+			{
+				State:    request.RetryWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "InvalidGroupNotFound",
+			},
+		},
+		Logger: c.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *DescribeSecurityGroupsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSecurityGroupsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+	w.ApplyOptions(opts...)
+
+	return w.WaitWithContext(ctx)
+}
+
 // WaitUntilSnapshotCompleted uses the Amazon EC2 API operation
 // DescribeSnapshots to wait for a condition to be met before returning.
 // If the condition is not met within the max attempt window, an error will

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
@@ -442,7 +442,10 @@ func (c *ECR) CreateRepositoryRequest(input *CreateRepositoryInput) (req *reques
 
 // CreateRepository API operation for Amazon EC2 Container Registry.
 //
-// Creates an image repository.
+// Creates an Amazon Elastic Container Registry (Amazon ECR) repository, where
+// users can push and pull Docker images. For more information, see Amazon ECR
+// Repositories (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html)
+// in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -772,6 +775,158 @@ func (c *ECR) DeleteRepositoryPolicyWithContext(ctx aws.Context, input *DeleteRe
 	return out, req.Send()
 }
 
+const opDescribeImageScanFindings = "DescribeImageScanFindings"
+
+// DescribeImageScanFindingsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeImageScanFindings operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeImageScanFindings for more information on using the DescribeImageScanFindings
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeImageScanFindingsRequest method.
+//    req, resp := client.DescribeImageScanFindingsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/DescribeImageScanFindings
+func (c *ECR) DescribeImageScanFindingsRequest(input *DescribeImageScanFindingsInput) (req *request.Request, output *DescribeImageScanFindingsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeImageScanFindings,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeImageScanFindingsInput{}
+	}
+
+	output = &DescribeImageScanFindingsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeImageScanFindings API operation for Amazon EC2 Container Registry.
+//
+// Describes the image scan findings for the specified image.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation DescribeImageScanFindings for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ErrCodeImageNotFoundException "ImageNotFoundException"
+//   The image requested does not exist in the specified repository.
+//
+//   * ErrCodeScanNotFoundException "ScanNotFoundException"
+//   The specified image scan could not be found. Ensure that image scanning is
+//   enabled on the repository and try again.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/DescribeImageScanFindings
+func (c *ECR) DescribeImageScanFindings(input *DescribeImageScanFindingsInput) (*DescribeImageScanFindingsOutput, error) {
+	req, out := c.DescribeImageScanFindingsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeImageScanFindingsWithContext is the same as DescribeImageScanFindings with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeImageScanFindings for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) DescribeImageScanFindingsWithContext(ctx aws.Context, input *DescribeImageScanFindingsInput, opts ...request.Option) (*DescribeImageScanFindingsOutput, error) {
+	req, out := c.DescribeImageScanFindingsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeImageScanFindingsPages iterates over the pages of a DescribeImageScanFindings operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeImageScanFindings method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeImageScanFindings operation.
+//    pageNum := 0
+//    err := client.DescribeImageScanFindingsPages(params,
+//        func(page *ecr.DescribeImageScanFindingsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ECR) DescribeImageScanFindingsPages(input *DescribeImageScanFindingsInput, fn func(*DescribeImageScanFindingsOutput, bool) bool) error {
+	return c.DescribeImageScanFindingsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeImageScanFindingsPagesWithContext same as DescribeImageScanFindingsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) DescribeImageScanFindingsPagesWithContext(ctx aws.Context, input *DescribeImageScanFindingsInput, fn func(*DescribeImageScanFindingsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeImageScanFindingsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImageScanFindingsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*DescribeImageScanFindingsOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
+}
+
 const opDescribeImages = "DescribeImages"
 
 // DescribeImagesRequest generates a "aws/request.Request" representing the
@@ -917,10 +1072,12 @@ func (c *ECR) DescribeImagesPagesWithContext(ctx aws.Context, input *DescribeIma
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeImagesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeImagesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1060,10 +1217,12 @@ func (c *ECR) DescribeRepositoriesPagesWithContext(ctx aws.Context, input *Descr
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeRepositoriesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeRepositoriesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1378,6 +1537,12 @@ func (c *ECR) GetLifecyclePolicyPreviewRequest(input *GetLifecyclePolicyPreviewI
 		Name:       opGetLifecyclePolicyPreview,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1435,6 +1600,58 @@ func (c *ECR) GetLifecyclePolicyPreviewWithContext(ctx aws.Context, input *GetLi
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// GetLifecyclePolicyPreviewPages iterates over the pages of a GetLifecyclePolicyPreview operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See GetLifecyclePolicyPreview method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a GetLifecyclePolicyPreview operation.
+//    pageNum := 0
+//    err := client.GetLifecyclePolicyPreviewPages(params,
+//        func(page *ecr.GetLifecyclePolicyPreviewOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ECR) GetLifecyclePolicyPreviewPages(input *GetLifecyclePolicyPreviewInput, fn func(*GetLifecyclePolicyPreviewOutput, bool) bool) error {
+	return c.GetLifecyclePolicyPreviewPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// GetLifecyclePolicyPreviewPagesWithContext same as GetLifecyclePolicyPreviewPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) GetLifecyclePolicyPreviewPagesWithContext(ctx aws.Context, input *GetLifecyclePolicyPreviewInput, fn func(*GetLifecyclePolicyPreviewOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *GetLifecyclePolicyPreviewInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetLifecyclePolicyPreviewRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*GetLifecyclePolicyPreviewOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
 }
 
 const opGetRepositoryPolicy = "GetRepositoryPolicy"
@@ -1761,10 +1978,12 @@ func (c *ECR) ListImagesPagesWithContext(ctx aws.Context, input *ListImagesInput
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListImagesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListImagesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1964,6 +2183,93 @@ func (c *ECR) PutImageWithContext(ctx aws.Context, input *PutImageInput, opts ..
 	return out, req.Send()
 }
 
+const opPutImageScanningConfiguration = "PutImageScanningConfiguration"
+
+// PutImageScanningConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutImageScanningConfiguration operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutImageScanningConfiguration for more information on using the PutImageScanningConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutImageScanningConfigurationRequest method.
+//    req, resp := client.PutImageScanningConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/PutImageScanningConfiguration
+func (c *ECR) PutImageScanningConfigurationRequest(input *PutImageScanningConfigurationInput) (req *request.Request, output *PutImageScanningConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutImageScanningConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutImageScanningConfigurationInput{}
+	}
+
+	output = &PutImageScanningConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutImageScanningConfiguration API operation for Amazon EC2 Container Registry.
+//
+// Updates the image scanning configuration for a repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation PutImageScanningConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/PutImageScanningConfiguration
+func (c *ECR) PutImageScanningConfiguration(input *PutImageScanningConfigurationInput) (*PutImageScanningConfigurationOutput, error) {
+	req, out := c.PutImageScanningConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// PutImageScanningConfigurationWithContext is the same as PutImageScanningConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutImageScanningConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) PutImageScanningConfigurationWithContext(ctx aws.Context, input *PutImageScanningConfigurationInput, opts ...request.Option) (*PutImageScanningConfigurationOutput, error) {
+	req, out := c.PutImageScanningConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opPutImageTagMutability = "PutImageTagMutability"
 
 // PutImageTagMutabilityRequest generates a "aws/request.Request" representing the
@@ -2008,7 +2314,11 @@ func (c *ECR) PutImageTagMutabilityRequest(input *PutImageTagMutabilityInput) (r
 
 // PutImageTagMutability API operation for Amazon EC2 Container Registry.
 //
-// Updates the image tag mutability settings for a repository.
+// Updates the image tag mutability settings for a repository. When a repository
+// is configured with tag immutability, all image tags within the repository
+// will be prevented them from being overwritten. For more information, see
+// Image Tag Mutability (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
+// in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2223,6 +2533,99 @@ func (c *ECR) SetRepositoryPolicy(input *SetRepositoryPolicyInput) (*SetReposito
 // for more information on using Contexts.
 func (c *ECR) SetRepositoryPolicyWithContext(ctx aws.Context, input *SetRepositoryPolicyInput, opts ...request.Option) (*SetRepositoryPolicyOutput, error) {
 	req, out := c.SetRepositoryPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStartImageScan = "StartImageScan"
+
+// StartImageScanRequest generates a "aws/request.Request" representing the
+// client's request for the StartImageScan operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StartImageScan for more information on using the StartImageScan
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StartImageScanRequest method.
+//    req, resp := client.StartImageScanRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/StartImageScan
+func (c *ECR) StartImageScanRequest(input *StartImageScanInput) (req *request.Request, output *StartImageScanOutput) {
+	op := &request.Operation{
+		Name:       opStartImageScan,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &StartImageScanInput{}
+	}
+
+	output = &StartImageScanOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StartImageScan API operation for Amazon EC2 Container Registry.
+//
+// Starts an image vulnerability scan. An image scan can only be started once
+// per day on an individual image. This limit includes if an image was scanned
+// on initial push. For more information, see Image Scanning (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+// in the Amazon Elastic Container Registry User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation StartImageScan for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ErrCodeImageNotFoundException "ImageNotFoundException"
+//   The image requested does not exist in the specified repository.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/StartImageScan
+func (c *ECR) StartImageScan(input *StartImageScanInput) (*StartImageScanOutput, error) {
+	req, out := c.StartImageScanRequest(input)
+	return out, req.Send()
+}
+
+// StartImageScanWithContext is the same as StartImageScan with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StartImageScan for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) StartImageScanWithContext(ctx aws.Context, input *StartImageScanInput, opts ...request.Option) (*StartImageScanOutput, error) {
+	req, out := c.StartImageScanRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2621,6 +3024,41 @@ func (c *ECR) UploadLayerPartWithContext(ctx aws.Context, input *UploadLayerPart
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// This data type is used in the ImageScanFinding data type.
+type Attribute struct {
+	_ struct{} `type:"structure"`
+
+	// The attribute key.
+	//
+	// Key is a required field
+	Key *string `locationName:"key" min:"1" type:"string" required:"true"`
+
+	// The value assigned to the attribute key.
+	Value *string `locationName:"value" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s Attribute) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Attribute) GoString() string {
+	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Attribute) SetKey(v string) *Attribute {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Attribute) SetValue(v string) *Attribute {
+	s.Value = &v
+	return s
 }
 
 // An object representing authorization data for an Amazon ECR registry.
@@ -3146,6 +3584,11 @@ func (s *CompleteLayerUploadOutput) SetUploadId(v string) *CompleteLayerUploadOu
 type CreateRepositoryInput struct {
 	_ struct{} `type:"structure"`
 
+	// The image scanning configuration for the repository. This setting determines
+	// whether images are scanned for known vulnerabilities after being pushed to
+	// the repository.
+	ImageScanningConfiguration *ImageScanningConfiguration `locationName:"imageScanningConfiguration" type:"structure"`
+
 	// The tag mutability setting for the repository. If this parameter is omitted,
 	// the default setting of MUTABLE will be used which will allow image tags to
 	// be overwritten. If IMMUTABLE is specified, all image tags within the repository
@@ -3190,6 +3633,12 @@ func (s *CreateRepositoryInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetImageScanningConfiguration sets the ImageScanningConfiguration field's value.
+func (s *CreateRepositoryInput) SetImageScanningConfiguration(v *ImageScanningConfiguration) *CreateRepositoryInput {
+	s.ImageScanningConfiguration = v
+	return s
 }
 
 // SetImageTagMutability sets the ImageTagMutability field's value.
@@ -3507,6 +3956,180 @@ func (s *DeleteRepositoryPolicyOutput) SetRegistryId(v string) *DeleteRepository
 
 // SetRepositoryName sets the RepositoryName field's value.
 func (s *DeleteRepositoryPolicyOutput) SetRepositoryName(v string) *DeleteRepositoryPolicyOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+type DescribeImageScanFindingsInput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an Amazon ECR image.
+	//
+	// ImageId is a required field
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure" required:"true"`
+
+	// The maximum number of image scan results returned by DescribeImageScanFindings
+	// in paginated output. When this parameter is used, DescribeImageScanFindings
+	// only returns maxResults results in a single page along with a nextToken response
+	// element. The remaining results of the initial request can be seen by sending
+	// another DescribeImageScanFindings request with the returned nextToken value.
+	// This value can be between 1 and 1000. If this parameter is not used, then
+	// DescribeImageScanFindings returns up to 100 results and a nextToken value,
+	// if applicable.
+	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
+
+	// The nextToken value returned from a previous paginated DescribeImageScanFindings
+	// request where maxResults was used and the results exceeded the value of that
+	// parameter. Pagination continues from the end of the previous results that
+	// returned the nextToken value. This value is null when there are no more results
+	// to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The AWS account ID associated with the registry that contains the repository
+	// in which to describe the image scan findings for. If you do not specify a
+	// registry, the default registry is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The repository for the image for which to describe the scan findings.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeImageScanFindingsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImageScanFindingsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeImageScanFindingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeImageScanFindingsInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+	if s.ImageId != nil {
+		if err := s.ImageId.Validate(); err != nil {
+			invalidParams.AddNested("ImageId", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageScanFindingsInput) SetImageId(v *ImageIdentifier) *DescribeImageScanFindingsInput {
+	s.ImageId = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeImageScanFindingsInput) SetMaxResults(v int64) *DescribeImageScanFindingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImageScanFindingsInput) SetNextToken(v string) *DescribeImageScanFindingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DescribeImageScanFindingsInput) SetRegistryId(v string) *DescribeImageScanFindingsInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DescribeImageScanFindingsInput) SetRepositoryName(v string) *DescribeImageScanFindingsInput {
+	s.RepositoryName = &v
+	return s
+}
+
+type DescribeImageScanFindingsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an Amazon ECR image.
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
+
+	// The information contained in the image scan findings.
+	ImageScanFindings *ImageScanFindings `locationName:"imageScanFindings" type:"structure"`
+
+	// The current state of the scan.
+	ImageScanStatus *ImageScanStatus `locationName:"imageScanStatus" type:"structure"`
+
+	// The nextToken value to include in a future DescribeImageScanFindings request.
+	// When the results of a DescribeImageScanFindings request exceed maxResults,
+	// this value can be used to retrieve the next page of results. This value is
+	// null when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The registry ID associated with the request.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The repository name associated with the request.
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeImageScanFindingsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImageScanFindingsOutput) GoString() string {
+	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageScanFindingsOutput) SetImageId(v *ImageIdentifier) *DescribeImageScanFindingsOutput {
+	s.ImageId = v
+	return s
+}
+
+// SetImageScanFindings sets the ImageScanFindings field's value.
+func (s *DescribeImageScanFindingsOutput) SetImageScanFindings(v *ImageScanFindings) *DescribeImageScanFindingsOutput {
+	s.ImageScanFindings = v
+	return s
+}
+
+// SetImageScanStatus sets the ImageScanStatus field's value.
+func (s *DescribeImageScanFindingsOutput) SetImageScanStatus(v *ImageScanStatus) *DescribeImageScanFindingsOutput {
+	s.ImageScanStatus = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImageScanFindingsOutput) SetNextToken(v string) *DescribeImageScanFindingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DescribeImageScanFindingsOutput) SetRegistryId(v string) *DescribeImageScanFindingsOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DescribeImageScanFindingsOutput) SetRepositoryName(v string) *DescribeImageScanFindingsOutput {
 	s.RepositoryName = &v
 	return s
 }
@@ -4361,7 +4984,7 @@ type Image struct {
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
 
 	// The image manifest associated with the image.
-	ImageManifest *string `locationName:"imageManifest" type:"string"`
+	ImageManifest *string `locationName:"imageManifest" min:"1" type:"string"`
 
 	// The AWS account ID associated with the registry containing the image.
 	RegistryId *string `locationName:"registryId" type:"string"`
@@ -4415,6 +5038,12 @@ type ImageDetail struct {
 	// the current image was pushed to the repository.
 	ImagePushedAt *time.Time `locationName:"imagePushedAt" type:"timestamp"`
 
+	// A summary of the last completed image scan.
+	ImageScanFindingsSummary *ImageScanFindingsSummary `locationName:"imageScanFindingsSummary" type:"structure"`
+
+	// The current state of the scan.
+	ImageScanStatus *ImageScanStatus `locationName:"imageScanStatus" type:"structure"`
+
 	// The size, in bytes, of the image in the repository.
 	//
 	// Beginning with Docker version 1.9, the Docker client compresses image layers
@@ -4452,6 +5081,18 @@ func (s *ImageDetail) SetImageDigest(v string) *ImageDetail {
 // SetImagePushedAt sets the ImagePushedAt field's value.
 func (s *ImageDetail) SetImagePushedAt(v time.Time) *ImageDetail {
 	s.ImagePushedAt = &v
+	return s
+}
+
+// SetImageScanFindingsSummary sets the ImageScanFindingsSummary field's value.
+func (s *ImageDetail) SetImageScanFindingsSummary(v *ImageScanFindingsSummary) *ImageDetail {
+	s.ImageScanFindingsSummary = v
+	return s
+}
+
+// SetImageScanStatus sets the ImageScanStatus field's value.
+func (s *ImageDetail) SetImageScanStatus(v *ImageScanStatus) *ImageDetail {
+	s.ImageScanStatus = v
 	return s
 }
 
@@ -4564,6 +5205,220 @@ func (s *ImageIdentifier) SetImageDigest(v string) *ImageIdentifier {
 // SetImageTag sets the ImageTag field's value.
 func (s *ImageIdentifier) SetImageTag(v string) *ImageIdentifier {
 	s.ImageTag = &v
+	return s
+}
+
+// Contains information about an image scan finding.
+type ImageScanFinding struct {
+	_ struct{} `type:"structure"`
+
+	// A collection of attributes of the host from which the finding is generated.
+	Attributes []*Attribute `locationName:"attributes" type:"list"`
+
+	// The description of the finding.
+	Description *string `locationName:"description" type:"string"`
+
+	// The name associated with the finding, usually a CVE number.
+	Name *string `locationName:"name" type:"string"`
+
+	// The finding severity.
+	Severity *string `locationName:"severity" type:"string" enum:"FindingSeverity"`
+
+	// A link containing additional details about the security vulnerability.
+	Uri *string `locationName:"uri" type:"string"`
+}
+
+// String returns the string representation
+func (s ImageScanFinding) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageScanFinding) GoString() string {
+	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ImageScanFinding) SetAttributes(v []*Attribute) *ImageScanFinding {
+	s.Attributes = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImageScanFinding) SetDescription(v string) *ImageScanFinding {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ImageScanFinding) SetName(v string) *ImageScanFinding {
+	s.Name = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *ImageScanFinding) SetSeverity(v string) *ImageScanFinding {
+	s.Severity = &v
+	return s
+}
+
+// SetUri sets the Uri field's value.
+func (s *ImageScanFinding) SetUri(v string) *ImageScanFinding {
+	s.Uri = &v
+	return s
+}
+
+// The details of an image scan.
+type ImageScanFindings struct {
+	_ struct{} `type:"structure"`
+
+	// The image vulnerability counts, sorted by severity.
+	FindingSeverityCounts map[string]*int64 `locationName:"findingSeverityCounts" type:"map"`
+
+	// The findings from the image scan.
+	Findings []*ImageScanFinding `locationName:"findings" type:"list"`
+
+	// The time of the last completed image scan.
+	ImageScanCompletedAt *time.Time `locationName:"imageScanCompletedAt" type:"timestamp"`
+
+	// The time when the vulnerability data was last scanned.
+	VulnerabilitySourceUpdatedAt *time.Time `locationName:"vulnerabilitySourceUpdatedAt" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s ImageScanFindings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageScanFindings) GoString() string {
+	return s.String()
+}
+
+// SetFindingSeverityCounts sets the FindingSeverityCounts field's value.
+func (s *ImageScanFindings) SetFindingSeverityCounts(v map[string]*int64) *ImageScanFindings {
+	s.FindingSeverityCounts = v
+	return s
+}
+
+// SetFindings sets the Findings field's value.
+func (s *ImageScanFindings) SetFindings(v []*ImageScanFinding) *ImageScanFindings {
+	s.Findings = v
+	return s
+}
+
+// SetImageScanCompletedAt sets the ImageScanCompletedAt field's value.
+func (s *ImageScanFindings) SetImageScanCompletedAt(v time.Time) *ImageScanFindings {
+	s.ImageScanCompletedAt = &v
+	return s
+}
+
+// SetVulnerabilitySourceUpdatedAt sets the VulnerabilitySourceUpdatedAt field's value.
+func (s *ImageScanFindings) SetVulnerabilitySourceUpdatedAt(v time.Time) *ImageScanFindings {
+	s.VulnerabilitySourceUpdatedAt = &v
+	return s
+}
+
+// A summary of the last completed image scan.
+type ImageScanFindingsSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The image vulnerability counts, sorted by severity.
+	FindingSeverityCounts map[string]*int64 `locationName:"findingSeverityCounts" type:"map"`
+
+	// The time of the last completed image scan.
+	ImageScanCompletedAt *time.Time `locationName:"imageScanCompletedAt" type:"timestamp"`
+
+	// The time when the vulnerability data was last scanned.
+	VulnerabilitySourceUpdatedAt *time.Time `locationName:"vulnerabilitySourceUpdatedAt" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s ImageScanFindingsSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageScanFindingsSummary) GoString() string {
+	return s.String()
+}
+
+// SetFindingSeverityCounts sets the FindingSeverityCounts field's value.
+func (s *ImageScanFindingsSummary) SetFindingSeverityCounts(v map[string]*int64) *ImageScanFindingsSummary {
+	s.FindingSeverityCounts = v
+	return s
+}
+
+// SetImageScanCompletedAt sets the ImageScanCompletedAt field's value.
+func (s *ImageScanFindingsSummary) SetImageScanCompletedAt(v time.Time) *ImageScanFindingsSummary {
+	s.ImageScanCompletedAt = &v
+	return s
+}
+
+// SetVulnerabilitySourceUpdatedAt sets the VulnerabilitySourceUpdatedAt field's value.
+func (s *ImageScanFindingsSummary) SetVulnerabilitySourceUpdatedAt(v time.Time) *ImageScanFindingsSummary {
+	s.VulnerabilitySourceUpdatedAt = &v
+	return s
+}
+
+// The current status of an image scan.
+type ImageScanStatus struct {
+	_ struct{} `type:"structure"`
+
+	// The description of the image scan status.
+	Description *string `locationName:"description" type:"string"`
+
+	// The current state of an image scan.
+	Status *string `locationName:"status" type:"string" enum:"ScanStatus"`
+}
+
+// String returns the string representation
+func (s ImageScanStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageScanStatus) GoString() string {
+	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImageScanStatus) SetDescription(v string) *ImageScanStatus {
+	s.Description = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ImageScanStatus) SetStatus(v string) *ImageScanStatus {
+	s.Status = &v
+	return s
+}
+
+// The image scanning configuration for a repository.
+type ImageScanningConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The setting that determines whether images are scanned after being pushed
+	// to a repository. If set to true, images will be scanned after being pushed.
+	// If this parameter is not specified, it will default to false and images will
+	// not be scanned unless a scan is manually started with the StartImageScan
+	// API.
+	ScanOnPush *bool `locationName:"scanOnPush" type:"boolean"`
+}
+
+// String returns the string representation
+func (s ImageScanningConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageScanningConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetScanOnPush sets the ScanOnPush field's value.
+func (s *ImageScanningConfiguration) SetScanOnPush(v bool) *ImageScanningConfiguration {
+	s.ScanOnPush = &v
 	return s
 }
 
@@ -5101,7 +5956,7 @@ type PutImageInput struct {
 	// The image manifest corresponding to the image to be uploaded.
 	//
 	// ImageManifest is a required field
-	ImageManifest *string `locationName:"imageManifest" type:"string" required:"true"`
+	ImageManifest *string `locationName:"imageManifest" min:"1" type:"string" required:"true"`
 
 	// The tag to associate with the image. This parameter is required for images
 	// that use the Docker Image Manifest V2 Schema 2 or OCI formats.
@@ -5133,6 +5988,9 @@ func (s *PutImageInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutImageInput"}
 	if s.ImageManifest == nil {
 		invalidParams.Add(request.NewErrParamRequired("ImageManifest"))
+	}
+	if s.ImageManifest != nil && len(*s.ImageManifest) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImageManifest", 1))
 	}
 	if s.ImageTag != nil && len(*s.ImageTag) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ImageTag", 1))
@@ -5194,6 +6052,116 @@ func (s PutImageOutput) GoString() string {
 // SetImage sets the Image field's value.
 func (s *PutImageOutput) SetImage(v *Image) *PutImageOutput {
 	s.Image = v
+	return s
+}
+
+type PutImageScanningConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The image scanning configuration for the repository. This setting determines
+	// whether images are scanned for known vulnerabilities after being pushed to
+	// the repository.
+	//
+	// ImageScanningConfiguration is a required field
+	ImageScanningConfiguration *ImageScanningConfiguration `locationName:"imageScanningConfiguration" type:"structure" required:"true"`
+
+	// The AWS account ID associated with the registry that contains the repository
+	// in which to update the image scanning configuration setting. If you do not
+	// specify a registry, the default registry is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The name of the repository in which to update the image scanning configuration
+	// setting.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutImageScanningConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutImageScanningConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutImageScanningConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutImageScanningConfigurationInput"}
+	if s.ImageScanningConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageScanningConfiguration"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImageScanningConfiguration sets the ImageScanningConfiguration field's value.
+func (s *PutImageScanningConfigurationInput) SetImageScanningConfiguration(v *ImageScanningConfiguration) *PutImageScanningConfigurationInput {
+	s.ImageScanningConfiguration = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *PutImageScanningConfigurationInput) SetRegistryId(v string) *PutImageScanningConfigurationInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PutImageScanningConfigurationInput) SetRepositoryName(v string) *PutImageScanningConfigurationInput {
+	s.RepositoryName = &v
+	return s
+}
+
+type PutImageScanningConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The image scanning configuration setting for the repository.
+	ImageScanningConfiguration *ImageScanningConfiguration `locationName:"imageScanningConfiguration" type:"structure"`
+
+	// The registry ID associated with the request.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The repository name associated with the request.
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
+}
+
+// String returns the string representation
+func (s PutImageScanningConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutImageScanningConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetImageScanningConfiguration sets the ImageScanningConfiguration field's value.
+func (s *PutImageScanningConfigurationOutput) SetImageScanningConfiguration(v *ImageScanningConfiguration) *PutImageScanningConfigurationOutput {
+	s.ImageScanningConfiguration = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *PutImageScanningConfigurationOutput) SetRegistryId(v string) *PutImageScanningConfigurationOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PutImageScanningConfigurationOutput) SetRepositoryName(v string) *PutImageScanningConfigurationOutput {
+	s.RepositoryName = &v
 	return s
 }
 
@@ -5422,6 +6390,9 @@ type Repository struct {
 	// The date and time, in JavaScript date format, when the repository was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp"`
 
+	// The image scanning configuration for a repository.
+	ImageScanningConfiguration *ImageScanningConfiguration `locationName:"imageScanningConfiguration" type:"structure"`
+
 	// The tag mutability setting for the repository.
 	ImageTagMutability *string `locationName:"imageTagMutability" type:"string" enum:"ImageTagMutability"`
 
@@ -5455,6 +6426,12 @@ func (s Repository) GoString() string {
 // SetCreatedAt sets the CreatedAt field's value.
 func (s *Repository) SetCreatedAt(v time.Time) *Repository {
 	s.CreatedAt = &v
+	return s
+}
+
+// SetImageScanningConfiguration sets the ImageScanningConfiguration field's value.
+func (s *Repository) SetImageScanningConfiguration(v *ImageScanningConfiguration) *Repository {
+	s.ImageScanningConfiguration = v
 	return s
 }
 
@@ -5603,6 +6580,127 @@ func (s *SetRepositoryPolicyOutput) SetRegistryId(v string) *SetRepositoryPolicy
 
 // SetRepositoryName sets the RepositoryName field's value.
 func (s *SetRepositoryPolicyOutput) SetRepositoryName(v string) *SetRepositoryPolicyOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+type StartImageScanInput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an Amazon ECR image.
+	//
+	// ImageId is a required field
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure" required:"true"`
+
+	// The AWS account ID associated with the registry that contains the repository
+	// in which to start an image scan request. If you do not specify a registry,
+	// the default registry is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The name of the repository that contains the images to scan.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s StartImageScanInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartImageScanInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartImageScanInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartImageScanInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+	if s.ImageId != nil {
+		if err := s.ImageId.Validate(); err != nil {
+			invalidParams.AddNested("ImageId", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *StartImageScanInput) SetImageId(v *ImageIdentifier) *StartImageScanInput {
+	s.ImageId = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *StartImageScanInput) SetRegistryId(v string) *StartImageScanInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *StartImageScanInput) SetRepositoryName(v string) *StartImageScanInput {
+	s.RepositoryName = &v
+	return s
+}
+
+type StartImageScanOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an Amazon ECR image.
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
+
+	// The current state of the scan.
+	ImageScanStatus *ImageScanStatus `locationName:"imageScanStatus" type:"structure"`
+
+	// The registry ID associated with the request.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The repository name associated with the request.
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
+}
+
+// String returns the string representation
+func (s StartImageScanOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartImageScanOutput) GoString() string {
+	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *StartImageScanOutput) SetImageId(v *ImageIdentifier) *StartImageScanOutput {
+	s.ImageId = v
+	return s
+}
+
+// SetImageScanStatus sets the ImageScanStatus field's value.
+func (s *StartImageScanOutput) SetImageScanStatus(v *ImageScanStatus) *StartImageScanOutput {
+	s.ImageScanStatus = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *StartImageScanOutput) SetRegistryId(v string) *StartImageScanOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *StartImageScanOutput) SetRepositoryName(v string) *StartImageScanOutput {
 	s.RepositoryName = &v
 	return s
 }
@@ -6056,6 +7154,26 @@ func (s *UploadLayerPartOutput) SetUploadId(v string) *UploadLayerPartOutput {
 }
 
 const (
+	// FindingSeverityInformational is a FindingSeverity enum value
+	FindingSeverityInformational = "INFORMATIONAL"
+
+	// FindingSeverityLow is a FindingSeverity enum value
+	FindingSeverityLow = "LOW"
+
+	// FindingSeverityMedium is a FindingSeverity enum value
+	FindingSeverityMedium = "MEDIUM"
+
+	// FindingSeverityHigh is a FindingSeverity enum value
+	FindingSeverityHigh = "HIGH"
+
+	// FindingSeverityCritical is a FindingSeverity enum value
+	FindingSeverityCritical = "CRITICAL"
+
+	// FindingSeverityUndefined is a FindingSeverity enum value
+	FindingSeverityUndefined = "UNDEFINED"
+)
+
+const (
 	// ImageActionTypeExpire is a ImageActionType enum value
 	ImageActionTypeExpire = "EXPIRE"
 )
@@ -6113,6 +7231,17 @@ const (
 
 	// LifecyclePolicyPreviewStatusFailed is a LifecyclePolicyPreviewStatus enum value
 	LifecyclePolicyPreviewStatusFailed = "FAILED"
+)
+
+const (
+	// ScanStatusInProgress is a ScanStatus enum value
+	ScanStatusInProgress = "IN_PROGRESS"
+
+	// ScanStatusComplete is a ScanStatus enum value
+	ScanStatusComplete = "COMPLETE"
+
+	// ScanStatusFailed is a ScanStatus enum value
+	ScanStatusFailed = "FAILED"
 )
 
 const (

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
@@ -140,6 +140,13 @@ const (
 	// repository policy.
 	ErrCodeRepositoryPolicyNotFoundException = "RepositoryPolicyNotFoundException"
 
+	// ErrCodeScanNotFoundException for service response error code
+	// "ScanNotFoundException".
+	//
+	// The specified image scan could not be found. Ensure that image scanning is
+	// enabled on the repository and try again.
+	ErrCodeScanNotFoundException = "ScanNotFoundException"
+
 	// ErrCodeServerException for service response error code
 	// "ServerException".
 	//

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ecr"     // Name of service.
 	EndpointsID = "api.ecr" // ID to lookup a service endpoint with.
-	ServiceID   = "ECR"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ECR"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ECR client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a ECR client from just a session.
 //     svc := ecr.New(mySession)
 //
@@ -49,11 +51,11 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *ECR {
 	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "ecr"
 	}
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ECR {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ECR {
 	svc := &ECR{
 		Client: client.New(
 			cfg,
@@ -62,6 +64,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2015-09-21",
 				JSONVersion:   "1.1",

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
@@ -1807,10 +1807,12 @@ func (c *ELB) DescribeLoadBalancersPagesWithContext(ctx aws.Context, input *Desc
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeLoadBalancersOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeLoadBalancersOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticloadbalancing"   // Name of service.
 	EndpointsID = ServiceName              // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Load Balancing" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Load Balancing" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ELB client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a ELB client from just a session.
 //     svc := elb.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := elb.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ELB {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ELB {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ELB {
 	svc := &ELB{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2012-06-01",
 			},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -58,7 +58,7 @@ func (c *ELBV2) AddListenerCertificatesRequest(input *AddListenerCertificatesInp
 // AddListenerCertificates API operation for Elastic Load Balancing.
 //
 // Adds the specified SSL server certificate to the certificate list for the
-// specified HTTPS listener.
+// specified HTTPS or TLS listener.
 //
 // If the certificate in already in the certificate list, the call is successful
 // but the certificate is not added again.
@@ -319,6 +319,11 @@ func (c *ELBV2) CreateListenerRequest(input *CreateListenerInput) (req *request.
 //
 //   * ErrCodeInvalidLoadBalancerActionException "InvalidLoadBalancerAction"
 //   The requested action is not valid.
+//
+//   * ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException "TooManyUniqueTargetGroupsPerLoadBalancer"
+//   You've reached the limit on the number of unique target groups per load balancer
+//   across all listeners. If a target group is used by multiple actions for a
+//   load balancer, it is counted as only one use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/CreateListener
 func (c *ELBV2) CreateListener(input *CreateListenerInput) (*CreateListenerOutput, error) {
@@ -582,6 +587,11 @@ func (c *ELBV2) CreateRuleRequest(input *CreateRuleInput) (req *request.Request,
 //
 //   * ErrCodeInvalidLoadBalancerActionException "InvalidLoadBalancerAction"
 //   The requested action is not valid.
+//
+//   * ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException "TooManyUniqueTargetGroupsPerLoadBalancer"
+//   You've reached the limit on the number of unique target groups per load balancer
+//   across all listeners. If a target group is used by multiple actions for a
+//   load balancer, it is counted as only one use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/CreateRule
 func (c *ELBV2) CreateRule(input *CreateRuleInput) (*CreateRuleOutput, error) {
@@ -1264,7 +1274,7 @@ func (c *ELBV2) DescribeListenerCertificatesRequest(input *DescribeListenerCerti
 // DescribeListenerCertificates API operation for Elastic Load Balancing.
 //
 // Describes the default certificate and the certificate list for the specified
-// HTTPS listener.
+// HTTPS or TLS listener.
 //
 // If the default certificate is also in the certificate list, it appears twice
 // in the results (once with IsDefault set to true and once with IsDefault set
@@ -1446,10 +1456,12 @@ func (c *ELBV2) DescribeListenersPagesWithContext(ctx aws.Context, input *Descri
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeListenersOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeListenersOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1668,10 +1680,12 @@ func (c *ELBV2) DescribeLoadBalancersPagesWithContext(ctx aws.Context, input *De
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeLoadBalancersOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeLoadBalancersOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2153,10 +2167,12 @@ func (c *ELBV2) DescribeTargetGroupsPagesWithContext(ctx aws.Context, input *Des
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*DescribeTargetGroupsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*DescribeTargetGroupsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2291,13 +2307,17 @@ func (c *ELBV2) ModifyListenerRequest(input *ModifyListenerInput) (req *request.
 
 // ModifyListener API operation for Elastic Load Balancing.
 //
-// Modifies the specified properties of the specified listener.
+// Replaces the specified properties of the specified listener. Any properties
+// that you do not specify remain unchanged.
 //
-// Any properties that you do not specify retain their current values. However,
-// changing the protocol from HTTPS to HTTP, or from TLS to TCP, removes the
+// Changing the protocol from HTTPS to HTTP, or from TLS to TCP, removes the
 // security policy and default certificate properties. If you change the protocol
 // from HTTP to HTTPS, or from TCP to TLS, you must add the security policy
 // and default certificate properties.
+//
+// To add an item to a list, remove an item from a list, or update an item in
+// a list, you must provide the entire list. For example, to add an action,
+// specify a list with the current actions plus the new action.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2352,6 +2372,11 @@ func (c *ELBV2) ModifyListenerRequest(input *ModifyListenerInput) (req *request.
 //
 //   * ErrCodeInvalidLoadBalancerActionException "InvalidLoadBalancerAction"
 //   The requested action is not valid.
+//
+//   * ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException "TooManyUniqueTargetGroupsPerLoadBalancer"
+//   You've reached the limit on the number of unique target groups per load balancer
+//   across all listeners. If a target group is used by multiple actions for a
+//   load balancer, it is counted as only one use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/ModifyListener
 func (c *ELBV2) ModifyListener(input *ModifyListenerInput) (*ModifyListenerOutput, error) {
@@ -2506,9 +2531,12 @@ func (c *ELBV2) ModifyRuleRequest(input *ModifyRuleInput) (req *request.Request,
 
 // ModifyRule API operation for Elastic Load Balancing.
 //
-// Modifies the specified rule.
+// Replaces the specified properties of the specified rule. Any properties that
+// you do not specify are unchanged.
 //
-// Any existing properties that you do not modify retain their current values.
+// To add an item to a list, remove an item from a list, or update an item in
+// a list, you must provide the entire list. For example, to add an action,
+// specify a list with the current actions plus the new action.
 //
 // To modify the actions for the default rule, use ModifyListener.
 //
@@ -2550,6 +2578,11 @@ func (c *ELBV2) ModifyRuleRequest(input *ModifyRuleInput) (req *request.Request,
 //
 //   * ErrCodeInvalidLoadBalancerActionException "InvalidLoadBalancerAction"
 //   The requested action is not valid.
+//
+//   * ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException "TooManyUniqueTargetGroupsPerLoadBalancer"
+//   You've reached the limit on the number of unique target groups per load balancer
+//   across all listeners. If a target group is used by multiple actions for a
+//   load balancer, it is counted as only one use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/ModifyRule
 func (c *ELBV2) ModifyRule(input *ModifyRuleInput) (*ModifyRuleOutput, error) {
@@ -2892,7 +2925,7 @@ func (c *ELBV2) RemoveListenerCertificatesRequest(input *RemoveListenerCertifica
 // RemoveListenerCertificates API operation for Elastic Load Balancing.
 //
 // Removes the specified certificate from the certificate list for the specified
-// HTTPS listener.
+// HTTPS or TLS listener.
 //
 // You can't remove the default certificate for a listener. To replace the default
 // certificate, call ModifyListener.
@@ -3337,11 +3370,12 @@ func (c *ELBV2) SetSubnetsRequest(input *SetSubnetsInput) (req *request.Request,
 
 // SetSubnets API operation for Elastic Load Balancing.
 //
-// Enables the Availability Zone for the specified public subnets for the specified
-// Application Load Balancer. The specified subnets replace the previously enabled
-// subnets.
+// Enables the Availability Zones for the specified public subnets for the specified
+// load balancer. The specified subnets replace the previously enabled subnets.
 //
-// You can't change the subnets for a Network Load Balancer.
+// When you specify subnets for a Network Load Balancer, you must include all
+// subnets that were enabled previously, with their existing configurations,
+// plus any additional subnets.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3407,9 +3441,17 @@ type Action struct {
 	// a custom HTTP response. Specify only when Type is fixed-response.
 	FixedResponseConfig *FixedResponseActionConfig `type:"structure"`
 
+	// Information for creating an action that distributes requests among one or
+	// more target groups. For Network Load Balancers, you can specify a single
+	// target group. Specify only when Type is forward. If you specify both ForwardConfig
+	// and TargetGroupArn, you can specify only one target group using ForwardConfig
+	// and it must be the same target group specified in TargetGroupArn.
+	ForwardConfig *ForwardActionConfig `type:"structure"`
+
 	// The order for the action. This value is required for rules with multiple
 	// actions. The action with the lowest value for order is performed first. The
-	// final action to be performed must be a forward or a fixed-response action.
+	// last action to be performed must be one of the following types of actions:
+	// a forward, fixed-response, or redirect.
 	Order *int64 `min:"1" type:"integer"`
 
 	// [Application Load Balancer] Information for creating a redirect action. Specify
@@ -3417,11 +3459,11 @@ type Action struct {
 	RedirectConfig *RedirectActionConfig `type:"structure"`
 
 	// The Amazon Resource Name (ARN) of the target group. Specify only when Type
-	// is forward.
+	// is forward and you want to route to a single target group. To route to one
+	// or more target groups, use ForwardConfig instead.
 	TargetGroupArn *string `type:"string"`
 
-	// The type of action. Each rule must include exactly one of the following types
-	// of actions: forward, fixed-response, or redirect.
+	// The type of action.
 	//
 	// Type is a required field
 	Type *string `type:"string" required:"true" enum:"ActionTypeEnum"`
@@ -3488,6 +3530,12 @@ func (s *Action) SetAuthenticateOidcConfig(v *AuthenticateOidcActionConfig) *Act
 // SetFixedResponseConfig sets the FixedResponseConfig field's value.
 func (s *Action) SetFixedResponseConfig(v *FixedResponseActionConfig) *Action {
 	s.FixedResponseConfig = v
+	return s
+}
+
+// SetForwardConfig sets the ForwardConfig field's value.
+func (s *Action) SetForwardConfig(v *ForwardActionConfig) *Action {
+	s.ForwardConfig = v
 	return s
 }
 
@@ -3982,10 +4030,13 @@ func (s *AuthenticateOidcActionConfig) SetUserInfoEndpoint(v string) *Authentica
 type AvailabilityZone struct {
 	_ struct{} `type:"structure"`
 
-	// [Network Load Balancers] The static IP address.
+	// [Network Load Balancers] If you need static IP addresses for your load balancer,
+	// you can specify one Elastic IP address per Availability Zone when you create
+	// an internal-facing load balancer. For internal load balancers, you can specify
+	// a private IP address from the IPv4 range of the subnet.
 	LoadBalancerAddresses []*LoadBalancerAddress `type:"list"`
 
-	// The ID of the subnet.
+	// The ID of the subnet. You can specify one subnet per Availability Zone.
 	SubnetId *string `type:"string"`
 
 	// The name of the Availability Zone.
@@ -4102,10 +4153,10 @@ type CreateListenerInput struct {
 	// The actions for the default rule. The rule must include one forward action
 	// or one or more fixed-response actions.
 	//
-	// If the action type is forward, you specify a target group. The protocol of
-	// the target group must be HTTP or HTTPS for an Application Load Balancer.
-	// The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP for a
-	// Network Load Balancer.
+	// If the action type is forward, you specify one or more target groups. The
+	// protocol of the target group must be HTTP or HTTPS for an Application Load
+	// Balancer. The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP
+	// for a Network Load Balancer.
 	//
 	// [HTTPS listeners] If the action type is authenticate-oidc, you authenticate
 	// users through an identity provider that is OpenID Connect (OIDC) compliant.
@@ -4274,8 +4325,8 @@ type CreateLoadBalancerInput struct {
 	//
 	// The nodes of an internal load balancer have only private IP addresses. The
 	// DNS name of an internal load balancer is publicly resolvable to the private
-	// IP addresses of the nodes. Therefore, internal load balancers can only route
-	// requests from clients with access to the VPC for the load balancer.
+	// IP addresses of the nodes. Therefore, internal load balancers can route requests
+	// only from clients with access to the VPC for the load balancer.
 	//
 	// The default is an Internet-facing load balancer.
 	Scheme *string `type:"string" enum:"LoadBalancerSchemeEnum"`
@@ -4291,7 +4342,10 @@ type CreateLoadBalancerInput struct {
 	// Zones. You cannot specify Elastic IP addresses for your subnets.
 	//
 	// [Network Load Balancers] You can specify subnets from one or more Availability
-	// Zones. You can specify one Elastic IP address per subnet.
+	// Zones. You can specify one Elastic IP address per subnet if you need static
+	// IP addresses for your internet-facing load balancer. For internal load balancers,
+	// you can specify one private IP address per subnet from the IPv4 range of
+	// the subnet.
 	SubnetMappings []*SubnetMapping `type:"list"`
 
 	// The IDs of the public subnets. You can specify only one subnet per Availability
@@ -4422,12 +4476,13 @@ type CreateRuleInput struct {
 	_ struct{} `type:"structure"`
 
 	// The actions. Each rule must include exactly one of the following types of
-	// actions: forward, fixed-response, or redirect.
+	// actions: forward, fixed-response, or redirect, and it must be the last action
+	// to be performed.
 	//
-	// If the action type is forward, you specify a target group. The protocol of
-	// the target group must be HTTP or HTTPS for an Application Load Balancer.
-	// The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP for a
-	// Network Load Balancer.
+	// If the action type is forward, you specify one or more target groups. The
+	// protocol of the target group must be HTTP or HTTPS for an Application Load
+	// Balancer. The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP
+	// for a Network Load Balancer.
 	//
 	// [HTTPS listeners] If the action type is authenticate-oidc, you authenticate
 	// users through an identity provider that is OpenID Connect (OIDC) compliant.
@@ -4649,7 +4704,7 @@ type CreateTargetGroupInput struct {
 	UnhealthyThresholdCount *int64 `min:"2" type:"integer"`
 
 	// The identifier of the virtual private cloud (VPC). If the target is a Lambda
-	// function, this parameter does not apply.
+	// function, this parameter does not apply. Otherwise, this parameter is required.
 	VpcId *string `type:"string"`
 }
 
@@ -6072,6 +6127,40 @@ func (s *FixedResponseActionConfig) SetStatusCode(v string) *FixedResponseAction
 	return s
 }
 
+// Information about a forward action.
+type ForwardActionConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The target group stickiness for the rule.
+	TargetGroupStickinessConfig *TargetGroupStickinessConfig `type:"structure"`
+
+	// One or more target groups. For Network Load Balancers, you can specify a
+	// single target group.
+	TargetGroups []*TargetGroupTuple `type:"list"`
+}
+
+// String returns the string representation
+func (s ForwardActionConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ForwardActionConfig) GoString() string {
+	return s.String()
+}
+
+// SetTargetGroupStickinessConfig sets the TargetGroupStickinessConfig field's value.
+func (s *ForwardActionConfig) SetTargetGroupStickinessConfig(v *TargetGroupStickinessConfig) *ForwardActionConfig {
+	s.TargetGroupStickinessConfig = v
+	return s
+}
+
+// SetTargetGroups sets the TargetGroups field's value.
+func (s *ForwardActionConfig) SetTargetGroups(v []*TargetGroupTuple) *ForwardActionConfig {
+	s.TargetGroups = v
+	return s
+}
+
 // Information about a host header condition.
 type HostHeaderConditionConfig struct {
 	_ struct{} `type:"structure"`
@@ -6208,6 +6297,12 @@ type Limit struct {
 	//    * rules-per-application-load-balancer
 	//
 	//    * target-groups
+	//
+	//    * target-groups-per-action-on-application-load-balancer
+	//
+	//    * target-groups-per-action-on-network-load-balancer
+	//
+	//    * target-groups-per-application-load-balancer
 	//
 	//    * targets-per-application-load-balancer
 	//
@@ -6352,8 +6447,8 @@ type LoadBalancer struct {
 	//
 	// The nodes of an internal load balancer have only private IP addresses. The
 	// DNS name of an internal load balancer is publicly resolvable to the private
-	// IP addresses of the nodes. Therefore, internal load balancers can only route
-	// requests from clients with access to the VPC for the load balancer.
+	// IP addresses of the nodes. Therefore, internal load balancers can route requests
+	// only from clients with access to the VPC for the load balancer.
 	Scheme *string `type:"string" enum:"LoadBalancerSchemeEnum"`
 
 	// The IDs of the security groups for the load balancer.
@@ -6455,11 +6550,15 @@ func (s *LoadBalancer) SetVpcId(v string) *LoadBalancer {
 type LoadBalancerAddress struct {
 	_ struct{} `type:"structure"`
 
-	// [Network Load Balancers] The allocation ID of the Elastic IP address.
+	// [Network Load Balancers] The allocation ID of the Elastic IP address for
+	// an internal-facing load balancer.
 	AllocationId *string `type:"string"`
 
 	// The static IP address.
 	IpAddress *string `type:"string"`
+
+	// [Network Load Balancers] The private IPv4 address for an internal load balancer.
+	PrivateIPv4Address *string `type:"string"`
 }
 
 // String returns the string representation
@@ -6481,6 +6580,12 @@ func (s *LoadBalancerAddress) SetAllocationId(v string) *LoadBalancerAddress {
 // SetIpAddress sets the IpAddress field's value.
 func (s *LoadBalancerAddress) SetIpAddress(v string) *LoadBalancerAddress {
 	s.IpAddress = &v
+	return s
+}
+
+// SetPrivateIPv4Address sets the PrivateIPv4Address field's value.
+func (s *LoadBalancerAddress) SetPrivateIPv4Address(v string) *LoadBalancerAddress {
+	s.PrivateIPv4Address = &v
 	return s
 }
 
@@ -6511,6 +6616,10 @@ type LoadBalancerAttribute struct {
 	//
 	//    * idle_timeout.timeout_seconds - The idle timeout value, in seconds. The
 	//    valid range is 1-4000 seconds. The default is 60 seconds.
+	//
+	//    * routing.http.drop_invalid_header_fields.enabled - Indicates whether
+	//    HTTP headers with invalid header fields are removed by the load balancer
+	//    (true) or routed to targets (false). The default is false.
 	//
 	//    * routing.http2.enabled - Indicates whether HTTP/2 is enabled. The value
 	//    is true or false. The default is true.
@@ -6640,10 +6749,10 @@ type ModifyListenerInput struct {
 	// The actions for the default rule. The rule must include one forward action
 	// or one or more fixed-response actions.
 	//
-	// If the action type is forward, you specify a target group. The protocol of
-	// the target group must be HTTP or HTTPS for an Application Load Balancer.
-	// The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP for a
-	// Network Load Balancer.
+	// If the action type is forward, you specify one or more target groups. The
+	// protocol of the target group must be HTTP or HTTPS for an Application Load
+	// Balancer. The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP
+	// for a Network Load Balancer.
 	//
 	// [HTTPS listeners] If the action type is authenticate-oidc, you authenticate
 	// users through an identity provider that is OpenID Connect (OIDC) compliant.
@@ -6851,12 +6960,13 @@ type ModifyRuleInput struct {
 	_ struct{} `type:"structure"`
 
 	// The actions. Each rule must include exactly one of the following types of
-	// actions: forward, fixed-response, or redirect.
+	// actions: forward, fixed-response, or redirect, and it must be the last action
+	// to be performed.
 	//
-	// If the action type is forward, you specify a target group. The protocol of
-	// the target group must be HTTP or HTTPS for an Application Load Balancer.
-	// The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP for a
-	// Network Load Balancer.
+	// If the action type is forward, you specify one or more target groups. The
+	// protocol of the target group must be HTTP or HTTPS for an Application Load
+	// Balancer. The protocol of the target group must be TCP, TLS, UDP, or TCP_UDP
+	// for a Network Load Balancer.
 	//
 	// [HTTPS listeners] If the action type is authenticate-oidc, you authenticate
 	// users through an identity provider that is OpenID Connect (OIDC) compliant.
@@ -7041,7 +7151,7 @@ type ModifyTargetGroupInput struct {
 	// target. For Application Load Balancers, the range is 5 to 300 seconds. For
 	// Network Load Balancers, the supported values are 10 or 30 seconds.
 	//
-	// If the protocol of the target group is TCP, you can't modify this setting.
+	// With Network Load Balancers, you can't modify this setting.
 	HealthCheckIntervalSeconds *int64 `min:"5" type:"integer"`
 
 	// [HTTP/HTTPS health checks] The ping path that is the destination for the
@@ -7056,13 +7166,13 @@ type ModifyTargetGroupInput struct {
 	// target group is TCP, TLS, UDP, or TCP_UDP. The TLS, UDP, and TCP_UDP protocols
 	// are not supported for health checks.
 	//
-	// If the protocol of the target group is TCP, you can't modify this setting.
+	// With Network Load Balancers, you can't modify this setting.
 	HealthCheckProtocol *string `type:"string" enum:"ProtocolEnum"`
 
 	// [HTTP/HTTPS health checks] The amount of time, in seconds, during which no
 	// response means a failed health check.
 	//
-	// If the protocol of the target group is TCP, you can't modify this setting.
+	// With Network Load Balancers, you can't modify this setting.
 	HealthCheckTimeoutSeconds *int64 `min:"2" type:"integer"`
 
 	// The number of consecutive health checks successes required before considering
@@ -7072,7 +7182,7 @@ type ModifyTargetGroupInput struct {
 	// [HTTP/HTTPS health checks] The HTTP codes to use when checking for a successful
 	// response from a target.
 	//
-	// If the protocol of the target group is TCP, you can't modify this setting.
+	// With Network Load Balancers, you can't modify this setting.
 	Matcher *Matcher `type:"structure"`
 
 	// The Amazon Resource Name (ARN) of the target group.
@@ -8112,11 +8222,17 @@ type SetSubnetsInput struct {
 	// LoadBalancerArn is a required field
 	LoadBalancerArn *string `type:"string" required:"true"`
 
-	// The IDs of the public subnets. You must specify subnets from at least two
-	// Availability Zones. You can specify only one subnet per Availability Zone.
-	// You must specify either subnets or subnet mappings.
+	// The IDs of the public subnets. You can specify only one subnet per Availability
+	// Zone. You must specify either subnets or subnet mappings.
 	//
-	// You cannot specify Elastic IP addresses for your subnets.
+	// [Application Load Balancers] You must specify subnets from at least two Availability
+	// Zones. You cannot specify Elastic IP addresses for your subnets.
+	//
+	// [Network Load Balancers] You can specify subnets from one or more Availability
+	// Zones. If you need static IP addresses for your internet-facing load balancer,
+	// you can specify one Elastic IP address per subnet. For internal load balancers,
+	// you can specify one private IP address per subnet from the IPv4 range of
+	// the subnet.
 	SubnetMappings []*SubnetMapping `type:"list"`
 
 	// The IDs of the public subnets. You must specify subnets from at least two
@@ -8269,8 +8385,12 @@ func (s *SslPolicy) SetSslProtocols(v []*string) *SslPolicy {
 type SubnetMapping struct {
 	_ struct{} `type:"structure"`
 
-	// [Network Load Balancers] The allocation ID of the Elastic IP address.
+	// [Network Load Balancers] The allocation ID of the Elastic IP address for
+	// an internet-facing load balancer.
 	AllocationId *string `type:"string"`
+
+	// [Network Load Balancers] The private IPv4 address for an internal load balancer.
+	PrivateIPv4Address *string `type:"string"`
 
 	// The ID of the subnet.
 	SubnetId *string `type:"string"`
@@ -8289,6 +8409,12 @@ func (s SubnetMapping) GoString() string {
 // SetAllocationId sets the AllocationId field's value.
 func (s *SubnetMapping) SetAllocationId(v string) *SubnetMapping {
 	s.AllocationId = &v
+	return s
+}
+
+// SetPrivateIPv4Address sets the PrivateIPv4Address field's value.
+func (s *SubnetMapping) SetPrivateIPv4Address(v string) *SubnetMapping {
+	s.PrivateIPv4Address = &v
 	return s
 }
 
@@ -8412,7 +8538,8 @@ type TargetDescription struct {
 	// Id is a required field
 	Id *string `type:"string" required:"true"`
 
-	// The port on which the target is listening.
+	// The port on which the target is listening. Not used if the target is a Lambda
+	// function.
 	Port *int64 `min:"1" type:"integer"`
 }
 
@@ -8495,7 +8622,8 @@ type TargetGroup struct {
 	// The HTTP codes to use when checking for a successful response from a target.
 	Matcher *Matcher `type:"structure"`
 
-	// The port on which the targets are listening.
+	// The port on which the targets are listening. Not used if the target is a
+	// Lambda function.
 	Port *int64 `min:"1" type:"integer"`
 
 	// The protocol to use for routing traffic to the targets.
@@ -8644,6 +8772,10 @@ type TargetGroupAttribute struct {
 	// The following attributes are supported by Application Load Balancers if the
 	// target is not a Lambda function:
 	//
+	//    * load_balancing.algorithm.type - The load balancing algorithm determines
+	//    how the load balancer selects targets when routing requests. The value
+	//    is round_robin or least_outstanding_requests. The default is round_robin.
+	//
 	//    * slow_start.duration_seconds - The time period, in seconds, during which
 	//    a newly registered target receives a linearly increasing share of the
 	//    traffic to the target group. After this time period ends, the target receives
@@ -8703,6 +8835,74 @@ func (s *TargetGroupAttribute) SetValue(v string) *TargetGroupAttribute {
 	return s
 }
 
+// Information about the target group stickiness for a rule.
+type TargetGroupStickinessConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The time period, in seconds, during which requests from a client should be
+	// routed to the same target group. The range is 1-604800 seconds (7 days).
+	DurationSeconds *int64 `type:"integer"`
+
+	// Indicates whether target group stickiness is enabled.
+	Enabled *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s TargetGroupStickinessConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TargetGroupStickinessConfig) GoString() string {
+	return s.String()
+}
+
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *TargetGroupStickinessConfig) SetDurationSeconds(v int64) *TargetGroupStickinessConfig {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *TargetGroupStickinessConfig) SetEnabled(v bool) *TargetGroupStickinessConfig {
+	s.Enabled = &v
+	return s
+}
+
+// Information about how traffic will be distributed between multiple target
+// groups in a forward rule.
+type TargetGroupTuple struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the target group.
+	TargetGroupArn *string `type:"string"`
+
+	// The weight. The range is 0 to 999.
+	Weight *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s TargetGroupTuple) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TargetGroupTuple) GoString() string {
+	return s.String()
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *TargetGroupTuple) SetTargetGroupArn(v string) *TargetGroupTuple {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetWeight sets the Weight field's value.
+func (s *TargetGroupTuple) SetWeight(v int64) *TargetGroupTuple {
+	s.Weight = &v
+	return s
+}
+
 // Information about the current health of a target.
 type TargetHealth struct {
 	_ struct{} `type:"structure"`
@@ -8728,15 +8928,16 @@ type TargetHealth struct {
 	// values:
 	//
 	//    * Target.ResponseCodeMismatch - The health checks did not return an expected
-	//    HTTP code.
+	//    HTTP code. Applies only to Application Load Balancers.
 	//
-	//    * Target.Timeout - The health check requests timed out.
+	//    * Target.Timeout - The health check requests timed out. Applies only to
+	//    Application Load Balancers.
 	//
-	//    * Target.FailedHealthChecks - The health checks failed because the connection
-	//    to the target timed out, the target response was malformed, or the target
-	//    failed the health check for an unknown reason.
+	//    * Target.FailedHealthChecks - The load balancer received an error while
+	//    establishing a connection to the target or the target response was malformed.
 	//
 	//    * Elb.InternalError - The health checks failed due to an internal error.
+	//    Applies only to Application Load Balancers.
 	//
 	// If the target state is unused, the reason code can be one of the following
 	// values:
@@ -8748,10 +8949,10 @@ type TargetHealth struct {
 	//    or the target is in an Availability Zone that is not enabled for its load
 	//    balancer.
 	//
+	//    * Target.InvalidState - The target is in the stopped or terminated state.
+	//
 	//    * Target.IpUnusable - The target IP address is reserved for use by a load
 	//    balancer.
-	//
-	//    * Target.InvalidState - The target is in the stopped or terminated state.
 	//
 	// If the target state is draining, the reason code can be the following value:
 	//
@@ -8762,7 +8963,10 @@ type TargetHealth struct {
 	// value:
 	//
 	//    * Target.HealthCheckDisabled - Health checks are disabled for the target
-	//    group.
+	//    group. Applies only to Application Load Balancers.
+	//
+	//    * Elb.InternalError - Target health is unavailable due to an internal
+	//    error. Applies only to Network Load Balancers.
 	Reason *string `type:"string" enum:"TargetHealthReasonEnum"`
 
 	// The state of the target.

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/doc.go
@@ -15,40 +15,16 @@
 // the targets.
 //
 // Elastic Load Balancing supports the following types of load balancers: Application
-// Load Balancers, Network Load Balancers, and Classic Load Balancers.
+// Load Balancers, Network Load Balancers, and Classic Load Balancers. This
+// reference covers Application Load Balancers and Network Load Balancers.
 //
 // An Application Load Balancer makes routing and load balancing decisions at
 // the application layer (HTTP/HTTPS). A Network Load Balancer makes routing
 // and load balancing decisions at the transport layer (TCP/TLS). Both Application
 // Load Balancers and Network Load Balancers can route requests to one or more
 // ports on each EC2 instance or container instance in your virtual private
-// cloud (VPC).
-//
-// A Classic Load Balancer makes routing and load balancing decisions either
-// at the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS), and
-// supports either EC2-Classic or a VPC. For more information, see the Elastic
-// Load Balancing User Guide (https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/).
-//
-// This reference covers the 2015-12-01 API, which supports Application Load
-// Balancers and Network Load Balancers. The 2012-06-01 API supports Classic
-// Load Balancers.
-//
-// To get started, complete the following tasks:
-//
-// Create a load balancer using CreateLoadBalancer.
-//
-// Create a target group using CreateTargetGroup.
-//
-// Register targets for the target group using RegisterTargets.
-//
-// Create one or more listeners for your load balancer using CreateListener.
-//
-// To delete a load balancer and its related resources, complete the following
-// tasks:
-//
-// Delete the load balancer using DeleteLoadBalancer.
-//
-// Delete the target group using DeleteTargetGroup.
+// cloud (VPC). For more information, see the Elastic Load Balancing User Guide
+// (https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/).
 //
 // All Elastic Load Balancing operations are idempotent, which means that they
 // complete at most one time. If you repeat an operation, it succeeds.

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
@@ -211,6 +211,14 @@ const (
 	// You've reached the limit on the number of targets.
 	ErrCodeTooManyTargetsException = "TooManyTargets"
 
+	// ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException for service response error code
+	// "TooManyUniqueTargetGroupsPerLoadBalancer".
+	//
+	// You've reached the limit on the number of unique target groups per load balancer
+	// across all listeners. If a target group is used by multiple actions for a
+	// load balancer, it is counted as only one use.
+	ErrCodeTooManyUniqueTargetGroupsPerLoadBalancerException = "TooManyUniqueTargetGroupsPerLoadBalancer"
+
 	// ErrCodeUnsupportedProtocolException for service response error code
 	// "UnsupportedProtocol".
 	//

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticloadbalancing"      // Name of service.
 	EndpointsID = ServiceName                 // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Load Balancing v2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Load Balancing v2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ELBV2 client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a ELBV2 client from just a session.
 //     svc := elbv2.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := elbv2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ELBV2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ELBV2 {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ELBV2 {
 	svc := &ELBV2{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2015-12-01",
 			},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -58,16 +58,15 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 // CancelKeyDeletion API operation for AWS Key Management Service.
 //
 // Cancels the deletion of a customer master key (CMK). When this operation
-// is successful, the CMK is set to the Disabled state. To enable a CMK, use
-// EnableKey. You cannot perform this operation on a CMK in a different AWS
-// account.
+// succeeds, the key state of the CMK is Disabled. To enable the CMK, use EnableKey.
+// You cannot perform this operation on a CMK in a different AWS account.
 //
 // For more information about scheduling and canceling deletion of a CMK, see
 // Deleting Customer Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
 // in the AWS Key Management Service Developer Guide.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -100,7 +99,7 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CancelKeyDeletion
 func (c *KMS) CancelKeyDeletion(input *CancelKeyDeletionInput) (*CancelKeyDeletionOutput, error) {
@@ -350,32 +349,68 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 // CreateAlias API operation for AWS Key Management Service.
 //
 // Creates a display name for a customer managed customer master key (CMK).
-// You can use an alias to identify a CMK in selected operations, such as Encrypt
-// and GenerateDataKey.
+// You can use an alias to identify a CMK in cryptographic operations, such
+// as Encrypt and GenerateDataKey. You can change the CMK associated with the
+// alias at any time.
 //
-// Each CMK can have multiple aliases, but each alias points to only one CMK.
-// The alias name must be unique in the AWS account and region. To simplify
-// code that runs in multiple regions, use the same alias name, but point it
-// to a different CMK in each region.
+// Aliases are easier to remember than key IDs. They can also help to simplify
+// your applications. For example, if you use an alias in your code, you can
+// change the CMK your code uses by associating a given alias with a different
+// CMK.
+//
+// To run the same code in multiple AWS regions, use an alias in your code,
+// such as alias/ApplicationKey. Then, in each AWS Region, create an alias/ApplicationKey
+// alias that is associated with a CMK in that Region. When you run your code,
+// it uses the alias/ApplicationKey CMK for that AWS Region without any Region-specific
+// code.
+//
+// This operation does not return a response. To get the alias that you created,
+// use the ListAliases operation.
+//
+// To use aliases successfully, be aware of the following information.
+//
+//    * Each alias points to only one CMK at a time, although a single CMK can
+//    have multiple aliases. The alias and its associated CMK must be in the
+//    same AWS account and Region.
+//
+//    * You can associate an alias with any customer managed CMK in the same
+//    AWS account and Region. However, you do not have permission to associate
+//    an alias with an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+//    or an AWS owned CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk).
+//
+//    * To change the CMK associated with an alias, use the UpdateAlias operation.
+//    The current CMK and the new CMK must be the same type (both symmetric
+//    or both asymmetric) and they must have the same key usage (ENCRYPT_DECRYPT
+//    or SIGN_VERIFY). This restriction prevents cryptographic errors in code
+//    that uses aliases.
+//
+//    * The alias name must begin with alias/ followed by a name, such as alias/ExampleAlias.
+//    It can contain only alphanumeric characters, forward slashes (/), underscores
+//    (_), and dashes (-). The alias name cannot begin with alias/aws/. The
+//    alias/aws/ prefix is reserved for AWS managed CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+//
+//    * The alias name must be unique within an AWS Region. However, you can
+//    use the same alias name in multiple Regions of the same AWS account. Each
+//    instance of the alias is associated with a CMK in its Region.
+//
+//    * After you create an alias, you cannot change its alias name. However,
+//    you can use the DeleteAlias operation to delete the alias and then create
+//    a new alias with the desired name.
+//
+//    * You can use an alias name or alias ARN to identify a CMK in AWS KMS
+//    cryptographic operations and in the DescribeKey operation. However, you
+//    cannot use alias names or alias ARNs in API operations that manage CMKs,
+//    such as DisableKey or GetKeyPolicy. For information about the valid CMK
+//    identifiers for each AWS KMS API operation, see the descriptions of the
+//    KeyId parameter in the API operation documentation.
 //
 // Because an alias is not a property of a CMK, you can delete and change the
 // aliases of a CMK without affecting the CMK. Also, aliases do not appear in
-// the response from the DescribeKey operation. To get the aliases of all CMKs,
-// use the ListAliases operation.
+// the response from the DescribeKey operation. To get the aliases and alias
+// ARNs of CMKs in each AWS account and Region, use the ListAliases operation.
 //
-// The alias name must begin with alias/ followed by a name, such as alias/ExampleAlias.
-// It can contain only alphanumeric characters, forward slashes (/), underscores
-// (_), and dashes (-). The alias name cannot begin with alias/aws/. The alias/aws/
-// prefix is reserved for AWS managed CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
-//
-// The alias and the CMK it is mapped to must be in the same AWS account and
-// the same region. You cannot perform this operation on an alias in a different
-// AWS account.
-//
-// To map an existing alias to a different CMK, call UpdateAlias.
-//
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -416,7 +451,7 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateAlias
 func (c *KMS) CreateAlias(input *CreateAliasInput) (*CreateAliasOutput, error) {
@@ -657,17 +692,44 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 // principal to use the CMK when the conditions specified in the grant are met.
 // When setting permissions, grants are an alternative to key policies.
 //
-// To create a grant that allows a cryptographic operation only when the encryption
-// context in the operation request matches or includes a specified encryption
-// context, use the Constraints parameter. For details, see GrantConstraints.
+// To create a grant that allows a cryptographic operation only when the request
+// includes a particular encryption context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context),
+// use the Constraints parameter. For details, see GrantConstraints.
+//
+// You can create grants on symmetric and asymmetric CMKs. However, if the grant
+// allows an operation that the CMK does not support, CreateGrant fails with
+// a ValidationException.
+//
+//    * Grants for symmetric CMKs cannot allow operations that are not supported
+//    for symmetric CMKs, including Sign, Verify, and GetPublicKey. (There are
+//    limited exceptions to this rule for legacy operations, but you should
+//    not create a grant for an operation that AWS KMS does not support.)
+//
+//    * Grants for asymmetric CMKs cannot allow operations that are not supported
+//    for asymmetric CMKs, including operations that generate data keys (https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKey)
+//    or data key pairs (https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyPair),
+//    or operations related to automatic key rotation (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html),
+//    imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+//    or CMKs in custom key stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+//
+//    * Grants for asymmetric CMKs with a KeyUsage of ENCRYPT_DECRYPT cannot
+//    allow the Sign or Verify operations. Grants for asymmetric CMKs with a
+//    KeyUsage of SIGN_VERIFY cannot allow the Encrypt or Decrypt operations.
+//
+//    * Grants for asymmetric CMKs cannot include an encryption context grant
+//    constraint. An encryption context is not supported on asymmetric CMKs.
+//
+// For information about symmetric and asymmetric CMKs, see Using Symmetric
+// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
 //
 // To perform this operation on a CMK in a different AWS account, specify the
 // key ARN in the value of the KeyId parameter. For more information about grants,
 // see Grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
 // in the AWS Key Management Service Developer Guide .
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -711,7 +773,7 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateGrant
 func (c *KMS) CreateGrant(input *CreateGrantInput) (*CreateGrantOutput, error) {
@@ -779,23 +841,67 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 
 // CreateKey API operation for AWS Key Management Service.
 //
-// Creates a customer managed customer master key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
-// (CMK) in your AWS account.
+// Creates a unique customer managed customer master key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master-keys)
+// (CMK) in your AWS account and Region. You cannot use this operation to create
+// a CMK in a different AWS account.
 //
-// You can use a CMK to encrypt small amounts of data (up to 4096 bytes) directly.
-// But CMKs are more commonly used to encrypt the data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
-// that are used to encrypt data.
+// You can use the CreateKey operation to create symmetric or asymmetric CMKs.
 //
-// To create a CMK for imported key material, use the Origin parameter with
-// a value of EXTERNAL.
+//    * Symmetric CMKs contain a 256-bit symmetric key that never leaves AWS
+//    KMS unencrypted. To use the CMK, you must call AWS KMS. You can use a
+//    symmetric CMK to encrypt and decrypt small amounts of data, but they are
+//    typically used to generate data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
+//    or data key pairs. For details, see GenerateDataKey and GenerateDataKeyPair.
 //
-// To create a CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+//    * Asymmetric CMKs can contain an RSA key pair or an Elliptic Curve (ECC)
+//    key pair. The private key in an asymmetric CMK never leaves AWS KMS unencrypted.
+//    However, you can use the GetPublicKey operation to download the public
+//    key so it can be used outside of AWS KMS. CMKs with RSA key pairs can
+//    be used to encrypt or decrypt data or sign and verify messages (but not
+//    both). CMKs with ECC key pairs can be used only to sign and verify messages.
+//
+// For information about symmetric and asymmetric CMKs, see Using Symmetric
+// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// To create different types of CMKs, use the following guidance:
+//
+// Asymmetric CMKs
+//
+// To create an asymmetric CMK, use the CustomerMasterKeySpec parameter to specify
+// the type of key material in the CMK. Then, use the KeyUsage parameter to
+// determine whether the CMK will be used to encrypt and decrypt or sign and
+// verify. You can't change these properties after the CMK is created.
+//
+// Symmetric CMKs
+//
+// When creating a symmetric CMK, you don't need to specify the CustomerMasterKeySpec
+// or KeyUsage parameters. The default value for CustomerMasterKeySpec, SYMMETRIC_DEFAULT,
+// and the default value for KeyUsage, ENCRYPT_DECRYPT, are the only valid values
+// for symmetric CMKs.
+//
+// Imported Key Material
+//
+// To import your own key material, begin by creating a symmetric CMK with no
+// key material. To do this, use the Origin parameter of CreateKey with a value
+// of EXTERNAL. Next, use GetParametersForImport operation to get a public key
+// and import token, and use the public key to encrypt your key material. Then,
+// use ImportKeyMaterial with your import token to import the key material.
+// For step-by-step instructions, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the AWS Key Management Service Developer Guide . You cannot import the
+// key material into an asymmetric CMK.
+//
+// Custom Key Stores
+//
+// To create a symmetric CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
 // use the CustomKeyStoreId parameter to specify the custom key store. You must
 // also use the Origin parameter with a value of AWS_CLOUDHSM. The AWS CloudHSM
 // cluster that is associated with the custom key store must have at least two
 // active HSMs in different Availability Zones in the AWS Region.
 //
-// You cannot use this operation to create a CMK in a different AWS account.
+// You cannot create an asymmetric CMK in a custom key store. For information
+// about custom key stores in AWS KMS see Using Custom Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+// in the AWS Key Management Service Developer Guide .
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -954,25 +1060,51 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 
 // Decrypt API operation for AWS Key Management Service.
 //
-// Decrypts ciphertext. Ciphertext is plaintext that has been previously encrypted
-// by using any of the following operations:
-//
-//    * GenerateDataKey
-//
-//    * GenerateDataKeyWithoutPlaintext
+// Decrypts ciphertext that was encrypted by a AWS KMS customer master key (CMK)
+// using any of the following operations:
 //
 //    * Encrypt
 //
-// Whenever possible, use key policies to give users permission to call the
-// Decrypt operation on the CMK, instead of IAM policies. Otherwise, you might
-// create an IAM user policy that gives the user Decrypt permission on all CMKs.
-// This user could decrypt ciphertext that was encrypted by CMKs in other accounts
-// if the key policy for the cross-account CMK permits it. If you must use an
-// IAM policy for Decrypt permissions, limit the user to particular CMKs or
-// particular trusted accounts.
+//    * GenerateDataKey
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//    * GenerateDataKeyPair
+//
+//    * GenerateDataKeyWithoutPlaintext
+//
+//    * GenerateDataKeyPairWithoutPlaintext
+//
+// You can use this operation to decrypt ciphertext that was encrypted under
+// a symmetric or asymmetric CMK. When the CMK is asymmetric, you must specify
+// the CMK and the encryption algorithm that was used to encrypt the ciphertext.
+// For information about symmetric and asymmetric CMKs, see Using Symmetric
+// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// The Decrypt operation also decrypts ciphertext that was encrypted outside
+// of AWS KMS by the public key in an AWS KMS asymmetric CMK. However, it cannot
+// decrypt ciphertext produced by other libraries, such as the AWS Encryption
+// SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
+// These libraries return a ciphertext format that is incompatible with AWS
+// KMS.
+//
+// If the ciphertext was encrypted under a symmetric CMK, you do not need to
+// specify the CMK or the encryption algorithm. AWS KMS can get this information
+// from metadata that it adds to the symmetric ciphertext blob. However, if
+// you prefer, you can specify the KeyId to ensure that a particular CMK is
+// used to decrypt the ciphertext. If you specify a different CMK than the one
+// used to encrypt the ciphertext, the Decrypt operation fails.
+//
+// Whenever possible, use key policies to give users permission to call the
+// Decrypt operation on a particular CMK, instead of using IAM policies. Otherwise,
+// you might create an IAM user policy that gives the user Decrypt permission
+// on all CMKs. This user could decrypt ciphertext that was encrypted by CMKs
+// in other accounts if the key policy for the cross-account CMK permits it.
+// If you must use an IAM policy for Decrypt permissions, limit the user to
+// particular CMKs or particular trusted accounts.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -991,13 +1123,37 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   The request was rejected because the specified CMK is not enabled.
 //
 //   * ErrCodeInvalidCiphertextException "InvalidCiphertextException"
-//   The request was rejected because the specified ciphertext, or additional
-//   authenticated data incorporated into the ciphertext, such as the encryption
-//   context, is corrupted, missing, or otherwise invalid.
+//   From the Decrypt or ReEncrypt operation, the request was rejected because
+//   the specified ciphertext, or additional authenticated data incorporated into
+//   the ciphertext, such as the encryption context, is corrupted, missing, or
+//   otherwise invalid.
+//
+//   From the ImportKeyMaterial operation, the request was rejected because AWS
+//   KMS could not decrypt the encrypted (wrapped) key material.
 //
 //   * ErrCodeKeyUnavailableException "KeyUnavailableException"
-//   The request was rejected because the specified CMK was not available. The
-//   request can be retried.
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeIncorrectKeyException "IncorrectKeyException"
+//   The request was rejected because the specified CMK cannot decrypt the data.
+//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same CMK that was used to encrypt the ciphertext.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
 //
 //   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
 //   The system timed out while trying to fulfill the request. The request can
@@ -1016,7 +1172,7 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Decrypt
 func (c *KMS) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
@@ -1123,7 +1279,7 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteAlias
 func (c *KMS) DeleteAlias(input *DeleteAliasInput) (*DeleteAliasOutput, error) {
@@ -1342,8 +1498,8 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 // After you delete key material, you can use ImportKeyMaterial to reimport
 // the same key material into the CMK.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1380,7 +1536,7 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteImportedKeyMaterial
 func (c *KMS) DeleteImportedKeyMaterial(input *DeleteImportedKeyMaterialInput) (*DeleteImportedKeyMaterialOutput, error) {
@@ -1558,12 +1714,38 @@ func (c *KMS) DescribeKeyRequest(input *DescribeKeyInput) (req *request.Request,
 
 // DescribeKey API operation for AWS Key Management Service.
 //
-// Provides detailed information about the specified customer master key (CMK).
+// Provides detailed information about a customer master key (CMK). You can
+// run DescribeKey on a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+// or an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 //
-// You can use DescribeKey on a predefined AWS alias, that is, an AWS alias
-// with no key ID. When you do, AWS KMS associates the alias with an AWS managed
-// CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
-// and returns its KeyId and Arn in the response.
+// This detailed information includes the key ARN, creation date (and deletion
+// date, if applicable), the key state, and the origin and expiration date (if
+// any) of the key material. For CMKs in custom key stores, it includes information
+// about the custom key store, such as the key store ID and the AWS CloudHSM
+// cluster ID. It includes fields, like KeySpec, that help you distinguish symmetric
+// from asymmetric CMKs. It also provides information that is particularly important
+// to asymmetric CMKs, such as the key usage (encryption or signing) and the
+// encryption algorithms or signing algorithms that the CMK supports.
+//
+// DescribeKey does not return the following information:
+//
+//    * Aliases associated with the CMK. To get this information, use ListAliases.
+//
+//    * Whether automatic key rotation is enabled on the CMK. To get this information,
+//    use GetKeyRotationStatus. Also, some key states prevent a CMK from being
+//    automatically rotated. For details, see How Automatic Key Rotation Works
+//    (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works)
+//    in AWS Key Management Service Developer Guide.
+//
+//    * Tags on the CMK. To get this information, use ListResourceTags.
+//
+//    * Key policies and grants on the CMK. To get this information, use GetKeyPolicy
+//    and ListGrants.
+//
+// If you call the DescribeKey operation on a predefined AWS alias, that is,
+// an AWS alias with no key ID, AWS KMS creates an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
+// Then, it associates the alias with the new CMK, and returns the KeyId and
+// Arn of the new CMK in the response.
 //
 // To perform this operation on a CMK in a different AWS account, specify the
 // key ARN or alias ARN in the value of the KeyId parameter.
@@ -1667,8 +1849,8 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 // Key State Affects the Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide .
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1701,7 +1883,7 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DisableKey
 func (c *KMS) DisableKey(input *DisableKeyInput) (*DisableKeyOutput, error) {
@@ -1771,11 +1953,14 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 // DisableKeyRotation API operation for AWS Key Management Service.
 //
 // Disables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified customer master key (CMK). You cannot perform this operation
-// on a CMK in a different AWS account.
+// for the specified symmetric customer master key (CMK).
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
+// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot perform this operation on a CMK in a different AWS account.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1811,7 +1996,7 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeUnsupportedOperationException "UnsupportedOperationException"
 //   The request was rejected because a specified parameter is not supported or
@@ -2011,8 +2196,8 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 // you to use the CMK for cryptographic operations. You cannot perform this
 // operation on a CMK in a different AWS account.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2050,7 +2235,7 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/EnableKey
 func (c *KMS) EnableKey(input *EnableKeyInput) (*EnableKeyOutput, error) {
@@ -2120,14 +2305,14 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 // EnableKeyRotation API operation for AWS Key Management Service.
 //
 // Enables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified customer master key (CMK). You cannot perform this operation
-// on a CMK in a different AWS account.
+// for the specified symmetric customer master key (CMK). You cannot perform
+// this operation on a CMK in a different AWS account.
 //
-// You cannot enable automatic rotation of CMKs with imported key material or
-// CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
+// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2163,7 +2348,7 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeUnsupportedOperationException "UnsupportedOperationException"
 //   The request was rejected because a specified parameter is not supported or
@@ -2238,8 +2423,8 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 // Encrypts plaintext into ciphertext by using a customer master key (CMK).
 // The Encrypt operation has two primary use cases:
 //
-//    * You can encrypt up to 4 kilobytes (4096 bytes) of arbitrary data such
-//    as an RSA key, a database password, or other sensitive information.
+//    * You can encrypt small amounts of arbitrary data, such as a personal
+//    identifier or database password, or other sensitive information.
 //
 //    * You can use the Encrypt operation to move encrypted data from one AWS
 //    region to another. In the first region, generate a data key and use the
@@ -2248,16 +2433,50 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //    data and encrypted data key to the new region, and decrypt in the new
 //    region when necessary.
 //
-// You don't need use this operation to encrypt a data key within a region.
-// The GenerateDataKey and GenerateDataKeyWithoutPlaintext operations return
-// an encrypted data key.
+// You don't need to use the Encrypt operation to encrypt a data key. The GenerateDataKey
+// and GenerateDataKeyPair operations return a plaintext data key and an encrypted
+// copy of that data key.
 //
-// Also, you don't need to use this operation to encrypt data in your application.
-// You can use the plaintext and encrypted data keys that the GenerateDataKey
-// operation returns.
+// When you encrypt data, you must specify a symmetric or asymmetric CMK to
+// use in the encryption operation. The CMK must have a KeyUsage value of ENCRYPT_DECRYPT.
+// To find the KeyUsage of a CMK, use the DescribeKey operation.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// If you use a symmetric CMK, you can use an encryption context to add additional
+// security to your encryption operation. If you specify an EncryptionContext
+// when encrypting data, you must specify the same encryption context (a case-sensitive
+// exact match) when decrypting the data. Otherwise, the request to decrypt
+// fails with an InvalidCiphertextException. For more information, see Encryption
+// Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// in the AWS Key Management Service Developer Guide.
+//
+// If you specify an asymmetric CMK, you must also specify the encryption algorithm.
+// The algorithm must be compatible with the CMK type.
+//
+// When you use an asymmetric CMK to encrypt or reencrypt data, be sure to record
+// the CMK and encryption algorithm that you choose. You will be required to
+// provide the same CMK and encryption algorithm when you decrypt the data.
+// If the CMK and algorithm do not match the values used to encrypt the data,
+// the decrypt operation fails.
+//
+// You are not required to supply the CMK ID and encryption algorithm when you
+// decrypt with symmetric CMKs because AWS KMS stores this information in the
+// ciphertext blob. AWS KMS cannot store metadata in ciphertext generated with
+// asymmetric keys. The standard format for asymmetric key ciphertext does not
+// include configurable fields.
+//
+// The maximum size of the data that you can encrypt varies with the type of
+// CMK and the encryption algorithm that you choose.
+//
+//    * Symmetric CMKs SYMMETRIC_DEFAULT: 4096 bytes
+//
+//    * RSA_2048 RSAES_OAEP_SHA_1: 214 bytes RSAES_OAEP_SHA_256: 190 bytes
+//
+//    * RSA_3072 RSAES_OAEP_SHA_1: 342 bytes RSAES_OAEP_SHA_256: 318 bytes
+//
+//    * RSA_4096 RSAES_OAEP_SHA_1: 470 bytes RSAES_OAEP_SHA_256: 446 bytes
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // To perform this operation on a CMK in a different AWS account, specify the
@@ -2279,15 +2498,27 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   The request was rejected because the specified CMK is not enabled.
 //
 //   * ErrCodeKeyUnavailableException "KeyUnavailableException"
-//   The request was rejected because the specified CMK was not available. The
-//   request can be retried.
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
 //
 //   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
 //   The system timed out while trying to fulfill the request. The request can
 //   be retried.
 //
 //   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
-//   The request was rejected because the specified KeySpec value is not valid.
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
 //
 //   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
 //   The request was rejected because the specified grant token is not valid.
@@ -2302,7 +2533,7 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Encrypt
 func (c *KMS) Encrypt(input *EncryptInput) (*EncryptOutput, error) {
@@ -2370,25 +2601,41 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 
 // GenerateDataKey API operation for AWS Key Management Service.
 //
-// Generates a unique data key. This operation returns a plaintext copy of the
-// data key and a copy that is encrypted under a customer master key (CMK) that
-// you specify. You can use the plaintext key to encrypt your data outside of
-// KMS and store the encrypted data key with the encrypted data.
+// Generates a unique symmetric data key. This operation returns a plaintext
+// copy of the data key and a copy that is encrypted under a customer master
+// key (CMK) that you specify. You can use the plaintext key to encrypt your
+// data outside of AWS KMS and store the encrypted data key with the encrypted
+// data.
 //
 // GenerateDataKey returns a unique data key for each request. The bytes in
 // the key are not related to the caller or CMK that is used to encrypt the
 // data key.
 //
-// To generate a data key, you need to specify the customer master key (CMK)
-// that will be used to encrypt the data key. You must also specify the length
-// of the data key using either the KeySpec or NumberOfBytes field (but not
-// both). For common key lengths (128-bit and 256-bit symmetric keys), we recommend
-// that you use KeySpec. To perform this operation on a CMK in a different AWS
-// account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// To generate a data key, specify the symmetric CMK that will be used to encrypt
+// the data key. You cannot use an asymmetric CMK to generate data keys.
 //
-// You will find the plaintext copy of the data key in the Plaintext field of
-// the response, and the encrypted copy of the data key in the CiphertextBlob
+// You must also specify the length of the data key. Use either the KeySpec
+// or NumberOfBytes parameters (but not both). For 128-bit and 256-bit data
+// keys, use the KeySpec parameter.
+//
+// If the operation succeeds, the plaintext copy of the data key is in the Plaintext
+// field of the response, and the encrypted copy of the data key in the CiphertextBlob
 // field.
+//
+// To get only an encrypted copy of the data key, use GenerateDataKeyWithoutPlaintext.
+// To generate an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
+// operation. To get a cryptographically secure random byte string, use GenerateRandom.
+//
+// You can use the optional encryption context to add additional security to
+// the encryption operation. If you specify an EncryptionContext, you must specify
+// the same encryption context (a case-sensitive exact match) when decrypting
+// the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
+// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// in the AWS Key Management Service Developer Guide.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
 //
 // We recommend that you use the following pattern to encrypt data locally in
 // your application:
@@ -2409,21 +2656,6 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 // Use the plaintext data key to decrypt data locally, then erase the plaintext
 // data key from memory.
 //
-// To get only an encrypted copy of the data key, use GenerateDataKeyWithoutPlaintext.
-// To get a cryptographically secure random byte string, use GenerateRandom.
-//
-// You can use the optional encryption context to add additional security to
-// your encryption operation. When you specify an EncryptionContext in the GenerateDataKey
-// operation, you must specify the same encryption context (a case-sensitive
-// exact match) in your request to Decrypt the data key. Otherwise, the request
-// to decrypt fails with an InvalidCiphertextException. For more information,
-// see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide .
-//
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
-//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -2440,15 +2672,27 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   The request was rejected because the specified CMK is not enabled.
 //
 //   * ErrCodeKeyUnavailableException "KeyUnavailableException"
-//   The request was rejected because the specified CMK was not available. The
-//   request can be retried.
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
 //
 //   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
 //   The system timed out while trying to fulfill the request. The request can
 //   be retried.
 //
 //   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
-//   The request was rejected because the specified KeySpec value is not valid.
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
 //
 //   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
 //   The request was rejected because the specified grant token is not valid.
@@ -2463,7 +2707,7 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKey
 func (c *KMS) GenerateDataKey(input *GenerateDataKeyInput) (*GenerateDataKeyOutput, error) {
@@ -2482,6 +2726,312 @@ func (c *KMS) GenerateDataKey(input *GenerateDataKeyInput) (*GenerateDataKeyOutp
 // for more information on using Contexts.
 func (c *KMS) GenerateDataKeyWithContext(ctx aws.Context, input *GenerateDataKeyInput, opts ...request.Option) (*GenerateDataKeyOutput, error) {
 	req, out := c.GenerateDataKeyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGenerateDataKeyPair = "GenerateDataKeyPair"
+
+// GenerateDataKeyPairRequest generates a "aws/request.Request" representing the
+// client's request for the GenerateDataKeyPair operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GenerateDataKeyPair for more information on using the GenerateDataKeyPair
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GenerateDataKeyPairRequest method.
+//    req, resp := client.GenerateDataKeyPairRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyPair
+func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *request.Request, output *GenerateDataKeyPairOutput) {
+	op := &request.Operation{
+		Name:       opGenerateDataKeyPair,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GenerateDataKeyPairInput{}
+	}
+
+	output = &GenerateDataKeyPairOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GenerateDataKeyPair API operation for AWS Key Management Service.
+//
+// Generates a unique asymmetric data key pair. The GenerateDataKeyPair operation
+// returns a plaintext public key, a plaintext private key, and a copy of the
+// private key that is encrypted under the symmetric CMK you specify. You can
+// use the data key pair to perform asymmetric cryptography outside of AWS KMS.
+//
+// GenerateDataKeyPair returns a unique data key pair for each request. The
+// bytes in the keys are not related to the caller or the CMK that is used to
+// encrypt the private key.
+//
+// You can use the public key that GenerateDataKeyPair returns to encrypt data
+// or verify a signature outside of AWS KMS. Then, store the encrypted private
+// key with the data. When you are ready to decrypt data or sign a message,
+// you can use the Decrypt operation to decrypt the encrypted private key.
+//
+// To generate a data key pair, you must specify a symmetric customer master
+// key (CMK) to encrypt the private key in a data key pair. You cannot use an
+// asymmetric CMK. To get the type of your CMK, use the DescribeKey operation.
+//
+// If you are using the data key pair to encrypt data, or for any operation
+// where you don't immediately need a private key, consider using the GenerateDataKeyPairWithoutPlaintext
+// operation. GenerateDataKeyPairWithoutPlaintext returns a plaintext public
+// key and an encrypted private key, but omits the plaintext private key that
+// you need only to decrypt ciphertext or sign a message. Later, when you need
+// to decrypt the data or sign a message, use the Decrypt operation to decrypt
+// the encrypted private key in the data key pair.
+//
+// You can use the optional encryption context to add additional security to
+// the encryption operation. If you specify an EncryptionContext, you must specify
+// the same encryption context (a case-sensitive exact match) when decrypting
+// the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
+// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// in the AWS Key Management Service Developer Guide.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation GenerateDataKeyPair for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeDisabledException "DisabledException"
+//   The request was rejected because the specified CMK is not enabled.
+//
+//   * ErrCodeKeyUnavailableException "KeyUnavailableException"
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
+//   The system timed out while trying to fulfill the request. The request can
+//   be retried.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
+//
+//   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
+//   The request was rejected because the specified grant token is not valid.
+//
+//   * ErrCodeInternalException "KMSInternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeInvalidStateException "KMSInvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide .
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyPair
+func (c *KMS) GenerateDataKeyPair(input *GenerateDataKeyPairInput) (*GenerateDataKeyPairOutput, error) {
+	req, out := c.GenerateDataKeyPairRequest(input)
+	return out, req.Send()
+}
+
+// GenerateDataKeyPairWithContext is the same as GenerateDataKeyPair with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GenerateDataKeyPair for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) GenerateDataKeyPairWithContext(ctx aws.Context, input *GenerateDataKeyPairInput, opts ...request.Option) (*GenerateDataKeyPairOutput, error) {
+	req, out := c.GenerateDataKeyPairRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGenerateDataKeyPairWithoutPlaintext = "GenerateDataKeyPairWithoutPlaintext"
+
+// GenerateDataKeyPairWithoutPlaintextRequest generates a "aws/request.Request" representing the
+// client's request for the GenerateDataKeyPairWithoutPlaintext operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GenerateDataKeyPairWithoutPlaintext for more information on using the GenerateDataKeyPairWithoutPlaintext
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GenerateDataKeyPairWithoutPlaintextRequest method.
+//    req, resp := client.GenerateDataKeyPairWithoutPlaintextRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyPairWithoutPlaintext
+func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyPairWithoutPlaintextInput) (req *request.Request, output *GenerateDataKeyPairWithoutPlaintextOutput) {
+	op := &request.Operation{
+		Name:       opGenerateDataKeyPairWithoutPlaintext,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GenerateDataKeyPairWithoutPlaintextInput{}
+	}
+
+	output = &GenerateDataKeyPairWithoutPlaintextOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GenerateDataKeyPairWithoutPlaintext API operation for AWS Key Management Service.
+//
+// Generates a unique asymmetric data key pair. The GenerateDataKeyPairWithoutPlaintext
+// operation returns a plaintext public key and a copy of the private key that
+// is encrypted under the symmetric CMK you specify. Unlike GenerateDataKeyPair,
+// this operation does not return a plaintext private key.
+//
+// To generate a data key pair, you must specify a symmetric customer master
+// key (CMK) to encrypt the private key in the data key pair. You cannot use
+// an asymmetric CMK. To get the type of your CMK, use the KeySpec field in
+// the DescribeKey response.
+//
+// You can use the public key that GenerateDataKeyPairWithoutPlaintext returns
+// to encrypt data or verify a signature outside of AWS KMS. Then, store the
+// encrypted private key with the data. When you are ready to decrypt data or
+// sign a message, you can use the Decrypt operation to decrypt the encrypted
+// private key.
+//
+// GenerateDataKeyPairWithoutPlaintext returns a unique data key pair for each
+// request. The bytes in the key are not related to the caller or CMK that is
+// used to encrypt the private key.
+//
+// You can use the optional encryption context to add additional security to
+// the encryption operation. If you specify an EncryptionContext, you must specify
+// the same encryption context (a case-sensitive exact match) when decrypting
+// the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
+// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// in the AWS Key Management Service Developer Guide.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation GenerateDataKeyPairWithoutPlaintext for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeDisabledException "DisabledException"
+//   The request was rejected because the specified CMK is not enabled.
+//
+//   * ErrCodeKeyUnavailableException "KeyUnavailableException"
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
+//   The system timed out while trying to fulfill the request. The request can
+//   be retried.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
+//
+//   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
+//   The request was rejected because the specified grant token is not valid.
+//
+//   * ErrCodeInternalException "KMSInternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeInvalidStateException "KMSInvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide .
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyPairWithoutPlaintext
+func (c *KMS) GenerateDataKeyPairWithoutPlaintext(input *GenerateDataKeyPairWithoutPlaintextInput) (*GenerateDataKeyPairWithoutPlaintextOutput, error) {
+	req, out := c.GenerateDataKeyPairWithoutPlaintextRequest(input)
+	return out, req.Send()
+}
+
+// GenerateDataKeyPairWithoutPlaintextWithContext is the same as GenerateDataKeyPairWithoutPlaintext with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GenerateDataKeyPairWithoutPlaintext for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) GenerateDataKeyPairWithoutPlaintextWithContext(ctx aws.Context, input *GenerateDataKeyPairWithoutPlaintextInput, opts ...request.Option) (*GenerateDataKeyPairWithoutPlaintextOutput, error) {
+	req, out := c.GenerateDataKeyPairWithoutPlaintextRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2531,18 +3081,16 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 
 // GenerateDataKeyWithoutPlaintext API operation for AWS Key Management Service.
 //
-// Generates a unique data key. This operation returns a data key that is encrypted
-// under a customer master key (CMK) that you specify. GenerateDataKeyWithoutPlaintext
-// is identical to GenerateDataKey except that returns only the encrypted copy
-// of the data key.
+// Generates a unique symmetric data key. This operation returns a data key
+// that is encrypted under a customer master key (CMK) that you specify. To
+// request an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
+// operations.
 //
-// Like GenerateDataKey, GenerateDataKeyWithoutPlaintext returns a unique data
-// key for each request. The bytes in the key are not related to the caller
-// or CMK that is used to encrypt the data key.
-//
-// This operation is useful for systems that need to encrypt data at some point,
-// but not immediately. When you need to encrypt the data, you call the Decrypt
-// operation on the encrypted copy of the key.
+// GenerateDataKeyWithoutPlaintext is identical to the GenerateDataKey operation
+// except that returns only the encrypted copy of the data key. This operation
+// is useful for systems that need to encrypt data at some point, but not immediately.
+// When you need to encrypt the data, you call the Decrypt operation on the
+// encrypted copy of the key.
 //
 // It's also useful in distributed systems with different levels of trust. For
 // example, you might store encrypted data in containers. One component of your
@@ -2553,8 +3101,31 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // the plaintext data key. In this system, the component that creates the containers
 // never sees the plaintext data key.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// GenerateDataKeyWithoutPlaintext returns a unique data key for each request.
+// The bytes in the keys are not related to the caller or CMK that is used to
+// encrypt the private key.
+//
+// To generate a data key, you must specify the symmetric customer master key
+// (CMK) that is used to encrypt the data key. You cannot use an asymmetric
+// CMK to generate a data key. To get the type of your CMK, use the KeySpec
+// field in the DescribeKey response. You must also specify the length of the
+// data key using either the KeySpec or NumberOfBytes field (but not both).
+// For common key lengths (128-bit and 256-bit symmetric keys), use the KeySpec
+// parameter.
+//
+// If the operation succeeds, you will find the plaintext copy of the data key
+// in the Plaintext field of the response, and the encrypted copy of the data
+// key in the CiphertextBlob field.
+//
+// You can use the optional encryption context to add additional security to
+// the encryption operation. If you specify an EncryptionContext, you must specify
+// the same encryption context (a case-sensitive exact match) when decrypting
+// the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
+// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// in the AWS Key Management Service Developer Guide.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2573,15 +3144,27 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   The request was rejected because the specified CMK is not enabled.
 //
 //   * ErrCodeKeyUnavailableException "KeyUnavailableException"
-//   The request was rejected because the specified CMK was not available. The
-//   request can be retried.
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
 //
 //   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
 //   The system timed out while trying to fulfill the request. The request can
 //   be retried.
 //
 //   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
-//   The request was rejected because the specified KeySpec value is not valid.
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
 //
 //   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
 //   The request was rejected because the specified grant token is not valid.
@@ -2596,7 +3179,7 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyWithoutPlaintext
 func (c *KMS) GenerateDataKeyWithoutPlaintext(input *GenerateDataKeyWithoutPlaintextInput) (*GenerateDataKeyWithoutPlaintextOutput, error) {
@@ -2813,7 +3396,7 @@ func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Reques
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetKeyPolicy
 func (c *KMS) GetKeyPolicy(input *GetKeyPolicyInput) (*GetKeyPolicyOutput, error) {
@@ -2885,8 +3468,12 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 // material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
 // is enabled for the specified customer master key (CMK).
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
+// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// The key rotation status for these CMKs is always false.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 //    * Disabled: The key rotation status does not change when you disable a
@@ -2930,7 +3517,7 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeUnsupportedOperationException "UnsupportedOperationException"
 //   The request was rejected because a specified parameter is not supported or
@@ -3002,26 +3589,29 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 
 // GetParametersForImport API operation for AWS Key Management Service.
 //
-// Returns the items you need in order to import key material into AWS KMS from
-// your existing key management infrastructure. For more information about importing
-// key material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// Returns the items you need to import key material into a symmetric, customer
+// managed customer master key (CMK). For more information about importing key
+// material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
 // in the AWS Key Management Service Developer Guide.
 //
-// You must specify the key ID of the customer master key (CMK) into which you
-// will import key material. This CMK's Origin must be EXTERNAL. You must also
-// specify the wrapping algorithm and type of wrapping key (public key) that
-// you will use to encrypt the key material. You cannot perform this operation
-// on a CMK in a different AWS account.
-//
 // This operation returns a public key and an import token. Use the public key
-// to encrypt the key material. Store the import token to send with a subsequent
-// ImportKeyMaterial request. The public key and import token from the same
-// response must be used together. These items are valid for 24 hours. When
-// they expire, they cannot be used for a subsequent ImportKeyMaterial request.
-// To get new ones, send another GetParametersForImport request.
+// to encrypt the symmetric key material. Store the import token to send with
+// a subsequent ImportKeyMaterial request.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// You must specify the key ID of the symmetric CMK into which you will import
+// key material. This CMK's Origin must be EXTERNAL. You must also specify the
+// wrapping algorithm and type of wrapping key (public key) that you will use
+// to encrypt the key material. You cannot perform this operation on an asymmetric
+// CMK or on any CMK in a different AWS account.
+//
+// To import key material, you must use the public key and import token from
+// the same response. These items are valid for 24 hours. The expiration date
+// and time appear in the GetParametersForImport response. You cannot use an
+// expired token in an ImportKeyMaterial request. If your key and token expire,
+// send another GetParametersForImport request.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3058,7 +3648,7 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetParametersForImport
 func (c *KMS) GetParametersForImport(input *GetParametersForImportInput) (*GetParametersForImportOutput, error) {
@@ -3077,6 +3667,175 @@ func (c *KMS) GetParametersForImport(input *GetParametersForImportInput) (*GetPa
 // for more information on using Contexts.
 func (c *KMS) GetParametersForImportWithContext(ctx aws.Context, input *GetParametersForImportInput, opts ...request.Option) (*GetParametersForImportOutput, error) {
 	req, out := c.GetParametersForImportRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetPublicKey = "GetPublicKey"
+
+// GetPublicKeyRequest generates a "aws/request.Request" representing the
+// client's request for the GetPublicKey operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetPublicKey for more information on using the GetPublicKey
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetPublicKeyRequest method.
+//    req, resp := client.GetPublicKeyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetPublicKey
+func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Request, output *GetPublicKeyOutput) {
+	op := &request.Operation{
+		Name:       opGetPublicKey,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetPublicKeyInput{}
+	}
+
+	output = &GetPublicKeyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetPublicKey API operation for AWS Key Management Service.
+//
+// Returns the public key of an asymmetric CMK. Unlike the private key of a
+// asymmetric CMK, which never leaves AWS KMS unencrypted, callers with kms:GetPublicKey
+// permission can download the public key of an asymmetric CMK. You can share
+// the public key to allow others to encrypt messages and verify signatures
+// outside of AWS KMS. For information about symmetric and asymmetric CMKs,
+// see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// You do not need to download the public key. Instead, you can use the public
+// key within AWS KMS by calling the Encrypt, ReEncrypt, or Verify operations
+// with the identifier of an asymmetric CMK. When you use the public key within
+// AWS KMS, you benefit from the authentication, authorization, and logging
+// that are part of every AWS KMS operation. You also reduce of risk of encrypting
+// data that cannot be decrypted. These features are not effective outside of
+// AWS KMS. For details, see Special Considerations for Downloading Public Keys
+// (https://docs.aws.amazon.com/kms/latest/developerguide/download-public-key.html#download-public-key-considerations).
+//
+// To help you use the public key safely outside of AWS KMS, GetPublicKey returns
+// important information about the public key in the response, including:
+//
+//    * CustomerMasterKeySpec (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-CustomerMasterKeySpec):
+//    The type of key material in the public key, such as RSA_4096 or ECC_NIST_P521.
+//
+//    * KeyUsage (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeyUsage):
+//    Whether the key is used for encryption or signing.
+//
+//    * EncryptionAlgorithms (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-EncryptionAlgorithms)
+//    or SigningAlgorithms (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-SigningAlgorithms):
+//    A list of the encryption algorithms or the signing algorithms for the
+//    key.
+//
+// Although AWS KMS cannot enforce these restrictions on external operations,
+// it is crucial that you use this information to prevent the public key from
+// being used improperly. For example, you can prevent a public signing key
+// from being used encrypt data, or prevent a public key from being used with
+// an encryption algorithm that is not supported by AWS KMS. You can also avoid
+// errors, such as using the wrong signing algorithm in a verification operation.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation GetPublicKey for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeDisabledException "DisabledException"
+//   The request was rejected because the specified CMK is not enabled.
+//
+//   * ErrCodeKeyUnavailableException "KeyUnavailableException"
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
+//   The system timed out while trying to fulfill the request. The request can
+//   be retried.
+//
+//   * ErrCodeUnsupportedOperationException "UnsupportedOperationException"
+//   The request was rejected because a specified parameter is not supported or
+//   a specified resource is not valid for this operation.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The request was rejected because a specified ARN, or an ARN in a key policy,
+//   is not valid.
+//
+//   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
+//   The request was rejected because the specified grant token is not valid.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
+//
+//   * ErrCodeInternalException "KMSInternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeInvalidStateException "KMSInvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide .
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetPublicKey
+func (c *KMS) GetPublicKey(input *GetPublicKeyInput) (*GetPublicKeyOutput, error) {
+	req, out := c.GetPublicKeyRequest(input)
+	return out, req.Send()
+}
+
+// GetPublicKeyWithContext is the same as GetPublicKey with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetPublicKey for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) GetPublicKeyWithContext(ctx aws.Context, input *GetPublicKeyInput, opts ...request.Option) (*GetPublicKeyOutput, error) {
+	req, out := c.GetPublicKeyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -3127,11 +3886,14 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 
 // ImportKeyMaterial API operation for AWS Key Management Service.
 //
-// Imports key material into an existing AWS KMS customer master key (CMK) that
-// was created without key material. You cannot perform this operation on a
-// CMK in a different AWS account. For more information about creating CMKs
-// with no key material and then importing key material, see Importing Key Material
-// (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// Imports key material into an existing symmetric AWS KMS customer master key
+// (CMK) that was created without key material. After you successfully import
+// key material into a CMK, you can reimport the same key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material)
+// into that CMK, but you cannot import different key material.
+//
+// You cannot perform this operation on an asymmetric CMK or on any CMK in a
+// different AWS account. For more information about creating CMKs with no key
+// material and then importing key material, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Before using this operation, call GetParametersForImport. Its response includes
@@ -3148,23 +3910,27 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //    * The encrypted key material. To get the public key to encrypt the key
 //    material, call GetParametersForImport.
 //
-//    * The import token that GetParametersForImport returned. This token and
-//    the public key used to encrypt the key material must have come from the
-//    same response.
+//    * The import token that GetParametersForImport returned. You must use
+//    a public key and token from the same GetParametersForImport response.
 //
 //    * Whether the key material expires and if so, when. If you set an expiration
-//    date, you can change it only by reimporting the same key material and
-//    specifying a new expiration date. If the key material expires, AWS KMS
-//    deletes the key material and the CMK becomes unusable. To use the CMK
-//    again, you must reimport the same key material.
+//    date, AWS KMS deletes the key material from the CMK on the specified date,
+//    and the CMK becomes unusable. To use the CMK again, you must reimport
+//    the same key material. The only way to change an expiration date is by
+//    reimporting the same key material and specifying a new expiration date.
 //
 // When this operation is successful, the key state of the CMK changes from
-// PendingImport to Enabled, and you can use the CMK. After you successfully
-// import key material into a CMK, you can reimport the same key material into
-// that CMK, but you cannot import different key material.
+// PendingImport to Enabled, and you can use the CMK.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// If this operation fails, use the exception to help determine the problem.
+// If the error is related to the key material, the import token, or wrapping
+// key, use GetParametersForImport to get a new public key and import token
+// for the CMK and repeat the import procedure. For help, see How To Import
+// Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#importing-keys-overview)
+// in the AWS Key Management Service Developer Guide.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3201,20 +3967,24 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeInvalidCiphertextException "InvalidCiphertextException"
-//   The request was rejected because the specified ciphertext, or additional
-//   authenticated data incorporated into the ciphertext, such as the encryption
-//   context, is corrupted, missing, or otherwise invalid.
+//   From the Decrypt or ReEncrypt operation, the request was rejected because
+//   the specified ciphertext, or additional authenticated data incorporated into
+//   the ciphertext, such as the encryption context, is corrupted, missing, or
+//   otherwise invalid.
+//
+//   From the ImportKeyMaterial operation, the request was rejected because AWS
+//   KMS could not decrypt the encrypted (wrapped) key material.
 //
 //   * ErrCodeIncorrectKeyMaterialException "IncorrectKeyMaterialException"
-//   The request was rejected because the provided key material is invalid or
-//   is not the same key material that was previously imported into this customer
-//   master key (CMK).
+//   The request was rejected because the key material in the request is, expired,
+//   invalid, or is not the same key material that was previously imported into
+//   this customer master key (CMK).
 //
 //   * ErrCodeExpiredImportTokenException "ExpiredImportTokenException"
-//   The request was rejected because the provided import token is expired. Use
+//   The request was rejected because the specified import token is expired. Use
 //   GetParametersForImport to get a new import token and public key, use the
 //   new public key to encrypt the key material, and then try the request again.
 //
@@ -3404,10 +4174,12 @@ func (c *KMS) ListAliasesPagesWithContext(ctx aws.Context, input *ListAliasesInp
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListAliasesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListAliasesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3500,7 +4272,7 @@ func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, o
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListGrants
 func (c *KMS) ListGrants(input *ListGrantsInput) (*ListGrantsResponse, error) {
@@ -3567,10 +4339,12 @@ func (c *KMS) ListGrantsPagesWithContext(ctx aws.Context, input *ListGrantsInput
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListGrantsResponse), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListGrantsResponse), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3659,7 +4433,7 @@ func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListKeyPolicies
 func (c *KMS) ListKeyPolicies(input *ListKeyPoliciesInput) (*ListKeyPoliciesOutput, error) {
@@ -3726,10 +4500,12 @@ func (c *KMS) ListKeyPoliciesPagesWithContext(ctx aws.Context, input *ListKeyPol
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListKeyPoliciesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListKeyPoliciesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -3784,7 +4560,7 @@ func (c *KMS) ListKeysRequest(input *ListKeysInput) (req *request.Request, outpu
 // ListKeys API operation for AWS Key Management Service.
 //
 // Gets a list of all customer master keys (CMKs) in the caller's AWS account
-// and region.
+// and Region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3871,10 +4647,12 @@ func (c *KMS) ListKeysPagesWithContext(ctx aws.Context, input *ListKeysInput, fn
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListKeysOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListKeysOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -4166,7 +4944,7 @@ func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Reques
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/PutKeyPolicy
 func (c *KMS) PutKeyPolicy(input *PutKeyPolicyInput) (*PutKeyPolicyOutput, error) {
@@ -4234,23 +5012,66 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 
 // ReEncrypt API operation for AWS Key Management Service.
 //
-// Encrypts data on the server side with a new customer master key (CMK) without
-// exposing the plaintext of the data on the client side. The data is first
-// decrypted and then reencrypted. You can also use this operation to change
-// the encryption context of a ciphertext.
+// Decrypts ciphertext and then reencrypts it entirely within AWS KMS. You can
+// use this operation to change the customer master key (CMK) under which data
+// is encrypted, such as when you manually rotate (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
+// a CMK or change the CMK that protects a ciphertext. You can also use it to
+// reencrypt ciphertext under the same CMK, such as to change the encryption
+// context of a ciphertext.
 //
-// You can reencrypt data using CMKs in different AWS accounts.
+// The ReEncrypt operation can decrypt ciphertext that was encrypted by using
+// an AWS KMS CMK in an AWS KMS operation, such as Encrypt or GenerateDataKey.
+// It can also decrypt ciphertext that was encrypted by using the public key
+// of an asymmetric CMK outside of AWS KMS. However, it cannot decrypt ciphertext
+// produced by other libraries, such as the AWS Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
+// These libraries return a ciphertext format that is incompatible with AWS
+// KMS.
 //
-// Unlike other operations, ReEncrypt is authorized twice, once as ReEncryptFrom
-// on the source CMK and once as ReEncryptTo on the destination CMK. We recommend
-// that you include the "kms:ReEncrypt*" permission in your key policies (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
-// to permit reencryption from or to the CMK. This permission is automatically
-// included in the key policy when you create a CMK through the console. But
-// you must include it manually when you create a CMK programmatically or when
-// you set a key policy with the PutKeyPolicy operation.
+// When you use the ReEncrypt operation, you need to provide information for
+// the decrypt operation and the subsequent encrypt operation.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//    * If your ciphertext was encrypted under an asymmetric CMK, you must identify
+//    the source CMK, that is, the CMK that encrypted the ciphertext. You must
+//    also supply the encryption algorithm that was used. This information is
+//    required to decrypt the data.
+//
+//    * It is optional, but you can specify a source CMK even when the ciphertext
+//    was encrypted under a symmetric CMK. This ensures that the ciphertext
+//    is decrypted only by using a particular CMK. If the CMK that you specify
+//    cannot decrypt the ciphertext, the ReEncrypt operation fails.
+//
+//    * To reencrypt the data, you must specify the destination CMK, that is,
+//    the CMK that re-encrypts the data after it is decrypted. You can select
+//    a symmetric or asymmetric CMK. If the destination CMK is an asymmetric
+//    CMK, you must also provide the encryption algorithm. The algorithm that
+//    you choose must be compatible with the CMK. When you use an asymmetric
+//    CMK to encrypt or reencrypt data, be sure to record the CMK and encryption
+//    algorithm that you choose. You will be required to provide the same CMK
+//    and encryption algorithm when you decrypt the data. If the CMK and algorithm
+//    do not match the values used to encrypt the data, the decrypt operation
+//    fails. You are not required to supply the CMK ID and encryption algorithm
+//    when you decrypt with symmetric CMKs because AWS KMS stores this information
+//    in the ciphertext blob. AWS KMS cannot store metadata in ciphertext generated
+//    with asymmetric keys. The standard format for asymmetric key ciphertext
+//    does not include configurable fields.
+//
+// Unlike other AWS KMS API operations, ReEncrypt callers must have two permissions:
+//
+//    * kms:EncryptFrom permission on the source CMK
+//
+//    * kms:EncryptTo permission on the destination CMK
+//
+// To permit reencryption from
+//
+// or to a CMK, include the "kms:ReEncrypt*" permission in your key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html).
+// This permission is automatically included in the key policy when you use
+// the console to create a CMK. But you must include it manually when you create
+// a CMK programmatically or when you use the PutKeyPolicy operation set a key
+// policy.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4269,20 +5090,41 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   The request was rejected because the specified CMK is not enabled.
 //
 //   * ErrCodeInvalidCiphertextException "InvalidCiphertextException"
-//   The request was rejected because the specified ciphertext, or additional
-//   authenticated data incorporated into the ciphertext, such as the encryption
-//   context, is corrupted, missing, or otherwise invalid.
+//   From the Decrypt or ReEncrypt operation, the request was rejected because
+//   the specified ciphertext, or additional authenticated data incorporated into
+//   the ciphertext, such as the encryption context, is corrupted, missing, or
+//   otherwise invalid.
+//
+//   From the ImportKeyMaterial operation, the request was rejected because AWS
+//   KMS could not decrypt the encrypted (wrapped) key material.
 //
 //   * ErrCodeKeyUnavailableException "KeyUnavailableException"
-//   The request was rejected because the specified CMK was not available. The
-//   request can be retried.
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeIncorrectKeyException "IncorrectKeyException"
+//   The request was rejected because the specified CMK cannot decrypt the data.
+//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same CMK that was used to encrypt the ciphertext.
 //
 //   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
 //   The system timed out while trying to fulfill the request. The request can
 //   be retried.
 //
 //   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
-//   The request was rejected because the specified KeySpec value is not valid.
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
 //
 //   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
 //   The request was rejected because the specified grant token is not valid.
@@ -4297,7 +5139,7 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ReEncrypt
 func (c *KMS) ReEncrypt(input *ReEncryptInput) (*ReEncryptOutput, error) {
@@ -4419,7 +5261,7 @@ func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RetireGrant
 func (c *KMS) RetireGrant(input *RetireGrantInput) (*RetireGrantOutput, error) {
@@ -4527,7 +5369,7 @@ func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RevokeGrant
 func (c *KMS) RevokeGrant(input *RevokeGrantInput) (*RevokeGrantOutput, error) {
@@ -4621,8 +5463,8 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 // Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
 // in the AWS Key Management Service Developer Guide.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4655,7 +5497,7 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ScheduleKeyDeletion
 func (c *KMS) ScheduleKeyDeletion(input *ScheduleKeyDeletionInput) (*ScheduleKeyDeletionOutput, error) {
@@ -4674,6 +5516,164 @@ func (c *KMS) ScheduleKeyDeletion(input *ScheduleKeyDeletionInput) (*ScheduleKey
 // for more information on using Contexts.
 func (c *KMS) ScheduleKeyDeletionWithContext(ctx aws.Context, input *ScheduleKeyDeletionInput, opts ...request.Option) (*ScheduleKeyDeletionOutput, error) {
 	req, out := c.ScheduleKeyDeletionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opSign = "Sign"
+
+// SignRequest generates a "aws/request.Request" representing the
+// client's request for the Sign operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See Sign for more information on using the Sign
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SignRequest method.
+//    req, resp := client.SignRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Sign
+func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignOutput) {
+	op := &request.Operation{
+		Name:       opSign,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &SignInput{}
+	}
+
+	output = &SignOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// Sign API operation for AWS Key Management Service.
+//
+// Creates a digital signature (https://en.wikipedia.org/wiki/Digital_signature)
+// for a message or message digest by using the private key in an asymmetric
+// CMK. To verify the signature, use the Verify operation, or use the public
+// key in the same asymmetric CMK outside of AWS KMS. For information about
+// symmetric and asymmetric CMKs, see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Digital signatures are generated and verified by using asymmetric key pair,
+// such as an RSA or ECC pair that is represented by an asymmetric customer
+// master key (CMK). The key owner (or an authorized user) uses their private
+// key to sign a message. Anyone with the public key can verify that the message
+// was signed with that particular private key and that the message hasn't changed
+// since it was signed.
+//
+// To use the Sign operation, provide the following information:
+//
+//    * Use the KeyId parameter to identify an asymmetric CMK with a KeyUsage
+//    value of SIGN_VERIFY. To get the KeyUsage value of a CMK, use the DescribeKey
+//    operation. The caller must have kms:Sign permission on the CMK.
+//
+//    * Use the Message parameter to specify the message or message digest to
+//    sign. You can submit messages of up to 4096 bytes. To sign a larger message,
+//    generate a hash digest of the message, and then provide the hash digest
+//    in the Message parameter. To indicate whether the message is a full message
+//    or a digest, use the MessageType parameter.
+//
+//    * Choose a signing algorithm that is compatible with the CMK.
+//
+// When signing a message, be sure to record the CMK and the signing algorithm.
+// This information is required to verify the signature.
+//
+// To verify the signature that this operation generates, use the Verify operation.
+// Or use the GetPublicKey operation to download the public key and then use
+// the public key to verify the signature outside of AWS KMS.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation Sign for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeDisabledException "DisabledException"
+//   The request was rejected because the specified CMK is not enabled.
+//
+//   * ErrCodeKeyUnavailableException "KeyUnavailableException"
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
+//   The system timed out while trying to fulfill the request. The request can
+//   be retried.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
+//
+//   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
+//   The request was rejected because the specified grant token is not valid.
+//
+//   * ErrCodeInternalException "KMSInternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeInvalidStateException "KMSInvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide .
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Sign
+func (c *KMS) Sign(input *SignInput) (*SignOutput, error) {
+	req, out := c.SignRequest(input)
+	return out, req.Send()
+}
+
+// SignWithContext is the same as Sign with the addition of
+// the ability to pass a context and additional request options.
+//
+// See Sign for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) SignWithContext(ctx aws.Context, input *SignInput, opts ...request.Option) (*SignOutput, error) {
+	req, out := c.SignRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4737,8 +5737,8 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 // User-Defined Tag Restrictions (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html)
 // in the AWS Billing and Cost Management User Guide.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4767,7 +5767,7 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The request was rejected because a limit was exceeded. For more information,
@@ -4850,8 +5850,8 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 // To remove a tag, specify the tag key. To change the tag value of an existing
 // tag key, use TagResource.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4880,7 +5880,7 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 //   * ErrCodeTagException "TagException"
 //   The request was rejected because one or more tags are not valid.
@@ -4952,27 +5952,28 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 
 // UpdateAlias API operation for AWS Key Management Service.
 //
-// Associates an existing alias with a different customer master key (CMK).
-// Each CMK can have multiple aliases, but the aliases must be unique within
-// the account and region. You cannot perform this operation on an alias in
-// a different AWS account.
+// Associates an existing AWS KMS alias with a different customer master key
+// (CMK). Each alias is associated with only one CMK at a time, although a CMK
+// can have multiple aliases. The alias and the CMK must be in the same AWS
+// account and region. You cannot perform this operation on an alias in a different
+// AWS account.
 //
-// This operation works only on existing aliases. To change the alias of a CMK
-// to a new value, use CreateAlias to create a new alias and DeleteAlias to
-// delete the old alias.
+// The current and new CMK must be the same type (both symmetric or both asymmetric),
+// and they must have the same key usage (ENCRYPT_DECRYPT or SIGN_VERIFY). This
+// restriction prevents errors in code that uses aliases. If you must assign
+// an alias to a different type of CMK, use DeleteAlias to delete the old alias
+// and CreateAlias to create a new alias.
+//
+// You cannot use UpdateAlias to change an alias name. To change an alias name,
+// use DeleteAlias to delete the old alias and CreateAlias to create a new alias.
 //
 // Because an alias is not a property of a CMK, you can create, update, and
 // delete the aliases of a CMK without affecting the CMK. Also, aliases do not
 // appear in the response from the DescribeKey operation. To get the aliases
 // of all CMKs in the account, use the ListAliases operation.
 //
-// The alias name must begin with alias/ followed by a name, such as alias/ExampleAlias.
-// It can contain only alphanumeric characters, forward slashes (/), underscores
-// (_), and dashes (-). The alias name cannot begin with alias/aws/. The alias/aws/
-// prefix is reserved for AWS managed CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
-//
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5001,7 +6002,7 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateAlias
 func (c *KMS) UpdateAlias(input *UpdateAliasInput) (*UpdateAliasOutput, error) {
@@ -5116,6 +6117,11 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //   * ErrCodeCustomKeyStoreNotFoundException "CustomKeyStoreNotFoundException"
 //   The request was rejected because AWS KMS cannot find a custom key store with
 //   the specified key store name or ID.
+//
+//   * ErrCodeCustomKeyStoreNameInUseException "CustomKeyStoreNameInUseException"
+//   The request was rejected because the specified custom key store name is already
+//   assigned to another custom key store in the account. Try again with a custom
+//   key store name that is unique in the account.
 //
 //   * ErrCodeCloudHsmClusterNotFoundException "CloudHsmClusterNotFoundException"
 //   The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
@@ -5270,8 +6276,8 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 //
 // You cannot perform this operation on a CMK in a different AWS account.
 //
-// The result of this operation varies with the key state of the CMK. For details,
-// see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5304,7 +6310,7 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 //
 //   For more information about how key state affects the use of a CMK, see How
 //   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the AWS Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateKeyDescription
 func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKeyDescriptionOutput, error) {
@@ -5323,6 +6329,161 @@ func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKey
 // for more information on using Contexts.
 func (c *KMS) UpdateKeyDescriptionWithContext(ctx aws.Context, input *UpdateKeyDescriptionInput, opts ...request.Option) (*UpdateKeyDescriptionOutput, error) {
 	req, out := c.UpdateKeyDescriptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opVerify = "Verify"
+
+// VerifyRequest generates a "aws/request.Request" representing the
+// client's request for the Verify operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See Verify for more information on using the Verify
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the VerifyRequest method.
+//    req, resp := client.VerifyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Verify
+func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *VerifyOutput) {
+	op := &request.Operation{
+		Name:       opVerify,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &VerifyInput{}
+	}
+
+	output = &VerifyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// Verify API operation for AWS Key Management Service.
+//
+// Verifies a digital signature that was generated by the Sign operation.
+//
+// Verification confirms that an authorized user signed the message with the
+// specified CMK and signing algorithm, and the message hasn't changed since
+// it was signed. If the signature is verified, the value of the SignatureValid
+// field in the response is True. If the signature verification fails, the Verify
+// operation fails with an KMSInvalidSignatureException exception.
+//
+// A digital signature is generated by using the private key in an asymmetric
+// CMK. The signature is verified by using the public key in the same asymmetric
+// CMK. For information about symmetric and asymmetric CMKs, see Using Symmetric
+// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// To verify a digital signature, you can use the Verify operation. Specify
+// the same asymmetric CMK, message, and signing algorithm that were used to
+// produce the signature.
+//
+// You can also verify the digital signature by using the public key of the
+// CMK outside of AWS KMS. Use the GetPublicKey operation to download the public
+// key in the asymmetric CMK and then use the public key to verify the signature
+// outside of AWS KMS. The advantage of using the Verify operation is that it
+// is performed within AWS KMS. As a result, it's easy to call, the operation
+// is performed within the FIPS boundary, it is logged in AWS CloudTrail, and
+// you can use key policy and IAM policy to determine who is authorized to use
+// the CMK to verify signatures.
+//
+// The CMK that you use for this operation must be in a compatible key state.
+// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the AWS Key Management Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation Verify for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeDisabledException "DisabledException"
+//   The request was rejected because the specified CMK is not enabled.
+//
+//   * ErrCodeKeyUnavailableException "KeyUnavailableException"
+//   The request was rejected because the specified CMK was not available. You
+//   can retry the request.
+//
+//   * ErrCodeDependencyTimeoutException "DependencyTimeoutException"
+//   The system timed out while trying to fulfill the request. The request can
+//   be retried.
+//
+//   * ErrCodeInvalidKeyUsageException "InvalidKeyUsageException"
+//   The request was rejected for one of the following reasons:
+//
+//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//
+//      * The encryption algorithm or signing algorithm specified for the operation
+//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//
+//   For encrypting, decrypting, re-encrypting, and generating data keys, the
+//   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//
+//   To find the encryption or signing algorithms supported for a particular CMK,
+//   use the DescribeKey operation.
+//
+//   * ErrCodeInvalidGrantTokenException "InvalidGrantTokenException"
+//   The request was rejected because the specified grant token is not valid.
+//
+//   * ErrCodeInternalException "KMSInternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeInvalidStateException "KMSInvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide .
+//
+//   * ErrCodeKMSInvalidSignatureException "KMSInvalidSignatureException"
+//   The request was rejected because the signature verification failed. Signature
+//   verification fails when it cannot confirm that signature was produced by
+//   signing the specified message with the specified CMK and signing algorithm.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Verify
+func (c *KMS) Verify(input *VerifyInput) (*VerifyOutput, error) {
+	req, out := c.VerifyRequest(input)
+	return out, req.Send()
+}
+
+// VerifyWithContext is the same as Verify with the addition of
+// the ability to pass a context and additional request options.
+//
+// See Verify for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) VerifyWithContext(ctx aws.Context, input *VerifyInput, opts ...request.Option) (*VerifyOutput, error) {
+	req, out := c.VerifyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5925,6 +7086,9 @@ type CreateKeyInput struct {
 	// the custom key store must have at least two active HSMs, each in a different
 	// Availability Zone in the Region.
 	//
+	// This parameter is valid only for symmetric CMKs. You cannot create an asymmetric
+	// CMK in a custom key store.
+	//
 	// To find the ID of a custom key store, use the DescribeCustomKeyStores operation.
 	//
 	// The response includes the custom key store ID and the ID of the AWS CloudHSM
@@ -5935,33 +7099,69 @@ type CreateKeyInput struct {
 	// of AWS KMS with the isolation and control of a single-tenant key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
+	// Specifies the type of CMK to create. The CustomerMasterKeySpec determines
+	// whether the CMK contains a symmetric key or an asymmetric key pair. It also
+	// determines the encryption algorithms or signing algorithms that the CMK supports.
+	// You can't change the CustomerMasterKeySpec after the CMK is created. To further
+	// restrict the algorithms that can be used with the CMK, use its key policy
+	// or IAM policy.
+	//
+	// For help with choosing a key spec for your CMK, see Selecting a Customer
+	// Master Key Spec (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#cmk-key-spec)
+	// in the AWS Key Management Service Developer Guide.
+	//
+	// The default value, SYMMETRIC_DEFAULT, creates a CMK with a 256-bit symmetric
+	// key.
+	//
+	// AWS KMS supports the following key specs for CMKs:
+	//
+	//    * Symmetric key (default) SYMMETRIC_DEFAULT (AES-256-GCM)
+	//
+	//    * Asymmetric RSA key pairs RSA_2048 RSA_3072 RSA_4096
+	//
+	//    * Asymmetric NIST-recommended elliptic curve key pairs ECC_NIST_P256 (secp256r1)
+	//    ECC_NIST_P384 (secp384r1) ECC_NIST_P521 (secp521r1)
+	//
+	//    * Other asymmetric elliptic curve key pairs ECC_SECG_P256K1 (secp256k1),
+	//    commonly used for cryptocurrencies.
+	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
+
 	// A description of the CMK.
 	//
 	// Use a description that helps you decide whether the CMK is appropriate for
 	// a task.
 	Description *string `type:"string"`
 
-	// The cryptographic operations for which you can use the CMK. The only valid
-	// value is ENCRYPT_DECRYPT, which means you can use the CMK to encrypt and
-	// decrypt data.
+	// Determines the cryptographic operations for which you can use the CMK. The
+	// default value is ENCRYPT_DECRYPT. This parameter is required only for asymmetric
+	// CMKs. You can't change the KeyUsage value after the CMK is created.
+	//
+	// Select only one valid value.
+	//
+	//    * For symmetric CMKs, omit the parameter or specify ENCRYPT_DECRYPT.
+	//
+	//    * For asymmetric CMKs with RSA key material, specify ENCRYPT_DECRYPT or
+	//    SIGN_VERIFY.
+	//
+	//    * For asymmetric CMKs with ECC key material, specify SIGN_VERIFY.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
 	// The source of the key material for the CMK. You cannot change the origin
-	// after you create the CMK.
-	//
-	// The default is AWS_KMS, which means AWS KMS creates the key material in its
-	// own key store.
+	// after you create the CMK. The default is AWS_KMS, which means AWS KMS creates
+	// the key material.
 	//
 	// When the parameter value is EXTERNAL, AWS KMS creates a CMK without key material
 	// so that you can import key material from your existing key management infrastructure.
 	// For more information about importing key material into AWS KMS, see Importing
 	// Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the AWS Key Management Service Developer Guide. This value is valid only
+	// for symmetric CMKs.
 	//
 	// When the parameter value is AWS_CLOUDHSM, AWS KMS creates the CMK in an AWS
 	// KMS custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
 	// and creates its key material in the associated AWS CloudHSM cluster. You
 	// must also use the CustomKeyStoreId parameter to identify the custom key store.
+	// This value is valid only for symmetric CMKs.
 	Origin *string `type:"string" enum:"OriginType"`
 
 	// The key policy to attach to the CMK.
@@ -5991,11 +7191,16 @@ type CreateKeyInput struct {
 	// The key policy size limit is 32 kilobytes (32768 bytes).
 	Policy *string `min:"1" type:"string"`
 
-	// One or more tags. Each tag consists of a tag key and a tag value. Tag keys
-	// and tag values are both required, but tag values can be empty (null) strings.
+	// One or more tags. Each tag consists of a tag key and a tag value. Both the
+	// tag key and the tag value are required, but the tag value can be an empty
+	// (null) string.
 	//
-	// Use this parameter to tag the CMK when it is created. Alternately, you can
-	// omit this parameter and instead tag the CMK after it is created using TagResource.
+	// When you add tags to an AWS resource, AWS generates a cost allocation report
+	// with usage and costs aggregated by tags. For information about adding, changing,
+	// deleting and listing tags for CMKs, see Tagging Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+	//
+	// Use this parameter to tag the CMK when it is created. To add tags to an existing
+	// CMK, use the TagResource operation.
 	Tags []*Tag `type:"list"`
 }
 
@@ -6044,6 +7249,12 @@ func (s *CreateKeyInput) SetBypassPolicyLockoutSafetyCheck(v bool) *CreateKeyInp
 // SetCustomKeyStoreId sets the CustomKeyStoreId field's value.
 func (s *CreateKeyInput) SetCustomKeyStoreId(v string) *CreateKeyInput {
 	s.CustomKeyStoreId = &v
+	return s
+}
+
+// SetCustomerMasterKeySpec sets the CustomerMasterKeySpec field's value.
+func (s *CreateKeyInput) SetCustomerMasterKeySpec(v string) *CreateKeyInput {
+	s.CustomerMasterKeySpec = &v
 	return s
 }
 
@@ -6233,9 +7444,28 @@ type DecryptInput struct {
 	// CiphertextBlob is a required field
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
-	// The encryption context. If this was specified in the Encrypt function, it
-	// must be specified here or the decryption operation will fail. For more information,
-	// see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context).
+	// Specifies the encryption algorithm that will be used to decrypt the ciphertext.
+	// Specify the same algorithm that was used to encrypt the data. If you specify
+	// a different algorithm, the Decrypt operation fails.
+	//
+	// This parameter is required only when the ciphertext was encrypted under an
+	// asymmetric CMK. The default value, SYMMETRIC_DEFAULT, represents the only
+	// supported algorithm that is valid for symmetric CMKs.
+	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
+	// Specifies the encryption context to use when decrypting the data. An encryption
+	// context is valid only for cryptographic operations with a symmetric CMK.
+	// The standard asymmetric encryption algorithms that AWS KMS uses do not support
+	// an encryption context.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
@@ -6243,6 +7473,35 @@ type DecryptInput struct {
 	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
+
+	// Specifies the customer master key (CMK) that AWS KMS will use to decrypt
+	// the ciphertext. Enter a key ID of the CMK that was used to encrypt the ciphertext.
+	//
+	// If you specify a KeyId value, the Decrypt operation succeeds only if the
+	// specified CMK was used to encrypt the ciphertext.
+	//
+	// This parameter is required only when the ciphertext was encrypted under an
+	// asymmetric CMK. Otherwise, AWS KMS uses the metadata that it adds to the
+	// ciphertext blob to determine which CMK was used to encrypt the ciphertext.
+	// However, you can use this parameter to ensure that a particular CMK (of any
+	// kind) is used to decrypt the ciphertext.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/".
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	KeyId *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -6264,6 +7523,9 @@ func (s *DecryptInput) Validate() error {
 	if s.CiphertextBlob != nil && len(s.CiphertextBlob) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("CiphertextBlob", 1))
 	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6274,6 +7536,12 @@ func (s *DecryptInput) Validate() error {
 // SetCiphertextBlob sets the CiphertextBlob field's value.
 func (s *DecryptInput) SetCiphertextBlob(v []byte) *DecryptInput {
 	s.CiphertextBlob = v
+	return s
+}
+
+// SetEncryptionAlgorithm sets the EncryptionAlgorithm field's value.
+func (s *DecryptInput) SetEncryptionAlgorithm(v string) *DecryptInput {
+	s.EncryptionAlgorithm = &v
 	return s
 }
 
@@ -6289,15 +7557,23 @@ func (s *DecryptInput) SetGrantTokens(v []*string) *DecryptInput {
 	return s
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *DecryptInput) SetKeyId(v string) *DecryptInput {
+	s.KeyId = &v
+	return s
+}
+
 type DecryptOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN of the key used to perform the decryption. This value is returned if
-	// no errors are encountered during the operation.
+	// The encryption algorithm that was used to decrypt the ciphertext.
+	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
+	// The ARN of the customer master key that was used to perform the decryption.
 	KeyId *string `min:"1" type:"string"`
 
 	// Decrypted plaintext data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -6311,6 +7587,12 @@ func (s DecryptOutput) String() string {
 // GoString returns the string representation
 func (s DecryptOutput) GoString() string {
 	return s.String()
+}
+
+// SetEncryptionAlgorithm sets the EncryptionAlgorithm field's value.
+func (s *DecryptOutput) SetEncryptionAlgorithm(v string) *DecryptOutput {
+	s.EncryptionAlgorithm = &v
+	return s
 }
 
 // SetKeyId sets the KeyId field's value.
@@ -6801,7 +8083,10 @@ func (s DisableKeyOutput) GoString() string {
 type DisableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Identifies a symmetric customer master key (CMK). You cannot enable automatic
+	// rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks),
+	// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+	// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	//
 	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
 	//
@@ -6987,7 +8272,9 @@ func (s EnableKeyOutput) GoString() string {
 type EnableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Identifies a symmetric customer master key (CMK). You cannot enable automatic
+	// rotation of asymmetric CMKs, CMKs with imported key material, or CMKs in
+	// a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	//
 	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
 	//
@@ -7052,10 +8339,27 @@ func (s EnableKeyRotationOutput) GoString() string {
 type EncryptInput struct {
 	_ struct{} `type:"structure"`
 
-	// Name-value pair that specifies the encryption context to be used for authenticated
-	// encryption. If used here, the same value must be supplied to the Decrypt
-	// API or decryption will fail. For more information, see Encryption Context
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context).
+	// Specifies the encryption algorithm that AWS KMS will use to encrypt the plaintext
+	// message. The algorithm must be compatible with the CMK that you specify.
+	//
+	// This parameter is required only for asymmetric CMKs. The default value, SYMMETRIC_DEFAULT,
+	// is the algorithm used for symmetric CMKs. If you are using an asymmetric
+	// CMK, we recommend RSAES_OAEP_SHA_256.
+	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
+	// Specifies the encryption context that will be used to encrypt the data. An
+	// encryption context is valid only for cryptographic operations with a symmetric
+	// CMK. The standard asymmetric encryption algorithms that AWS KMS uses do not
+	// support an encryption context.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
@@ -7126,6 +8430,12 @@ func (s *EncryptInput) Validate() error {
 	return nil
 }
 
+// SetEncryptionAlgorithm sets the EncryptionAlgorithm field's value.
+func (s *EncryptInput) SetEncryptionAlgorithm(v string) *EncryptInput {
+	s.EncryptionAlgorithm = &v
+	return s
+}
+
 // SetEncryptionContext sets the EncryptionContext field's value.
 func (s *EncryptInput) SetEncryptionContext(v map[string]*string) *EncryptInput {
 	s.EncryptionContext = v
@@ -7154,10 +8464,13 @@ type EncryptOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
+
+	// The encryption algorithm that was used to encrypt the plaintext.
+	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The ID of the key used during encryption.
 	KeyId *string `min:"1" type:"string"`
@@ -7179,6 +8492,12 @@ func (s *EncryptOutput) SetCiphertextBlob(v []byte) *EncryptOutput {
 	return s
 }
 
+// SetEncryptionAlgorithm sets the EncryptionAlgorithm field's value.
+func (s *EncryptOutput) SetEncryptionAlgorithm(v string) *EncryptOutput {
+	s.EncryptionAlgorithm = &v
+	return s
+}
+
 // SetKeyId sets the KeyId field's value.
 func (s *EncryptOutput) SetKeyId(v string) *EncryptOutput {
 	s.KeyId = &v
@@ -7188,7 +8507,14 @@ func (s *EncryptOutput) SetKeyId(v string) *EncryptOutput {
 type GenerateDataKeyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A set of key-value pairs that represents additional authenticated data.
+	// Specifies the encryption context that will be used when encrypting the data
+	// key.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
 	// in the AWS Key Management Service Developer Guide.
@@ -7200,7 +8526,7 @@ type GenerateDataKeyInput struct {
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// An identifier for the CMK that encrypts the data key.
+	// Identifies the symmetric CMK that encrypts the data key.
 	//
 	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
 	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
@@ -7222,14 +8548,19 @@ type GenerateDataKeyInput struct {
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The length of the data key. Use AES_128 to generate a 128-bit symmetric key,
-	// or AES_256 to generate a 256-bit symmetric key.
+	// Specifies the length of the data key. Use AES_128 to generate a 128-bit symmetric
+	// key, or AES_256 to generate a 256-bit symmetric key.
+	//
+	// You must specify either the KeySpec or the NumberOfBytes parameter (but not
+	// both) in every GenerateDataKey request.
 	KeySpec *string `type:"string" enum:"DataKeySpec"`
 
-	// The length of the data key in bytes. For example, use the value 64 to generate
-	// a 512-bit data key (64 bytes is 512 bits). For common key lengths (128-bit
-	// and 256-bit symmetric keys), we recommend that you use the KeySpec field
-	// instead of this one.
+	// Specifies the length of the data key in bytes. For example, use the value
+	// 64 to generate a 512-bit data key (64 bytes is 512 bits). For 128-bit (16-byte)
+	// and 256-bit (32-byte) data keys, use the KeySpec parameter.
+	//
+	// You must specify either the KeySpec or the NumberOfBytes parameter (but not
+	// both) in every GenerateDataKey request.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 }
 
@@ -7296,7 +8627,7 @@ type GenerateDataKeyOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The encrypted copy of the data key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not encoded.
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
@@ -7305,8 +8636,9 @@ type GenerateDataKeyOutput struct {
 	KeyId *string `min:"1" type:"string"`
 
 	// The plaintext data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded. Use this data key to encrypt
-	// your data outside of KMS. Then, remove it from memory as soon as possible.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded. Use this data key
+	// to encrypt your data outside of KMS. Then, remove it from memory as soon
+	// as possible.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -7340,10 +8672,17 @@ func (s *GenerateDataKeyOutput) SetPlaintext(v []byte) *GenerateDataKeyOutput {
 	return s
 }
 
-type GenerateDataKeyWithoutPlaintextInput struct {
+type GenerateDataKeyPairInput struct {
 	_ struct{} `type:"structure"`
 
-	// A set of key-value pairs that represents additional authenticated data.
+	// Specifies the encryption context that will be used when encrypting the private
+	// key in the data key pair.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
 	// in the AWS Key Management Service Developer Guide.
@@ -7355,7 +8694,364 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// The identifier of the customer master key (CMK) that encrypts the data key.
+	// Specifies the symmetric CMK that encrypts the private key in the data key
+	// pair. You cannot specify an asymmetric CMKs.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
+	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// Determines the type of data key pair that is generated.
+	//
+	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// and decrypt or to sign and verify (but not both), and the rule that permits
+	// you to use ECC CMKs only to sign and verify, are not effective outside of
+	// AWS KMS.
+	//
+	// KeyPairSpec is a required field
+	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
+}
+
+// String returns the string representation
+func (s GenerateDataKeyPairInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyPairInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateDataKeyPairInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateDataKeyPairInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.KeyPairSpec == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyPairSpec"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *GenerateDataKeyPairInput) SetEncryptionContext(v map[string]*string) *GenerateDataKeyPairInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *GenerateDataKeyPairInput) SetGrantTokens(v []*string) *GenerateDataKeyPairInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyPairInput) SetKeyId(v string) *GenerateDataKeyPairInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyPairSpec sets the KeyPairSpec field's value.
+func (s *GenerateDataKeyPairInput) SetKeyPairSpec(v string) *GenerateDataKeyPairInput {
+	s.KeyPairSpec = &v
+	return s
+}
+
+type GenerateDataKeyPairOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The identifier of the CMK that encrypted the private key.
+	KeyId *string `min:"1" type:"string"`
+
+	// The type of data key pair that was generated.
+	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
+
+	// The encrypted copy of the private key. When you use the HTTP API or the AWS
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
+	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
+
+	// The plaintext copy of the private key. When you use the HTTP API or the AWS
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// PrivateKeyPlaintext is automatically base64 encoded/decoded by the SDK.
+	PrivateKeyPlaintext []byte `min:"1" type:"blob" sensitive:"true"`
+
+	// The public key (in plaintext).
+	//
+	// PublicKey is automatically base64 encoded/decoded by the SDK.
+	PublicKey []byte `min:"1" type:"blob"`
+}
+
+// String returns the string representation
+func (s GenerateDataKeyPairOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyPairOutput) GoString() string {
+	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyPairOutput) SetKeyId(v string) *GenerateDataKeyPairOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyPairSpec sets the KeyPairSpec field's value.
+func (s *GenerateDataKeyPairOutput) SetKeyPairSpec(v string) *GenerateDataKeyPairOutput {
+	s.KeyPairSpec = &v
+	return s
+}
+
+// SetPrivateKeyCiphertextBlob sets the PrivateKeyCiphertextBlob field's value.
+func (s *GenerateDataKeyPairOutput) SetPrivateKeyCiphertextBlob(v []byte) *GenerateDataKeyPairOutput {
+	s.PrivateKeyCiphertextBlob = v
+	return s
+}
+
+// SetPrivateKeyPlaintext sets the PrivateKeyPlaintext field's value.
+func (s *GenerateDataKeyPairOutput) SetPrivateKeyPlaintext(v []byte) *GenerateDataKeyPairOutput {
+	s.PrivateKeyPlaintext = v
+	return s
+}
+
+// SetPublicKey sets the PublicKey field's value.
+func (s *GenerateDataKeyPairOutput) SetPublicKey(v []byte) *GenerateDataKeyPairOutput {
+	s.PublicKey = v
+	return s
+}
+
+type GenerateDataKeyPairWithoutPlaintextInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the encryption context that will be used when encrypting the private
+	// key in the data key pair.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
+	EncryptionContext map[string]*string `type:"map"`
+
+	// A list of grant tokens.
+	//
+	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
+	// in the AWS Key Management Service Developer Guide.
+	GrantTokens []*string `type:"list"`
+
+	// Specifies the CMK that encrypts the private key in the data key pair. You
+	// must specify a symmetric CMK. You cannot use an asymmetric CMK.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/".
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// Determines the type of data key pair that is generated.
+	//
+	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// and decrypt or to sign and verify (but not both), and the rule that permits
+	// you to use ECC CMKs only to sign and verify, are not effective outside of
+	// AWS KMS.
+	//
+	// KeyPairSpec is a required field
+	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
+}
+
+// String returns the string representation
+func (s GenerateDataKeyPairWithoutPlaintextInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyPairWithoutPlaintextInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateDataKeyPairWithoutPlaintextInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateDataKeyPairWithoutPlaintextInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.KeyPairSpec == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyPairSpec"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextInput) SetEncryptionContext(v map[string]*string) *GenerateDataKeyPairWithoutPlaintextInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextInput) SetGrantTokens(v []*string) *GenerateDataKeyPairWithoutPlaintextInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextInput) SetKeyId(v string) *GenerateDataKeyPairWithoutPlaintextInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyPairSpec sets the KeyPairSpec field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextInput) SetKeyPairSpec(v string) *GenerateDataKeyPairWithoutPlaintextInput {
+	s.KeyPairSpec = &v
+	return s
+}
+
+type GenerateDataKeyPairWithoutPlaintextOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the CMK that encrypted the private key in the data key pair. You
+	// must specify a symmetric CMK. You cannot use an asymmetric CMK.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/".
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	KeyId *string `min:"1" type:"string"`
+
+	// The type of data key pair that was generated.
+	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
+
+	// The encrypted copy of the private key. When you use the HTTP API or the AWS
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
+	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
+
+	// The public key (in plaintext).
+	//
+	// PublicKey is automatically base64 encoded/decoded by the SDK.
+	PublicKey []byte `min:"1" type:"blob"`
+}
+
+// String returns the string representation
+func (s GenerateDataKeyPairWithoutPlaintextOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyPairWithoutPlaintextOutput) GoString() string {
+	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextOutput) SetKeyId(v string) *GenerateDataKeyPairWithoutPlaintextOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyPairSpec sets the KeyPairSpec field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextOutput) SetKeyPairSpec(v string) *GenerateDataKeyPairWithoutPlaintextOutput {
+	s.KeyPairSpec = &v
+	return s
+}
+
+// SetPrivateKeyCiphertextBlob sets the PrivateKeyCiphertextBlob field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextOutput) SetPrivateKeyCiphertextBlob(v []byte) *GenerateDataKeyPairWithoutPlaintextOutput {
+	s.PrivateKeyCiphertextBlob = v
+	return s
+}
+
+// SetPublicKey sets the PublicKey field's value.
+func (s *GenerateDataKeyPairWithoutPlaintextOutput) SetPublicKey(v []byte) *GenerateDataKeyPairWithoutPlaintextOutput {
+	s.PublicKey = v
+	return s
+}
+
+type GenerateDataKeyWithoutPlaintextInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the encryption context that will be used when encrypting the data
+	// key.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
+	EncryptionContext map[string]*string `type:"map"`
+
+	// A list of grant tokens.
+	//
+	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
+	// in the AWS Key Management Service Developer Guide.
+	GrantTokens []*string `type:"list"`
+
+	// The identifier of the symmetric customer master key (CMK) that encrypts the
+	// data key.
 	//
 	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
 	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
@@ -7451,7 +9147,7 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The encrypted data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
@@ -7536,7 +9232,7 @@ type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The random byte string. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -7728,8 +9424,8 @@ func (s *GetKeyRotationStatusOutput) SetKeyRotationEnabled(v bool) *GetKeyRotati
 type GetParametersForImportInput struct {
 	_ struct{} `type:"structure"`
 
-	// The identifier of the CMK into which you will import key material. The CMK's
-	// Origin must be EXTERNAL.
+	// The identifier of the symmetric CMK into which you will import key material.
+	// The Origin of the CMK must be EXTERNAL.
 	//
 	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
 	//
@@ -7864,6 +9560,164 @@ func (s *GetParametersForImportOutput) SetParametersValidTo(v time.Time) *GetPar
 // SetPublicKey sets the PublicKey field's value.
 func (s *GetParametersForImportOutput) SetPublicKey(v []byte) *GetParametersForImportOutput {
 	s.PublicKey = v
+	return s
+}
+
+type GetPublicKeyInput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of grant tokens.
+	//
+	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
+	// in the AWS Key Management Service Developer Guide.
+	GrantTokens []*string `type:"list"`
+
+	// Identifies the asymmetric CMK that includes the public key.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
+	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetPublicKeyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPublicKeyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPublicKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPublicKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *GetPublicKeyInput) SetGrantTokens(v []*string) *GetPublicKeyInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GetPublicKeyInput) SetKeyId(v string) *GetPublicKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+type GetPublicKeyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The type of the of the public key that was downloaded.
+	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
+
+	// The encryption algorithms that AWS KMS supports for this key.
+	//
+	// This information is critical. If a public key encrypts data outside of AWS
+	// KMS by using an unsupported encryption algorithm, the ciphertext cannot be
+	// decrypted.
+	//
+	// This field appears in the response only when the KeyUsage of the public key
+	// is ENCRYPT_DECRYPT.
+	EncryptionAlgorithms []*string `type:"list"`
+
+	// The identifier of the asymmetric CMK from which the public key was downloaded.
+	KeyId *string `min:"1" type:"string"`
+
+	// The permitted use of the public key. Valid values are ENCRYPT_DECRYPT or
+	// SIGN_VERIFY.
+	//
+	// This information is critical. If a public key with SIGN_VERIFY key usage
+	// encrypts data outside of AWS KMS, the ciphertext cannot be decrypted.
+	KeyUsage *string `type:"string" enum:"KeyUsageType"`
+
+	// The exported public key.
+	//
+	// This value is returned as a binary Distinguished Encoding Rules (https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf)
+	// (DER)-encoded object. To decode it, use an ASN.1 parsing tool, such as OpenSSL
+	// asn1parse (https://www.openssl.org/docs/man1.0.2/man1/asn1parse.html).
+	//
+	// PublicKey is automatically base64 encoded/decoded by the SDK.
+	PublicKey []byte `min:"1" type:"blob"`
+
+	// The signing algorithms that AWS KMS supports for this key.
+	//
+	// This field appears in the response only when the KeyUsage of the public key
+	// is SIGN_VERIFY.
+	SigningAlgorithms []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s GetPublicKeyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPublicKeyOutput) GoString() string {
+	return s.String()
+}
+
+// SetCustomerMasterKeySpec sets the CustomerMasterKeySpec field's value.
+func (s *GetPublicKeyOutput) SetCustomerMasterKeySpec(v string) *GetPublicKeyOutput {
+	s.CustomerMasterKeySpec = &v
+	return s
+}
+
+// SetEncryptionAlgorithms sets the EncryptionAlgorithms field's value.
+func (s *GetPublicKeyOutput) SetEncryptionAlgorithms(v []*string) *GetPublicKeyOutput {
+	s.EncryptionAlgorithms = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GetPublicKeyOutput) SetKeyId(v string) *GetPublicKeyOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyUsage sets the KeyUsage field's value.
+func (s *GetPublicKeyOutput) SetKeyUsage(v string) *GetPublicKeyOutput {
+	s.KeyUsage = &v
+	return s
+}
+
+// SetPublicKey sets the PublicKey field's value.
+func (s *GetPublicKeyOutput) SetPublicKey(v []byte) *GetPublicKeyOutput {
+	s.PublicKey = v
+	return s
+}
+
+// SetSigningAlgorithms sets the SigningAlgorithms field's value.
+func (s *GetPublicKeyOutput) SetSigningAlgorithms(v []*string) *GetPublicKeyOutput {
+	s.SigningAlgorithms = v
 	return s
 }
 
@@ -8039,9 +9893,10 @@ func (s *GrantListEntry) SetRetiringPrincipal(v string) *GrantListEntry {
 type ImportKeyMaterialInput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted key material to import. It must be encrypted with the public
-	// key that you received in the response to a previous GetParametersForImport
-	// request, using the wrapping algorithm that you specified in that request.
+	// The encrypted key material to import. The key material must be encrypted
+	// with the public wrapping key that GetParametersForImport returned, using
+	// the wrapping algorithm that you specified in the same GetParametersForImport
+	// request.
 	//
 	// EncryptedKeyMaterial is automatically base64 encoded/decoded by the SDK.
 	//
@@ -8062,8 +9917,9 @@ type ImportKeyMaterialInput struct {
 	// ImportToken is a required field
 	ImportToken []byte `min:"1" type:"blob" required:"true"`
 
-	// The identifier of the CMK to import the key material into. The CMK's Origin
-	// must be EXTERNAL.
+	// The identifier of the symmetric CMK that receives the imported key material.
+	// The CMK's Origin must be EXTERNAL. This must be the same CMK specified in
+	// the KeyID parameter of the corresponding GetParametersForImport request.
 	//
 	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
 	//
@@ -8230,6 +10086,9 @@ type KeyMetadata struct {
 	// in a custom key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
+	// Describes the type of key material in the CMK.
+	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
+
 	// The date and time after which AWS KMS deletes the CMK. This value is present
 	// only when KeyState is PendingDeletion.
 	DeletionDate *time.Time `type:"timestamp"`
@@ -8240,6 +10099,12 @@ type KeyMetadata struct {
 	// Specifies whether the CMK is enabled. When KeyState is Enabled this value
 	// is true, otherwise it is false.
 	Enabled *bool `type:"boolean"`
+
+	// A list of encryption algorithms that the CMK supports. You cannot use the
+	// CMK with other encryption algorithms within AWS KMS.
+	//
+	// This field appears only when the KeyUsage of the CMK is ENCRYPT_DECRYPT.
+	EncryptionAlgorithms []*string `type:"list"`
 
 	// Specifies whether the CMK's key material expires. This value is present only
 	// when Origin is EXTERNAL, otherwise this value is omitted.
@@ -8263,9 +10128,7 @@ type KeyMetadata struct {
 	// in the AWS Key Management Service Developer Guide.
 	KeyState *string `type:"string" enum:"KeyState"`
 
-	// The cryptographic operations for which you can use the CMK. The only valid
-	// value is ENCRYPT_DECRYPT, which means you can use the CMK to encrypt and
-	// decrypt data.
+	// The cryptographic operations for which you can use the CMK.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
 	// The source of the CMK's key material. When this value is AWS_KMS, AWS KMS
@@ -8274,6 +10137,12 @@ type KeyMetadata struct {
 	// key material. When this value is AWS_CLOUDHSM, the key material was created
 	// in the AWS CloudHSM cluster associated with a custom key store.
 	Origin *string `type:"string" enum:"OriginType"`
+
+	// A list of signing algorithms that the CMK supports. You cannot use the CMK
+	// with other signing algorithms within AWS KMS.
+	//
+	// This field appears only when the KeyUsage of the CMK is SIGN_VERIFY.
+	SigningAlgorithms []*string `type:"list"`
 
 	// The time at which the imported key material expires. When the key material
 	// expires, AWS KMS deletes the key material and the CMK becomes unusable. This
@@ -8322,6 +10191,12 @@ func (s *KeyMetadata) SetCustomKeyStoreId(v string) *KeyMetadata {
 	return s
 }
 
+// SetCustomerMasterKeySpec sets the CustomerMasterKeySpec field's value.
+func (s *KeyMetadata) SetCustomerMasterKeySpec(v string) *KeyMetadata {
+	s.CustomerMasterKeySpec = &v
+	return s
+}
+
 // SetDeletionDate sets the DeletionDate field's value.
 func (s *KeyMetadata) SetDeletionDate(v time.Time) *KeyMetadata {
 	s.DeletionDate = &v
@@ -8337,6 +10212,12 @@ func (s *KeyMetadata) SetDescription(v string) *KeyMetadata {
 // SetEnabled sets the Enabled field's value.
 func (s *KeyMetadata) SetEnabled(v bool) *KeyMetadata {
 	s.Enabled = &v
+	return s
+}
+
+// SetEncryptionAlgorithms sets the EncryptionAlgorithms field's value.
+func (s *KeyMetadata) SetEncryptionAlgorithms(v []*string) *KeyMetadata {
+	s.EncryptionAlgorithms = v
 	return s
 }
 
@@ -8373,6 +10254,12 @@ func (s *KeyMetadata) SetKeyUsage(v string) *KeyMetadata {
 // SetOrigin sets the Origin field's value.
 func (s *KeyMetadata) SetOrigin(v string) *KeyMetadata {
 	s.Origin = &v
+	return s
+}
+
+// SetSigningAlgorithms sets the SigningAlgorithms field's value.
+func (s *KeyMetadata) SetSigningAlgorithms(v []*string) *KeyMetadata {
+	s.SigningAlgorithms = v
 	return s
 }
 
@@ -9216,10 +11103,33 @@ type ReEncryptInput struct {
 	// CiphertextBlob is a required field
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
-	// Encryption context to use when the data is reencrypted.
+	// Specifies the encryption algorithm that AWS KMS will use to reecrypt the
+	// data after it has decrypted it. The default value, SYMMETRIC_DEFAULT, represents
+	// the encryption algorithm used for symmetric CMKs.
+	//
+	// This parameter is required only when the destination CMK is an asymmetric
+	// CMK.
+	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
+	// Specifies that encryption context to use when the reencrypting the data.
+	//
+	// A destination encryption context is valid only when the destination CMK is
+	// a symmetric CMK. The standard ciphertext format for asymmetric CMKs does
+	// not include fields for metadata.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
 	DestinationEncryptionContext map[string]*string `type:"map"`
 
-	// A unique identifier for the CMK that is used to reencrypt the data.
+	// A unique identifier for the CMK that is used to reencrypt the data. Specify
+	// a symmetric or asymmetric CMK with a KeyUsage value of ENCRYPT_DECRYPT. To
+	// find the KeyUsage value of a CMK, use the DescribeKey operation.
 	//
 	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
 	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
@@ -9247,9 +11157,58 @@ type ReEncryptInput struct {
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Encryption context used to encrypt and decrypt the data specified in the
-	// CiphertextBlob parameter.
+	// Specifies the encryption algorithm that AWS KMS will use to decrypt the ciphertext
+	// before it is reencrypted. The default value, SYMMETRIC_DEFAULT, represents
+	// the algorithm used for symmetric CMKs.
+	//
+	// Specify the same algorithm that was used to encrypt the ciphertext. If you
+	// specify a different algorithm, the decrypt attempt fails.
+	//
+	// This parameter is required only when the ciphertext was encrypted under an
+	// asymmetric CMK.
+	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
+	// Specifies the encryption context to use to decrypt the ciphertext. Enter
+	// the same encryption context that was used to encrypt the ciphertext.
+	//
+	// An encryption context is a collection of non-secret key-value pairs that
+	// represents additional authenticated data. When you use an encryption context
+	// to encrypt data, you must specify the same (an exact case-sensitive match)
+	// encryption context to decrypt the data. An encryption context is optional
+	// when encrypting with a symmetric CMK, but it is highly recommended.
+	//
+	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the AWS Key Management Service Developer Guide.
 	SourceEncryptionContext map[string]*string `type:"map"`
+
+	// A unique identifier for the CMK that is used to decrypt the ciphertext before
+	// it reencrypts it using the destination CMK.
+	//
+	// This parameter is required only when the ciphertext was encrypted under an
+	// asymmetric CMK. Otherwise, AWS KMS uses the metadata that it adds to the
+	// ciphertext blob to determine which CMK was used to encrypt the ciphertext.
+	// However, you can use this parameter to ensure that a particular CMK (of any
+	// kind) is used to decrypt the ciphertext before it is reencrypted.
+	//
+	// If you specify a KeyId value, the decrypt part of the ReEncrypt operation
+	// succeeds only if the specified CMK was used to encrypt the ciphertext.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/".
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	SourceKeyId *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -9277,6 +11236,9 @@ func (s *ReEncryptInput) Validate() error {
 	if s.DestinationKeyId != nil && len(*s.DestinationKeyId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("DestinationKeyId", 1))
 	}
+	if s.SourceKeyId != nil && len(*s.SourceKeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceKeyId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9287,6 +11249,12 @@ func (s *ReEncryptInput) Validate() error {
 // SetCiphertextBlob sets the CiphertextBlob field's value.
 func (s *ReEncryptInput) SetCiphertextBlob(v []byte) *ReEncryptInput {
 	s.CiphertextBlob = v
+	return s
+}
+
+// SetDestinationEncryptionAlgorithm sets the DestinationEncryptionAlgorithm field's value.
+func (s *ReEncryptInput) SetDestinationEncryptionAlgorithm(v string) *ReEncryptInput {
+	s.DestinationEncryptionAlgorithm = &v
 	return s
 }
 
@@ -9308,9 +11276,21 @@ func (s *ReEncryptInput) SetGrantTokens(v []*string) *ReEncryptInput {
 	return s
 }
 
+// SetSourceEncryptionAlgorithm sets the SourceEncryptionAlgorithm field's value.
+func (s *ReEncryptInput) SetSourceEncryptionAlgorithm(v string) *ReEncryptInput {
+	s.SourceEncryptionAlgorithm = &v
+	return s
+}
+
 // SetSourceEncryptionContext sets the SourceEncryptionContext field's value.
 func (s *ReEncryptInput) SetSourceEncryptionContext(v map[string]*string) *ReEncryptInput {
 	s.SourceEncryptionContext = v
+	return s
+}
+
+// SetSourceKeyId sets the SourceKeyId field's value.
+func (s *ReEncryptInput) SetSourceKeyId(v string) *ReEncryptInput {
+	s.SourceKeyId = &v
 	return s
 }
 
@@ -9318,13 +11298,20 @@ type ReEncryptOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The reencrypted data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not encoded.
+	// is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
+	// The encryption algorithm that was used to reencrypt the data.
+	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
+
 	// Unique identifier of the CMK used to reencrypt the data.
 	KeyId *string `min:"1" type:"string"`
+
+	// The encryption algorithm that was used to decrypt the ciphertext before it
+	// was reencrypted.
+	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Unique identifier of the CMK used to originally encrypt the data.
 	SourceKeyId *string `min:"1" type:"string"`
@@ -9346,9 +11333,21 @@ func (s *ReEncryptOutput) SetCiphertextBlob(v []byte) *ReEncryptOutput {
 	return s
 }
 
+// SetDestinationEncryptionAlgorithm sets the DestinationEncryptionAlgorithm field's value.
+func (s *ReEncryptOutput) SetDestinationEncryptionAlgorithm(v string) *ReEncryptOutput {
+	s.DestinationEncryptionAlgorithm = &v
+	return s
+}
+
 // SetKeyId sets the KeyId field's value.
 func (s *ReEncryptOutput) SetKeyId(v string) *ReEncryptOutput {
 	s.KeyId = &v
+	return s
+}
+
+// SetSourceEncryptionAlgorithm sets the SourceEncryptionAlgorithm field's value.
+func (s *ReEncryptOutput) SetSourceEncryptionAlgorithm(v string) *ReEncryptOutput {
+	s.SourceEncryptionAlgorithm = &v
 	return s
 }
 
@@ -9620,6 +11619,173 @@ func (s *ScheduleKeyDeletionOutput) SetKeyId(v string) *ScheduleKeyDeletionOutpu
 	return s
 }
 
+type SignInput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of grant tokens.
+	//
+	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
+	// in the AWS Key Management Service Developer Guide.
+	GrantTokens []*string `type:"list"`
+
+	// Identifies an asymmetric CMK. AWS KMS uses the private key in the asymmetric
+	// CMK to sign the message. The KeyUsage type of the CMK must be SIGN_VERIFY.
+	// To find the KeyUsage of a CMK, use the DescribeKey operation.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
+	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// Specifies the message or message digest to sign. Messages can be 0-4096 bytes.
+	// To sign a larger message, provide the message digest.
+	//
+	// If you provide a message, AWS KMS generates a hash digest of the message
+	// and then signs it.
+	//
+	// Message is automatically base64 encoded/decoded by the SDK.
+	//
+	// Message is a required field
+	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
+
+	// Tells AWS KMS whether the value of the Message parameter is a message or
+	// message digest. To indicate a message, enter RAW. To indicate a message digest,
+	// enter DIGEST.
+	MessageType *string `type:"string" enum:"MessageType"`
+
+	// Specifies the signing algorithm to use when signing the message.
+	//
+	// Choose an algorithm that is compatible with the type and size of the specified
+	// asymmetric CMK.
+	//
+	// SigningAlgorithm is a required field
+	SigningAlgorithm *string `type:"string" required:"true" enum:"SigningAlgorithmSpec"`
+}
+
+// String returns the string representation
+func (s SignInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SignInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SignInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SignInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Message != nil && len(s.Message) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Message", 1))
+	}
+	if s.SigningAlgorithm == nil {
+		invalidParams.Add(request.NewErrParamRequired("SigningAlgorithm"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *SignInput) SetGrantTokens(v []*string) *SignInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *SignInput) SetKeyId(v string) *SignInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *SignInput) SetMessage(v []byte) *SignInput {
+	s.Message = v
+	return s
+}
+
+// SetMessageType sets the MessageType field's value.
+func (s *SignInput) SetMessageType(v string) *SignInput {
+	s.MessageType = &v
+	return s
+}
+
+// SetSigningAlgorithm sets the SigningAlgorithm field's value.
+func (s *SignInput) SetSigningAlgorithm(v string) *SignInput {
+	s.SigningAlgorithm = &v
+	return s
+}
+
+type SignOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the asymmetric CMK that was used to sign
+	// the message.
+	KeyId *string `min:"1" type:"string"`
+
+	// The cryptographic signature that was generated for the message.
+	//
+	// Signature is automatically base64 encoded/decoded by the SDK.
+	Signature []byte `min:"1" type:"blob"`
+
+	// The signing algorithm that was used to sign the message.
+	SigningAlgorithm *string `type:"string" enum:"SigningAlgorithmSpec"`
+}
+
+// String returns the string representation
+func (s SignOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SignOutput) GoString() string {
+	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *SignOutput) SetKeyId(v string) *SignOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetSignature sets the Signature field's value.
+func (s *SignOutput) SetSignature(v []byte) *SignOutput {
+	s.Signature = v
+	return s
+}
+
+// SetSigningAlgorithm sets the SigningAlgorithm field's value.
+func (s *SignOutput) SetSigningAlgorithm(v string) *SignOutput {
+	s.SigningAlgorithm = &v
+	return s
+}
+
 // A key-value pair. A tag consists of a tag key and a tag value. Tag keys and
 // tag values are both required, but tag values can be empty (null) strings.
 //
@@ -9852,14 +12018,19 @@ func (s UntagResourceOutput) GoString() string {
 type UpdateAliasInput struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the name of the alias to change. This value must begin with alias/
-	// followed by the alias name, such as alias/ExampleAlias.
+	// Identifies the alias that is changing its CMK. This value must begin with
+	// alias/ followed by the alias name, such as alias/ExampleAlias. You cannot
+	// use UpdateAlias to change the alias name.
 	//
 	// AliasName is a required field
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	// Unique identifier of the customer master key (CMK) to be mapped to the alias.
-	// When the update operation completes, the alias will point to this CMK.
+	// Identifies the CMK to associate with the alias. When the update operation
+	// completes, the alias will point to this CMK.
+	//
+	// The CMK must be in the same AWS account and Region as the alias. Also, the
+	// new target CMK must be the same type as the current target CMK (both symmetric
+	// or both asymmetric) and they must have the same key usage.
 	//
 	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
 	//
@@ -10122,6 +12293,192 @@ func (s UpdateKeyDescriptionOutput) GoString() string {
 	return s.String()
 }
 
+type VerifyInput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of grant tokens.
+	//
+	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
+	// in the AWS Key Management Service Developer Guide.
+	GrantTokens []*string `type:"list"`
+
+	// Identifies the asymmetric CMK that will be used to verify the signature.
+	// This must be the same CMK that was used to generate the signature. If you
+	// specify a different CMK, the signature verification fails.
+	//
+	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
+	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
+	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	//
+	// For example:
+	//
+	//    * Key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Alias name: alias/ExampleAlias
+	//
+	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
+	//
+	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
+	// get the alias name and alias ARN, use ListAliases.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// Specifies the message that was signed, or a hash digest of that message.
+	// Messages can be 0-4096 bytes. To verify a larger message, provide a hash
+	// digest of the message.
+	//
+	// If the digest of the message specified here is different from the message
+	// digest that was signed, the signature verification fails.
+	//
+	// Message is automatically base64 encoded/decoded by the SDK.
+	//
+	// Message is a required field
+	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
+
+	// Tells AWS KMS whether the value of the Message parameter is a message or
+	// message digest. To indicate a message, enter RAW. To indicate a message digest,
+	// enter DIGEST.
+	MessageType *string `type:"string" enum:"MessageType"`
+
+	// The signature that the Sign operation generated.
+	//
+	// Signature is automatically base64 encoded/decoded by the SDK.
+	//
+	// Signature is a required field
+	Signature []byte `min:"1" type:"blob" required:"true"`
+
+	// The signing algorithm that was used to sign the message. If you submit a
+	// different algorithm, the signature verification fails.
+	//
+	// SigningAlgorithm is a required field
+	SigningAlgorithm *string `type:"string" required:"true" enum:"SigningAlgorithmSpec"`
+}
+
+// String returns the string representation
+func (s VerifyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s VerifyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Message != nil && len(s.Message) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Message", 1))
+	}
+	if s.Signature == nil {
+		invalidParams.Add(request.NewErrParamRequired("Signature"))
+	}
+	if s.Signature != nil && len(s.Signature) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Signature", 1))
+	}
+	if s.SigningAlgorithm == nil {
+		invalidParams.Add(request.NewErrParamRequired("SigningAlgorithm"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *VerifyInput) SetGrantTokens(v []*string) *VerifyInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *VerifyInput) SetKeyId(v string) *VerifyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *VerifyInput) SetMessage(v []byte) *VerifyInput {
+	s.Message = v
+	return s
+}
+
+// SetMessageType sets the MessageType field's value.
+func (s *VerifyInput) SetMessageType(v string) *VerifyInput {
+	s.MessageType = &v
+	return s
+}
+
+// SetSignature sets the Signature field's value.
+func (s *VerifyInput) SetSignature(v []byte) *VerifyInput {
+	s.Signature = v
+	return s
+}
+
+// SetSigningAlgorithm sets the SigningAlgorithm field's value.
+func (s *VerifyInput) SetSigningAlgorithm(v string) *VerifyInput {
+	s.SigningAlgorithm = &v
+	return s
+}
+
+type VerifyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique identifier for the asymmetric CMK that was used to verify the
+	// signature.
+	KeyId *string `min:"1" type:"string"`
+
+	// A Boolean value that indicates whether the signature was verified. A value
+	// of True indicates that the Signature was produced by signing the Message
+	// with the specified KeyID and SigningAlgorithm. If the signature is not verified,
+	// the Verify operation fails with a KMSInvalidSignatureException exception.
+	SignatureValid *bool `type:"boolean"`
+
+	// The signing algorithm that was used to verify the signature.
+	SigningAlgorithm *string `type:"string" enum:"SigningAlgorithmSpec"`
+}
+
+// String returns the string representation
+func (s VerifyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s VerifyOutput) GoString() string {
+	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *VerifyOutput) SetKeyId(v string) *VerifyOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetSignatureValid sets the SignatureValid field's value.
+func (s *VerifyOutput) SetSignatureValid(v bool) *VerifyOutput {
+	s.SignatureValid = &v
+	return s
+}
+
+// SetSigningAlgorithm sets the SigningAlgorithm field's value.
+func (s *VerifyOutput) SetSigningAlgorithm(v string) *VerifyOutput {
+	s.SigningAlgorithm = &v
+	return s
+}
+
 const (
 	// AlgorithmSpecRsaesPkcs1V15 is a AlgorithmSpec enum value
 	AlgorithmSpecRsaesPkcs1V15 = "RSAES_PKCS1_V1_5"
@@ -10171,11 +12528,71 @@ const (
 )
 
 const (
+	// CustomerMasterKeySpecRsa2048 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecRsa2048 = "RSA_2048"
+
+	// CustomerMasterKeySpecRsa3072 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecRsa3072 = "RSA_3072"
+
+	// CustomerMasterKeySpecRsa4096 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecRsa4096 = "RSA_4096"
+
+	// CustomerMasterKeySpecEccNistP256 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecEccNistP256 = "ECC_NIST_P256"
+
+	// CustomerMasterKeySpecEccNistP384 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecEccNistP384 = "ECC_NIST_P384"
+
+	// CustomerMasterKeySpecEccNistP521 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecEccNistP521 = "ECC_NIST_P521"
+
+	// CustomerMasterKeySpecEccSecgP256k1 is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecEccSecgP256k1 = "ECC_SECG_P256K1"
+
+	// CustomerMasterKeySpecSymmetricDefault is a CustomerMasterKeySpec enum value
+	CustomerMasterKeySpecSymmetricDefault = "SYMMETRIC_DEFAULT"
+)
+
+const (
+	// DataKeyPairSpecRsa2048 is a DataKeyPairSpec enum value
+	DataKeyPairSpecRsa2048 = "RSA_2048"
+
+	// DataKeyPairSpecRsa3072 is a DataKeyPairSpec enum value
+	DataKeyPairSpecRsa3072 = "RSA_3072"
+
+	// DataKeyPairSpecRsa4096 is a DataKeyPairSpec enum value
+	DataKeyPairSpecRsa4096 = "RSA_4096"
+
+	// DataKeyPairSpecEccNistP256 is a DataKeyPairSpec enum value
+	DataKeyPairSpecEccNistP256 = "ECC_NIST_P256"
+
+	// DataKeyPairSpecEccNistP384 is a DataKeyPairSpec enum value
+	DataKeyPairSpecEccNistP384 = "ECC_NIST_P384"
+
+	// DataKeyPairSpecEccNistP521 is a DataKeyPairSpec enum value
+	DataKeyPairSpecEccNistP521 = "ECC_NIST_P521"
+
+	// DataKeyPairSpecEccSecgP256k1 is a DataKeyPairSpec enum value
+	DataKeyPairSpecEccSecgP256k1 = "ECC_SECG_P256K1"
+)
+
+const (
 	// DataKeySpecAes256 is a DataKeySpec enum value
 	DataKeySpecAes256 = "AES_256"
 
 	// DataKeySpecAes128 is a DataKeySpec enum value
 	DataKeySpecAes128 = "AES_128"
+)
+
+const (
+	// EncryptionAlgorithmSpecSymmetricDefault is a EncryptionAlgorithmSpec enum value
+	EncryptionAlgorithmSpecSymmetricDefault = "SYMMETRIC_DEFAULT"
+
+	// EncryptionAlgorithmSpecRsaesOaepSha1 is a EncryptionAlgorithmSpec enum value
+	EncryptionAlgorithmSpecRsaesOaepSha1 = "RSAES_OAEP_SHA_1"
+
+	// EncryptionAlgorithmSpecRsaesOaepSha256 is a EncryptionAlgorithmSpec enum value
+	EncryptionAlgorithmSpecRsaesOaepSha256 = "RSAES_OAEP_SHA_256"
 )
 
 const (
@@ -10205,6 +12622,15 @@ const (
 	// GrantOperationReEncryptTo is a GrantOperation enum value
 	GrantOperationReEncryptTo = "ReEncryptTo"
 
+	// GrantOperationSign is a GrantOperation enum value
+	GrantOperationSign = "Sign"
+
+	// GrantOperationVerify is a GrantOperation enum value
+	GrantOperationVerify = "Verify"
+
+	// GrantOperationGetPublicKey is a GrantOperation enum value
+	GrantOperationGetPublicKey = "GetPublicKey"
+
 	// GrantOperationCreateGrant is a GrantOperation enum value
 	GrantOperationCreateGrant = "CreateGrant"
 
@@ -10213,6 +12639,12 @@ const (
 
 	// GrantOperationDescribeKey is a GrantOperation enum value
 	GrantOperationDescribeKey = "DescribeKey"
+
+	// GrantOperationGenerateDataKeyPair is a GrantOperation enum value
+	GrantOperationGenerateDataKeyPair = "GenerateDataKeyPair"
+
+	// GrantOperationGenerateDataKeyPairWithoutPlaintext is a GrantOperation enum value
+	GrantOperationGenerateDataKeyPairWithoutPlaintext = "GenerateDataKeyPairWithoutPlaintext"
 )
 
 const (
@@ -10241,8 +12673,19 @@ const (
 )
 
 const (
+	// KeyUsageTypeSignVerify is a KeyUsageType enum value
+	KeyUsageTypeSignVerify = "SIGN_VERIFY"
+
 	// KeyUsageTypeEncryptDecrypt is a KeyUsageType enum value
 	KeyUsageTypeEncryptDecrypt = "ENCRYPT_DECRYPT"
+)
+
+const (
+	// MessageTypeRaw is a MessageType enum value
+	MessageTypeRaw = "RAW"
+
+	// MessageTypeDigest is a MessageType enum value
+	MessageTypeDigest = "DIGEST"
 )
 
 const (
@@ -10254,6 +12697,35 @@ const (
 
 	// OriginTypeAwsCloudhsm is a OriginType enum value
 	OriginTypeAwsCloudhsm = "AWS_CLOUDHSM"
+)
+
+const (
+	// SigningAlgorithmSpecRsassaPssSha256 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPssSha256 = "RSASSA_PSS_SHA_256"
+
+	// SigningAlgorithmSpecRsassaPssSha384 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPssSha384 = "RSASSA_PSS_SHA_384"
+
+	// SigningAlgorithmSpecRsassaPssSha512 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPssSha512 = "RSASSA_PSS_SHA_512"
+
+	// SigningAlgorithmSpecRsassaPkcs1V15Sha256 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPkcs1V15Sha256 = "RSASSA_PKCS1_V1_5_SHA_256"
+
+	// SigningAlgorithmSpecRsassaPkcs1V15Sha384 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPkcs1V15Sha384 = "RSASSA_PKCS1_V1_5_SHA_384"
+
+	// SigningAlgorithmSpecRsassaPkcs1V15Sha512 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecRsassaPkcs1V15Sha512 = "RSASSA_PKCS1_V1_5_SHA_512"
+
+	// SigningAlgorithmSpecEcdsaSha256 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecEcdsaSha256 = "ECDSA_SHA_256"
+
+	// SigningAlgorithmSpecEcdsaSha384 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecEcdsaSha384 = "ECDSA_SHA_384"
+
+	// SigningAlgorithmSpecEcdsaSha512 is a SigningAlgorithmSpec enum value
+	SigningAlgorithmSpecEcdsaSha512 = "ECDSA_SHA_512"
 )
 
 const (

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
@@ -156,17 +156,25 @@ const (
 	// ErrCodeExpiredImportTokenException for service response error code
 	// "ExpiredImportTokenException".
 	//
-	// The request was rejected because the provided import token is expired. Use
+	// The request was rejected because the specified import token is expired. Use
 	// GetParametersForImport to get a new import token and public key, use the
 	// new public key to encrypt the key material, and then try the request again.
 	ErrCodeExpiredImportTokenException = "ExpiredImportTokenException"
 
+	// ErrCodeIncorrectKeyException for service response error code
+	// "IncorrectKeyException".
+	//
+	// The request was rejected because the specified CMK cannot decrypt the data.
+	// The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+	// must identify the same CMK that was used to encrypt the ciphertext.
+	ErrCodeIncorrectKeyException = "IncorrectKeyException"
+
 	// ErrCodeIncorrectKeyMaterialException for service response error code
 	// "IncorrectKeyMaterialException".
 	//
-	// The request was rejected because the provided key material is invalid or
-	// is not the same key material that was previously imported into this customer
-	// master key (CMK).
+	// The request was rejected because the key material in the request is, expired,
+	// invalid, or is not the same key material that was previously imported into
+	// this customer master key (CMK).
 	ErrCodeIncorrectKeyMaterialException = "IncorrectKeyMaterialException"
 
 	// ErrCodeIncorrectTrustAnchorException for service response error code
@@ -203,9 +211,13 @@ const (
 	// ErrCodeInvalidCiphertextException for service response error code
 	// "InvalidCiphertextException".
 	//
-	// The request was rejected because the specified ciphertext, or additional
-	// authenticated data incorporated into the ciphertext, such as the encryption
-	// context, is corrupted, missing, or otherwise invalid.
+	// From the Decrypt or ReEncrypt operation, the request was rejected because
+	// the specified ciphertext, or additional authenticated data incorporated into
+	// the ciphertext, such as the encryption context, is corrupted, missing, or
+	// otherwise invalid.
+	//
+	// From the ImportKeyMaterial operation, the request was rejected because AWS
+	// KMS could not decrypt the encrypted (wrapped) key material.
 	ErrCodeInvalidCiphertextException = "InvalidCiphertextException"
 
 	// ErrCodeInvalidGrantIdException for service response error code
@@ -230,7 +242,19 @@ const (
 	// ErrCodeInvalidKeyUsageException for service response error code
 	// "InvalidKeyUsageException".
 	//
-	// The request was rejected because the specified KeySpec value is not valid.
+	// The request was rejected for one of the following reasons:
+	//
+	//    * The KeyUsage value of the CMK is incompatible with the API operation.
+	//
+	//    * The encryption algorithm or signing algorithm specified for the operation
+	//    is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+	//
+	// For encrypting, decrypting, re-encrypting, and generating data keys, the
+	// KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
+	// must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+	//
+	// To find the encryption or signing algorithms supported for a particular CMK,
+	// use the DescribeKey operation.
 	ErrCodeInvalidKeyUsageException = "InvalidKeyUsageException"
 
 	// ErrCodeInvalidMarkerException for service response error code
@@ -248,14 +272,22 @@ const (
 	//
 	// For more information about how key state affects the use of a CMK, see How
 	// Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the AWS Key Management Service Developer Guide .
 	ErrCodeInvalidStateException = "KMSInvalidStateException"
+
+	// ErrCodeKMSInvalidSignatureException for service response error code
+	// "KMSInvalidSignatureException".
+	//
+	// The request was rejected because the signature verification failed. Signature
+	// verification fails when it cannot confirm that signature was produced by
+	// signing the specified message with the specified CMK and signing algorithm.
+	ErrCodeKMSInvalidSignatureException = "KMSInvalidSignatureException"
 
 	// ErrCodeKeyUnavailableException for service response error code
 	// "KeyUnavailableException".
 	//
-	// The request was rejected because the specified CMK was not available. The
-	// request can be retried.
+	// The request was rejected because the specified CMK was not available. You
+	// can retry the request.
 	ErrCodeKeyUnavailableException = "KeyUnavailableException"
 
 	// ErrCodeLimitExceededException for service response error code

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kms"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "KMS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "KMS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KMS client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a KMS client from just a session.
 //     svc := kms.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := kms.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *KMS {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *KMS {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *KMS {
 	svc := &KMS{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2014-11-01",
 				JSONVersion:   "1.1",

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -78,6 +78,8 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
 // in the IAM User Guide.
 //
+// Session Duration
+//
 // By default, the temporary security credentials created by AssumeRole last
 // for one hour. However, you can use the optional DurationSeconds parameter
 // to specify the duration of your session. You can provide a value from 900
@@ -91,6 +93,8 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // URL. For more information, see Using IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
 // in the IAM User Guide.
 //
+// Permissions
+//
 // The temporary security credentials created by AssumeRole can be used to make
 // API calls to any AWS service with the following exception: You cannot call
 // the AWS STS GetFederationToken or GetSessionToken API operations.
@@ -99,7 +103,7 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // to this operation. You can pass a single JSON policy document to use as an
 // inline session policy. You can also specify up to 10 managed policies to
 // use as managed session policies. The plain text that you use for both inline
-// and managed session policies shouldn't exceed 2048 characters. Passing policies
+// and managed session policies can't exceed 2,048 characters. Passing policies
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
@@ -129,6 +133,24 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // in the same account as the role do not need explicit permission to assume
 // the role. For more information about trust policies and resource-based policies,
 // see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
+// in the IAM User Guide.
+//
+// Tags
+//
+// (Optional) You can pass tag key-value pairs to your session. These tags are
+// called session tags. For more information about session tags, see Passing
+// Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// in the IAM User Guide.
+//
+// An administrator must grant you the permissions necessary to pass session
+// tags. The administrator can also create granular permissions to allow you
+// to pass only specific session tags. For more information, see Tutorial: Using
+// Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+// in the IAM User Guide.
+//
+// You can set the session tags as transitive. Transitive tags persist during
+// role chaining. For more information, see Chaining Roles with Session Tags
+// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
 // in the IAM User Guide.
 //
 // Using MFA with AssumeRole
@@ -165,9 +187,18 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 //   message describes the specific error.
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
-//   The request was rejected because the policy document was too large. The error
-//   message describes how big the policy document is, in packed form, as a percentage
-//   of what the API allows.
+//   The request was rejected because the total packed size of the session policies
+//   and session tags combined was too large. An AWS conversion compresses the
+//   session policy document, session policy ARNs, and session tags into a packed
+//   binary format that has a separate limit. The error message indicates by percentage
+//   how close the policies and tags are to the upper size limit. For more information,
+//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   in the IAM User Guide.
+//
+//   You could receive this error even though you meet other defined session policy
+//   and session tag limits. For more information, see IAM and STS Entity Character
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   in the IAM User Guide.
 //
 //   * ErrCodeRegionDisabledException "RegionDisabledException"
 //   STS is not activated in the requested region for the account that is being
@@ -256,6 +287,8 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // an access key ID, a secret access key, and a security token. Applications
 // can use these temporary security credentials to sign calls to AWS services.
 //
+// Session Duration
+//
 // By default, the temporary security credentials created by AssumeRoleWithSAML
 // last for one hour. However, you can use the optional DurationSeconds parameter
 // to specify the duration of your session. Your role session lasts for the
@@ -271,6 +304,8 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // URL. For more information, see Using IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
 // in the IAM User Guide.
 //
+// Permissions
+//
 // The temporary security credentials created by AssumeRoleWithSAML can be used
 // to make API calls to any AWS service with the following exception: you cannot
 // call the STS GetFederationToken or GetSessionToken API operations.
@@ -279,7 +314,7 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // to this operation. You can pass a single JSON policy document to use as an
 // inline session policy. You can also specify up to 10 managed policies to
 // use as managed session policies. The plain text that you use for both inline
-// and managed session policies shouldn't exceed 2048 characters. Passing policies
+// and managed session policies can't exceed 2,048 characters. Passing policies
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
@@ -289,12 +324,6 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide.
 //
-// Before your application can call AssumeRoleWithSAML, you must configure your
-// SAML identity provider (IdP) to issue the claims required by AWS. Additionally,
-// you must use AWS Identity and Access Management (IAM) to create a SAML provider
-// entity in your AWS account that represents your identity provider. You must
-// also create an IAM role that specifies this SAML provider in its trust policy.
-//
 // Calling AssumeRoleWithSAML does not require the use of AWS security credentials.
 // The identity of the caller is validated by using keys in the metadata document
 // that is uploaded for the SAML provider entity for your identity provider.
@@ -302,8 +331,50 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // Calling AssumeRoleWithSAML can result in an entry in your AWS CloudTrail
 // logs. The entry includes the value in the NameID element of the SAML assertion.
 // We recommend that you use a NameIDType that is not associated with any personally
-// identifiable information (PII). For example, you could instead use the Persistent
-// Identifier (urn:oasis:names:tc:SAML:2.0:nameid-format:persistent).
+// identifiable information (PII). For example, you could instead use the persistent
+// identifier (urn:oasis:names:tc:SAML:2.0:nameid-format:persistent).
+//
+// Tags
+//
+// (Optional) You can configure your IdP to pass attributes into your SAML assertion
+// as session tags. Each session tag consists of a key name and an associated
+// value. For more information about session tags, see Passing Session Tags
+// in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// in the IAM User Guide.
+//
+// You can pass up to 50 session tags. The plain text session tag keys can’t
+// exceed 128 characters and the values can’t exceed 256 characters. For these
+// and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+// in the IAM User Guide.
+//
+// An AWS conversion compresses the passed session policies and session tags
+// into a packed binary format that has a separate limit. Your request can fail
+// for this limit even if your plain text meets the other requirements. The
+// PackedPolicySize response element indicates by percentage how close the policies
+// and tags for your request are to the upper size limit.
+//
+// You can pass a session tag with the same key as a tag that is attached to
+// the role. When you do, session tags override the role's tags with the same
+// key.
+//
+// An administrator must grant you the permissions necessary to pass session
+// tags. The administrator can also create granular permissions to allow you
+// to pass only specific session tags. For more information, see Tutorial: Using
+// Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+// in the IAM User Guide.
+//
+// You can set the session tags as transitive. Transitive tags persist during
+// role chaining. For more information, see Chaining Roles with Session Tags
+// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+// in the IAM User Guide.
+//
+// SAML Configuration
+//
+// Before your application can call AssumeRoleWithSAML, you must configure your
+// SAML identity provider (IdP) to issue the claims required by AWS. Additionally,
+// you must use AWS Identity and Access Management (IAM) to create a SAML provider
+// entity in your AWS account that represents your identity provider. You must
+// also create an IAM role that specifies this SAML provider in its trust policy.
 //
 // For more information, see the following resources:
 //
@@ -332,9 +403,18 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 //   message describes the specific error.
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
-//   The request was rejected because the policy document was too large. The error
-//   message describes how big the policy document is, in packed form, as a percentage
-//   of what the API allows.
+//   The request was rejected because the total packed size of the session policies
+//   and session tags combined was too large. An AWS conversion compresses the
+//   session policy document, session policy ARNs, and session tags into a packed
+//   binary format that has a separate limit. The error message indicates by percentage
+//   how close the policies and tags are to the upper size limit. For more information,
+//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   in the IAM User Guide.
+//
+//   You could receive this error even though you meet other defined session policy
+//   and session tag limits. For more information, see IAM and STS Entity Character
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   in the IAM User Guide.
 //
 //   * ErrCodeIDPRejectedClaimException "IDPRejectedClaim"
 //   The identity provider (IdP) reported that authentication failed. This might
@@ -456,6 +536,8 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // key ID, a secret access key, and a security token. Applications can use these
 // temporary security credentials to sign calls to AWS service API operations.
 //
+// Session Duration
+//
 // By default, the temporary security credentials created by AssumeRoleWithWebIdentity
 // last for one hour. However, you can use the optional DurationSeconds parameter
 // to specify the duration of your session. You can provide a value from 900
@@ -469,6 +551,8 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // URL. For more information, see Using IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
 // in the IAM User Guide.
 //
+// Permissions
+//
 // The temporary security credentials created by AssumeRoleWithWebIdentity can
 // be used to make API calls to any AWS service with the following exception:
 // you cannot call the STS GetFederationToken or GetSessionToken API operations.
@@ -477,7 +561,7 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // to this operation. You can pass a single JSON policy document to use as an
 // inline session policy. You can also specify up to 10 managed policies to
 // use as managed session policies. The plain text that you use for both inline
-// and managed session policies shouldn't exceed 2048 characters. Passing policies
+// and managed session policies can't exceed 2,048 characters. Passing policies
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
@@ -486,6 +570,42 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // by the identity-based policy of the role that is being assumed. For more
 // information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide.
+//
+// Tags
+//
+// (Optional) You can configure your IdP to pass attributes into your web identity
+// token as session tags. Each session tag consists of a key name and an associated
+// value. For more information about session tags, see Passing Session Tags
+// in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// in the IAM User Guide.
+//
+// You can pass up to 50 session tags. The plain text session tag keys can’t
+// exceed 128 characters and the values can’t exceed 256 characters. For these
+// and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+// in the IAM User Guide.
+//
+// An AWS conversion compresses the passed session policies and session tags
+// into a packed binary format that has a separate limit. Your request can fail
+// for this limit even if your plain text meets the other requirements. The
+// PackedPolicySize response element indicates by percentage how close the policies
+// and tags for your request are to the upper size limit.
+//
+// You can pass a session tag with the same key as a tag that is attached to
+// the role. When you do, the session tag overrides the role tag with the same
+// key.
+//
+// An administrator must grant you the permissions necessary to pass session
+// tags. The administrator can also create granular permissions to allow you
+// to pass only specific session tags. For more information, see Tutorial: Using
+// Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+// in the IAM User Guide.
+//
+// You can set the session tags as transitive. Transitive tags persist during
+// role chaining. For more information, see Chaining Roles with Session Tags
+// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+// in the IAM User Guide.
+//
+// Identities
 //
 // Before your application can call AssumeRoleWithWebIdentity, you must have
 // an identity token from a supported identity provider and create a role that
@@ -514,8 +634,8 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //    * AWS SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/) and
 //    AWS SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/).
 //    These toolkits contain sample apps that show how to invoke the identity
-//    providers, and then how to use the information from these providers to
-//    get and use temporary security credentials.
+//    providers. The toolkits then show how to use the information from these
+//    providers to get and use temporary security credentials.
 //
 //    * Web Identity Federation with Mobile Applications (http://aws.amazon.com/articles/web-identity-federation-with-mobile-applications).
 //    This article discusses web identity federation and shows an example of
@@ -535,9 +655,18 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //   message describes the specific error.
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
-//   The request was rejected because the policy document was too large. The error
-//   message describes how big the policy document is, in packed form, as a percentage
-//   of what the API allows.
+//   The request was rejected because the total packed size of the session policies
+//   and session tags combined was too large. An AWS conversion compresses the
+//   session policy document, session policy ARNs, and session tags into a packed
+//   binary format that has a separate limit. The error message indicates by percentage
+//   how close the policies and tags are to the upper size limit. For more information,
+//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   in the IAM User Guide.
+//
+//   You could receive this error even though you meet other defined session policy
+//   and session tag limits. For more information, see IAM and STS Entity Character
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   in the IAM User Guide.
 //
 //   * ErrCodeIDPRejectedClaimException "IDPRejectedClaim"
 //   The identity provider (IdP) reported that authentication failed. This might
@@ -547,11 +676,11 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //   can also mean that the claim has expired or has been explicitly revoked.
 //
 //   * ErrCodeIDPCommunicationErrorException "IDPCommunicationError"
-//   The request could not be fulfilled because the non-AWS identity provider
-//   (IDP) that was asked to verify the incoming identity token could not be reached.
-//   This is often a transient error caused by network conditions. Retry the request
+//   The request could not be fulfilled because the identity provider (IDP) that
+//   was asked to verify the incoming identity token could not be reached. This
+//   is often a transient error caused by network conditions. Retry the request
 //   a limited number of times so that you don't exceed the request rate. If the
-//   error persists, the non-AWS identity provider might be down or not responding.
+//   error persists, the identity provider might be down or not responding.
 //
 //   * ErrCodeInvalidIdentityTokenException "InvalidIdentityToken"
 //   The web identity token that was passed could not be validated by AWS. Get
@@ -763,7 +892,8 @@ func (c *STS) GetAccessKeyInfoRequest(input *GetAccessKeyInfoInput) (req *reques
 // pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
 // to learn which IAM user owns the keys. To learn who requested the temporary
 // credentials for an ASIA access key, view the STS events in your CloudTrail
-// logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
+// logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
+// in the IAM User Guide.
 //
 // This operation does not indicate the state of the access key. The key might
 // be active, inactive, or deleted. Active keys might not have permissions to
@@ -850,7 +980,8 @@ func (c *STS) GetCallerIdentityRequest(input *GetCallerIdentityInput) (req *requ
 // sts:GetCallerIdentity action, you can still perform this operation. Permissions
 // are not required because the same information is returned when an IAM user
 // or role is denied access. To view an example response, see I Am Not Authorized
-// to Perform: iam:DeleteVirtualMFADevice (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_access-denied-delete-mfa).
+// to Perform: iam:DeleteVirtualMFADevice (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_access-denied-delete-mfa)
+// in the IAM User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -942,7 +1073,8 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 // or an OpenID Connect-compatible identity provider. In this case, we recommend
 // that you use Amazon Cognito (http://aws.amazon.com/cognito/) or AssumeRoleWithWebIdentity.
 // For more information, see Federation Through a Web-based Identity Provider
-// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity).
+// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+// in the IAM User Guide.
 //
 // You can also call GetFederationToken using the security credentials of an
 // AWS account root user, but we do not recommend it. Instead, we recommend
@@ -952,40 +1084,66 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 // Practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
 // in the IAM User Guide.
 //
+// Session duration
+//
 // The temporary credentials are valid for the specified duration, from 900
 // seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The default
-// is 43,200 seconds (12 hours). Temporary credentials that are obtained by
-// using AWS account root user credentials have a maximum duration of 3,600
-// seconds (1 hour).
-//
-// The temporary security credentials created by GetFederationToken can be used
-// to make API calls to any AWS service with the following exceptions:
-//
-//    * You cannot use these credentials to call any IAM API operations.
-//
-//    * You cannot call any STS API operations except GetCallerIdentity.
+// session duration is 43,200 seconds (12 hours). Temporary credentials that
+// are obtained by using AWS account root user credentials have a maximum duration
+// of 3,600 seconds (1 hour).
 //
 // Permissions
+//
+// You can use the temporary credentials created by GetFederationToken in any
+// AWS service except the following:
+//
+//    * You cannot call any IAM operations using the AWS CLI or the AWS API.
+//
+//    * You cannot call any STS operations except GetCallerIdentity.
 //
 // You must pass an inline or managed session policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // to this operation. You can pass a single JSON policy document to use as an
 // inline session policy. You can also specify up to 10 managed policies to
 // use as managed session policies. The plain text that you use for both inline
-// and managed session policies shouldn't exceed 2048 characters.
+// and managed session policies can't exceed 2,048 characters.
 //
 // Though the session policy parameters are optional, if you do not pass a policy,
-// then the resulting federated user session has no permissions. The only exception
-// is when the credentials are used to access a resource that has a resource-based
-// policy that specifically references the federated user session in the Principal
-// element of the policy. When you pass session policies, the session permissions
-// are the intersection of the IAM user policies and the session policies that
-// you pass. This gives you a way to further restrict the permissions for a
-// federated user. You cannot use session policies to grant more permissions
-// than those that are defined in the permissions policy of the IAM user. For
-// more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+// then the resulting federated user session has no permissions. When you pass
+// session policies, the session permissions are the intersection of the IAM
+// user policies and the session policies that you pass. This gives you a way
+// to further restrict the permissions for a federated user. You cannot use
+// session policies to grant more permissions than those that are defined in
+// the permissions policy of the IAM user. For more information, see Session
+// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide. For information about using GetFederationToken to
 // create temporary security credentials, see GetFederationToken—Federation
 // Through a Custom Identity Broker (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getfederationtoken).
+//
+// You can use the credentials to access a resource that has a resource-based
+// policy. If that policy specifically references the federated user session
+// in the Principal element of the policy, the session has the permissions allowed
+// by the policy. These permissions are granted in addition to the permissions
+// granted by the session policies.
+//
+// Tags
+//
+// (Optional) You can pass tag key-value pairs to your session. These are called
+// session tags. For more information about session tags, see Passing Session
+// Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// in the IAM User Guide.
+//
+// An administrator must grant you the permissions necessary to pass session
+// tags. The administrator can also create granular permissions to allow you
+// to pass only specific session tags. For more information, see Tutorial: Using
+// Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+// in the IAM User Guide.
+//
+// Tag key–value pairs are not case sensitive, but case is preserved. This
+// means that you cannot have separate Department and department tag keys. Assume
+// that the user that you are federating has the Department=Marketing tag and
+// you pass the department=engineering session tag. Department and department
+// are not saved as separate tags, and the session tag passed in the request
+// takes precedence over the user tag.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1000,9 +1158,18 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 //   message describes the specific error.
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
-//   The request was rejected because the policy document was too large. The error
-//   message describes how big the policy document is, in packed form, as a percentage
-//   of what the API allows.
+//   The request was rejected because the total packed size of the session policies
+//   and session tags combined was too large. An AWS conversion compresses the
+//   session policy document, session policy ARNs, and session tags into a packed
+//   binary format that has a separate limit. The error message indicates by percentage
+//   how close the policies and tags are to the upper size limit. For more information,
+//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   in the IAM User Guide.
+//
+//   You could receive this error even though you meet other defined session policy
+//   and session tag limits. For more information, see IAM and STS Entity Character
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   in the IAM User Guide.
 //
 //   * ErrCodeRegionDisabledException "RegionDisabledException"
 //   STS is not activated in the requested region for the account that is being
@@ -1091,6 +1258,8 @@ func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *request.
 // and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
+// Session Duration
+//
 // The GetSessionToken operation must be called by using the long-term AWS security
 // credentials of the AWS account root user or an IAM user. Credentials that
 // are created by IAM users are valid for the duration that you specify. This
@@ -1098,6 +1267,8 @@ func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *request.
 // seconds (36 hours), with a default of 43,200 seconds (12 hours). Credentials
 // based on account credentials can range from 900 seconds (15 minutes) up to
 // 3,600 seconds (1 hour), with a default of 1 hour.
+//
+// Permissions
 //
 // The temporary security credentials created by GetSessionToken can be used
 // to make API calls to any AWS service with the following exceptions:
@@ -1213,16 +1384,16 @@ type AssumeRoleInput struct {
 	// in the IAM User Guide.
 	//
 	// The plain text that you use for both inline and managed session policies
-	// shouldn't exceed 2048 characters. The JSON policy characters can be any ASCII
+	// can't exceed 2,048 characters. The JSON policy characters can be any ASCII
 	// character from the space character to the end of the valid character list
 	// (\u0020 through \u00FF). It can also include the tab (\u0009), linefeed (\u000A),
 	// and carriage return (\u000D) characters.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -1231,15 +1402,15 @@ type AssumeRoleInput struct {
 	//
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plain text that you use for both inline and managed session
-	// policies shouldn't exceed 2048 characters. For more information about ARNs,
+	// policies can't exceed 2,048 characters. For more information about ARNs,
 	// see Amazon Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
@@ -1284,6 +1455,41 @@ type AssumeRoleInput struct {
 	// also include underscores or any of the following characters: =,.@-
 	SerialNumber *string `min:"9" type:"string"`
 
+	// A list of session tags that you want to pass. Each session tag consists of
+	// a key name and an associated value. For more information about session tags,
+	// see Tagging AWS STS Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide.
+	//
+	// This parameter is optional. You can pass up to 50 session tags. The plain
+	// text session tag keys can’t exceed 128 characters, and the values can’t
+	// exceed 256 characters. For these and additional limits, see IAM and STS Character
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// in the IAM User Guide.
+	//
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
+	//
+	// You can pass a session tag with the same key as a tag that is already attached
+	// to the role. When you do, session tags override a role tag with the same
+	// key.
+	//
+	// Tag key–value pairs are not case sensitive, but case is preserved. This
+	// means that you cannot have separate Department and department tag keys. Assume
+	// that the role has the Department=Marketing tag and you pass the department=engineering
+	// session tag. Department and department are not saved as separate tags, and
+	// the session tag passed in the request takes precedence over the role tag.
+	//
+	// Additionally, if you used temporary credentials to perform this operation,
+	// the new session inherits any transitive session tags from the calling session.
+	// If you pass a session tag with the same key as an inherited tag, the operation
+	// fails. To view the inherited tags for a session, see the AWS CloudTrail logs.
+	// For more information, see Viewing Session Tags in CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/session-tags.html#id_session-tags_ctlogs)
+	// in the IAM User Guide.
+	Tags []*Tag `type:"list"`
+
 	// The value provided by the MFA device, if the trust policy of the role being
 	// assumed requires MFA (that is, if the policy includes a condition that tests
 	// for MFA). If the role being assumed requires MFA and if the TokenCode value
@@ -1292,6 +1498,19 @@ type AssumeRoleInput struct {
 	// The format for this parameter, as described by its regex pattern, is a sequence
 	// of six numeric digits.
 	TokenCode *string `min:"6" type:"string"`
+
+	// A list of keys for session tags that you want to set as transitive. If you
+	// set a tag key as transitive, the corresponding key and value passes to subsequent
+	// sessions in a role chain. For more information, see Chaining Roles with Session
+	// Tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+	// in the IAM User Guide.
+	//
+	// This parameter is optional. When you set session tags as transitive, the
+	// session policy and session tags packed binary limit is not affected.
+	//
+	// If you choose not to specify a transitive tag key, then no tags are passed
+	// from this session to any subsequent sessions.
+	TransitiveTagKeys []*string `type:"list"`
 }
 
 // String returns the string representation
@@ -1344,6 +1563,16 @@ func (s *AssumeRoleInput) Validate() error {
 			}
 		}
 	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1393,9 +1622,21 @@ func (s *AssumeRoleInput) SetSerialNumber(v string) *AssumeRoleInput {
 	return s
 }
 
+// SetTags sets the Tags field's value.
+func (s *AssumeRoleInput) SetTags(v []*Tag) *AssumeRoleInput {
+	s.Tags = v
+	return s
+}
+
 // SetTokenCode sets the TokenCode field's value.
 func (s *AssumeRoleInput) SetTokenCode(v string) *AssumeRoleInput {
 	s.TokenCode = &v
+	return s
+}
+
+// SetTransitiveTagKeys sets the TransitiveTagKeys field's value.
+func (s *AssumeRoleInput) SetTransitiveTagKeys(v []*string) *AssumeRoleInput {
+	s.TransitiveTagKeys = v
 	return s
 }
 
@@ -1418,9 +1659,10 @@ type AssumeRoleOutput struct {
 	// We strongly recommend that you make no assumptions about the maximum size.
 	Credentials *Credentials `type:"structure"`
 
-	// A percentage value that indicates the size of the policy in packed form.
-	// The service rejects any policy with a packed size greater than 100 percent,
-	// which means the policy exceeded the allowed space.
+	// A percentage value that indicates the packed size of the session policies
+	// and session tags combined passed in the request. The request fails if the
+	// packed size is greater than 100 percent, which means the policies and tags
+	// exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 }
 
@@ -1491,16 +1733,16 @@ type AssumeRoleWithSAMLInput struct {
 	// in the IAM User Guide.
 	//
 	// The plain text that you use for both inline and managed session policies
-	// shouldn't exceed 2048 characters. The JSON policy characters can be any ASCII
+	// can't exceed 2,048 characters. The JSON policy characters can be any ASCII
 	// character from the space character to the end of the valid character list
 	// (\u0020 through \u00FF). It can also include the tab (\u0009), linefeed (\u000A),
 	// and carriage return (\u000D) characters.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -1509,15 +1751,15 @@ type AssumeRoleWithSAMLInput struct {
 	//
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plain text that you use for both inline and managed session
-	// policies shouldn't exceed 2048 characters. For more information about ARNs,
+	// policies can't exceed 2,048 characters. For more information about ARNs,
 	// see Amazon Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
@@ -1673,9 +1915,10 @@ type AssumeRoleWithSAMLOutput struct {
 	// ) )
 	NameQualifier *string `type:"string"`
 
-	// A percentage value that indicates the size of the policy in packed form.
-	// The service rejects any policy with a packed size greater than 100 percent,
-	// which means the policy exceeded the allowed space.
+	// A percentage value that indicates the packed size of the session policies
+	// and session tags combined passed in the request. The request fails if the
+	// packed size is greater than 100 percent, which means the policies and tags
+	// exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 
 	// The value of the NameID element in the Subject element of the SAML assertion.
@@ -1786,16 +2029,16 @@ type AssumeRoleWithWebIdentityInput struct {
 	// in the IAM User Guide.
 	//
 	// The plain text that you use for both inline and managed session policies
-	// shouldn't exceed 2048 characters. The JSON policy characters can be any ASCII
+	// can't exceed 2,048 characters. The JSON policy characters can be any ASCII
 	// character from the space character to the end of the valid character list
 	// (\u0020 through \u00FF). It can also include the tab (\u0009), linefeed (\u000A),
 	// and carriage return (\u000D) characters.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -1804,15 +2047,15 @@ type AssumeRoleWithWebIdentityInput struct {
 	//
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plain text that you use for both inline and managed session
-	// policies shouldn't exceed 2048 characters. For more information about ARNs,
+	// policies can't exceed 2,048 characters. For more information about ARNs,
 	// see Amazon Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
@@ -1983,9 +2226,10 @@ type AssumeRoleWithWebIdentityOutput struct {
 	// We strongly recommend that you make no assumptions about the maximum size.
 	Credentials *Credentials `type:"structure"`
 
-	// A percentage value that indicates the size of the policy in packed form.
-	// The service rejects any policy with a packed size greater than 100 percent,
-	// which means the policy exceeded the allowed space.
+	// A percentage value that indicates the packed size of the session policies
+	// and session tags combined passed in the request. The request fails if the
+	// packed size is greater than 100 percent, which means the policies and tags
+	// exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 
 	// The issuing authority of the web identity token presented. For OpenID Connect
@@ -2057,7 +2301,7 @@ type AssumedRoleUser struct {
 	// The ARN of the temporary security credentials that are returned from the
 	// AssumeRole action. For more information about ARNs and how to use them in
 	// policies, see IAM Identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
-	// in Using IAM.
+	// in the IAM User Guide.
 	//
 	// Arn is a required field
 	Arn *string `min:"20" type:"string" required:"true"`
@@ -2225,7 +2469,7 @@ type FederatedUser struct {
 	// The ARN that specifies the federated user that is associated with the credentials.
 	// For more information about ARNs and how to use them in policies, see IAM
 	// Identifiers (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
-	// in Using IAM.
+	// in the IAM User Guide.
 	//
 	// Arn is a required field
 	Arn *string `min:"20" type:"string" required:"true"`
@@ -2265,7 +2509,7 @@ type GetAccessKeyInfoInput struct {
 	// The identifier of an access key.
 	//
 	// This parameter allows (through its regex pattern) a string of characters
-	// that can consist of any upper- or lowercased letter or digit.
+	// that can consist of any upper- or lowercase letter or digit.
 	//
 	// AccessKeyId is a required field
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
@@ -2418,10 +2662,7 @@ type GetFederationTokenInput struct {
 	// use as managed session policies.
 	//
 	// This parameter is optional. However, if you do not pass any session policies,
-	// then the resulting federated user session has no permissions. The only exception
-	// is when the credentials are used to access a resource that has a resource-based
-	// policy that specifically references the federated user session in the Principal
-	// element of the policy.
+	// then the resulting federated user session has no permissions.
 	//
 	// When you pass session policies, the session permissions are the intersection
 	// of the IAM user policies and the session policies that you pass. This gives
@@ -2431,17 +2672,23 @@ type GetFederationTokenInput struct {
 	// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	//
+	// The resulting credentials can be used to access a resource that has a resource-based
+	// policy. If that policy specifically references the federated user session
+	// in the Principal element of the policy, the session has the permissions allowed
+	// by the policy. These permissions are granted in addition to the permissions
+	// that are granted by the session policies.
+	//
 	// The plain text that you use for both inline and managed session policies
-	// shouldn't exceed 2048 characters. The JSON policy characters can be any ASCII
+	// can't exceed 2,048 characters. The JSON policy characters can be any ASCII
 	// character from the space character to the end of the valid character list
 	// (\u0020 through \u00FF). It can also include the tab (\u0009), linefeed (\u000A),
 	// and carriage return (\u000D) characters.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -2452,16 +2699,13 @@ type GetFederationTokenInput struct {
 	// to this operation. You can pass a single JSON policy document to use as an
 	// inline session policy. You can also specify up to 10 managed policies to
 	// use as managed session policies. The plain text that you use for both inline
-	// and managed session policies shouldn't exceed 2048 characters. You can provide
+	// and managed session policies can't exceed 2,048 characters. You can provide
 	// up to 10 managed policy ARNs. For more information about ARNs, see Amazon
 	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	//
 	// This parameter is optional. However, if you do not pass any session policies,
-	// then the resulting federated user session has no permissions. The only exception
-	// is when the credentials are used to access a resource that has a resource-based
-	// policy that specifically references the federated user session in the Principal
-	// element of the policy.
+	// then the resulting federated user session has no permissions.
 	//
 	// When you pass session policies, the session permissions are the intersection
 	// of the IAM user policies and the session policies that you pass. This gives
@@ -2471,12 +2715,46 @@ type GetFederationTokenInput struct {
 	// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	//
-	// The characters in this parameter count towards the 2048 character session
-	// policy guideline. However, an AWS conversion compresses the session policies
-	// into a packed binary format that has a separate limit. This is the enforced
-	// limit. The PackedPolicySize response element indicates by percentage how
-	// close the policy is to the upper size limit.
+	// The resulting credentials can be used to access a resource that has a resource-based
+	// policy. If that policy specifically references the federated user session
+	// in the Principal element of the policy, the session has the permissions allowed
+	// by the policy. These permissions are granted in addition to the permissions
+	// that are granted by the session policies.
+	//
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
+
+	// A list of session tags. Each session tag consists of a key name and an associated
+	// value. For more information about session tags, see Passing Session Tags
+	// in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide.
+	//
+	// This parameter is optional. You can pass up to 50 session tags. The plain
+	// text session tag keys can’t exceed 128 characters and the values can’t
+	// exceed 256 characters. For these and additional limits, see IAM and STS Character
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// in the IAM User Guide.
+	//
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
+	//
+	// You can pass a session tag with the same key as a tag that is already attached
+	// to the user you are federating. When you do, session tags override a user
+	// tag with the same key.
+	//
+	// Tag key–value pairs are not case sensitive, but case is preserved. This
+	// means that you cannot have separate Department and department tag keys. Assume
+	// that the role has the Department=Marketing tag and you pass the department=engineering
+	// session tag. Department and department are not saved as separate tags, and
+	// the session tag passed in the request takes precedence over the role tag.
+	Tags []*Tag `type:"list"`
 }
 
 // String returns the string representation
@@ -2514,6 +2792,16 @@ func (s *GetFederationTokenInput) Validate() error {
 			}
 		}
 	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2545,6 +2833,12 @@ func (s *GetFederationTokenInput) SetPolicyArns(v []*PolicyDescriptorType) *GetF
 	return s
 }
 
+// SetTags sets the Tags field's value.
+func (s *GetFederationTokenInput) SetTags(v []*Tag) *GetFederationTokenInput {
+	s.Tags = v
+	return s
+}
+
 // Contains the response to a successful GetFederationToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetFederationTokenOutput struct {
@@ -2563,9 +2857,10 @@ type GetFederationTokenOutput struct {
 	// an Amazon S3 bucket policy.
 	FederatedUser *FederatedUser `type:"structure"`
 
-	// A percentage value indicating the size of the policy in packed form. The
-	// service rejects policies for which the packed size is greater than 100 percent
-	// of the allowed value.
+	// A percentage value that indicates the packed size of the session policies
+	// and session tags combined passed in the request. The request fails if the
+	// packed size is greater than 100 percent, which means the policies and tags
+	// exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 }
 
@@ -2746,5 +3041,75 @@ func (s *PolicyDescriptorType) Validate() error {
 // SetArn sets the Arn field's value.
 func (s *PolicyDescriptorType) SetArn(v string) *PolicyDescriptorType {
 	s.Arn = &v
+	return s
+}
+
+// You can pass custom key-value pair attributes when you assume a role or federate
+// a user. These are called session tags. You can then use the session tags
+// to control access to resources. For more information, see Tagging AWS STS
+// Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// in the IAM User Guide.
+type Tag struct {
+	_ struct{} `type:"structure"`
+
+	// The key for a session tag.
+	//
+	// You can pass up to 50 session tags. The plain text session tag keys can’t
+	// exceed 128 characters. For these and additional limits, see IAM and STS Character
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// in the IAM User Guide.
+	//
+	// Key is a required field
+	Key *string `min:"1" type:"string" required:"true"`
+
+	// The value for a session tag.
+	//
+	// You can pass up to 50 session tags. The plain text session tag values can’t
+	// exceed 256 characters. For these and additional limits, see IAM and STS Character
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// in the IAM User Guide.
+	//
+	// Value is a required field
+	Value *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
 	return s
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/errors.go
@@ -14,11 +14,11 @@ const (
 	// ErrCodeIDPCommunicationErrorException for service response error code
 	// "IDPCommunicationError".
 	//
-	// The request could not be fulfilled because the non-AWS identity provider
-	// (IDP) that was asked to verify the incoming identity token could not be reached.
-	// This is often a transient error caused by network conditions. Retry the request
+	// The request could not be fulfilled because the identity provider (IDP) that
+	// was asked to verify the incoming identity token could not be reached. This
+	// is often a transient error caused by network conditions. Retry the request
 	// a limited number of times so that you don't exceed the request rate. If the
-	// error persists, the non-AWS identity provider might be down or not responding.
+	// error persists, the identity provider might be down or not responding.
 	ErrCodeIDPCommunicationErrorException = "IDPCommunicationError"
 
 	// ErrCodeIDPRejectedClaimException for service response error code
@@ -56,9 +56,18 @@ const (
 	// ErrCodePackedPolicyTooLargeException for service response error code
 	// "PackedPolicyTooLarge".
 	//
-	// The request was rejected because the policy document was too large. The error
-	// message describes how big the policy document is, in packed form, as a percentage
-	// of what the API allows.
+	// The request was rejected because the total packed size of the session policies
+	// and session tags combined was too large. An AWS conversion compresses the
+	// session policy document, session policy ARNs, and session tags into a packed
+	// binary format that has a separate limit. The error message indicates by percentage
+	// how close the policies and tags are to the upper size limit. For more information,
+	// see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide.
+	//
+	// You could receive this error even though you meet other defined session policy
+	// and session tag limits. For more information, see IAM and STS Entity Character
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+	// in the IAM User Guide.
 	ErrCodePackedPolicyTooLargeException = "PackedPolicyTooLarge"
 
 	// ErrCodeRegionDisabledException for service response error code

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sts"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "STS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "STS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the STS client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a STS client from just a session.
 //     svc := sts.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := sts.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *STS {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *STS {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *STS {
 	svc := &STS{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2011-06-15",
 			},

--- a/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
+++ b/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
@@ -71,8 +71,8 @@ func addToGroupVersion(scheme *runtime.Scheme) error {
 		&metav1.UpdateOptions{},
 	)
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&metav1.Table{},
-		&metav1.TableOptions{},
+		&metav1beta1.Table{},
+		&metav1beta1.TableOptions{},
 		&metav1beta1.PartialObjectMetadata{},
 		&metav1beta1.PartialObjectMetadataList{},
 	)

--- a/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation/BUILD
+++ b/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation/BUILD
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation/validation.go
+++ b/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation/validation.go
@@ -18,11 +18,12 @@ package validation
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidateTableOptions returns any invalid flags on TableOptions.
-func ValidateTableOptions(opts *metav1.TableOptions) field.ErrorList {
+func ValidateTableOptions(opts *metav1beta1.TableOptions) field.ErrorList {
 	var allErrs field.ErrorList
 	switch opts.IncludeObject {
 	case metav1.IncludeMetadata, metav1.IncludeNone, metav1.IncludeObject, "":

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -74,7 +74,7 @@ func doTransformObject(ctx context.Context, obj runtime.Object, opts interface{}
 		return asPartialObjectMetadataList(obj, target.GroupVersion())
 
 	case target.Kind == "Table":
-		options, ok := opts.(*metav1.TableOptions)
+		options, ok := opts.(*metav1beta1.TableOptions)
 		if !ok {
 			return nil, fmt.Errorf("unexpected TableOptions, got %T", opts)
 		}
@@ -93,8 +93,8 @@ func optionsForTransform(mediaType negotiation.MediaTypeOptions, req *http.Reque
 	switch target := mediaType.Convert; {
 	case target == nil:
 	case target.Kind == "Table" && (target.GroupVersion() == metav1beta1.SchemeGroupVersion || target.GroupVersion() == metav1.SchemeGroupVersion):
-		opts := &metav1.TableOptions{}
-		if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), metav1.SchemeGroupVersion, opts); err != nil {
+		opts := &metav1beta1.TableOptions{}
+		if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), metav1beta1.SchemeGroupVersion, opts); err != nil {
 			return nil, err
 		}
 		switch errs := validation.ValidateTableOptions(opts); len(errs) {
@@ -159,7 +159,7 @@ func (e errNotAcceptable) Status() metav1.Status {
 	}
 }
 
-func asTable(ctx context.Context, result runtime.Object, opts *metav1.TableOptions, scope *RequestScope, groupVersion schema.GroupVersion) (runtime.Object, error) {
+func asTable(ctx context.Context, result runtime.Object, opts *metav1beta1.TableOptions, scope *RequestScope, groupVersion schema.GroupVersion) (runtime.Object, error) {
 	switch groupVersion {
 	case metav1beta1.SchemeGroupVersion, metav1.SchemeGroupVersion:
 	default:

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -124,7 +125,7 @@ func serveWatch(watcher watch.Interface, scope *RequestScope, mediaTypeOptions n
 			// When we are transformed to a table, use the table options as the state for whether we
 			// should print headers - on watch, we only want to print table headers on the first object
 			// and omit them on subsequent events.
-			if tableOptions, ok := options.(*metav1.TableOptions); ok {
+			if tableOptions, ok := options.(*metav1beta1.TableOptions); ok {
 				tableOptions.NoHeaders = true
 			}
 			return result

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/BUILD
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -24,6 +24,7 @@ import (
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -98,8 +99,6 @@ type Lister interface {
 	NewList() runtime.Object
 	// List selects resources in the storage which match to the selector. 'options' can be nil.
 	List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error)
-	// TableConvertor ensures all list implementers also implement table conversion
-	TableConvertor
 }
 
 // Exporter is an object that knows how to strip a RESTful resource for export. A store should implement this interface
@@ -142,7 +141,7 @@ type GetterWithOptions interface {
 }
 
 type TableConvertor interface {
-	ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error)
+	ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error)
 }
 
 // GracefulDeleter knows how to pass deletion options to allow delayed deletion of a

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -39,14 +40,14 @@ func NewDefaultTableConvertor(resource schema.GroupResource) TableConvertor {
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
-func (c defaultTableConvertor) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
-	var table metav1.Table
+func (c defaultTableConvertor) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	var table metav1beta1.Table
 	fn := func(obj runtime.Object) error {
 		m, err := meta.Accessor(obj)
 		if err != nil {
 			return errNotAcceptable{resource: c.qualifiedResource}
 		}
-		table.Rows = append(table.Rows, metav1.TableRow{
+		table.Rows = append(table.Rows, metav1beta1.TableRow{
 			Cells:  []interface{}{m.GetName(), m.GetCreationTimestamp().Time.UTC().Format(time.RFC3339)},
 			Object: runtime.RawExtension{Object: obj},
 		})
@@ -73,8 +74,8 @@ func (c defaultTableConvertor) ConvertToTable(ctx context.Context, object runtim
 			table.SelfLink = m.GetSelfLink()
 		}
 	}
-	if opt, ok := tableOptions.(*metav1.TableOptions); !ok || !opt.NoHeaders {
-		table.ColumnDefinitions = []metav1.TableColumnDefinition{
+	if opt, ok := tableOptions.(*metav1beta1.TableOptions); !ok || !opt.NoHeaders {
+		table.ColumnDefinitions = []metav1beta1.TableColumnDefinition{
 			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
 			{Name: "Created At", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 		}

--- a/cluster-autoscaler/vendor/k8s.io/client-go/tools/cache/mutation_detector.go
+++ b/cluster-autoscaler/vendor/k8s.io/client-go/tools/cache/mutation_detector.go
@@ -48,7 +48,7 @@ func NewCacheMutationDetector(name string) MutationDetector {
 		return dummyMutationDetector{}
 	}
 	klog.Warningln("Mutation detector is enabled, this will result in memory leakage.")
-	return &defaultCacheMutationDetector{name: name, period: 1 * time.Second, retainDuration: 2 * time.Minute}
+	return &defaultCacheMutationDetector{name: name, period: 1 * time.Second}
 }
 
 type dummyMutationDetector struct{}
@@ -68,10 +68,6 @@ type defaultCacheMutationDetector struct {
 	lock       sync.Mutex
 	cachedObjs []cacheObj
 
-	retainDuration     time.Duration
-	lastRotated        time.Time
-	retainedCachedObjs []cacheObj
-
 	// failureFunc is injectable for unit testing.  If you don't have it, the process will panic.
 	// This panic is intentional, since turning on this detection indicates you want a strong
 	// failure signal.  This failure is effectively a p0 bug and you can't trust process results
@@ -88,14 +84,6 @@ type cacheObj struct {
 func (d *defaultCacheMutationDetector) Run(stopCh <-chan struct{}) {
 	// we DON'T want protection from panics.  If we're running this code, we want to die
 	for {
-		if d.lastRotated.IsZero() {
-			d.lastRotated = time.Now()
-		} else if time.Now().Sub(d.lastRotated) > d.retainDuration {
-			d.retainedCachedObjs = d.cachedObjs
-			d.cachedObjs = nil
-			d.lastRotated = time.Now()
-		}
-
 		d.CompareObjects()
 
 		select {
@@ -127,12 +115,6 @@ func (d *defaultCacheMutationDetector) CompareObjects() {
 
 	altered := false
 	for i, obj := range d.cachedObjs {
-		if !reflect.DeepEqual(obj.cached, obj.copied) {
-			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectGoPrintSideBySide(obj.cached, obj.copied))
-			altered = true
-		}
-	}
-	for i, obj := range d.retainedCachedObjs {
 		if !reflect.DeepEqual(obj.cached, obj.copied) {
 			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectGoPrintSideBySide(obj.cached, obj.copied))
 			altered = true

--- a/cluster-autoscaler/vendor/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
+++ b/cluster-autoscaler/vendor/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
@@ -1,4 +1,4 @@
-// To regenerate api.pb.go run hack/update-generated-device-plugin.sh
+// To regenerate api.pb.go run hack/update-device-plugin.sh
 syntax = 'proto3';
 
 package v1beta1;

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
@@ -287,7 +287,8 @@ func decodeDockerConfigFieldAuth(field string) (username, password string, err e
 
 	// StdEncoding can only decode padded string
 	// RawStdEncoding can only decode unpadded string
-	if strings.HasSuffix(strings.TrimSpace(field), "=") {
+	// a string is correctly padded if and only if its length is a multiple of 4
+	if (len(field) % 4) == 0 {
 		// decode padded data
 		decoded, err = base64.StdEncoding.DecodeString(field)
 	} else {

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager.go
@@ -177,9 +177,7 @@ func (m *ManagerImpl) genericDeviceUpdateCallback(resourceName string, devices [
 		}
 	}
 	m.mutex.Unlock()
-	if err := m.writeCheckpoint(); err != nil {
-		klog.Errorf("writing checkpoint encountered %v", err)
-	}
+	m.writeCheckpoint()
 }
 
 func (m *ManagerImpl) removeContents(dir string) error {
@@ -543,9 +541,7 @@ func (m *ManagerImpl) GetCapacity() (v1.ResourceList, v1.ResourceList, []string)
 	}
 	m.mutex.Unlock()
 	if needsUpdateCheckpoint {
-		if err := m.writeCheckpoint(); err != nil {
-			klog.Errorf("writing checkpoint encountered %v", err)
-		}
+		m.writeCheckpoint()
 	}
 	return capacity, allocatable, deletedResources.UnsortedList()
 }

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubemark/hollow_kubelet.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubemark/hollow_kubelet.go
@@ -159,7 +159,6 @@ func GetHollowKubeletConfig(opt *HollowKubletOptions) (*options.KubeletFlags, *k
 	f.MinimumGCAge = metav1.Duration{Duration: 1 * time.Minute}
 	f.MaxContainerCount = 100
 	f.MaxPerPodContainerCount = 2
-	f.NodeLabels = opt.NodeLabels
 	f.RegisterNode = true
 	f.RegisterSchedulable = true
 	f.ProviderID = fmt.Sprintf("kubemark://%v", opt.NodeName)

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/internal/cache/cache.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/internal/cache/cache.go
@@ -209,14 +209,6 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapsh
 	// Get the last generation of the snapshot.
 	snapshotGeneration := nodeSnapshot.Generation
 
-	// NodeInfoList and HavePodsWithAffinityNodeInfoList must be re-created if a node was added
-	// or removed from the cache.
-	updateAllLists := false
-	// HavePodsWithAffinityNodeInfoList must be re-created if a node changed its
-	// status from having pods with affinity to NOT having pods with affinity or the other
-	// way around.
-	updateNodesHavePodsWithAffinity := false
-
 	// Start from the head of the NodeInfo doubly linked list and update snapshot
 	// of NodeInfos updated after the last snapshot.
 	for node := cache.headNode; node != nil; node = node.next {
@@ -229,22 +221,7 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapsh
 			node.info.TransientInfo.ResetTransientSchedulerInfo()
 		}
 		if np := node.info.Node(); np != nil {
-			existing, ok := nodeSnapshot.NodeInfoMap[np.Name]
-			if !ok {
-				updateAllLists = true
-				existing = &schedulernodeinfo.NodeInfo{}
-				nodeSnapshot.NodeInfoMap[np.Name] = existing
-			}
-			clone := node.info.Clone()
-			// We track nodes that have pods with affinity, here we check if this node changed its
-			// status from having pods with affinity to NOT having pods with affinity or the other
-			// way around.
-			if (len(existing.PodsWithAffinity()) > 0) != (len(clone.PodsWithAffinity()) > 0) {
-				updateNodesHavePodsWithAffinity = true
-			}
-			// We need to preserve the original pointer of the NodeInfo struct since it
-			// is used in the NodeInfoList, which we may not update.
-			*existing = *clone
+			nodeSnapshot.NodeInfoMap[np.Name] = node.info.Clone()
 		}
 	}
 	// Update the snapshot generation with the latest NodeInfo generation.
@@ -253,67 +230,28 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapsh
 	}
 
 	if len(nodeSnapshot.NodeInfoMap) > len(cache.nodes) {
-		cache.removeDeletedNodesFromSnapshot(nodeSnapshot)
-		updateAllLists = true
-	}
-
-	if updateAllLists || updateNodesHavePodsWithAffinity {
-		cache.updateNodeInfoSnapshotList(nodeSnapshot, updateAllLists)
-	}
-
-	if len(nodeSnapshot.NodeInfoList) != len(nodeSnapshot.NodeInfoMap) {
-		errMsg := fmt.Sprintf("snapshot state is not consistent, length of NodeInfoList=%v not equal to length of NodeInfoMap=%v "+
-			"length of nodes in cache=%v, length of nodes in tree=%v"+
-			", trying to recover",
-			len(nodeSnapshot.NodeInfoList), len(nodeSnapshot.NodeInfoMap),
-			len(cache.nodes), cache.nodeTree.numNodes)
-		klog.Error(errMsg)
-		// We will try to recover by re-creating the lists for the next scheduling cycle, but still return an
-		// error to surface the problem, the error will likely cause a failure to the current scheduling cycle.
-		cache.updateNodeInfoSnapshotList(nodeSnapshot, true)
-		return fmt.Errorf(errMsg)
-	}
-
-	return nil
-}
-
-func (cache *schedulerCache) updateNodeInfoSnapshotList(nodeSnapshot *nodeinfosnapshot.Snapshot, updateAll bool) {
-	nodeSnapshot.HavePodsWithAffinityNodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
-	if updateAll {
-		// Take a snapshot of the nodes order in the tree
-		nodeSnapshot.NodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
-		for i := 0; i < cache.nodeTree.numNodes; i++ {
-			nodeName := cache.nodeTree.next()
-			if n := nodeSnapshot.NodeInfoMap[nodeName]; n != nil {
-				nodeSnapshot.NodeInfoList = append(nodeSnapshot.NodeInfoList, n)
-				if len(n.PodsWithAffinity()) > 0 {
-					nodeSnapshot.HavePodsWithAffinityNodeInfoList = append(nodeSnapshot.HavePodsWithAffinityNodeInfoList, n)
-				}
-			} else {
-				klog.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen.", nodeName)
+		for name := range nodeSnapshot.NodeInfoMap {
+			if _, ok := cache.nodes[name]; !ok {
+				delete(nodeSnapshot.NodeInfoMap, name)
 			}
 		}
-	} else {
-		for _, n := range nodeSnapshot.NodeInfoList {
+	}
+
+	// Take a snapshot of the nodes order in the tree
+	nodeSnapshot.NodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
+	nodeSnapshot.HavePodsWithAffinityNodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
+	for i := 0; i < cache.nodeTree.numNodes; i++ {
+		nodeName := cache.nodeTree.next()
+		if n := nodeSnapshot.NodeInfoMap[nodeName]; n != nil {
+			nodeSnapshot.NodeInfoList = append(nodeSnapshot.NodeInfoList, n)
 			if len(n.PodsWithAffinity()) > 0 {
 				nodeSnapshot.HavePodsWithAffinityNodeInfoList = append(nodeSnapshot.HavePodsWithAffinityNodeInfoList, n)
 			}
+		} else {
+			klog.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen.", nodeName)
 		}
 	}
-}
-
-// If certain nodes were deleted after the last snapshot was taken, we should remove them from the snapshot.
-func (cache *schedulerCache) removeDeletedNodesFromSnapshot(nodeSnapshot *nodeinfosnapshot.Snapshot) {
-	toDelete := len(nodeSnapshot.NodeInfoMap) - len(cache.nodes)
-	for name := range nodeSnapshot.NodeInfoMap {
-		if toDelete <= 0 {
-			break
-		}
-		if _, ok := cache.nodes[name]; !ok {
-			delete(nodeSnapshot.NodeInfoMap, name)
-			toDelete--
-		}
-	}
+	return nil
 }
 
 func (cache *schedulerCache) List(selector labels.Selector) ([]*v1.Pod, error) {
@@ -604,7 +542,6 @@ func (cache *schedulerCache) UpdateNode(oldNode, newNode *v1.Node) error {
 	if !ok {
 		n = newNodeInfoListItem(schedulernodeinfo.NewNodeInfo())
 		cache.nodes[newNode.Name] = n
-		cache.nodeTree.addNode(newNode)
 	} else {
 		cache.removeNodeImageStates(n.info.Node())
 	}

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info.go
@@ -548,21 +548,11 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 			n.UpdateUsedPorts(pod, false)
 
 			n.generation = nextGeneration()
-			n.resetSlicesIfEmpty()
+
 			return nil
 		}
 	}
 	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, n.node.Name)
-}
-
-// resets the slices to nil so that we can do DeepEqual in unit tests.
-func (n *NodeInfo) resetSlicesIfEmpty() {
-	if len(n.podsWithAffinity) == 0 {
-		n.podsWithAffinity = nil
-	}
-	if len(n.pods) == 0 {
-		n.pods = nil
-	}
 }
 
 func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64) {

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/iscsi/BUILD
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/iscsi/BUILD
@@ -42,7 +42,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/kubelet/config:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/iscsi/iscsi_util.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/iscsi/iscsi_util.go
@@ -926,13 +926,9 @@ func isSessionBusy(host volume.VolumeHost, portal, iqn string) bool {
 // getVolCount returns the number of volumes in use by the kubelet.
 // It does so by counting the number of directories prefixed by the given portal and IQN.
 func getVolCount(dir, portal, iqn string) (int, error) {
-	// For FileSystem volumes, the topmost dirs are named after the ifaces, e.g., iface-default or iface-127.0.0.1:3260:pv0.
-	// For Block volumes, the default topmost dir is volumeDevices.
+	// The topmost dirs are named after the ifaces, e.g., iface-default or iface-127.0.0.1:3260:pv0
 	contents, err := ioutil.ReadDir(dir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
 		return 0, err
 	}
 

--- a/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -2105,18 +2105,17 @@ func (c *Cloud) applyUnSchedulableTaint(nodeName types.NodeName, reason string) 
 
 // waitForAttachmentStatus polls until the attachment status is the expected value
 // On success, it returns the last attachment state.
-func (d *awsDisk) waitForAttachmentStatus(status string, expectedInstance, expectedDevice string) (*ec2.VolumeAttachment, error) {
+func (d *awsDisk) waitForAttachmentStatus(status string) (*ec2.VolumeAttachment, error) {
 	backoff := wait.Backoff{
 		Duration: volumeAttachmentStatusPollDelay,
 		Factor:   volumeAttachmentStatusFactor,
 		Steps:    volumeAttachmentStatusSteps,
 	}
 
-	// Because of rate limiting, we often see errors from describeVolume.
-	// Or AWS eventual consistency returns unexpected data.
+	// Because of rate limiting, we often see errors from describeVolume
 	// So we tolerate a limited number of failures.
-	// But once we see more than 10 errors in a row, we return the error.
-	errorCount := 0
+	// But once we see more than 10 errors in a row, we return the error
+	describeErrorCount := 0
 
 	// Attach/detach usually takes time. It does not make sense to start
 	// polling DescribeVolumes before some initial delay to let AWS
@@ -2145,8 +2144,8 @@ func (d *awsDisk) waitForAttachmentStatus(status string, expectedInstance, expec
 					return false, err
 				}
 			}
-			errorCount++
-			if errorCount > volumeAttachmentStatusConsecutiveErrorLimit {
+			describeErrorCount++
+			if describeErrorCount > volumeAttachmentStatusConsecutiveErrorLimit {
 				// report the error
 				return false, err
 			}
@@ -2154,6 +2153,8 @@ func (d *awsDisk) waitForAttachmentStatus(status string, expectedInstance, expec
 			klog.Warningf("Ignoring error from describe volume for volume %q; will retry: %q", d.awsID, err)
 			return false, nil
 		}
+
+		describeErrorCount = 0
 
 		if len(info.Attachments) > 1 {
 			// Shouldn't happen; log so we know if it is
@@ -2176,39 +2177,11 @@ func (d *awsDisk) waitForAttachmentStatus(status string, expectedInstance, expec
 		if attachmentStatus == "" {
 			attachmentStatus = "detached"
 		}
-		if attachment != nil {
-			// AWS eventual consistency can go back in time.
-			// For example, we're waiting for a volume to be attached as /dev/xvdba, but AWS can tell us it's
-			// attached as /dev/xvdbb, where it was attached before and it was already detached.
-			// Retry couple of times, hoping AWS starts reporting the right status.
-			device := aws.StringValue(attachment.Device)
-			if expectedDevice != "" && device != "" && device != expectedDevice {
-				klog.Warningf("Expected device %s %s for volume %s, but found device %s %s", expectedDevice, status, d.name, device, attachmentStatus)
-				errorCount++
-				if errorCount > volumeAttachmentStatusConsecutiveErrorLimit {
-					// report the error
-					return false, fmt.Errorf("attachment of disk %q failed: requested device %q but found %q", d.name, expectedDevice, device)
-				}
-				return false, nil
-			}
-			instanceID := aws.StringValue(attachment.InstanceId)
-			if expectedInstance != "" && instanceID != "" && instanceID != expectedInstance {
-				klog.Warningf("Expected instance %s/%s for volume %s, but found instance %s/%s", expectedInstance, status, d.name, instanceID, attachmentStatus)
-				errorCount++
-				if errorCount > volumeAttachmentStatusConsecutiveErrorLimit {
-					// report the error
-					return false, fmt.Errorf("attachment of disk %q failed: requested device %q but found %q", d.name, expectedDevice, device)
-				}
-				return false, nil
-			}
-		}
-
 		if attachmentStatus == status {
 			// Attachment is in requested state, finish waiting
 			return true, nil
 		}
 		// continue waiting
-		errorCount = 0
 		klog.V(2).Infof("Waiting for volume %q state: actual=%s, desired=%s", d.awsID, attachmentStatus, status)
 		return false, nil
 	})
@@ -2348,7 +2321,7 @@ func (c *Cloud) AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 		klog.V(2).Infof("AttachVolume volume=%q instance=%q request returned %v", disk.awsID, awsInstance.awsID, attachResponse)
 	}
 
-	attachment, err := disk.waitForAttachmentStatus("attached", awsInstance.awsID, ec2Device)
+	attachment, err := disk.waitForAttachmentStatus("attached")
 
 	if err != nil {
 		if err == wait.ErrWaitTimeout {
@@ -2368,7 +2341,6 @@ func (c *Cloud) AttachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 		return "", fmt.Errorf("unexpected state: attachment nil after attached %q to %q", diskName, nodeName)
 	}
 	if ec2Device != aws.StringValue(attachment.Device) {
-		// Already checked in waitForAttachmentStatus(), but just to be sure...
 		return "", fmt.Errorf("disk attachment of %q to %q failed: requested device %q but found %q", diskName, nodeName, ec2Device, aws.StringValue(attachment.Device))
 	}
 	if awsInstance.awsID != aws.StringValue(attachment.InstanceId) {
@@ -2426,7 +2398,7 @@ func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 		return "", errors.New("no response from DetachVolume")
 	}
 
-	attachment, err := diskInfo.disk.waitForAttachmentStatus("detached", awsInstance.awsID, "")
+	attachment, err := diskInfo.disk.waitForAttachmentStatus("detached")
 	if err != nil {
 		return "", err
 	}

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/PuerkitoBio/urlesc
 github.com/armon/circbuf
 # github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 github.com/asaskevich/govalidator
-# github.com/aws/aws-sdk-go v1.23.18 => github.com/aws/aws-sdk-go v1.23.18
+# github.com/aws/aws-sdk-go v1.26.6 => github.com/aws/aws-sdk-go v1.26.6
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/ec2metadata
 github.com/aws/aws-sdk-go/aws/endpoints
@@ -93,13 +93,13 @@ github.com/aws/aws-sdk-go/aws/awsutil
 github.com/aws/aws-sdk-go/aws/signer/v4
 github.com/aws/aws-sdk-go/private/protocol
 github.com/aws/aws-sdk-go/private/protocol/query
-github.com/aws/aws-sdk-go/internal/sdkrand
 github.com/aws/aws-sdk-go/private/protocol/ec2query
 github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
 github.com/aws/aws-sdk-go/service/elb
 github.com/aws/aws-sdk-go/service/elbv2
 github.com/aws/aws-sdk-go/service/kms
 github.com/aws/aws-sdk-go/service/sts
+github.com/aws/aws-sdk-go/internal/sdkrand
 github.com/aws/aws-sdk-go/service/sts/stsiface
 github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
 github.com/aws/aws-sdk-go/private/protocol/rest
@@ -666,7 +666,7 @@ gopkg.in/square/go-jose.v2/json
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.2.4 => gopkg.in/yaml.v2 v2.2.4
 gopkg.in/yaml.v2
-# k8s.io/api v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/api
+# k8s.io/api v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/api
 k8s.io/api/core/v1
 k8s.io/api/apps/v1
 k8s.io/api/policy/v1beta1
@@ -710,13 +710,14 @@ k8s.io/api/authorization/v1beta1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admission/v1
 k8s.io/api/imagepolicy/v1alpha1
-# k8s.io/apiextensions-apiserver v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apiextensions-apiserver
+# k8s.io/apiextensions-apiserver v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apiextensions-apiserver
 k8s.io/apiextensions-apiserver/pkg/features
-# k8s.io/apimachinery v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apimachinery
+# k8s.io/apimachinery v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apimachinery
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/wait
+k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/runtime
@@ -732,7 +733,6 @@ k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
-k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/version
@@ -770,7 +770,7 @@ k8s.io/apimachinery/pkg/api/validation/path
 k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation
-# k8s.io/apiserver v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/apiserver
+# k8s.io/apiserver v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/apiserver
 k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/features
 k8s.io/apiserver/pkg/admission
@@ -854,7 +854,7 @@ k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal
 k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission
 k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1
 k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1
-# k8s.io/client-go v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/client-go
+# k8s.io/client-go v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/client-go
 k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
 k8s.io/client-go/tools/clientcmd
@@ -1081,14 +1081,14 @@ k8s.io/client-go/tools/watch
 k8s.io/client-go/metadata/metadatainformer
 k8s.io/client-go/metadata
 k8s.io/client-go/metadata/metadatalister
-# k8s.io/cloud-provider v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cloud-provider
+# k8s.io/cloud-provider v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cloud-provider
 k8s.io/cloud-provider/volume
 k8s.io/cloud-provider
 k8s.io/cloud-provider/node/helpers
 k8s.io/cloud-provider/service/helpers
 k8s.io/cloud-provider/volume/errors
 k8s.io/cloud-provider/volume/helpers
-# k8s.io/component-base v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/component-base
+# k8s.io/component-base v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/component-base
 k8s.io/component-base/cli/flag
 k8s.io/component-base/config
 k8s.io/component-base/metrics/legacyregistry
@@ -1100,10 +1100,10 @@ k8s.io/component-base/version/verflag
 k8s.io/component-base/logs
 k8s.io/component-base/config/validation
 k8s.io/component-base/config/v1alpha1
-# k8s.io/cri-api v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/cri-api
+# k8s.io/cri-api v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/cri-api
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
-# k8s.io/csi-translation-lib v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/csi-translation-lib
+# k8s.io/csi-translation-lib v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 k8s.io/csi-translation-lib
 # k8s.io/klog v1.0.0 => k8s.io/klog v1.0.0
@@ -1115,18 +1115,18 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/handler
 k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/schemaconv
-# k8s.io/kube-proxy v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-proxy
+# k8s.io/kube-proxy v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-proxy
 k8s.io/kube-proxy/config/v1alpha1
-# k8s.io/kube-scheduler v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kube-scheduler
+# k8s.io/kube-scheduler v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kube-scheduler
 k8s.io/kube-scheduler/config/v1
 k8s.io/kube-scheduler/config/v1alpha1
-# k8s.io/kubectl v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kubectl
+# k8s.io/kubectl v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kubectl
 k8s.io/kubectl/pkg/scale
-# k8s.io/kubelet v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/kubelet
+# k8s.io/kubelet v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/kubelet
 k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis/pluginregistration/v1
 k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1
-# k8s.io/kubernetes v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes
+# k8s.io/kubernetes v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes
 k8s.io/kubernetes/pkg/client/leaderelectionconfig
 k8s.io/kubernetes/pkg/apis/scheduling
 k8s.io/kubernetes/pkg/kubelet/types
@@ -1507,7 +1507,7 @@ k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp
 k8s.io/kubernetes/pkg/security/podsecuritypolicy/util
 k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations
 k8s.io/kubernetes/pkg/serviceaccount
-# k8s.io/legacy-cloud-providers v0.0.0 => /tmp/ca-update-vendor.Mm8E/kubernetes/staging/src/k8s.io/legacy-cloud-providers
+# k8s.io/legacy-cloud-providers v0.0.0 => /tmp/ca-update-vendor.eHTc/kubernetes/staging/src/k8s.io/legacy-cloud-providers
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/azure
 k8s.io/legacy-cloud-providers/gce


### PR DESCRIPTION
This brings in the new EC2 `DescribeInstanceTypes` API.

Also updates the AWS-Manager test for Region fetching due to changes in the SDK in how this is done due to https://github.com/aws/aws-sdk-go/pull/2969

Updating vendor against git@github.com:kubernetes/kubernetes.git:711790af23a231ade04c6c39d6bc5dcf1a996f73 (711790af23a231ade04c6c39d6bc5dcf1a996f73)

Broken out from the changes to the EC2 instance type list enabled by this SDK update to simplify reviewing of the PRs.

Related to #2696