### PR TITLE
Allow any subset of nodes to be deleted in test

### DIFF
--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -81,7 +81,8 @@ type scaleTestConfig struct {
 	nodeDeletionTracker     *NodeDeletionTracker
 	expansionOptionToChoose groupSizeChange // this will be selected by assertingStrategy.BestOption
 
-	expectedScaleDowns []string
+	expectedScaleDowns     []string
+	expectedScaleDownCount int
 }
 
 type scaleTestResults struct {


### PR DESCRIPTION
Using snapshot, we will no longer always choose the first 10 empty nodes to remove. Fix test to account for it. (This is probably a good thing, there is no reason to remove the oldest nodes first, and in other places we even shuffle nodes explicitly.)