### PR TITLE
Add delta snapshot implementation

### DIFF
--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -109,7 +109,7 @@ func filterOutSchedulableByPacking(
 	for _, pod := range allScheduled {
 		if utils.IsExpendablePod(pod, expendablePodsPriorityCutoff) {
 			klog.V(4).Infof("Removing expandable pod %s.%s", pod.Namespace, pod.Name)
-			if err := clusterSnapshot.RemovePod(pod.Namespace, pod.Name); err != nil {
+			if err := clusterSnapshot.RemovePod(pod.Namespace, pod.Name, pod.Spec.NodeName); err != nil {
 				return nil, err
 			}
 		}

--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -17,7 +17,6 @@ limitations under the License.
 package core
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -94,10 +93,7 @@ func filterOutSchedulableByPacking(
 	predicateChecker simulator.PredicateChecker,
 	expendablePodsPriorityCutoff int) ([]*apiv1.Pod, error) {
 
-	allScheduled, err := clusterSnapshot.GetAllPods()
-	if err != nil {
-		return nil, fmt.Errorf("could not list all pods from snapshot; %v", err)
-	}
+	allScheduled := clusterSnapshot.GetAllPods()
 
 	// Sort unschedulable pods by importance
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {

--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -93,7 +94,10 @@ func filterOutSchedulableByPacking(
 	predicateChecker simulator.PredicateChecker,
 	expendablePodsPriorityCutoff int) ([]*apiv1.Pod, error) {
 
-	allScheduled := clusterSnapshot.GetAllPods()
+	allScheduled, err := clusterSnapshot.Pods().List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
 
 	// Sort unschedulable pods by importance
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -410,19 +410,9 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	// Only scheduled non expendable pods and pods waiting for lower priority pods preemption can prevent node delete.
 
 	// Extract cluster state from snapshot for initial analysis
-	pods, err := sd.context.ClusterSnapshot.GetAllPods()
-	if err != nil {
-		return errors.ToAutoscalerError(errors.InternalError, err)
-	}
-	allNodes, err := sd.context.ClusterSnapshot.GetAllNodes()
-	if err != nil {
-		return errors.ToAutoscalerError(errors.InternalError, err)
-	}
+	pods := sd.context.ClusterSnapshot.GetAllPods()
+	allNodeInfos := sd.context.ClusterSnapshot.GetAllNodes()
 
-	allNodeInfos, err := sd.context.ClusterSnapshot.NodeInfos().List()
-	if err != nil {
-		return errors.ToAutoscalerError(errors.InternalError, err)
-	}
 	nodeNameToNodeInfo := make(map[string]*schedulernodeinfo.NodeInfo)
 	for _, nodeInfo := range allNodeInfos {
 		node := nodeInfo.Node()
@@ -447,7 +437,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 
 	utilizationMap := make(map[string]simulator.UtilizationInfo)
 
-	sd.updateUnremovableNodes(allNodes)
+	sd.updateUnremovableNodes(allNodeInfos)
 	// Filter out nodes that were recently checked
 	filteredNodesToCheck := make([]*apiv1.Node, 0)
 	for _, node := range scaleDownCandidates {
@@ -542,7 +532,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 		additionalCandidatesCount = len(currentNonCandidates)
 	}
 	// Limit the additional candidates pool size for better performance.
-	additionalCandidatesPoolSize := int(math.Ceil(float64(len(allNodes)) * sd.context.ScaleDownCandidatesPoolRatio))
+	additionalCandidatesPoolSize := int(math.Ceil(float64(len(allNodeInfos)) * sd.context.ScaleDownCandidatesPoolRatio))
 	if additionalCandidatesPoolSize < sd.context.ScaleDownCandidatesPoolMinCount {
 		additionalCandidatesPoolSize = sd.context.ScaleDownCandidatesPoolMinCount
 	}
@@ -628,7 +618,7 @@ func (sd *ScaleDown) isNodeBelowUtilzationThreshold(node *apiv1.Node, utilInfo s
 // updateUnremovableNodes updates unremovableNodes map according to current
 // state of the cluster. Removes from the map nodes that are no longer in the
 // nodes list.
-func (sd *ScaleDown) updateUnremovableNodes(nodes []*apiv1.Node) {
+func (sd *ScaleDown) updateUnremovableNodes(nodes []*schedulernodeinfo.NodeInfo) {
 	if len(sd.unremovableNodes) <= 0 {
 		return
 	}
@@ -639,8 +629,8 @@ func (sd *ScaleDown) updateUnremovableNodes(nodes []*apiv1.Node) {
 	}
 	// Nodes that are in the cluster should not be deleted.
 	for _, node := range nodes {
-		if _, ok := nodesToDelete[node.Name]; ok {
-			delete(nodesToDelete, node.Name)
+		if _, ok := nodesToDelete[node.Node().Name]; ok {
+			delete(nodesToDelete, node.Node().Name)
 		}
 	}
 	for nodeName := range nodesToDelete {

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -435,7 +435,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	var nonExpendablePods []*apiv1.Pod
 	for _, pod := range pods {
 		if core_utils.IsExpendablePod(pod, sd.context.ExpendablePodsPriorityCutoff) {
-			if err := sd.context.ClusterSnapshot.RemovePod(pod.Namespace, pod.Name); err != nil {
+			if err := sd.context.ClusterSnapshot.RemovePod(pod.Namespace, pod.Name, pod.Spec.NodeName); err != nil {
 				klog.Errorf("Could not remove expendable pod %s/%s from ClusterSnaphshot; %v", pod.Namespace, pod.Name, err)
 			}
 		} else {

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -41,13 +41,13 @@ import (
 	policyv1 "k8s.io/api/policy/v1beta1"
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kube_client "k8s.io/client-go/kubernetes"
-	kube_record "k8s.io/client-go/tools/record"
-
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	kube_client "k8s.io/client-go/kubernetes"
+	kube_record "k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 )
 
@@ -410,8 +410,16 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	// Only scheduled non expendable pods and pods waiting for lower priority pods preemption can prevent node delete.
 
 	// Extract cluster state from snapshot for initial analysis
-	pods := sd.context.ClusterSnapshot.GetAllPods()
-	allNodeInfos := sd.context.ClusterSnapshot.GetAllNodes()
+	pods, err := sd.context.ClusterSnapshot.Pods().List(labels.Everything())
+	if err != nil {
+		// This should never happen, List() returns err only because scheduler interface requires it.
+		return errors.ToAutoscalerError(errors.InternalError, err)
+	}
+	allNodeInfos, err := sd.context.ClusterSnapshot.NodeInfos().List()
+	if err != nil {
+		// This should never happen, List() returns err only because scheduler interface requires it.
+		return errors.ToAutoscalerError(errors.InternalError, err)
+	}
 
 	nodeNameToNodeInfo := make(map[string]*schedulernodeinfo.NodeInfo)
 	for _, nodeInfo := range allNodeInfos {

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -189,17 +189,11 @@ func (a *StaticAutoscaler) cleanUpIfRequired() {
 }
 
 func (a *StaticAutoscaler) initializeClusterSnapshot(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod) errors.AutoscalerError {
-	var err error
-	err = a.ClusterSnapshot.Clear()
-	if err != nil {
-		klog.Errorf("Failed to clear cluster snapshot: %v", err)
-		return errors.ToAutoscalerError(errors.InternalError, err)
-	}
+	a.ClusterSnapshot.Clear()
 
 	knownNodes := make(map[string]bool)
 	for _, node := range nodes {
-		err = a.ClusterSnapshot.AddNode(node)
-		if err != nil {
+		if err := a.ClusterSnapshot.AddNode(node); err != nil {
 			klog.Errorf("Failed to add node %s to cluster snapshot: %v", node.Name, err)
 			return errors.ToAutoscalerError(errors.InternalError, err)
 		}
@@ -207,8 +201,7 @@ func (a *StaticAutoscaler) initializeClusterSnapshot(nodes []*apiv1.Node, schedu
 	}
 	for _, pod := range scheduledPods {
 		if knownNodes[pod.Spec.NodeName] {
-			err = a.ClusterSnapshot.AddPod(pod, pod.Spec.NodeName)
-			if err != nil {
+			if err := a.ClusterSnapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
 				klog.Errorf("Failed to add pod %s scheduled to node %s to cluster snapshot: %v", pod.Name, pod.Spec.NodeName, err)
 				return errors.ToAutoscalerError(errors.InternalError, err)
 			}

--- a/cluster-autoscaler/simulator/basic_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/basic_cluster_snapshot.go
@@ -51,6 +51,7 @@ func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithAffinityList
 			havePodsWithAffinityList = append(havePodsWithAffinityList, v)
 		}
 	}
+
 	return havePodsWithAffinityList, nil
 }
 
@@ -107,6 +108,15 @@ func (data *internalBasicSnapshotData) addNode(node *apiv1.Node) error {
 	return nil
 }
 
+func (data *internalBasicSnapshotData) addNodes(nodes []*apiv1.Node) error {
+	for _, node := range nodes {
+		if err := data.addNode(node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (data *internalBasicSnapshotData) removeNode(nodeName string) error {
 	if _, found := data.nodeInfoMap[nodeName]; !found {
 		return fmt.Errorf("node %s not in snapshot", nodeName)
@@ -138,26 +148,26 @@ func (data *internalBasicSnapshotData) removePod(namespace string, podName strin
 	return fmt.Errorf("pod %s/%s not in snapshot", namespace, podName)
 }
 
-func (data *internalBasicSnapshotData) getAllPods() ([]*apiv1.Pod, error) {
+func (data *internalBasicSnapshotData) getAllPods() []*apiv1.Pod {
 	var pods []*apiv1.Pod
 	for _, nodeInfo := range data.nodeInfoMap {
 		pods = append(pods, nodeInfo.Pods()...)
 	}
-	return pods, nil
+	return pods
 }
 
-func (data *internalBasicSnapshotData) getAllNodes() ([]*apiv1.Node, error) {
-	var nodes []*apiv1.Node
-	for _, nodeInfo := range data.nodeInfoMap {
-		nodes = append(nodes, nodeInfo.Node())
+func (data *internalBasicSnapshotData) getAllNodes() []*schedulernodeinfo.NodeInfo {
+	nodeInfoList := make([]*schedulernodeinfo.NodeInfo, 0, len(data.nodeInfoMap))
+	for _, v := range data.nodeInfoMap {
+		nodeInfoList = append(nodeInfoList, v)
 	}
-	return nodes, nil
+	return nodeInfoList
 }
 
 // NewBasicClusterSnapshot creates instances of BasicClusterSnapshot.
 func NewBasicClusterSnapshot() *BasicClusterSnapshot {
 	snapshot := &BasicClusterSnapshot{}
-	_ = snapshot.Clear()
+	snapshot.Clear()
 	return snapshot
 }
 
@@ -171,6 +181,11 @@ func (snapshot *BasicClusterSnapshot) getInternalData() *internalBasicSnapshotDa
 // AddNode adds node to the snapshot.
 func (snapshot *BasicClusterSnapshot) AddNode(node *apiv1.Node) error {
 	return snapshot.getInternalData().addNode(node)
+}
+
+// AddNodes adds nodes in batch to the snapshot.
+func (snapshot *BasicClusterSnapshot) AddNodes(nodes []*apiv1.Node) error {
+	return snapshot.getInternalData().addNodes(nodes)
 }
 
 // AddNodeWithPods adds a node and set of pods to be scheduled to this node to the snapshot.
@@ -202,12 +217,12 @@ func (snapshot *BasicClusterSnapshot) RemovePod(namespace string, podName string
 }
 
 // GetAllPods returns list of all the pods in snapshot
-func (snapshot *BasicClusterSnapshot) GetAllPods() ([]*apiv1.Pod, error) {
+func (snapshot *BasicClusterSnapshot) GetAllPods() []*apiv1.Pod {
 	return snapshot.getInternalData().getAllPods()
 }
 
 // GetAllNodes returns list of all the nodes in snapshot
-func (snapshot *BasicClusterSnapshot) GetAllNodes() ([]*apiv1.Node, error) {
+func (snapshot *BasicClusterSnapshot) GetAllNodes() []*schedulernodeinfo.NodeInfo {
 	return snapshot.getInternalData().getAllNodes()
 }
 
@@ -239,10 +254,9 @@ func (snapshot *BasicClusterSnapshot) Commit() error {
 }
 
 // Clear reset cluster snapshot to empty, unforked state
-func (snapshot *BasicClusterSnapshot) Clear() error {
+func (snapshot *BasicClusterSnapshot) Clear() {
 	snapshot.baseData = newInternalBasicSnapshotData()
 	snapshot.forkedData = nil
-	return nil
 }
 
 // implementation of SharedLister interface

--- a/cluster-autoscaler/simulator/basic_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/basic_cluster_snapshot.go
@@ -133,16 +133,18 @@ func (data *internalBasicSnapshotData) addPod(pod *apiv1.Pod, nodeName string) e
 	return nil
 }
 
-func (data *internalBasicSnapshotData) removePod(namespace string, podName string) error {
-	for _, nodeInfo := range data.nodeInfoMap {
-		for _, pod := range nodeInfo.Pods() {
-			if pod.Namespace == namespace && pod.Name == podName {
-				err := nodeInfo.RemovePod(pod)
-				if err != nil {
-					return fmt.Errorf("cannot remove pod; %v", err)
-				}
-				return nil
+func (data *internalBasicSnapshotData) removePod(namespace, podName, nodeName string) error {
+	nodeInfo, found := data.nodeInfoMap[nodeName]
+	if !found {
+		return fmt.Errorf("node not found")
+	}
+	for _, pod := range nodeInfo.Pods() {
+		if pod.Namespace == namespace && pod.Name == podName {
+			err := nodeInfo.RemovePod(pod)
+			if err != nil {
+				return fmt.Errorf("cannot remove pod; %v", err)
 			}
+			return nil
 		}
 	}
 	return fmt.Errorf("pod %s/%s not in snapshot", namespace, podName)
@@ -196,8 +198,8 @@ func (snapshot *BasicClusterSnapshot) AddPod(pod *apiv1.Pod, nodeName string) er
 }
 
 // RemovePod removes pod from the snapshot.
-func (snapshot *BasicClusterSnapshot) RemovePod(namespace string, podName string) error {
-	return snapshot.getInternalData().removePod(namespace, podName)
+func (snapshot *BasicClusterSnapshot) RemovePod(namespace, podName, nodeName string) error {
+	return snapshot.getInternalData().removePod(namespace, podName, nodeName)
 }
 
 // Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()

--- a/cluster-autoscaler/simulator/basic_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/basic_cluster_snapshot.go
@@ -148,22 +148,6 @@ func (data *internalBasicSnapshotData) removePod(namespace string, podName strin
 	return fmt.Errorf("pod %s/%s not in snapshot", namespace, podName)
 }
 
-func (data *internalBasicSnapshotData) getAllPods() []*apiv1.Pod {
-	var pods []*apiv1.Pod
-	for _, nodeInfo := range data.nodeInfoMap {
-		pods = append(pods, nodeInfo.Pods()...)
-	}
-	return pods
-}
-
-func (data *internalBasicSnapshotData) getAllNodes() []*schedulernodeinfo.NodeInfo {
-	nodeInfoList := make([]*schedulernodeinfo.NodeInfo, 0, len(data.nodeInfoMap))
-	for _, v := range data.nodeInfoMap {
-		nodeInfoList = append(nodeInfoList, v)
-	}
-	return nodeInfoList
-}
-
 // NewBasicClusterSnapshot creates instances of BasicClusterSnapshot.
 func NewBasicClusterSnapshot() *BasicClusterSnapshot {
 	snapshot := &BasicClusterSnapshot{}
@@ -214,16 +198,6 @@ func (snapshot *BasicClusterSnapshot) AddPod(pod *apiv1.Pod, nodeName string) er
 // RemovePod removes pod from the snapshot.
 func (snapshot *BasicClusterSnapshot) RemovePod(namespace string, podName string) error {
 	return snapshot.getInternalData().removePod(namespace, podName)
-}
-
-// GetAllPods returns list of all the pods in snapshot
-func (snapshot *BasicClusterSnapshot) GetAllPods() []*apiv1.Pod {
-	return snapshot.getInternalData().getAllPods()
-}
-
-// GetAllNodes returns list of all the nodes in snapshot
-func (snapshot *BasicClusterSnapshot) GetAllNodes() []*schedulernodeinfo.NodeInfo {
-	return snapshot.getInternalData().getAllNodes()
 }
 
 // Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -260,7 +260,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node,
 
 	// remove pods from clusterSnaphot first
 	for _, pod := range pods {
-		if err := clusterSnaphost.RemovePod(pod.Namespace, pod.Name); err != nil {
+		if err := clusterSnaphost.RemovePod(pod.Namespace, pod.Name, removedNode); err != nil {
 			// just log error
 			klog.Errorf("Simulating removal of %s/%s return error; %v", pod.Namespace, pod.Name, err)
 		}

--- a/cluster-autoscaler/simulator/cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot.go
@@ -19,12 +19,10 @@ package simulator
 import (
 	apiv1 "k8s.io/api/core/v1"
 	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
-// It exposes efficient mutation methods and can be viewed as scheduler's SharedLister
-// via GetSchedulerLister() method.
+// It exposes mutation methods and can be viewed as scheduler's SharedLister.
 type ClusterSnapshot interface {
 	schedulerlisters.SharedLister
 	// AddNode adds node to the snapshot.
@@ -39,11 +37,6 @@ type ClusterSnapshot interface {
 	RemovePod(namespace string, podName string) error
 	// AddNodeWithPods adds a node and set of pods to be scheduled to this node to the snapshot.
 	AddNodeWithPods(node *apiv1.Node, pods []*apiv1.Pod) error
-
-	// GetAllPods returns list of all the pods in snapshot
-	GetAllPods() []*apiv1.Pod
-	// GetAllNodes returns list of all the nodes in snapshot
-	GetAllNodes() []*schedulernodeinfo.NodeInfo
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()
 	// Forking already forked snapshot is not allowed and will result with an error.

--- a/cluster-autoscaler/simulator/cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot.go
@@ -19,6 +19,7 @@ package simulator
 import (
 	apiv1 "k8s.io/api/core/v1"
 	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
@@ -28,6 +29,8 @@ type ClusterSnapshot interface {
 	schedulerlisters.SharedLister
 	// AddNode adds node to the snapshot.
 	AddNode(node *apiv1.Node) error
+	// AddNodes adds nodes to the snapshot.
+	AddNodes(nodes []*apiv1.Node) error
 	// RemoveNode removes nodes (and pods scheduled to it) from the snapshot.
 	RemoveNode(nodeName string) error
 	// AddPod adds pod to the snapshot and schedules it to given node.
@@ -38,9 +41,9 @@ type ClusterSnapshot interface {
 	AddNodeWithPods(node *apiv1.Node, pods []*apiv1.Pod) error
 
 	// GetAllPods returns list of all the pods in snapshot
-	GetAllPods() ([]*apiv1.Pod, error)
-	// GetAllNodes returns list of ll the nodes in snapshot
-	GetAllNodes() ([]*apiv1.Node, error)
+	GetAllPods() []*apiv1.Pod
+	// GetAllNodes returns list of all the nodes in snapshot
+	GetAllNodes() []*schedulernodeinfo.NodeInfo
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()
 	// Forking already forked snapshot is not allowed and will result with an error.
@@ -50,5 +53,5 @@ type ClusterSnapshot interface {
 	// Commit commits changes done after forking.
 	Commit() error
 	// Clear reset cluster snapshot to empty, unforked state
-	Clear() error
+	Clear()
 }

--- a/cluster-autoscaler/simulator/cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot.go
@@ -34,7 +34,7 @@ type ClusterSnapshot interface {
 	// AddPod adds pod to the snapshot and schedules it to given node.
 	AddPod(pod *apiv1.Pod, nodeName string) error
 	// RemovePod removes pod from the snapshot.
-	RemovePod(namespace string, podName string) error
+	RemovePod(namespace string, podName string, nodeName string) error
 	// AddNodeWithPods adds a node and set of pods to be scheduled to this node to the snapshot.
 	AddNodeWithPods(node *apiv1.Node, pods []*apiv1.Pod) error
 

--- a/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
@@ -267,3 +267,74 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkBuildPodList(b *testing.B) {
+	testCases := []struct {
+		nodeCount int
+	}{
+		{
+			nodeCount: 1000,
+		},
+		{
+			nodeCount: 5000,
+		},
+		{
+			nodeCount: 15000,
+		},
+	}
+	for _, modifiedPodCount := range []int{0, 1, 100} {
+		for _, extraNodeCount := range []int{0, 1, 100} {
+			for _, tc := range testCases {
+				b.Run(fmt.Sprintf("%s: modified %v, added nodes %v, nodes %v", "delta", modifiedPodCount, extraNodeCount, tc.nodeCount), func(b *testing.B) {
+					nodes := createTestNodes(tc.nodeCount)
+					pods := createTestPods(tc.nodeCount * 30)
+					assignPodsToNodes(pods, nodes)
+
+					modifiedPods := createTestPods(modifiedPodCount)
+					assignPodsToNodes(modifiedPods, nodes)
+
+					newNodes := createTestNodesWithPrefix("new-", extraNodeCount)
+					newPods := createTestPods(extraNodeCount * 30)
+					assignPodsToNodes(newPods, newNodes)
+
+					snapshot := NewDeltaClusterSnapshot()
+
+					if err := snapshot.AddNodes(nodes); err != nil {
+						assert.NoError(b, err)
+					}
+					for _, pod := range pods {
+						if err := snapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
+							assert.NoError(b, err)
+						}
+					}
+
+					if err := snapshot.Fork(); err != nil {
+						assert.NoError(b, err)
+					}
+					for _, pod := range modifiedPods {
+						if err := snapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
+							assert.NoError(b, err)
+						}
+					}
+
+					if err := snapshot.AddNodes(newNodes); err != nil {
+						assert.NoError(b, err)
+					}
+					for _, pod := range newPods {
+						if err := snapshot.AddPod(pod, pod.Spec.NodeName); err != nil {
+							assert.NoError(b, err)
+						}
+					}
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						list := snapshot.data.buildPodList()
+						if len(list) != tc.nodeCount*30+modifiedPodCount+extraNodeCount*30 {
+							assert.Equal(b, tc.nodeCount*30+modifiedPodCount+extraNodeCount*30, len(list))
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
@@ -27,10 +27,10 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
-func createTestNodesWithPrefix(name string, n int) []*apiv1.Node {
+func createTestNodesWithPrefix(prefix string, n int) []*apiv1.Node {
 	nodes := make([]*apiv1.Node, n, n)
 	for i := 0; i < n; i++ {
-		nodes[i] = BuildTestNode(fmt.Sprintf("%s-%d", name, i), 2000, 2000000)
+		nodes[i] = BuildTestNode(fmt.Sprintf("%s-%d", prefix, i), 2000, 2000000)
 		SetNodeReadyState(nodes[i], true, time.Time{})
 	}
 	return nodes
@@ -40,12 +40,16 @@ func createTestNodes(n int) []*apiv1.Node {
 	return createTestNodesWithPrefix("n", n)
 }
 
-func createTestPods(n int) []*apiv1.Pod {
+func createTestPodsWithPrefix(prefix string, n int) []*apiv1.Pod {
 	pods := make([]*apiv1.Pod, n, n)
 	for i := 0; i < n; i++ {
-		pods[i] = BuildTestPod(fmt.Sprintf("p-%d", i), 1000, 2000000)
+		pods[i] = BuildTestPod(fmt.Sprintf("%s-%d", prefix, i), 1000, 2000000)
 	}
 	return pods
+}
+
+func createTestPods(n int) []*apiv1.Pod {
+	return createTestPodsWithPrefix("p", n)
 }
 
 func assignPodsToNodes(pods []*apiv1.Pod, nodes []*apiv1.Node) {

--- a/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func createTestNodesWithPrefix(name string, n int) []*apiv1.Node {
+	nodes := make([]*apiv1.Node, n, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = BuildTestNode(fmt.Sprintf("%s-%d", name, i), 2000, 2000000)
+		SetNodeReadyState(nodes[i], true, time.Time{})
+	}
+	return nodes
+}
+
+func createTestNodes(n int) []*apiv1.Node {
+	return createTestNodesWithPrefix("n", n)
+}
+
+func createTestPods(n int) []*apiv1.Pod {
+	pods := make([]*apiv1.Pod, n, n)
+	for i := 0; i < n; i++ {
+		pods[i] = BuildTestPod(fmt.Sprintf("p-%d", i), 1000, 2000000)
+	}
+	return pods
+}
+
+func assignPodsToNodes(pods []*apiv1.Pod, nodes []*apiv1.Node) {
+	j := 0
+	for i := 0; i < len(pods); i++ {
+		if j >= len(nodes) {
+			j = 0
+		}
+		pods[i].Spec.NodeName = nodes[j].Name
+		j++
+	}
+}
+
+func BenchmarkAddNodes(b *testing.B) {
+	testCases := []int{1, 10, 100, 1000, 5000, 15000, 100000}
+
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range testCases {
+			nodes := createTestNodes(tc)
+			clusterSnapshot := snapshotFactory()
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s: AddNode() %d", snapshotName, tc), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					clusterSnapshot.Clear()
+					b.StartTimer()
+					for _, node := range nodes {
+						err := clusterSnapshot.AddNode(node)
+						if err != nil {
+							assert.NoError(b, err)
+						}
+					}
+				}
+			})
+		}
+	}
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range testCases {
+			nodes := createTestNodes(tc)
+			clusterSnapshot := snapshotFactory()
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s: AddNodes() %d", snapshotName, tc), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					clusterSnapshot.Clear()
+					b.StartTimer()
+					err := clusterSnapshot.AddNodes(nodes)
+					if err != nil {
+						assert.NoError(b, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkListNodeInfos(b *testing.B) {
+	testCases := []int{1, 10, 100, 1000, 5000, 15000, 100000}
+
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range testCases {
+			nodes := createTestNodes(tc)
+			clusterSnapshot := snapshotFactory()
+			err := clusterSnapshot.AddNodes(nodes)
+			if err != nil {
+				assert.NoError(b, err)
+			}
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s: List() %d", snapshotName, tc), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					nodeInfos, err := clusterSnapshot.NodeInfos().List()
+					if err != nil {
+						assert.NoError(b, err)
+					}
+					if len(nodeInfos) != tc {
+						assert.Equal(b, len(nodeInfos), tc)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkAddPods(b *testing.B) {
+	testCases := []int{1, 10, 100, 1000, 5000, 15000}
+
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, tc := range testCases {
+			clusterSnapshot := snapshotFactory()
+			nodes := createTestNodes(tc)
+			err := clusterSnapshot.AddNodes(nodes)
+			assert.NoError(b, err)
+			pods := createTestPods(tc * 30)
+			assignPodsToNodes(pods, nodes)
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s: AddPod() 30*%d", snapshotName, tc), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					clusterSnapshot.Clear()
+
+					err = clusterSnapshot.AddNodes(nodes)
+					if err != nil {
+						assert.NoError(b, err)
+					}
+					/*
+						// uncomment to test effect of pod caching
+							_, err = clusterSnapshot.Pods().List(labels.Everything())
+							if err != nil {
+								assert.NoError(b, err)
+							}
+					*/
+					b.StartTimer()
+					for _, pod := range pods {
+						err = clusterSnapshot.AddPod(pod, pod.Spec.NodeName)
+						if err != nil {
+							assert.NoError(b, err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkForkAddRevert(b *testing.B) {
+	nodeTestCases := []int{1, 10, 100, 1000, 5000, 15000, 100000}
+	podTestCases := []int{0, 1, 30}
+
+	for snapshotName, snapshotFactory := range snapshots {
+		for _, ntc := range nodeTestCases {
+			nodes := createTestNodes(ntc)
+			for _, ptc := range podTestCases {
+				pods := createTestPods(ntc * ptc)
+				assignPodsToNodes(pods, nodes)
+				clusterSnapshot := snapshotFactory()
+				err := clusterSnapshot.AddNodes(nodes)
+				assert.NoError(b, err)
+				for _, pod := range pods {
+					err = clusterSnapshot.AddPod(pod, pod.Spec.NodeName)
+					assert.NoError(b, err)
+				}
+				tmpNode := BuildTestNode("tmp", 2000, 2000000)
+				b.ResetTimer()
+				b.Run(fmt.Sprintf("%s: ForkAddRevert (%d nodes, %d pods)", snapshotName, ntc, ptc), func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						err = clusterSnapshot.Fork()
+						if err != nil {
+							assert.NoError(b, err)
+						}
+						err = clusterSnapshot.AddNode(tmpNode)
+						if err != nil {
+							assert.NoError(b, err)
+						}
+						err = clusterSnapshot.Revert()
+						if err != nil {
+							assert.NoError(b, err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkBuildNodeInfoList(b *testing.B) {
+	testCases := []struct {
+		nodeCount int
+	}{
+		{
+			nodeCount: 1000,
+		},
+		{
+			nodeCount: 5000,
+		},
+		{
+			nodeCount: 15000,
+		},
+		{
+			nodeCount: 100000,
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(fmt.Sprintf("fork add 1000 to %d", tc.nodeCount), func(b *testing.B) {
+			nodes := createTestNodes(tc.nodeCount + 1000)
+			snapshot := NewDeltaClusterSnapshot()
+			if err := snapshot.AddNodes(nodes[:tc.nodeCount]); err != nil {
+				assert.NoError(b, err)
+			}
+			if err := snapshot.Fork(); err != nil {
+				assert.NoError(b, err)
+			}
+			if err := snapshot.AddNodes(nodes[tc.nodeCount:]); err != nil {
+				assert.NoError(b, err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				list := snapshot.data.buildNodeInfoList()
+				if len(list) != tc.nodeCount+1000 {
+					assert.Equal(b, len(list), tc.nodeCount+1000)
+				}
+			}
+		})
+	}
+	for _, tc := range testCases {
+		b.Run(fmt.Sprintf("base %d", tc.nodeCount), func(b *testing.B) {
+			nodes := createTestNodes(tc.nodeCount)
+			snapshot := NewDeltaClusterSnapshot()
+			if err := snapshot.AddNodes(nodes); err != nil {
+				assert.NoError(b, err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				list := snapshot.data.buildNodeInfoList()
+				if len(list) != tc.nodeCount {
+					assert.Equal(b, len(list), tc.nodeCount)
+				}
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/simulator/cluster_snapshot_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_test.go
@@ -103,6 +103,17 @@ func TestForking(t *testing.T) {
 			},
 		},
 		{
+			name: "add node with pods",
+			op: func(snapshot ClusterSnapshot) {
+				err := snapshot.AddNodeWithPods(node, []*apiv1.Pod{pod})
+				assert.NoError(t, err)
+			},
+			modifiedState: snapshotState{
+				nodes: []*apiv1.Node{node},
+				pods:  []*apiv1.Pod{pod},
+			},
+		},
+		{
 			name: "remove node",
 			state: snapshotState{
 				nodes: []*apiv1.Node{node},

--- a/cluster-autoscaler/simulator/cluster_snapshot_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var snapshots = map[string]func() ClusterSnapshot{
+	"basic": func() ClusterSnapshot { return NewBasicClusterSnapshot() },
+	"delta": func() ClusterSnapshot { return NewDeltaClusterSnapshot() },
+}
+
+func TestForkAddNode(t *testing.T) {
+	nodeCount := 3
+
+	nodes := createTestNodes(nodeCount)
+	extraNodes := createTestNodesWithPrefix("tmp", 2)
+
+	for name, snapshotFactory := range snapshots {
+		t.Run(fmt.Sprintf("%s: fork should not affect base data: adding nodes", name),
+			func(t *testing.T) {
+				clusterSnapshot := snapshotFactory()
+				err := clusterSnapshot.AddNodes(nodes)
+				assert.NoError(t, err)
+
+				err = clusterSnapshot.Fork()
+				assert.NoError(t, err)
+
+				for _, node := range extraNodes {
+					err = clusterSnapshot.AddNode(node)
+					assert.NoError(t, err)
+				}
+				forkNodes, err := clusterSnapshot.NodeInfos().List()
+				assert.NoError(t, err)
+				assert.Equal(t, nodeCount+len(extraNodes), len(forkNodes))
+
+				err = clusterSnapshot.Revert()
+				assert.NoError(t, err)
+
+				baseNodes, err := clusterSnapshot.NodeInfos().List()
+				assert.NoError(t, err)
+				assert.Equal(t, nodeCount, len(baseNodes))
+			})
+	}
+}
+
+func TestForkAddPods(t *testing.T) {
+	nodeCount := 3
+	podCount := 90
+
+	nodes := createTestNodes(nodeCount)
+	pods := createTestPods(podCount)
+	assignPodsToNodes(pods, nodes)
+
+	for name, snapshotFactory := range snapshots {
+		t.Run(fmt.Sprintf("%s: fork should not affect base data: adding pods", name),
+			func(t *testing.T) {
+				clusterSnapshot := snapshotFactory()
+				err := clusterSnapshot.AddNodes(nodes)
+				assert.NoError(t, err)
+
+				err = clusterSnapshot.Fork()
+				assert.NoError(t, err)
+
+				for _, pod := range pods {
+					err = clusterSnapshot.AddPod(pod, pod.Spec.NodeName)
+					assert.NoError(t, err)
+				}
+				forkPods, err := clusterSnapshot.Pods().List(labels.Everything())
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, pods, forkPods)
+
+				err = clusterSnapshot.Revert()
+				assert.NoError(t, err)
+
+				basePods, err := clusterSnapshot.Pods().List(labels.Everything())
+				assert.NoError(t, err)
+				assert.Equal(t, 0, len(basePods))
+			})
+	}
+}

--- a/cluster-autoscaler/simulator/cluster_snapshot_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_test.go
@@ -156,7 +156,7 @@ func TestForkRemovePods(t *testing.T) {
 				assert.NoError(t, err)
 
 				for _, pod := range pods[:deletedPodCount] {
-					err = clusterSnapshot.RemovePod(pod.Namespace, pod.Name)
+					err = clusterSnapshot.RemovePod(pod.Namespace, pod.Name, pod.Spec.NodeName)
 					assert.NoError(t, err)
 				}
 

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -246,8 +246,6 @@ func (data *internalDeltaSnapshotData) removePod(namespace, name, nodeName strin
 		data.clearCaches()
 	}
 
-	preAffinityPods := len(dni.PodsWithAffinity())
-
 	podFound := false
 	for _, pod := range dni.Pods() {
 		if pod.Namespace == namespace && pod.Name == name {
@@ -263,13 +261,7 @@ func (data *internalDeltaSnapshotData) removePod(namespace, name, nodeName strin
 	}
 
 	// Maybe consider deleting from the list in the future. Maybe not.
-	postAffinityPods := len(dni.PodsWithAffinity())
-	if preAffinityPods == 1 && postAffinityPods == 0 {
-		data.havePodsWithAffinity = nil
-	}
-	if data.podList != nil {
-		data.clearPodCaches()
-	}
+	data.clearCaches()
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -294,18 +294,20 @@ func (data *internalDeltaSnapshotData) getPodList() []*apiv1.Pod {
 }
 
 func (data *internalDeltaSnapshotData) buildPodList() []*apiv1.Pod {
-	podList := []*apiv1.Pod{}
 	if len(data.deletedNodeInfos) > 0 || len(data.modifiedNodeInfoMap) > 0 {
+		podList := []*apiv1.Pod{}
 		nodeInfos := data.getNodeInfoList()
 		for _, ni := range nodeInfos {
 			podList = append(podList, ni.Pods()...)
 		}
-	} else {
-		basePodList := data.baseData.getPodList()
-		copy(podList, basePodList)
-		for _, ni := range data.addedNodeInfoMap {
-			podList = append(podList, ni.Pods()...)
-		}
+		return podList
+	}
+
+	basePodList := data.baseData.getPodList()
+	podList := make([]*apiv1.Pod, len(basePodList), len(basePodList))
+	copy(podList, basePodList)
+	for _, ni := range data.addedNodeInfoMap {
+		podList = append(podList, ni.Pods()...)
 	}
 	return podList
 }

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -114,7 +114,7 @@ func (data *internalDeltaSnapshotData) buildNodeInfoList() []*schedulernodeinfo.
 	var nodeInfoList []*schedulernodeinfo.NodeInfo
 
 	if len(data.deletedNodeInfos) > 0 || len(data.modifiedNodeInfoMap) > 0 {
-		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, totalLen+100)
+		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, totalLen)
 		for _, bni := range baseList {
 			if data.deletedNodeInfos[bni.Node().Name] {
 				continue
@@ -126,7 +126,7 @@ func (data *internalDeltaSnapshotData) buildNodeInfoList() []*schedulernodeinfo.
 			nodeInfoList = append(nodeInfoList, bni)
 		}
 	} else {
-		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, len(baseList), totalLen+100)
+		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, len(baseList), totalLen)
 		copy(nodeInfoList, baseList)
 	}
 

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -1,0 +1,519 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"errors"
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// DeltaClusterSnapshot is an implementation of ClusterSnapshot optimized for typical Cluster Autoscaler usage - (fork, add stuff, revert), repeated many times per loop.
+//
+// Complexity of some notable operations:
+//	fork - O(1)
+//	revert - O(1)
+//	commit - O(n)
+//	list all pods (no filtering) - O(n), cached
+//	list all pods (with filtering) - O(n)
+//	list node infos - O(n), cached
+//
+// Watch out for:
+//	node deletions, pod additions & deletions - invalidates cache of current snapshot
+//		(when forked affects delta, but not base.)
+//	pod affinity - causes scheduler framework to list pods with non-empty selector,
+//		so basic caching doesn't help.
+//
+type DeltaClusterSnapshot struct {
+	data *internalDeltaSnapshotData
+}
+
+type deltaSnapshotNodeLister DeltaClusterSnapshot
+type deltaSnapshotPodLister DeltaClusterSnapshot
+
+type internalDeltaSnapshotData struct {
+	baseData *internalDeltaSnapshotData
+
+	addedNodeInfoMap    map[string]*schedulernodeinfo.NodeInfo
+	modifiedNodeInfoMap map[string]*schedulernodeinfo.NodeInfo
+	deletedNodeInfos    map[string]bool
+
+	nodeInfoList         []*schedulernodeinfo.NodeInfo
+	podList              []*apiv1.Pod
+	havePodsWithAffinity []*schedulernodeinfo.NodeInfo
+}
+
+var errNodeNotFound = errors.New("node not found")
+
+func newInternalDeltaSnapshotData() *internalDeltaSnapshotData {
+	return &internalDeltaSnapshotData{
+		addedNodeInfoMap:    make(map[string]*schedulernodeinfo.NodeInfo),
+		modifiedNodeInfoMap: make(map[string]*schedulernodeinfo.NodeInfo),
+		deletedNodeInfos:    make(map[string]bool),
+	}
+}
+
+func (data *internalDeltaSnapshotData) getNodeInfo(name string) (*schedulernodeinfo.NodeInfo, bool) {
+	if data == nil {
+		return nil, false
+	}
+	if nodeInfo, found := data.getNodeInfoLocal(name); found {
+		return nodeInfo, found
+	}
+	if data.deletedNodeInfos[name] {
+		return nil, false
+	}
+	return data.baseData.getNodeInfo(name)
+}
+
+func (data *internalDeltaSnapshotData) getNodeInfoLocal(name string) (*schedulernodeinfo.NodeInfo, bool) {
+	if data == nil {
+		return nil, false
+	}
+	if nodeInfo, found := data.addedNodeInfoMap[name]; found {
+		return nodeInfo, true
+	}
+	if nodeInfo, found := data.modifiedNodeInfoMap[name]; found {
+		return nodeInfo, true
+	}
+	return nil, false
+}
+
+func (data *internalDeltaSnapshotData) getNodeInfoList() []*schedulernodeinfo.NodeInfo {
+	if data == nil {
+		return nil
+	}
+	if data.nodeInfoList == nil {
+		data.nodeInfoList = data.buildNodeInfoList()
+	}
+	return data.nodeInfoList
+}
+
+// Contains costly copying throughout the struct chain. Use wisely.
+func (data *internalDeltaSnapshotData) buildNodeInfoList() []*schedulernodeinfo.NodeInfo {
+	baseList := data.baseData.getNodeInfoList()
+	totalLen := len(baseList) + len(data.addedNodeInfoMap)
+	var nodeInfoList []*schedulernodeinfo.NodeInfo
+
+	if len(data.deletedNodeInfos) > 0 || len(data.modifiedNodeInfoMap) > 0 {
+		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, totalLen+100)
+		for _, bni := range baseList {
+			if data.deletedNodeInfos[bni.Node().Name] {
+				continue
+			}
+			if mni, found := data.modifiedNodeInfoMap[bni.Node().Name]; found {
+				nodeInfoList = append(nodeInfoList, mni)
+				continue
+			}
+			nodeInfoList = append(nodeInfoList, bni)
+		}
+	} else {
+		nodeInfoList = make([]*schedulernodeinfo.NodeInfo, len(baseList), totalLen+100)
+		copy(nodeInfoList, baseList)
+	}
+
+	for _, ani := range data.addedNodeInfoMap {
+		nodeInfoList = append(nodeInfoList, ani)
+	}
+
+	return nodeInfoList
+}
+
+// Convenience method to avoid writing loop for adding nodes.
+func (data *internalDeltaSnapshotData) addNodes(nodes []*apiv1.Node) error {
+	for _, node := range nodes {
+		if err := data.addNode(node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (data *internalDeltaSnapshotData) addNode(node *apiv1.Node) error {
+	nodeInfo := schedulernodeinfo.NewNodeInfo()
+	if err := nodeInfo.SetNode(node); err != nil {
+		return fmt.Errorf("cannot set node in NodeInfo: %v", err)
+	}
+	return data.addNodeInfo(nodeInfo)
+}
+
+func (data *internalDeltaSnapshotData) addNodeInfo(nodeInfo *schedulernodeinfo.NodeInfo) error {
+	if _, found := data.getNodeInfo(nodeInfo.Node().Name); found {
+		return fmt.Errorf("node %s already in snapshot", nodeInfo.Node().Name)
+	}
+	data.addedNodeInfoMap[nodeInfo.Node().Name] = nodeInfo
+	if data.nodeInfoList != nil {
+		data.nodeInfoList = append(data.nodeInfoList, nodeInfo)
+	}
+	return nil
+}
+
+func (data *internalDeltaSnapshotData) clearCaches() {
+	data.nodeInfoList = nil
+	data.clearPodCaches()
+}
+
+func (data *internalDeltaSnapshotData) clearPodCaches() {
+	data.podList = nil
+	data.havePodsWithAffinity = nil
+}
+
+func (data *internalDeltaSnapshotData) updateNode(node *schedulernodeinfo.NodeInfo) error {
+	if _, found := data.addedNodeInfoMap[node.Node().Name]; found {
+		data.removeNode(node.Node().Name)
+	}
+	if _, found := data.modifiedNodeInfoMap[node.Node().Name]; found {
+		data.removeNode(node.Node().Name)
+	}
+
+	return data.addNodeInfo(node)
+}
+
+func (data *internalDeltaSnapshotData) removeNode(nodeName string) error {
+	_, foundInDelta := data.addedNodeInfoMap[nodeName]
+	if foundInDelta {
+		// If node was added within this delta, delete this change.
+		delete(data.addedNodeInfoMap, nodeName)
+	}
+
+	if _, modified := data.modifiedNodeInfoMap[nodeName]; modified {
+		// If node was modified within this delta, delete this change.
+		delete(data.modifiedNodeInfoMap, nodeName)
+	}
+
+	_, foundInBase := data.baseData.getNodeInfo(nodeName)
+	if foundInBase {
+		// If node was found in the underlying data, mark it as deleted in delta.
+		data.deletedNodeInfos[nodeName] = true
+	}
+
+	if !foundInBase && !foundInDelta {
+		// Node not found in the chain.
+		return errNodeNotFound
+	}
+
+	// Maybe consider deleting from the lists instead. Maybe not.
+	data.clearCaches()
+	return nil
+}
+
+func (data *internalDeltaSnapshotData) addPod(pod *apiv1.Pod, nodeName string) error {
+	dni, found := data.getNodeInfoLocal(nodeName)
+	if !found {
+		bni, found := data.baseData.getNodeInfo(nodeName)
+		if !found {
+			return errNodeNotFound
+		}
+		dni = bni.Clone()
+		data.modifiedNodeInfoMap[nodeName] = dni
+		data.clearCaches()
+	}
+
+	dni.AddPod(pod)
+	if data.podList != nil || data.havePodsWithAffinity != nil {
+		data.clearPodCaches()
+	}
+	return nil
+}
+
+func (data *internalDeltaSnapshotData) getNodeForPod(namespace, name string) (string, error) {
+	if data == nil {
+		return "", fmt.Errorf("pod %s/%s not in snapshot", namespace, name)
+	}
+
+	for nodeName, nodeInfo := range data.addedNodeInfoMap {
+		for _, pod := range nodeInfo.Pods() {
+			if pod.Name == name && pod.Namespace == namespace {
+				return nodeName, nil
+			}
+		}
+	}
+	for nodeName, nodeInfo := range data.modifiedNodeInfoMap {
+		for _, pod := range nodeInfo.Pods() {
+			if pod.Name == name && pod.Namespace == namespace {
+				return nodeName, nil
+			}
+		}
+	}
+
+	nodeName, err := data.baseData.getNodeForPod(namespace, name)
+	if err != nil {
+		return "", err
+	}
+	if data.deletedNodeInfos[nodeName] {
+		return "", fmt.Errorf("pod %s/%s not in snapshot", namespace, name)
+	}
+	return nodeName, nil
+}
+
+func (data *internalDeltaSnapshotData) removePod(namespace string, name string) error {
+	nodeName, err := data.getNodeForPod(namespace, name)
+	if err != nil {
+		return err
+	}
+
+	dni, found := data.getNodeInfoLocal(nodeName)
+	if !found {
+		bni, found := data.baseData.getNodeInfo(nodeName)
+		if !found {
+			return errNodeNotFound
+		}
+		dni = bni.Clone()
+		data.modifiedNodeInfoMap[nodeName] = dni
+		data.clearCaches()
+	}
+
+	preAffinityPods := len(dni.PodsWithAffinity())
+
+	podFound := false
+	for _, pod := range dni.Pods() {
+		if pod.Namespace == namespace && pod.Name == name {
+			if err := dni.RemovePod(pod); err != nil {
+				return fmt.Errorf("cannot remove pod; %v", err)
+			}
+			podFound = true
+			break
+		}
+	}
+	if !podFound {
+		return fmt.Errorf("pod %s/%s not in snapshot", namespace, name)
+	}
+
+	// Maybe consider deleting from the list in the future. Maybe not.
+	postAffinityPods := len(dni.PodsWithAffinity())
+	if preAffinityPods == 1 && postAffinityPods == 0 {
+		data.havePodsWithAffinity = nil
+	}
+	if data.podList != nil {
+		data.clearPodCaches()
+	}
+	return nil
+}
+
+func (data *internalDeltaSnapshotData) getPodList() []*apiv1.Pod {
+	if data == nil {
+		return nil
+	}
+	if data.podList == nil {
+		data.podList = data.buildPodList()
+	}
+	return data.podList
+}
+
+func (data *internalDeltaSnapshotData) buildPodList() []*apiv1.Pod {
+	podList := []*apiv1.Pod{}
+	if len(data.deletedNodeInfos) > 0 || len(data.modifiedNodeInfoMap) > 0 {
+		nodeInfos := data.getNodeInfoList()
+		for _, ni := range nodeInfos {
+			podList = append(podList, ni.Pods()...)
+		}
+	} else {
+		basePodList := data.baseData.getPodList()
+		copy(podList, basePodList)
+		for _, ni := range data.addedNodeInfoMap {
+			podList = append(podList, ni.Pods()...)
+		}
+	}
+	return podList
+}
+
+func (data *internalDeltaSnapshotData) fork() *internalDeltaSnapshotData {
+	forkedData := newInternalDeltaSnapshotData()
+	forkedData.baseData = data
+	return forkedData
+}
+
+func (data *internalDeltaSnapshotData) commit() *internalDeltaSnapshotData {
+	for _, node := range data.modifiedNodeInfoMap {
+		data.baseData.updateNode(node)
+	}
+	for _, node := range data.addedNodeInfoMap {
+		data.baseData.addNodeInfo(node)
+	}
+	for node := range data.deletedNodeInfos {
+		data.baseData.removeNode(node)
+	}
+	return data.baseData
+}
+
+// List returns list of all node infos.
+func (snapshot *deltaSnapshotNodeLister) List() ([]*schedulernodeinfo.NodeInfo, error) {
+	return snapshot.data.getNodeInfoList(), nil
+}
+
+// HavePodsWithAffinityList returns list of all node infos with pods that have affinity constrints.
+func (snapshot *deltaSnapshotNodeLister) HavePodsWithAffinityList() ([]*schedulernodeinfo.NodeInfo, error) {
+	data := snapshot.data
+	if data.havePodsWithAffinity != nil {
+		return data.havePodsWithAffinity, nil
+	}
+
+	nodeInfoList := snapshot.data.getNodeInfoList()
+	havePodsWithAffinityList := make([]*schedulernodeinfo.NodeInfo, 0, len(nodeInfoList))
+	for _, node := range nodeInfoList {
+		if len(node.PodsWithAffinity()) > 0 {
+			havePodsWithAffinityList = append(havePodsWithAffinityList, node)
+		}
+	}
+	data.havePodsWithAffinity = havePodsWithAffinityList
+	return data.havePodsWithAffinity, nil
+}
+
+// Get returns node info by node name.
+func (snapshot *deltaSnapshotNodeLister) Get(nodeName string) (*schedulernodeinfo.NodeInfo, error) {
+	return (*DeltaClusterSnapshot)(snapshot).getNodeInfo(nodeName)
+}
+
+func (snapshot *DeltaClusterSnapshot) getNodeInfo(nodeName string) (*schedulernodeinfo.NodeInfo, error) {
+	data := snapshot.data
+	node, found := data.getNodeInfo(nodeName)
+	if !found {
+		return nil, errNodeNotFound
+	}
+	return node, nil
+}
+
+// List returns all pods matching selector.
+func (snapshot *deltaSnapshotPodLister) List(selector labels.Selector) ([]*apiv1.Pod, error) {
+	data := snapshot.data
+	if data.podList == nil {
+		data.podList = data.buildPodList()
+	}
+
+	if selector.Empty() {
+		// no restrictions, yay
+		return data.podList, nil
+	}
+
+	selectedPods := make([]*apiv1.Pod, 0, len(data.podList))
+	for _, pod := range data.podList {
+		if selector.Matches(labels.Set(pod.Labels)) {
+			selectedPods = append(selectedPods, pod)
+		}
+	}
+	return selectedPods, nil
+}
+
+// FilteredList returns all pods matching selector and filter.
+func (snapshot *deltaSnapshotPodLister) FilteredList(podFilter schedulerlisters.PodFilter, selector labels.Selector) ([]*apiv1.Pod, error) {
+	data := snapshot.data
+	if data.podList == nil {
+		data.podList = data.buildPodList()
+	}
+
+	selectedPods := make([]*apiv1.Pod, 0, len(data.podList))
+	for _, pod := range data.podList {
+		if podFilter(pod) && selector.Matches(labels.Set(pod.Labels)) {
+			selectedPods = append(selectedPods, pod)
+		}
+	}
+	return selectedPods, nil
+}
+
+// Pods returns pod lister.
+func (snapshot *DeltaClusterSnapshot) Pods() schedulerlisters.PodLister {
+	return (*deltaSnapshotPodLister)(snapshot)
+}
+
+// NodeInfos returns node lister.
+func (snapshot *DeltaClusterSnapshot) NodeInfos() schedulerlisters.NodeInfoLister {
+	return (*deltaSnapshotNodeLister)(snapshot)
+}
+
+// NewDeltaClusterSnapshot creates instances of DeltaClusterSnapshot.
+func NewDeltaClusterSnapshot() *DeltaClusterSnapshot {
+	snapshot := &DeltaClusterSnapshot{}
+	snapshot.Clear()
+	return snapshot
+}
+
+// AddNode adds node to the snapshot.
+func (snapshot *DeltaClusterSnapshot) AddNode(node *apiv1.Node) error {
+	return snapshot.data.addNode(node)
+}
+
+// AddNodes adds nodes in batch to the snapshot.
+func (snapshot *DeltaClusterSnapshot) AddNodes(nodes []*apiv1.Node) error {
+	return snapshot.data.addNodes(nodes)
+}
+
+// AddNodeWithPods adds a node and set of pods to be scheduled to this node to the snapshot.
+func (snapshot *DeltaClusterSnapshot) AddNodeWithPods(node *apiv1.Node, pods []*apiv1.Pod) error {
+	if err := snapshot.AddNode(node); err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		if err := snapshot.AddPod(pod, node.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveNode removes nodes (and pods scheduled to it) from the snapshot.
+func (snapshot *DeltaClusterSnapshot) RemoveNode(nodeName string) error {
+	return snapshot.data.removeNode(nodeName)
+}
+
+// AddPod adds pod to the snapshot and schedules it to given node.
+func (snapshot *DeltaClusterSnapshot) AddPod(pod *apiv1.Pod, nodeName string) error {
+	return snapshot.data.addPod(pod, nodeName)
+}
+
+// RemovePod removes pod from the snapshot.
+func (snapshot *DeltaClusterSnapshot) RemovePod(namespace string, podName string) error {
+	return snapshot.data.removePod(namespace, podName)
+}
+
+// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()
+// Forking already forked snapshot is not allowed and will result with an error.
+// Time: O(1)
+func (snapshot *DeltaClusterSnapshot) Fork() error {
+	if snapshot.data.baseData != nil {
+		return fmt.Errorf("snapshot already forked")
+	}
+	snapshot.data = snapshot.data.fork()
+	return nil
+}
+
+// Revert reverts snapshot state to moment of forking.
+// Time: O(1)
+func (snapshot *DeltaClusterSnapshot) Revert() error {
+	if snapshot.data.baseData == nil {
+		return fmt.Errorf("snapshot not forked")
+	}
+	snapshot.data = snapshot.data.baseData
+	return nil
+
+}
+
+// Commit commits changes done after forking.
+// Time: O(n), where n = size of delta (number of nodes added, modified or deleted since forking)
+func (snapshot *DeltaClusterSnapshot) Commit() error {
+	snapshot.data = snapshot.data.commit()
+	return nil
+}
+
+// Clear reset cluster snapshot to empty, unforked state
+// Time: O(1)
+func (snapshot *DeltaClusterSnapshot) Clear() {
+	snapshot.data = newInternalDeltaSnapshotData()
+}

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -171,6 +171,10 @@ func (data *internalDeltaSnapshotData) addNodeInfo(nodeInfo *schedulernodeinfo.N
 		data.nodeInfoList = append(data.nodeInfoList, nodeInfo)
 	}
 
+	if len(nodeInfo.Pods()) > 0 {
+		data.clearPodCaches()
+	}
+
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -32,6 +32,7 @@ import (
 	scheduler_listers "k8s.io/kubernetes/pkg/scheduler/listers"
 	scheduler_nodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	scheduler_volumebinder "k8s.io/kubernetes/pkg/scheduler/volumebinder"
+
 	// We need to import provider to initialize default scheduler.
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 )
@@ -94,10 +95,10 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot ClusterSnap
 	if clusterSnapshot == nil {
 		return "", fmt.Errorf("ClusterSnapshot not provided")
 	}
+
 	if nodeInfos != nil {
 		klog.Errorf("clusterSnapshot and nodeInfos are mutually exclusive!!!!")
 	}
-	var nodeInfosList []*scheduler_nodeinfo.NodeInfo
 
 	nodeInfosList, err := clusterSnapshot.NodeInfos().List()
 	if err != nil {
@@ -105,6 +106,7 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot ClusterSnap
 		klog.Errorf("Error obtaining nodeInfos from schedulerLister")
 		return "", fmt.Errorf("error obtaining nodeInfos from schedulerLister")
 	}
+
 	p.delegatingSharedLister.UpdateDelegate(clusterSnapshot)
 	defer p.delegatingSharedLister.ResetDelegate()
 	state := scheduler_framework.NewCycleState()

--- a/cluster-autoscaler/simulator/test_utils.go
+++ b/cluster-autoscaler/simulator/test_utils.go
@@ -33,8 +33,7 @@ func InitializeClusterSnapshotOrDie(
 	pods []*apiv1.Pod) {
 	var err error
 
-	err = snapshot.Clear()
-	assert.NoError(t, err, "error on ClusterSnapshot.Clear()")
+	snapshot.Clear()
 
 	for _, node := range nodes {
 		err = snapshot.AddNode(node)


### PR DESCRIPTION
Delta snapshot stores a chain of changes-since-last-fork (although forking more than once is illegal for now, following basic snapshot's implementation). It's optimized for frequent fork-add a bit of stuff-run lots of predicates-revert flow by:
1) copy-on-write - Fork() and Revert() are O(1), at cost of O(n) Commit() and copying NodeInfo objects on some add/remove operations. In the pessimistic case where all the original nodes are modified (e.g. by AddPod()) after Fork(), total copying cost reaches that of basic snapshot's O(n) Fork().
2) caching of frequently obtained lists of all nodes and pods.