### PR TITLE
fix case that became flaky after scale set refresh interval change

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -36,9 +36,10 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager: manager,
-		minSize: 1,
-		maxSize: 5,
+		manager:           manager,
+		minSize:           1,
+		maxSize:           5,
+		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}
 }
 


### PR DESCRIPTION
For the unit tests, we create the scale set object directly and not through the `NewScaleSet()` call so we don't populate the size refresh properly and this lead to a flaky test failure.


https://travis-ci.org/kubernetes/autoscaler/jobs/652299234?utm_medium=notification&utm_source=github_status