### PR TITLE
Make VMSS info cache TTL configurable

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -105,6 +105,9 @@ type Config struct {
 	// ASG cache TTL in seconds
 	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
 
+	// VMSS metadata cache TTL in seconds, only applies for vmss type
+	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
+
 	// number of latest deployments that will not be deleted
 	MaxDeploymentsCount int64 `json:"maxDeploymentsCount" yaml:"maxDeploymentsCount"`
 }
@@ -175,6 +178,13 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
+			}
+		}
+
+		if vmssCacheTTL := os.Getenv("AZURE_VMSS_CACHE_TTL"); vmssCacheTTL != "" {
+			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL %q: %v", vmssCacheTTL, err)
 			}
 		}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -40,6 +40,7 @@ const validAzureCfg = `{
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
 	"asgCacheTTL": 900,
+	"vmssCacheTTL": 60,
 	"maxDeploymentsCount": 8}`
 
 const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
@@ -56,6 +57,7 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		AADClientID:         "fakeId",
 		AADClientSecret:     "fakeId",
 		AsgCacheTTL:         900,
+		VmssCacheTTL:        60,
 		MaxDeploymentsCount: 8,
 	}
 
@@ -165,10 +167,11 @@ func TestListScalesets(t *testing.T) {
 				azureRef: azureRef{
 					Name: vmssName,
 				},
-				minSize: 5,
-				maxSize: 50,
-				manager: manager,
-				curSize: -1,
+				minSize:           5,
+				maxSize:           50,
+				manager:           manager,
+				curSize:           -1,
+				sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 			}},
 		},
 		{
@@ -270,10 +273,11 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 		azureRef: azureRef{
 			Name: vmssName,
 		},
-		minSize: minVal,
-		maxSize: maxVal,
-		manager: manager,
-		curSize: -1,
+		minSize:           minVal,
+		maxSize:           maxVal,
+		manager:           manager,
+		curSize:           -1,
+		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedAsgs, asgs), "expected %#v, but found: %#v", expectedAsgs, asgs)
 }


### PR DESCRIPTION
Instead of depending on the default TTL of 15 seconds which might be aggressive and can lead to throttling in multiple clusters scenarios, make it configurable via the provider config.