### PR TITLE
Use nodes and pods from snapshot in scale-down

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -752,7 +752,6 @@ func (sd *ScaleDown) TryToScaleDown(pdbs []*policyv1.PodDisruptionBudget, curren
 	nodesWithoutMaster := filterOutMasters(allNodeInfos)
 	nodesWithoutMasterNames := make(map[string]bool, len(nodesWithoutMaster))
 
-	candidates := make([]*schedulernodeinfo.NodeInfo, 0)
 	candidateNames := make([]string, 0)
 	readinessMap := make(map[string]bool)
 	candidateNodeGroups := make(map[string]cloudprovider.NodeGroup)
@@ -843,12 +842,11 @@ func (sd *ScaleDown) TryToScaleDown(pdbs []*policyv1.PodDisruptionBudget, curren
 			continue
 		}
 
-		candidates = append(candidates, nodeInfo)
 		candidateNames = append(candidateNames, node.Name)
 		candidateNodeGroups[node.Name] = nodeGroup
 	}
 
-	if len(candidates) == 0 {
+	if len(candidateNames) == 0 {
 		klog.V(1).Infof("No candidates for scale down")
 		scaleDownStatus.Result = status.ScaleDownNoUnneeded
 		return scaleDownStatus, nil

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -659,22 +659,20 @@ func (sd *ScaleDown) markSimulationError(simulatorErr errors.AutoscalerError,
 // chooseCandidates splits nodes into current candidates for scale-down and the
 // rest. Current candidates are unneeded nodes from the previous run that are
 // still in the nodes list.
-func (sd *ScaleDown) chooseCandidates(nodes []string) ([]string, []string) {
+func (sd *ScaleDown) chooseCandidates(nodes []string) (candidates []string, nonCandidates []string) {
 	// Number of candidates should not be capped. We will look for nodes to remove
 	// from the whole set of nodes.
 	if sd.context.ScaleDownNonEmptyCandidatesCount <= 0 {
 		return nodes, nil
 	}
-	currentCandidates := make([]string, 0, len(sd.unneededNodesList))
-	currentNonCandidates := make([]string, 0, len(nodes))
 	for _, node := range nodes {
 		if _, found := sd.unneededNodes[node]; found {
-			currentCandidates = append(currentCandidates, node)
+			candidates = append(candidates, node)
 		} else {
-			currentNonCandidates = append(currentNonCandidates, node)
+			nonCandidates = append(nonCandidates, node)
 		}
 	}
-	return currentCandidates, currentNonCandidates
+	return candidates, nonCandidates
 }
 
 func (sd *ScaleDown) mapNodesToStatusScaleDownNodes(nodes []*apiv1.Node, nodeGroups map[string]cloudprovider.NodeGroup, evictedPodLists map[string][]*apiv1.Pod) []*status.ScaleDownNode {

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -962,14 +962,6 @@ func updateScaleDownMetrics(scaleDownStart time.Time, findNodesToRemoveDuration 
 }
 
 func (sd *ScaleDown) getEmptyNodesNoResourceLimits(candidates []string, maxEmptyBulkDelete int) []*apiv1.Node {
-	/*	candidateNodeInfos := make([]*schedulernodeinfo.NodeInfo, len(candidates))
-		for i, name := range candidates {
-			if nodeInfo, err := sd.context.ClusterSnapshot.NodeInfos().Get(name); err != nil {
-				klog.Errorf("Can't retrive scale-down candidate %s from snapshot, err: %v", name, err)
-			} else {
-				candidateNodeInfos[i] = nodeInfo
-			}
-		}*/
 	return sd.getEmptyNodes(candidates, maxEmptyBulkDelete, noScaleDownLimitsOnResources())
 }
 

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -977,7 +977,7 @@ func TestScaleDown(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = scaleDown.UpdateUnneededNodes(nodes, nodes, time.Now().Add(-5*time.Minute), nil)
 	assert.NoError(t, autoscalererr)
-	scaleDownStatus, err := scaleDown.TryToScaleDown([]*apiv1.Pod{p1, p2}, nil, time.Now())
+	scaleDownStatus, err := scaleDown.TryToScaleDown(nil, time.Now())
 	waitForDeleteToFinish(t, scaleDown)
 	assert.NoError(t, err)
 	assert.Equal(t, status.ScaleDownNodeDeleteStarted, scaleDownStatus.Result)
@@ -1231,7 +1231,7 @@ func simpleScaleDownEmpty(t *testing.T, config *scaleTestConfig) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{})
 	autoscalererr = scaleDown.UpdateUnneededNodes(nodes, nodes, time.Now().Add(-5*time.Minute), nil)
 	assert.NoError(t, autoscalererr)
-	scaleDownStatus, err := scaleDown.TryToScaleDown([]*apiv1.Pod{}, nil, time.Now())
+	scaleDownStatus, err := scaleDown.TryToScaleDown(nil, time.Now())
 	assert.False(t, scaleDown.nodeDeletionTracker.IsNonEmptyNodeDeleteInProgress())
 
 	assert.NoError(t, err)
@@ -1317,7 +1317,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
 	autoscalererr = scaleDown.UpdateUnneededNodes(nodes, nodes, time.Now().Add(-5*time.Minute), nil)
 	assert.NoError(t, autoscalererr)
-	scaleDownStatus, err := scaleDown.TryToScaleDown([]*apiv1.Pod{p2}, nil, time.Now())
+	scaleDownStatus, err := scaleDown.TryToScaleDown(nil, time.Now())
 	waitForDeleteToFinish(t, scaleDown)
 
 	assert.NoError(t, err)
@@ -1340,7 +1340,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
 	autoscalererr = scaleDown.UpdateUnneededNodes(nodes, nodes, time.Now().Add(-2*time.Hour), nil)
 	assert.NoError(t, autoscalererr)
-	scaleDownStatus, err = scaleDown.TryToScaleDown([]*apiv1.Pod{p2}, nil, time.Now())
+	scaleDownStatus, err = scaleDown.TryToScaleDown(nil, time.Now())
 	waitForDeleteToFinish(t, scaleDown)
 
 	assert.NoError(t, err)
@@ -1427,7 +1427,7 @@ func TestScaleDownNoMove(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = scaleDown.UpdateUnneededNodes(nodes, nodes, time.Now().Add(-5*time.Minute), nil)
 	assert.NoError(t, autoscalererr)
-	scaleDownStatus, err := scaleDown.TryToScaleDown([]*apiv1.Pod{p1, p2}, nil, time.Now())
+	scaleDownStatus, err := scaleDown.TryToScaleDown(nil, time.Now())
 	waitForDeleteToFinish(t, scaleDown)
 
 	assert.NoError(t, err)
@@ -1524,7 +1524,7 @@ func TestFilterOutMasters(t *testing.T) {
 		}
 	}
 
-	withoutMasters := filterOutMasters(nodes, pods)
+	withoutMasters := filterOutMasters(nodes)
 
 	withoutMastersNames := make([]string, len(withoutMasters))
 	for i, n := range withoutMasters {

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -1456,16 +1456,14 @@ func TestCalculateCoresAndMemoryTotal(t *testing.T) {
 		{"n6", 8000, 6000 * utils.MiB, 0, true, "ng1"},
 		{"n7", 6000, 16000 * utils.MiB, 0, true, "ng1"},
 	}
-	nodes := make([]*schedulernodeinfo.NodeInfo, len(nodeConfigs))
+	nodes := make([]*apiv1.Node, len(nodeConfigs))
 	for i, n := range nodeConfigs {
 		node := BuildTestNode(n.name, n.cpu, n.memory)
 		SetNodeReadyState(node, n.ready, time.Now())
-		nodeInfo := schedulernodeinfo.NewNodeInfo()
-		nodeInfo.SetNode(node)
-		nodes[i] = nodeInfo
+		nodes[i] = node
 	}
 
-	nodes[6].Node().Spec.Taints = []apiv1.Taint{
+	nodes[6].Spec.Taints = []apiv1.Taint{
 		{
 			Key:    deletetaint.ToBeDeletedTaint,
 			Value:  fmt.Sprint(time.Now().Unix()),
@@ -1528,7 +1526,7 @@ func TestFilterOutMasters(t *testing.T) {
 
 	withoutMastersNames := make([]string, len(withoutMasters))
 	for i, n := range withoutMasters {
-		withoutMastersNames[i] = n.Node().Name
+		withoutMastersNames[i] = n.Name
 	}
 	assertEqualSet(t, []string{"n1", "n2", "n4", "n5", "n6"}, withoutMastersNames)
 }

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -1526,7 +1526,7 @@ func TestFilterOutMasters(t *testing.T) {
 
 	withoutMastersNames := make([]string, len(withoutMasters))
 	for i, n := range withoutMasters {
-		withoutMastersNames[i] = n.Name
+		withoutMastersNames[i] = n.Node().Name
 	}
 	assertEqualSet(t, []string{"n1", "n2", "n4", "n5", "n6"}, withoutMastersNames)
 }

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -1456,14 +1456,16 @@ func TestCalculateCoresAndMemoryTotal(t *testing.T) {
 		{"n6", 8000, 6000 * utils.MiB, 0, true, "ng1"},
 		{"n7", 6000, 16000 * utils.MiB, 0, true, "ng1"},
 	}
-	nodes := make([]*apiv1.Node, len(nodeConfigs))
+	nodes := make([]*schedulernodeinfo.NodeInfo, len(nodeConfigs))
 	for i, n := range nodeConfigs {
 		node := BuildTestNode(n.name, n.cpu, n.memory)
 		SetNodeReadyState(node, n.ready, time.Now())
-		nodes[i] = node
+		nodeInfo := schedulernodeinfo.NewNodeInfo()
+		nodeInfo.SetNode(node)
+		nodes[i] = nodeInfo
 	}
 
-	nodes[6].Spec.Taints = []apiv1.Taint{
+	nodes[6].Node().Spec.Taints = []apiv1.Taint{
 		{
 			Key:    deletetaint.ToBeDeletedTaint,
 			Value:  fmt.Sprint(time.Now().Unix()),

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -505,7 +505,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 
 			scaleDownStart := time.Now()
 			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
-			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(nonExpendableScheduledPods, pdbs, currentTime)
+			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(pdbs, currentTime)
 			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 
 			scaleDownStatus.RemovedNodeGroups = removedNodeGroups

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -505,7 +505,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 
 			scaleDownStart := time.Now()
 			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
-			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(allNodes, nonExpendableScheduledPods, pdbs, currentTime)
+			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(nonExpendableScheduledPods, pdbs, currentTime)
 			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 
 			scaleDownStatus.RemovedNodeGroups = removedNodeGroups

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -115,7 +115,6 @@ type UtilizationInfo struct {
 func FindNodesToRemove(
 	candidates []*schedulernodeinfo.NodeInfo,
 	destinationNodes []*schedulernodeinfo.NodeInfo,
-	pods []*apiv1.Pod,
 	listers kube_util.ListerRegistry,
 	clusterSnapshot ClusterSnapshot,
 	predicateChecker PredicateChecker,
@@ -195,7 +194,7 @@ candidateloop:
 }
 
 // FindEmptyNodesToRemove finds empty nodes that can be removed.
-func FindEmptyNodesToRemove(candidates []*schedulernodeinfo.NodeInfo, pods []*apiv1.Pod) []*apiv1.Node {
+func FindEmptyNodesToRemove(candidates []*schedulernodeinfo.NodeInfo) []*apiv1.Node {
 	result := make([]*apiv1.Node, 0)
 	for _, nodeInfo := range candidates {
 		// Should block on all pods.

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -196,6 +196,7 @@ func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string) []str
 		nodeInfo, err := snapshot.NodeInfos().Get(node)
 		if err != nil {
 			klog.Errorf("Can't retrieve node %s from snapshot, err: %v", node, err)
+			continue
 		}
 		// Should block on all pods.
 		podsToRemove, _, err := FastGetPodsToMove(nodeInfo, true, true, nil)

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -369,9 +369,9 @@ func TestFindNodesToRemove(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			destinations := map[string]bool{}
+			destinations := make([]string, 0, len(test.allNodes))
 			for _, node := range test.allNodes {
-				destinations[node.Name] = true
+				destinations = append(destinations, node.Name)
 			}
 			InitializeClusterSnapshotOrDie(t, clusterSnapshot, test.allNodes, test.pods)
 			toRemove, unremovable, _, err := FindNodesToRemove(

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -264,14 +264,15 @@ func TestFindEmptyNodes(t *testing.T) {
 	pod1 := BuildTestPod("p1", 300, 500000)
 	pod1.Spec.NodeName = "n1"
 	nodes[1].AddPod(pod1)
+
 	pod2 := BuildTestPod("p2", 300, 500000)
 	pod2.Spec.NodeName = "n2"
-	nodes[2].AddPod(pod2)
 	pod2.Annotations = map[string]string{
 		types.ConfigMirrorAnnotationKey: "",
 	}
+	nodes[2].AddPod(pod2)
 
-	emptyNodes := FindEmptyNodesToRemove(nodes, []*apiv1.Pod{pod1, pod2})
+	emptyNodes := FindEmptyNodesToRemove(nodes)
 	assert.Equal(t, []*apiv1.Node{nodes[0].Node(), nodes[2].Node(), nodes[3].Node()}, emptyNodes)
 }
 
@@ -399,7 +400,7 @@ func TestFindNodesToRemove(t *testing.T) {
 			}
 			InitializeClusterSnapshotOrDie(t, clusterSnapshot, allNodesForSnapshot, test.pods)
 			toRemove, unremovable, _, err := FindNodesToRemove(
-				test.candidates, test.allNodes, test.pods, nil,
+				test.candidates, test.allNodes, nil,
 				clusterSnapshot, predicateChecker, len(test.allNodes), true, map[string]string{},
 				tracker, time.Now(), []*policyv1.PodDisruptionBudget{})
 			assert.NoError(t, err)


### PR DESCRIPTION
Follow-up from #2797. Small refactors are only in the code already affected by this change.