### PR TITLE
Revert "VPA - Removing updater e2e test from scripts"

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -23,6 +23,7 @@ function print_help {
   echo "ERROR! Usage: run-e2e-tests.sh <suite>"
   echo "<suite> should be one of:"
   echo " - recommender"
+  echo " - updater"
   echo " - admission-controller"
   echo " - actuation"
   echo " - full-vpa"
@@ -44,7 +45,7 @@ SUITE=$1
 export GO111MODULE=on
 
 case ${SUITE} in
-  recommender|admission-controller|actuation|full-vpa)
+  recommender|updater|admission-controller|actuation|full-vpa)
     export KUBECONFIG=$HOME/.kube/config
     pushd ${SCRIPT_ROOT}/e2e
     go test -mod vendor ./v1beta2/*go -v --test.timeout=60m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump

--- a/vertical-pod-autoscaler/hack/run-e2e.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e.sh
@@ -23,6 +23,7 @@ function print_help {
   echo "ERROR! Usage: run-e2e.sh <suite>"
   echo "<suite> should be one of:"
   echo " - recommender"
+  echo " - updater"
   echo " - admission-controller"
   echo " - actuation"
   echo " - full-vpa"


### PR DESCRIPTION
Reverts kubernetes/autoscaler#2792

With [status e2e test being added](https://github.com/kubernetes/autoscaler/pull/2808), we need to support updater e2e tests.