### PR TITLE
Add ability to add handlers for new resources to AdmissionController via RegisterHandler()

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/pod_resource_handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/pod_resource_handler.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+	"k8s.io/klog"
+)
+
+const (
+	vpaAnnotationLabel = "vpaUpdates"
+)
+
+type patchRecord struct {
+	Op    string      `json:"op,inline"`
+	Path  string      `json:"path,inline"`
+	Value interface{} `json:"value"`
+}
+
+// podResourceHandler builds patches for Pods.
+type podResourceHandler struct {
+	podPreProcessor        PodPreProcessor
+	recommendationProvider RecommendationProvider
+	vpaMatcher             VpaMatcher
+}
+
+// newPodResourceHandler creates new instance of podResourceHandler.
+func newPodResourceHandler(podPreProcessor PodPreProcessor, recommendationProvider RecommendationProvider, vpaMatcher VpaMatcher) ResourceHandler {
+	return &podResourceHandler{
+		podPreProcessor:        podPreProcessor,
+		recommendationProvider: recommendationProvider,
+		vpaMatcher:             vpaMatcher,
+	}
+}
+
+// AdmissionResource returns resource type this handler accepts.
+func (h *podResourceHandler) AdmissionResource() admission.AdmissionResource {
+	return admission.Pod
+}
+
+// GroupResource returns Group and Resource type this handler accepts.
+func (h *podResourceHandler) GroupResource() metav1.GroupResource {
+	return metav1.GroupResource{Group: "", Resource: "pods"}
+}
+
+// DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
+func (h *podResourceHandler) DisallowIncorrectObjects() bool {
+	// Incorrect Pods are validated by API Server.
+	return false
+}
+
+// GetPatches builds patches for Pod in given admission request.
+func (h *podResourceHandler) GetPatches(ar *v1beta1.AdmissionRequest) ([]patchRecord, error) {
+	if ar.Resource.Version != "v1" {
+		return nil, fmt.Errorf("only v1 Pods are supported")
+	}
+	raw, namespace := ar.Object.Raw, ar.Namespace
+	pod := v1.Pod{}
+	if err := json.Unmarshal(raw, &pod); err != nil {
+		return nil, err
+	}
+	if len(pod.Name) == 0 {
+		pod.Name = pod.GenerateName + "%"
+		pod.Namespace = namespace
+	}
+	klog.V(4).Infof("Admitting pod %v", pod.ObjectMeta)
+	controllingVpa := h.vpaMatcher.GetMatchingVPA(&pod)
+	if controllingVpa == nil {
+		klog.V(4).Infof("No matching VPA found for pod %s/%s", pod.Namespace, pod.Name)
+		return []patchRecord{}, nil
+	}
+	containersResources, annotationsPerContainer, err := h.recommendationProvider.GetContainersResourcesForPod(&pod, controllingVpa)
+	if err != nil {
+		return nil, err
+	}
+	pod, err = h.podPreProcessor.Process(pod)
+	if err != nil {
+		return nil, err
+	}
+	if annotationsPerContainer == nil {
+		annotationsPerContainer = vpa_api_util.ContainerToAnnotationsMap{}
+	}
+
+	patches := []patchRecord{}
+	updatesAnnotation := []string{}
+	for i, containerResources := range containersResources {
+		newPatches, newUpdatesAnnotation := getContainerPatch(pod, i, annotationsPerContainer, containerResources)
+		patches = append(patches, newPatches...)
+		updatesAnnotation = append(updatesAnnotation, newUpdatesAnnotation)
+	}
+
+	if pod.Annotations == nil {
+		patches = append(patches, getAddEmptyAnnotationsPatch())
+	}
+	if len(updatesAnnotation) > 0 {
+		vpaAnnotationValue := fmt.Sprintf("Pod resources updated by %s: %s", controllingVpa.Name, strings.Join(updatesAnnotation, "; "))
+		patches = append(patches, getAddAnnotationPatch(vpaAnnotationLabel, vpaAnnotationValue))
+	}
+	vpaObservedContainersValue := annotations.GetVpaObservedContainersValue(&pod)
+	patches = append(patches, getAddAnnotationPatch(annotations.VpaObservedContainersLabel, vpaObservedContainersValue))
+
+	return patches, nil
+}
+
+func getContainerPatch(pod v1.Pod, i int, annotationsPerContainer vpa_api_util.ContainerToAnnotationsMap, containerResources vpa_api_util.ContainerResources) ([]patchRecord, string) {
+	var patches []patchRecord
+	// Add empty resources object if missing.
+	if pod.Spec.Containers[i].Resources.Limits == nil &&
+		pod.Spec.Containers[i].Resources.Requests == nil {
+		patches = append(patches, getPatchInitializingEmptyResources(i))
+	}
+
+	annotations, found := annotationsPerContainer[pod.Spec.Containers[i].Name]
+	if !found {
+		annotations = make([]string, 0)
+	}
+
+	patches, annotations = appendPatchesAndAnnotations(patches, annotations, pod.Spec.Containers[i].Resources.Requests, i, containerResources.Requests, "requests", "request")
+	patches, annotations = appendPatchesAndAnnotations(patches, annotations, pod.Spec.Containers[i].Resources.Limits, i, containerResources.Limits, "limits", "limit")
+
+	updatesAnnotation := fmt.Sprintf("container %d: ", i) + strings.Join(annotations, ", ")
+	return patches, updatesAnnotation
+}
+
+func getAddEmptyAnnotationsPatch() patchRecord {
+	return patchRecord{
+		Op:    "add",
+		Path:  "/metadata/annotations",
+		Value: map[string]string{},
+	}
+}
+
+func getAddAnnotationPatch(annotationName, annotationValue string) patchRecord {
+	return patchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/metadata/annotations/%s", annotationName),
+		Value: annotationValue,
+	}
+}
+
+func getPatchInitializingEmptyResources(i int) patchRecord {
+	return patchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources", i),
+		Value: v1.ResourceRequirements{},
+	}
+}
+
+func getPatchInitializingEmptyResourcesSubfield(i int, kind string) patchRecord {
+	return patchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s", i, kind),
+		Value: v1.ResourceList{},
+	}
+}
+
+func getAddResourceRequirementValuePatch(i int, kind string, resource v1.ResourceName, quantity resource.Quantity) patchRecord {
+	return patchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, resource),
+		Value: quantity.String()}
+}
+
+func appendPatchesAndAnnotations(patches []patchRecord, annotations []string, current v1.ResourceList, containerIndex int, resources v1.ResourceList, fieldName, resourceName string) ([]patchRecord, []string) {
+	// Add empty object if it's missing and we're about to fill it.
+	if current == nil && len(resources) > 0 {
+		patches = append(patches, getPatchInitializingEmptyResourcesSubfield(containerIndex, fieldName))
+	}
+	for resource, request := range resources {
+		patches = append(patches, getAddResourceRequirementValuePatch(containerIndex, fieldName, resource, request))
+		annotations = append(annotations, fmt.Sprintf("%s %s", resource, resourceName))
+	}
+	return patches, annotations
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/resource_handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/resource_handler.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+)
+
+// ResourceHandler represents a handler for a resource in Admission Server
+type ResourceHandler interface {
+	// GroupResource returns Group and Resource type this handler accepts.
+	GroupResource() metav1.GroupResource
+	// AdmissionResource returns resource type this handler accepts.
+	AdmissionResource() admission.AdmissionResource
+	// DisallowIncorrectObjects returns whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
+	DisallowIncorrectObjects() bool
+	// GetPatches returns patches for given AdmissionRequest
+	GetPatches(*v1beta1.AdmissionRequest) ([]patchRecord, error)
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/vpa_resource_handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/vpa_resource_handler.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+	"k8s.io/klog"
+)
+
+var (
+	possibleUpdateModes = map[vpa_types.UpdateMode]interface{}{
+		vpa_types.UpdateModeOff:      struct{}{},
+		vpa_types.UpdateModeInitial:  struct{}{},
+		vpa_types.UpdateModeRecreate: struct{}{},
+		vpa_types.UpdateModeAuto:     struct{}{},
+	}
+
+	possibleScalingModes = map[vpa_types.ContainerScalingMode]interface{}{
+		vpa_types.ContainerScalingModeAuto: struct{}{},
+		vpa_types.ContainerScalingModeOff:  struct{}{},
+	}
+)
+
+// vpaResourceHandler builds patches for VPAs.
+type vpaResourceHandler struct {
+	vpaPreProcessor VpaPreProcessor
+}
+
+// newVpaResourceHandler creates new instance of vpaResourceHandler.
+func newVpaResourceHandler(vpaPreProcessor VpaPreProcessor) ResourceHandler {
+	return &vpaResourceHandler{vpaPreProcessor: vpaPreProcessor}
+}
+
+// AdmissionResource returns resource type this handler accepts.
+func (h *vpaResourceHandler) AdmissionResource() admission.AdmissionResource {
+	return admission.Vpa
+}
+
+// GroupResource returns Group and Resource type this handler accepts.
+func (h *vpaResourceHandler) GroupResource() metav1.GroupResource {
+	return metav1.GroupResource{Group: "autoscaling.k8s.io", Resource: "verticalpodautoscalers"}
+}
+
+// DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
+func (h *vpaResourceHandler) DisallowIncorrectObjects() bool {
+	return true
+}
+
+// GetPatches builds patches for VPA in given admission request.
+func (h *vpaResourceHandler) GetPatches(ar *v1beta1.AdmissionRequest) ([]patchRecord, error) {
+	raw, isCreate := ar.Object.Raw, ar.Operation == v1beta1.Create
+	vpa, err := parseVPA(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	vpa, err = h.vpaPreProcessor.Process(vpa, isCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateVPA(vpa, isCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(4).Infof("Processing vpa: %v", vpa)
+	patches := []patchRecord{}
+	if vpa.Spec.UpdatePolicy == nil {
+		// Sets the default updatePolicy.
+		defaultUpdateMode := vpa_types.UpdateModeAuto
+		patches = append(patches, patchRecord{
+			Op:    "add",
+			Path:  "/spec/updatePolicy",
+			Value: vpa_types.PodUpdatePolicy{UpdateMode: &defaultUpdateMode}})
+	}
+	return patches, nil
+}
+
+func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
+	vpa := vpa_types.VerticalPodAutoscaler{}
+	if err := json.Unmarshal(raw, &vpa); err != nil {
+		return nil, err
+	}
+	return &vpa, nil
+}
+
+func validateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
+	if vpa.Spec.UpdatePolicy != nil {
+		mode := vpa.Spec.UpdatePolicy.UpdateMode
+		if mode == nil {
+			return fmt.Errorf("UpdateMode is required if UpdatePolicy is used")
+		}
+		if _, found := possibleUpdateModes[*mode]; !found {
+			return fmt.Errorf("unexpected UpdateMode value %s", *mode)
+		}
+	}
+
+	if vpa.Spec.ResourcePolicy != nil {
+		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
+			if policy.ContainerName == "" {
+				return fmt.Errorf("ContainerPolicies.ContainerName is required")
+			}
+			mode := policy.Mode
+			if mode != nil {
+				if _, found := possibleScalingModes[*mode]; !found {
+					return fmt.Errorf("unexpected Mode value %s", *mode)
+				}
+			}
+			for resource, min := range policy.MinAllowed {
+				max, found := policy.MaxAllowed[resource]
+				if found && max.Cmp(min) < 0 {
+					return fmt.Errorf("max resource for %v is lower than min", resource)
+				}
+			}
+		}
+	}
+
+	if isCreate && vpa.Spec.TargetRef == nil {
+		return fmt.Errorf("TargetRef is required. If you're using v1beta1 version of the API, please migrate to v1")
+	}
+
+	return nil
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/vpa_resource_handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/vpa_resource_handler_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+func TestValidateVPA(t *testing.T) {
+	badUpdateMode := vpa_types.UpdateMode("bad")
+	validUpdateMode := vpa_types.UpdateModeOff
+	badScalingMode := vpa_types.ContainerScalingMode("bad")
+	validScalingMode := vpa_types.ContainerScalingModeAuto
+	tests := []struct {
+		name        string
+		vpa         vpa_types.VerticalPodAutoscaler
+		isCreate    bool
+		expectError error
+	}{
+		{
+			name: "empty update",
+			vpa:  vpa_types.VerticalPodAutoscaler{},
+		},
+		{
+			name:        "empty create",
+			vpa:         vpa_types.VerticalPodAutoscaler{},
+			isCreate:    true,
+			expectError: fmt.Errorf("TargetRef is required. If you're using v1beta1 version of the API, please migrate to v1"),
+		},
+		{
+			name: "no update mode",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{},
+				},
+			},
+			expectError: fmt.Errorf("UpdateMode is required if UpdatePolicy is used"),
+		},
+		{
+			name: "bad update mode",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &badUpdateMode,
+					},
+				},
+			},
+			expectError: fmt.Errorf("unexpected UpdateMode value bad"),
+		},
+		{
+			name: "no policy name",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{{}},
+					},
+				},
+			},
+			expectError: fmt.Errorf("ContainerPolicies.ContainerName is required"),
+		},
+		{
+			name: "invalid scaling mode",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								Mode:          &badScalingMode,
+							},
+						},
+					},
+				},
+			},
+			expectError: fmt.Errorf("unexpected Mode value bad"),
+		},
+		{
+			name: "bad limits",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								MinAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("100"),
+								},
+								MaxAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("10"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: fmt.Errorf("max resource for cpu is lower than min"),
+		},
+		{
+			name: "all valid",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								Mode:          &validScalingMode,
+								MinAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("10"),
+								},
+								MaxAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("100"),
+								},
+							},
+						},
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &validUpdateMode,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
+			err := validateVPA(&tc.vpa, tc.isCreate)
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors AdmissionController and decouples its core logic from logic responsible for handling resources. Handlers for already supported resources are registered via the new mechanism.