### PR TITLE
refactor updater for a better structured update priority processing

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -32,6 +32,7 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	target_mock "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/mock"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/eviction"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
@@ -178,6 +179,7 @@ func testRunOnceBase(
 		selectorFetcher:              mockSelectorFetcher,
 		useAdmissionControllerStatus: true,
 		statusValidator:              statusValidator,
+		priorityProcessor:            priority.NewProcessor(),
 	}
 
 	if expectFetchCalls {

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -25,6 +25,7 @@ import (
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	updater "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/logic"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_updater "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/updater"
@@ -97,6 +98,7 @@ func main() {
 		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
 		nil,
 		targetSelectorFetcher,
+		priority.NewProcessor(),
 	)
 	if err != nil {
 		klog.Fatalf("Failed to create updater: %v", err)

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priority
+
+import (
+	"math"
+
+	apiv1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+	"k8s.io/klog"
+)
+
+// PriorityProcessor calculates priority for pod updates.
+type PriorityProcessor interface {
+	GetUpdatePriority(pod *apiv1.Pod, vpa *vpa_types.VerticalPodAutoscaler,
+		recommendation *vpa_types.RecommendedPodResources) podPriority
+}
+
+// NewProcessor creates a new default PriorityProcessor.
+func NewProcessor() PriorityProcessor {
+	return &defaultPriorityProcessor{}
+}
+
+type defaultPriorityProcessor struct {
+}
+
+func (*defaultPriorityProcessor) GetUpdatePriority(pod *apiv1.Pod, _ *vpa_types.VerticalPodAutoscaler,
+	recommendation *vpa_types.RecommendedPodResources) podPriority {
+	outsideRecommendedRange := false
+	scaleUp := false
+	// Sum of requests over all containers, per resource type.
+	totalRequestPerResource := make(map[apiv1.ResourceName]int64)
+	// Sum of recommendations over all containers, per resource type.
+	totalRecommendedPerResource := make(map[apiv1.ResourceName]int64)
+
+	hasObservedContainers, vpaContainerSet := parseVpaObservedContainers(pod)
+
+	for _, podContainer := range pod.Spec.Containers {
+		if hasObservedContainers && !vpaContainerSet.Has(podContainer.Name) {
+			klog.V(4).Infof("Not listed in %s:%s. Skipping container %s priority calculations",
+				annotations.VpaObservedContainersLabel, pod.GetAnnotations()[annotations.VpaObservedContainersLabel], podContainer.Name)
+			continue
+		}
+		recommendedRequest := vpa_api_util.GetRecommendationForContainer(podContainer.Name, recommendation)
+		if recommendedRequest == nil {
+			continue
+		}
+		for resourceName, recommended := range recommendedRequest.Target {
+			totalRecommendedPerResource[resourceName] += recommended.MilliValue()
+			lowerBound, hasLowerBound := recommendedRequest.LowerBound[resourceName]
+			upperBound, hasUpperBound := recommendedRequest.UpperBound[resourceName]
+			if request, hasRequest := podContainer.Resources.Requests[resourceName]; hasRequest {
+				totalRequestPerResource[resourceName] += request.MilliValue()
+				if recommended.MilliValue() > request.MilliValue() {
+					scaleUp = true
+				}
+				if (hasLowerBound && request.Cmp(lowerBound) < 0) ||
+					(hasUpperBound && request.Cmp(upperBound) > 0) {
+					outsideRecommendedRange = true
+				}
+			} else {
+				// Note: if the request is not specified, the container will use the
+				// namespace default request. Currently we ignore it and treat such
+				// containers as if they had 0 request. A more correct approach would
+				// be to always calculate the 'effective' request.
+				scaleUp = true
+				outsideRecommendedRange = true
+			}
+		}
+	}
+	resourceDiff := 0.0
+	for resource, totalRecommended := range totalRecommendedPerResource {
+		totalRequest := math.Max(float64(totalRequestPerResource[resource]), 1.0)
+		resourceDiff += math.Abs(totalRequest-float64(totalRecommended)) / totalRequest
+	}
+	return podPriority{
+		outsideRecommendedRange: outsideRecommendedRange,
+		scaleUp:                 scaleUp,
+		resourceDiff:            resourceDiff,
+	}
+}

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priority
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUpdatePriority(t *testing.T) {
+	containerName := "test-container"
+	testCases := []struct {
+		name         string
+		pod          *corev1.Pod
+		vpa          *vpa_types.VerticalPodAutoscaler
+		expectedPrio podPriority
+	}{
+		{
+			name: "simple scale up",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            4.0,
+				scaleUp:                 true,
+			},
+		}, {
+			name: "simple scale down",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            0.5,
+				scaleUp:                 false,
+			},
+		}, {
+			name: "no resource diff",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            0.0,
+				scaleUp:                 false,
+			},
+		}, {
+			name: "scale up on milliquanitites",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "10m", "")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("900m", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            89.0,
+				scaleUp:                 true,
+			},
+		}, {
+			name: "scale up outside recommended range",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("10", "").
+				WithLowerBound("6", "").
+				WithUpperBound("14", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: true,
+				resourceDiff:            1.5,
+				scaleUp:                 true,
+			},
+		}, {
+			name: "scale down outside recommended range",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "8", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("2", "").
+				WithLowerBound("1", "").
+				WithUpperBound("3", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: true,
+				resourceDiff:            0.75,
+				scaleUp:                 false,
+			},
+		}, {
+			name: "scale up with multiple quantities",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            4.0,
+				scaleUp:                 true,
+			},
+		}, {
+			name: "multiple resources, both scale up",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "10M")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("6", "20M").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            1.0 + 1.0, // summed relative diffs for resources
+				scaleUp:                 true,
+			},
+		}, {
+			name: "multiple resources, only one scale up",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "10M")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "20M").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            1.5 + 0.0, // summed relative diffs for resources
+				scaleUp:                 true,
+			},
+		}, {
+			name: "multiple resources, both scale down",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
+			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "10M").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            0.5 + 0.5, // summed relative diffs for resources
+				scaleUp:                 false,
+			},
+		}, {
+			name: "multiple resources, one outside recommended range",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("2", "10M").
+				WithLowerBound("1", "5M").
+				WithUpperBound("3", "30M").Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: true,
+				resourceDiff:            0.5 + 0.5, // summed relative diffs for resources
+				scaleUp:                 false,
+			},
+		}, {
+			name: "multiple containers, both scale up",
+			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
+				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("4", "").AppendRecommendation(
+				test.Recommendation().
+					WithContainer("test-container-2").
+					WithTarget("8", "").GetContainerResources()).Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            3.0, // relative diff between summed requests and summed recommendations
+				scaleUp:                 true,
+			},
+		}, {
+			name: "multiple containers, both scale down",
+			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "")).
+				AddContainer(test.BuildTestContainer("test-container-2", "7", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("1", "").AppendRecommendation(
+				test.Recommendation().
+					WithContainer("test-container-2").
+					WithTarget("2", "").GetContainerResources()).Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				resourceDiff:            0.7, // relative diff between summed requests and summed recommendations
+				scaleUp:                 false,
+			},
+		}, {
+			name: "multiple containers, both scale up, one outside range",
+			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
+				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("4", "").
+				WithLowerBound("1", "").AppendRecommendation(
+				test.Recommendation().
+					WithContainer("test-container-2").
+					WithTarget("8", "").
+					WithLowerBound("3", "").
+					WithUpperBound("10", "").GetContainerResources()).Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: true,
+				resourceDiff:            3.0, // relative diff between summed requests and summed recommendations
+				scaleUp:                 true,
+			},
+		}, {
+			name: "multiple containers, multiple resources",
+			//   container1: request={6 CPU, 10 MB}, recommended={8 CPU, 20 MB}
+			//   container2: request={4 CPU, 30 MB}, recommended={7 CPU, 30 MB}
+			//   total:      request={10 CPU, 40 MB}, recommended={15 CPU, 50 MB}
+			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "6", "10M")).
+				AddContainer(test.BuildTestContainer("test-container-2", "4", "30M")).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
+				WithTarget("8", "20M").AppendRecommendation(
+				test.Recommendation().
+					WithContainer("test-container-2").
+					WithTarget("7", "30M").GetContainerResources()).Get(),
+			expectedPrio: podPriority{
+				outsideRecommendedRange: false,
+				// relative diff between summed requests and summed recommendations, summed over resources
+				resourceDiff: 0.5 + 0.25,
+				scaleUp:      true,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			processor := NewProcessor()
+			prio := processor.GetUpdatePriority(tc.pod, tc.vpa, tc.vpa.Status.Recommendation)
+			assert.Equal(t, tc.expectedPrio, prio)
+		})
+	}
+}
+
+// Verify GetUpdatePriorty does not encounter a NPE when there is no
+// recommendation for a container.
+func TestGetUpdatePriority_NoRecommendationForContainer(t *testing.T) {
+	p := NewProcessor()
+	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer("test-container", "5", "10")).Get()
+	vpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithContainer("test-container").Get()
+	result := p.GetUpdatePriority(pod, vpa, nil)
+	assert.NotNil(t, result)
+}
+
+func TestGetUpdatePriority_VpaObservedContainers(t *testing.T) {
+	const (
+		// There is no VpaObservedContainers annotation
+		// or the container is listed in the annotation.
+		optedInContainerDiff = 9
+		// There is VpaObservedContainers annotation
+		// and the container is not listed in.
+		optedOutContainerDiff = 0
+	)
+	testVpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithContainer(containerName).Get()
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		recommendation *vpa_types.RecommendedPodResources
+		want           float64
+	}{
+		{
+			name:           "with no VpaObservedContainers annotation",
+			pod:            test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
+			want:           optedInContainerDiff,
+		},
+		{
+			name: "with container listed in VpaObservedContainers annotation",
+			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: containerName}).
+				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
+			want:           optedInContainerDiff,
+		},
+		{
+			name: "with container not listed in VpaObservedContainers annotation",
+			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: ""}).
+				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
+			want:           optedOutContainerDiff,
+		},
+		{
+			name: "with incorrect VpaObservedContainers annotation",
+			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: "abcd;';"}).
+				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
+			want:           optedInContainerDiff,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewProcessor()
+			result := p.GetUpdatePriority(tc.pod, testVpa, tc.recommendation)
+			assert.NotNil(t, result)
+			// The resourceDiff should be a difference between container resources
+			// and container resource recommendations. Containers not listed
+			// in an existing vpaObservedContainers annotations shouldn't be taken
+			// into account during calculations.
+			assert.InDelta(t, result.resourceDiff, tc.want, 0.0001)
+		})
+	}
+}
+
+type fakePriorityProcessor struct {
+	priorities map[string]podPriority
+}
+
+// NewFakeProcessor returns a fake processor for testing that can be initialized
+// with a map from pod name to priority expected to be returned.
+func NewFakeProcessor(priorities map[string]podPriority) PriorityProcessor {
+	return &fakePriorityProcessor{
+		priorities: priorities,
+	}
+}
+
+func (f *fakePriorityProcessor) GetUpdatePriority(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler,
+	recommendation *vpa_types.RecommendedPodResources) podPriority {
+	prio, ok := f.priorities[pod.Name]
+	if !ok {
+		panic(fmt.Sprintf("Unexpected pod name: %v", pod.Name))
+	}
+	return podPriority{
+		scaleUp:                 prio.scaleUp,
+		resourceDiff:            prio.resourceDiff,
+		outsideRecommendedRange: prio.outsideRecommendedRange,
+	}
+}


### PR DESCRIPTION
I believe this makes the code both more extensible and infinitely more testable.

- I moved the getPodPriority function to the priorityProcessor.GetPodPriority 1:1 
- I moved the getPodPrioriry tests to priorityProcessor's tests 1:1
- I converted some of the AddPod tests to priorityProcessor's (the ones that were only testing that we are calculating priority correctly and the sorting was actually secondary)

There's still room for improvement in the AddPod tests (hence the TODO to refactor them), but I didn't want to make this review gigantic