### PR TITLE
add VPA cli flag for specifying the name of the webhook service

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -56,7 +56,7 @@ func configTLS(clientset *kubernetes.Clientset, serverCert, serverKey []byte) *t
 
 // register this webhook admission controller with the kube-apiserver
 // by creating MutatingWebhookConfiguration.
-func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace *string, url string, registerByURL bool) {
+func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace *string, serviceName string, url string, registerByURL bool) {
 	time.Sleep(10 * time.Second)
 	client := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	_, err := client.Get(webhookConfigName, metav1.GetOptions{})
@@ -69,7 +69,7 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace 
 	if !registerByURL {
 		RegisterClientConfig.Service = &v1beta1.ServiceReference{
 			Namespace: *namespace,
-			Name:      "vpa-webhook",
+			Name:      serviceName,
 		}
 	} else {
 		RegisterClientConfig.URL = &url

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -56,7 +56,7 @@ func configTLS(clientset *kubernetes.Clientset, serverCert, serverKey []byte) *t
 
 // register this webhook admission controller with the kube-apiserver
 // by creating MutatingWebhookConfiguration.
-func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace *string, serviceName string, url string, registerByURL bool) {
+func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace *string, serviceName, url string, registerByURL bool) {
 	time.Sleep(10 * time.Second)
 	client := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	_, err := client.Get(webhookConfigName, metav1.GetOptions{})

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -55,6 +55,7 @@ var (
 	port           = flag.Int("port", 8000, "The port to listen on.")
 	address        = flag.String("address", ":8944", "The address to expose Prometheus metrics.")
 	namespace      = os.Getenv("NAMESPACE")
+	serviceName    = flag.String("webhook-service", "vpa-webhook", "Kubernetes service under which webhook is registered. Used when registerByURL is set to false.")
 	webhookAddress = flag.String("webhook-address", "", "Address under which webhook is registered. Used when registerByURL is set to true.")
 	webhookPort    = flag.String("webhook-port", "", "Server Port for Webhook")
 	registerByURL  = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
@@ -117,7 +118,7 @@ func main() {
 	}
 	url := fmt.Sprintf("%v:%v", *webhookAddress, *webhookPort)
 	go func() {
-		selfRegistration(clientset, certs.caCert, &namespace, url, *registerByURL)
+		selfRegistration(clientset, certs.caCert, &namespace, *serviceName, url, *registerByURL)
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)
 	}()


### PR DESCRIPTION
Hello, 

I am currently writing a Helm chart for the vertical pod autoscaler. During development I noticed that the webhook service name for the `WebhookClientConfig` is currently hardcoded to `vpa-webhook`.

As using the alternative webhook url is not recommended for in-cluster components, see https://github.com/kubernetes/api/blob/master/admissionregistration/v1beta1/types.go#L501, this PR adds a cli flag for specifying the service name.

The default value of this cli flag matches the current `vpa-webhook` setting, so this is a non breaking change.

Let me know if you have further questions or recommendations.
Thanks for your help!