### PR TITLE
Cleanup todo

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -424,10 +424,6 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	}
 
 	if a.ScaleDownEnabled {
-
-		// TODO(scheduler_framework migration) should we repropagate ClusterSnaphshot before scaled down?
-		// If we follow old logic it seems we should not.
-
 		pdbs, err := pdbLister.List()
 		if err != nil {
 			scaleDownStatus.Result = status.ScaleDownError


### PR DESCRIPTION
We've always used the same state for scale down, changing it doesn't seem related to scheduler migration.