### PR TITLE
VPA - Checking Admission Controller status

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -287,3 +287,30 @@ subjects:
   - kind: ServiceAccount
     name: vpa-admission-controller
     namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-reader
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -53,6 +53,9 @@ var (
 	evictionRateBurst = flag.Int("eviction-rate-burst", 1, `Burst of pods that can be evicted.`)
 
 	address = flag.String("address", ":8943", "The address to expose Prometheus metrics.")
+
+	useAdmissionControllerStatus = flag.Bool("use-admission-controller-status", true,
+		"If true, updater will only evict pods when admission controller status is valid.")
 )
 
 const (
@@ -83,7 +86,18 @@ func main() {
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
 	// TODO: use SharedInformerFactory in updater
-	updater, err := updater.NewUpdater(kubeClient, vpaClient, *minReplicas, *evictionRateLimit, *evictionRateBurst, *evictionToleranceFraction, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator), nil, targetSelectorFetcher)
+	updater, err := updater.NewUpdater(
+		kubeClient,
+		vpaClient,
+		*minReplicas,
+		*evictionRateLimit,
+		*evictionRateBurst,
+		*evictionToleranceFraction,
+		*useAdmissionControllerStatus,
+		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
+		nil,
+		targetSelectorFetcher,
+	)
 	if err != nil {
 		klog.Fatalf("Failed to create updater: %v", err)
 	}


### PR DESCRIPTION
Update check if there is valid Admission Controller status.
If not, eviction loop will be skipped.