### PR TITLE
cluster-autoscaler: support evict DaemonSet pods in scale down

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -679,6 +679,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `aws-use-static-instance-list` | Should CA fetch instance types in runtime or use a static list. AWS only | false
 | `skip-nodes-with-system-pods` | If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods | true
 | `skip-nodes-with-local-storage`| If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath | true
+| `skip-daemon-set-pods` | If true cluster autoscaler will never evict daemon sets controlled pods in nodes | true
 | `min-replica-count` | Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down | 0
 
 # Troubleshooting:

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -306,12 +306,14 @@ func TestFindNodesToRemove(t *testing.T) {
 	fullNodeInfo.AddPod(pod4)
 
 	emptyNodeToRemove := NodeToBeRemoved{
-		Node:             emptyNode,
-		PodsToReschedule: []*apiv1.Pod{},
+		Node:                  emptyNode,
+		PodsToReschedule:      []*apiv1.Pod{},
+		DaemonSetPodsToDelete: []*apiv1.Pod{},
 	}
 	drainableNodeToRemove := NodeToBeRemoved{
-		Node:             drainableNode,
-		PodsToReschedule: []*apiv1.Pod{pod1, pod2},
+		Node:                  drainableNode,
+		PodsToReschedule:      []*apiv1.Pod{pod1, pod2},
+		DaemonSetPodsToDelete: []*apiv1.Pod{},
 	}
 
 	clusterSnapshot := NewBasicClusterSnapshot()


### PR DESCRIPTION
## Background

Currently CA scale down ignore DaemonSet controlled pods, but in a production cluster, this may result in those pods killed not graceful. may lose data, etc.
And currently, kubelet will not handle with Pods graceful shutdown will be shutting down. And also cloud providers may(there is no restriction) kill node directly.

## Aim to

Handle with DaemonSets graceful shutdown while scaling down

ref #1578 