### PR TITLE
VPA - Adding e2e build check

### DIFF
--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -60,3 +60,8 @@ for project_name in ${PROJECT_NAMES[*]}; do
     esac
   )
 done;
+
+if [ "${CMD}" = "build" ] || [ "${CMD}" == "test" ]; then
+  cd ${CONTRIB_ROOT}/vertical-pod-autoscaler/e2e
+  go test -mod vendor -run=None ./...
+fi


### PR DESCRIPTION
It happens that vpa e2e tests are broken after merging a PR to autoscaler repo.
This PR adds check if e2e tests build.