### PR TITLE
Cherry pick #2842 to 1.17: Make VMSS info cache TTL configurable

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -102,6 +102,9 @@ type Config struct {
 
 	// ASG cache TTL in seconds
 	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
+
+	// VMSS metadata cache TTL in seconds, only applies for vmss type
+	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
 }
 
 // TrimSpace removes all leading and trailing white spaces.
@@ -165,6 +168,13 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
+			}
+		}
+
+		if vmssCacheTTL := os.Getenv("AZURE_VMSS_CACHE_TTL"); vmssCacheTTL != "" {
+			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL %q: %v", vmssCacheTTL, err)
 			}
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -39,7 +39,8 @@ const validAzureCfg = `{
 	"vnetName": "fakeName",
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
-	"asgCacheTTL": 900}`
+	"asgCacheTTL": 900,
+	"vmssCacheTTL": 60}`
 
 const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
 
@@ -55,6 +56,7 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		AADClientID:     "fakeId",
 		AADClientSecret: "fakeId",
 		AsgCacheTTL:     900,
+		VmssCacheTTL:    60,
 	}
 
 	assert.NoError(t, err)
@@ -163,10 +165,11 @@ func TestListScalesets(t *testing.T) {
 				azureRef: azureRef{
 					Name: vmssName,
 				},
-				minSize: 5,
-				maxSize: 50,
-				manager: manager,
-				curSize: -1,
+				minSize:           5,
+				maxSize:           50,
+				manager:           manager,
+				curSize:           -1,
+				sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 			}},
 		},
 		{
@@ -268,10 +271,11 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 		azureRef: azureRef{
 			Name: vmssName,
 		},
-		minSize: minVal,
-		maxSize: maxVal,
-		manager: manager,
-		curSize: -1,
+		minSize:           minVal,
+		maxSize:           maxVal,
+		manager:           manager,
+		curSize:           -1,
+		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedAsgs, asgs), "expected %#v, but found: %#v", expectedAsgs, asgs)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -36,9 +36,10 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager: manager,
-		minSize: 1,
-		maxSize: 5,
+		manager:           manager,
+		minSize:           1,
+		maxSize:           5,
+		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}
 }
 


### PR DESCRIPTION
Instead of depending on the default TTL of 15 seconds which might be aggressive and can lead to throttling in multiple clusters scenarios, make it configurable via the provider config.

/area provider/azure