### PR TITLE
CA - Resolve AWS TestGetRegion failure post 1.18 vendoring

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"sort"
@@ -26,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
@@ -46,9 +50,6 @@ func resetAWSRegion(value string, present bool) {
 	}
 }
 
-/*
-* This fails after vendor update for 1.18.
-*
 // TestGetRegion ensures correct source supplies AWS Region.
 func TestGetRegion(t *testing.T) {
 	key := "AWS_REGION"
@@ -57,18 +58,17 @@ func TestGetRegion(t *testing.T) {
 	expected1 := "the-shire-1"
 	os.Setenv(key, expected1)
 	assert.Equal(t, expected1, getRegion())
-	// Ensure without environment variable, EC2 Metadata used... and it merely
-	// chops the last character off the Availability Zone.
+	// Ensure without environment variable, EC2 Metadata is used.
 	expected2 := "mordor-2"
-	expected2a := expected2 + "a"
+	expectedjson := ec2metadata.EC2InstanceIdentityDocument{Region: expected2}
+	js, _ := json.Marshal(expectedjson)
 	os.Unsetenv(key)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(expected2a))
+		w.Write(js)
 	}))
 	cfg := aws.NewConfig().WithEndpoint(server.URL)
 	assert.Equal(t, expected2, getRegion(cfg))
 }
-*/
 
 func TestBuildGenericLabels(t *testing.T) {
 	labels := buildGenericLabels(&asgTemplate{


### PR DESCRIPTION
Resolves part of #2797 

Updates the AWS-Manager test for Region fetching due to changes in the SDK in how this is done due to aws/aws-sdk-go#2969