### PR TITLE
Cherry pick #2842 to 1.16: Make VMSS info cache TTL configurable

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -83,6 +83,9 @@ type Config struct {
 
 	// ASG cache TTL in seconds
 	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
+
+	// VMSS metadata cache TTL in seconds, only applies for vmss type
+	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
 }
 
 // TrimSpace removes all leading and trailing white spaces.
@@ -141,6 +144,13 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
+			}
+		}
+
+		if vmssCacheTTL := os.Getenv("AZURE_VMSS_CACHE_TTL"); vmssCacheTTL != "" {
+			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL %q: %v", vmssCacheTTL, err)
 			}
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -37,7 +37,8 @@ const validAzureCfg = `{
 	"vnetName": "fakeName",
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
-	"asgCacheTTL": 900}`
+	"asgCacheTTL": 900,
+	"vmssCacheTTL": 60}`
 
 const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
 
@@ -53,6 +54,7 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		AADClientID:     "fakeId",
 		AADClientSecret: "fakeId",
 		AsgCacheTTL:     900,
+		VmssCacheTTL:    60,
 	}
 
 	assert.NoError(t, err)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -40,9 +40,9 @@ import (
 )
 
 var (
-	vmssSizeRefreshPeriod      = 15 * time.Second
-	vmssInstancesRefreshPeriod = 5 * time.Minute
-	vmssSizeMutex              sync.Mutex
+	defaultVmssSizeRefreshPeriod = 15 * time.Second
+	vmssInstancesRefreshPeriod   = 5 * time.Minute
+	vmssSizeMutex                sync.Mutex
 )
 
 var scaleSetStatusCache struct {
@@ -74,9 +74,10 @@ type ScaleSet struct {
 	minSize int
 	maxSize int
 
-	sizeMutex       sync.Mutex
-	curSize         int64
-	lastSizeRefresh time.Time
+	sizeMutex         sync.Mutex
+	curSize           int64
+	lastSizeRefresh   time.Time
+	sizeRefreshPeriod time.Duration
 
 	instanceMutex       sync.Mutex
 	instanceCache       []cloudprovider.Instance
@@ -93,6 +94,12 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager) (*ScaleSet, erro
 		maxSize: spec.MaxSize,
 		manager: az,
 		curSize: -1,
+	}
+
+	if az.config.VmssCacheTTL != 0 {
+		scaleSet.sizeRefreshPeriod = time.Duration(az.config.VmssCacheTTL) * time.Second
+	} else {
+		scaleSet.sizeRefreshPeriod = defaultVmssSizeRefreshPeriod
 	}
 
 	return scaleSet, nil
@@ -134,7 +141,7 @@ func (scaleSet *ScaleSet) getVMSSInfo() (compute.VirtualMachineScaleSet, error) 
 	scaleSetStatusCache.mutex.Lock()
 	defer scaleSetStatusCache.mutex.Unlock()
 
-	if scaleSetStatusCache.lastRefresh.Add(vmssSizeRefreshPeriod).After(time.Now()) {
+	if scaleSetStatusCache.lastRefresh.Add(scaleSet.sizeRefreshPeriod).After(time.Now()) {
 		if status, exists := scaleSetStatusCache.scaleSets[scaleSet.Name]; exists {
 			return status, nil
 		}
@@ -180,7 +187,7 @@ func (scaleSet *ScaleSet) getCurSize() (int64, error) {
 	scaleSet.sizeMutex.Lock()
 	defer scaleSet.sizeMutex.Unlock()
 
-	if scaleSet.lastSizeRefresh.Add(vmssSizeRefreshPeriod).After(time.Now()) {
+	if scaleSet.lastSizeRefresh.Add(scaleSet.sizeRefreshPeriod).After(time.Now()) {
 		return scaleSet.curSize, nil
 	}
 
@@ -188,7 +195,7 @@ func (scaleSet *ScaleSet) getCurSize() (int64, error) {
 	set, err := scaleSet.getVMSSInfo()
 	if err != nil {
 		if isAzureRequestsThrottled(err) {
-			// Log a warning and update the size refresh time so that it would retry after next vmssSizeRefreshPeriod.
+			// Log a warning and update the size refresh time so that it would retry after next sizeRefreshPeriod.
 			klog.Warningf("getVMSSInfo() is throttled with message %v, would return the cached vmss size", err)
 			scaleSet.lastSizeRefresh = time.Now()
 			return scaleSet.curSize, nil
@@ -230,7 +237,7 @@ func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) {
 			// Invalidate the VMSS size cache in order to fetch the size from the API.
 			scaleSet.sizeMutex.Lock()
 			defer scaleSet.sizeMutex.Unlock()
-			scaleSet.lastSizeRefresh = time.Now().Add(-1 * vmssSizeRefreshPeriod)
+			scaleSet.lastSizeRefresh = time.Now().Add(-1 * scaleSet.sizeRefreshPeriod)
 		}
 	}()
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -35,9 +35,10 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager: manager,
-		minSize: 1,
-		maxSize: 5,
+		manager:           manager,
+		minSize:           1,
+		maxSize:           5,
+		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}
 }
 


### PR DESCRIPTION
Instead of depending on the default TTL of 15 seconds which might be aggressive and can lead to throttling in multiple clusters scenarios, make it configurable via the provider config.

/area provider/azure