### PR TITLE
Add eks.amazonaws.com/nodegroup label to awsIgnoredLabels

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -25,6 +25,7 @@ func IsAwsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 	awsIgnoredLabels := map[string]bool{
 		"alpha.eksctl.io/instance-id":    true, // this is a label used by eksctl to identify instances.
 		"alpha.eksctl.io/nodegroup-name": true, // this is a label used by eksctl to identify "node group" names.
+		"eks.amazonaws.com/nodegroup":    true, // this is a label used by eks to identify "node group".
 		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
 		"lifecycle":                      true, // this is a label used by the AWS for spot.
 	}


### PR DESCRIPTION
Adding `eks.amazonaws.com/nodegroup` to the AWS list of ignored labels since it added automatically by AWS and confuse CA.