### PR TITLE
Don't pass node infos to FitsAnyNode

### DIFF
--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -120,7 +120,7 @@ func filterOutSchedulableByPacking(
 
 	// Bin pack
 	for _, pod := range unschedulableCandidates {
-		nodeName, err := predicateChecker.FitsAnyNode(clusterSnapshot, pod, nil)
+		nodeName, err := predicateChecker.FitsAnyNode(clusterSnapshot, pod)
 		if err == nil {
 			klog.V(4).Infof("Pod %s.%s marked as unschedulable can be scheduled on node %s. Ignoring"+
 				" in scale up.", pod.Namespace, pod.Name, nodeName)

--- a/cluster-autoscaler/simulator/predicates_checker_interface.go
+++ b/cluster-autoscaler/simulator/predicates_checker_interface.go
@@ -18,12 +18,10 @@ package simulator
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	scheduler_nodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 // PredicateChecker checks whether all required predicates pass for given Pod and Node.
 type PredicateChecker interface {
-	// TODO drop "nodeInfos map[string]*scheduler_nodeinfo.NodeInfo" and check against schedulerLister
-	FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeInfos map[string]*scheduler_nodeinfo.NodeInfo) (string, error)
+	FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod) (string, error)
 	CheckPredicates(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError
 }

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -88,13 +88,9 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-
 }
 
 // FitsAnyNode checks if the given pod can be placed on any of the given nodes.
-func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeInfos map[string]*scheduler_nodeinfo.NodeInfo) (string, error) {
+func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod) (string, error) {
 	if clusterSnapshot == nil {
 		return "", fmt.Errorf("ClusterSnapshot not provided")
-	}
-
-	if nodeInfos != nil {
-		klog.Errorf("clusterSnapshot and nodeInfos are mutually exclusive!!!!")
 	}
 
 	nodeInfosList, err := clusterSnapshot.NodeInfos().List()

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker_test.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker_test.go
@@ -112,15 +112,15 @@ func TestFitsAnyNode(t *testing.T) {
 	predicateChecker, err := NewTestPredicateChecker()
 	assert.NoError(t, err)
 
-	nodeName, err := predicateChecker.FitsAnyNode(clusterSnapshot, p900, nil)
+	nodeName, err := predicateChecker.FitsAnyNode(clusterSnapshot, p900)
 	assert.NoError(t, err)
 	assert.True(t, nodeName == "n1000" || nodeName == "n2000")
 
-	nodeName, err = predicateChecker.FitsAnyNode(clusterSnapshot, p1900, nil)
+	nodeName, err = predicateChecker.FitsAnyNode(clusterSnapshot, p1900)
 	assert.NoError(t, err)
 	assert.Equal(t, "n2000", nodeName)
 
-	nodeName, err = predicateChecker.FitsAnyNode(clusterSnapshot, p2100, nil)
+	nodeName, err = predicateChecker.FitsAnyNode(clusterSnapshot, p2100)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
This parameter is no longer used. 

Follow-up from #2797.