### PR TITLE
Backporting AWS ignored labels and capacity memory changes to 1.16

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -293,6 +293,9 @@ func buildAutoscaler() (core.Autoscaler, error) {
 	if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {
 		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
 			Comparator: nodegroupset.IsAzureNodeInfoSimilar}
+	} else if autoscalingOptions.CloudProviderName == cloudprovider.AwsProviderName {
+		processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
+			Comparator: nodegroupset.IsAwsNodeInfoSimilar}
 	}
 
 	opts := core.AutoscalerOptions{

--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupset
+
+import (
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// IsAwsNodeInfoSimilar adds AWS specific node labels to the list of ignored labels.
+func IsAwsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
+	awsIgnoredLabels := map[string]bool{
+		"alpha.eksctl.io/instance-id":    true, // this is a label used by eksctl to identify instances.
+		"alpha.eksctl.io/nodegroup-name": true, // this is a label used by eksctl to identify "node group" names.
+		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
+		"lifecycle":                      true, // this is a label used by the AWS for spot.
+	}
+
+	for k, v := range BasicIgnoredLabels {
+		awsIgnoredLabels[k] = v
+	}
+	return IsCloudProviderNodeInfoSimilar(n1, n2, awsIgnoredLabels)
+}

--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -25,6 +25,7 @@ func IsAwsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 	awsIgnoredLabels := map[string]bool{
 		"alpha.eksctl.io/instance-id":    true, // this is a label used by eksctl to identify instances.
 		"alpha.eksctl.io/nodegroup-name": true, // this is a label used by eksctl to identify "node group" names.
+		"eks.amazonaws.com/nodegroup":    true, // this is a label used by eks to identify "node group".
 		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
 		"lifecycle":                      true, // this is a label used by the AWS for spot.
 	}

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -33,7 +33,7 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 	// MaxMemoryDifferenceInKiloBytes describes how much memory
 	// capacity can differ but still be considered equal.
-	MaxMemoryDifferenceInKiloBytes = 128000
+	MaxMemoryDifferenceInKiloBytes = 256000
 )
 
 // BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity


### PR DESCRIPTION
This PR is about backporting changes from master to 1.16. This is required when using EKS 1.14 with node groups because:
- EKS 1.14 (which is currently the latest version) does not work with CA 1.17
- Sometimes the memory capacity between instances within worker groups can differ quite a lot
- EKS add a label that confused CA 

I was able to test this against a 3 AZs group set which now spread the instances across all AZs.

Finally, I would like to get a new release of 1.16, can you guide me through the process of doing that? (or is it just something that happens by itself periodically?)