### PR TITLE
Cherry-pick #2638, #2717, and #2719 to 1.16: Log taint preventing scale-up

### DIFF
--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -18,14 +18,10 @@ package core
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"math/rand"
 	"reflect"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
@@ -39,15 +35,21 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/glogx"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
-
-	"k8s.io/klog"
 )
 
 const (
 	// ReschedulerTaintKey is the name of the taint created by rescheduler.
 	ReschedulerTaintKey = "CriticalAddonsOnly"
+
+	gkeNodeTerminationHandlerTaint = "cloud.google.com/impending-node-termination"
 )
 
 var (
@@ -61,6 +63,7 @@ var (
 		schedulerapi.TaintNodePIDPressure:        true,
 		schedulerapi.TaintExternalCloudProvider:  true,
 		schedulerapi.TaintNodeShutdown:           true,
+		gkeNodeTerminationHandlerTaint:           true,
 	}
 )
 

--- a/cluster-autoscaler/simulator/predicates.go
+++ b/cluster-autoscaler/simulator/predicates.go
@@ -283,6 +283,9 @@ type PredicateError struct {
 	predicateName  string
 	failureReasons []predicates.PredicateFailureReason
 	err            error
+	// debugInfo contains additional info that predicate doesn't include,
+	// but may be useful for debugging (e.g. taints on node blocking scale-up)
+	debugInfo string
 
 	reasons []string
 	message string
@@ -307,10 +310,10 @@ func (pe *PredicateError) VerboseError() string {
 	}
 	// Generate verbose message.
 	if pe.err != nil {
-		pe.message = fmt.Sprintf("%s predicate error: %v", pe.predicateName, pe.err)
+		pe.message = fmt.Sprintf("%s predicate error: %v, %v", pe.predicateName, pe.err, pe.debugInfo)
 		return pe.message
 	}
-	pe.message = fmt.Sprintf("%s predicate mismatch, reason: %s", pe.predicateName, strings.Join(pe.Reasons(), ", "))
+	pe.message = fmt.Sprintf("%s predicate mismatch, reason: %s, %v", pe.predicateName, strings.Join(pe.Reasons(), ", "), pe.debugInfo)
 	return pe.message
 }
 
@@ -366,8 +369,18 @@ func (p *PredicateChecker) CheckPredicates(pod *apiv1.Pod, predicateMetadata pre
 				predicateName:  predInfo.Name,
 				failureReasons: failureReasons,
 				err:            err,
+				debugInfo:      p.addDebugInfo(predInfo, nodeInfo),
 			}
 		}
 	}
 	return nil
+}
+
+func (p *PredicateChecker) addDebugInfo(predInfo PredicateInfo, nodeInfo *schedulernodeinfo.NodeInfo) string {
+	switch predInfo.Name {
+	case "PodToleratesNodeTaints":
+		return fmt.Sprintf("taints on node: %#v", nodeInfo.Node().Spec.Taints)
+	default:
+		return ""
+	}
 }

--- a/cluster-autoscaler/simulator/predicates.go
+++ b/cluster-autoscaler/simulator/predicates.go
@@ -285,7 +285,7 @@ type PredicateError struct {
 	err            error
 	// debugInfo contains additional info that predicate doesn't include,
 	// but may be useful for debugging (e.g. taints on node blocking scale-up)
-	debugInfo string
+	debugInfo func() string
 
 	reasons []string
 	message string
@@ -310,10 +310,10 @@ func (pe *PredicateError) VerboseError() string {
 	}
 	// Generate verbose message.
 	if pe.err != nil {
-		pe.message = fmt.Sprintf("%s predicate error: %v, %v", pe.predicateName, pe.err, pe.debugInfo)
+		pe.message = fmt.Sprintf("%s predicate error: %v, %v", pe.predicateName, pe.err, pe.debugInfo())
 		return pe.message
 	}
-	pe.message = fmt.Sprintf("%s predicate mismatch, reason: %s, %v", pe.predicateName, strings.Join(pe.Reasons(), ", "), pe.debugInfo)
+	pe.message = fmt.Sprintf("%s predicate mismatch, reason: %s, %v", pe.predicateName, strings.Join(pe.Reasons(), ", "), pe.debugInfo())
 	return pe.message
 }
 
@@ -369,18 +369,25 @@ func (p *PredicateChecker) CheckPredicates(pod *apiv1.Pod, predicateMetadata pre
 				predicateName:  predInfo.Name,
 				failureReasons: failureReasons,
 				err:            err,
-				debugInfo:      p.addDebugInfo(predInfo, nodeInfo),
+				debugInfo:      p.buildDebugInfo(predInfo, nodeInfo),
 			}
 		}
 	}
 	return nil
 }
 
-func (p *PredicateChecker) addDebugInfo(predInfo PredicateInfo, nodeInfo *schedulernodeinfo.NodeInfo) string {
+func emptyString() string {
+	return ""
+}
+
+func (p *PredicateChecker) buildDebugInfo(predInfo PredicateInfo, nodeInfo *schedulernodeinfo.NodeInfo) func() string {
 	switch predInfo.Name {
 	case "PodToleratesNodeTaints":
-		return fmt.Sprintf("taints on node: %#v", nodeInfo.Node().Spec.Taints)
+		taints := nodeInfo.Node().Spec.Taints
+		return func() string {
+			return fmt.Sprintf("taints on node: %#v", taints)
+		}
 	default:
-		return ""
+		return emptyString
 	}
 }


### PR DESCRIPTION
Useful for debugging, doesn't change scale-up behavior (except for GKE-specific taint that should be ignored).

