### PR TITLE
Cherry-pick #2638, #2717, and #2719 to 1.17: Log taint preventing scale-up

### DIFF
--- a/cluster-autoscaler/core/utils/taint_key_set.go
+++ b/cluster-autoscaler/core/utils/taint_key_set.go
@@ -21,6 +21,8 @@ import (
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 )
 
+const gkeNodeTerminationHandlerTaint = "cloud.google.com/impending-node-termination"
+
 // TaintKeySet is a set of taint key
 type TaintKeySet map[string]bool
 
@@ -36,5 +38,6 @@ var (
 		v1.TaintNodePIDPressure:                 true,
 		schedulerapi.TaintExternalCloudProvider: true,
 		schedulerapi.TaintNodeShutdown:          true,
+		gkeNodeTerminationHandlerTaint:          true,
 	}
 )


### PR DESCRIPTION
Useful for debugging, doesn't change scale-up behavior (except for GKE-specific taint that should be ignored).

