### PR TITLE
Remove unused asg cache TTL

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -74,8 +74,6 @@ Make a copy of [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.y
 
 > **_NOTE_**: Use a command such as `echo $CLIENT_ID | base64` to encode each of the fields above.
 
-> **_NOTE_** (optional) to specify the TTL of VMSS ASG cache to prevent throttling issue, please provide the env `AZURE_ASG_CACHE_TTL` in seconds which is set to one hour by default.
-
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
 
 #### Auto-Discovery Setup

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -71,7 +71,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 		},
 	}
 
-	cache, error := newAsgCache(int64(defaultAsgCacheTTL))
+	cache, error := newAsgCache()
 	assert.NoError(t, error)
 
 	manager.asgCache = cache

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -102,9 +102,6 @@ type Config struct {
 	//Config only for AKS
 	NodeResourceGroup string `json:"nodeResourceGroup" yaml:"nodeResourceGroup"`
 
-	// ASG cache TTL in seconds
-	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
-
 	// VMSS metadata cache TTL in seconds, only applies for vmss type
 	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
 
@@ -174,13 +171,6 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			cfg.UserAssignedIdentityID = userAssignedIdentityIDFromEnv
 		}
 
-		if asgCacheTTL := os.Getenv("AZURE_ASG_CACHE_TTL"); asgCacheTTL != "" {
-			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
-			}
-		}
-
 		if vmssCacheTTL := os.Getenv("AZURE_VMSS_CACHE_TTL"); vmssCacheTTL != "" {
 			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
 			if err != nil {
@@ -211,10 +201,6 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		}
 
 		cfg.DeploymentParameters = parameters
-	}
-
-	if cfg.AsgCacheTTL == 0 {
-		cfg.AsgCacheTTL = int64(defaultAsgCacheTTL)
 	}
 
 	if cfg.MaxDeploymentsCount == 0 {
@@ -249,7 +235,7 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		explicitlyConfigured: make(map[string]bool),
 	}
 
-	cache, err := newAsgCache(cfg.AsgCacheTTL)
+	cache, err := newAsgCache()
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -39,7 +39,6 @@ const validAzureCfg = `{
 	"vnetName": "fakeName",
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
-	"asgCacheTTL": 900,
 	"vmssCacheTTL": 60,
 	"maxDeploymentsCount": 8}`
 
@@ -56,7 +55,6 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		VMType:              "vmss",
 		AADClientID:         "fakeId",
 		AADClientSecret:     "fakeId",
-		AsgCacheTTL:         900,
 		VmssCacheTTL:        60,
 		MaxDeploymentsCount: 8,
 	}


### PR DESCRIPTION
The `AZURE_ASG_CACHE_TTL` used in the goroutine was effectively useless because this cache is already invalidated every azure manager loop (1 minute) and the result of invalidation indirectly depends on the decision the `Nodes()` call makes.
- If scaleset or agentpool, the TTL of the instances cache is 5 minutes so the TTL of the ASG cache becomes 5 minutes and you only do an API call every 5 minute.
- If AKS pool, `Nodes()` would return fresh data so your ASG cache TTL is 1 minute.
