### PR TITLE
Compute expansion options for additional created groups

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -176,6 +176,23 @@ func (tcp *TestCloudProvider) NewNodeGroup(machineType string, labels map[string
 	}, nil
 }
 
+// NewNodeGroupWithId creates a new node group with custom ID suffix.
+func (tcp *TestCloudProvider) NewNodeGroupWithId(machineType string, labels map[string]string, systemLabels map[string]string,
+	taints []apiv1.Taint, extraResources map[string]resource.Quantity, id string) (cloudprovider.NodeGroup, error) {
+	return &TestNodeGroup{
+		cloudProvider:   tcp,
+		id:              "autoprovisioned-" + machineType + "-" + id,
+		minSize:         0,
+		maxSize:         1000,
+		targetSize:      0,
+		exist:           false,
+		autoprovisioned: true,
+		machineType:     machineType,
+		labels:          labels,
+		taints:          taints,
+	}, nil
+}
+
 // InsertNodeGroup adds already created node group to test cloud provider.
 func (tcp *TestCloudProvider) InsertNodeGroup(nodeGroup cloudprovider.NodeGroup) {
 	tcp.Lock()
@@ -442,4 +459,9 @@ func (tng *TestNodeGroup) Labels() map[string]string {
 // Taints returns taintspassed to the test node group when it was created.
 func (tng *TestNodeGroup) Taints() []apiv1.Taint {
 	return tng.taints
+}
+
+// MachineType returns machine type passed to the test node group when it was created.
+func (tng *TestNodeGroup) MachineType() string {
+	return tng.machineType
 }

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -309,7 +309,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	onScaleDownMock := &onScaleDownMock{}
 	onNodeGroupCreateMock := &onNodeGroupCreateMock{}
 	onNodeGroupDeleteMock := &onNodeGroupDeleteMock{}
-	nodeGroupManager := &mockAutoprovisioningNodeGroupManager{t}
+	nodeGroupManager := &mockAutoprovisioningNodeGroupManager{t, 0}
 	nodeGroupListProcessor := &mockAutoprovisioningNodeGroupListProcessor{t}
 
 	n1 := BuildTestNode("n1", 100, 1000)


### PR DESCRIPTION
Compute expansion options for additional created groups.

(I'm working on a test that would have caught the bug, TBA in another commit to this PR.)