### PR TITLE
Cluster Autoscaler 1.18.0-beta.0

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.17.0-beta.2"
+const ClusterAutoscalerVersion = "1.18.0-beta.0"


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.18.0-beta.0.