### PR TITLE
Fix `test-unit` make targets for VPA

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -3,7 +3,8 @@ all: build
 TAG?=dev
 REGISTRY?=staging-k8s.gcr.io
 FLAGS=
-ENVVAR=CGO_ENABLED=0 LD_FLAGS=-s GO111MODULE=on
+TEST_ENVVAR=LD_FLAGS=-s GO111MODULE=on
+ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=admission-controller
 FULL_COMPONENT=vpa-${COMPONENT}
@@ -19,7 +20,7 @@ build-binary-with-vendor: clean
 	$(ENVVAR) GOOS=$(GOOS) go build -mod vendor -o ${COMPONENT}
 
 test-unit: clean build
-	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)
+	$(TEST_ENVVAR) go test --test.short -race ./... $(FLAGS)
 
 docker-build:
 ifndef REGISTRY

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -3,7 +3,8 @@ all: build
 TAG?=dev
 REGISTRY?=staging-k8s.gcr.io
 FLAGS=
-ENVVAR=CGO_ENABLED=0 LD_FLAGS=-s GO111MODULE=on
+TEST_ENVVAR=LD_FLAGS=-s GO111MODULE=on
+ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=recommender
 FULL_COMPONENT=vpa-${COMPONENT}
@@ -19,7 +20,7 @@ build-binary-with-vendor: clean
 	$(ENVVAR) GOOS=$(GOOS) go build -mod vendor -o ${COMPONENT}
 
 test-unit: clean build
-	$(ENVVAR) go test --test.short -race ./... $(FLAGS)
+	$(TEST_ENVVAR) go test --test.short -race ./... $(FLAGS)
 
 docker-build:
 ifndef REGISTRY

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -3,7 +3,8 @@ all: build
 TAG?=dev
 REGISTRY?=staging-k8s.gcr.io
 FLAGS=
-ENVVAR=CGO_ENABLED=0 LD_FLAGS=-s GO111MODULE=on
+TEST_ENVVAR=LD_FLAGS=-s GO111MODULE=on
+ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=updater
 FULL_COMPONENT=vpa-${COMPONENT}
@@ -19,7 +20,7 @@ build-binary-with-vendor: clean
 	$(ENVVAR) GOOS=$(GOOS) go build -mod vendor -o ${COMPONENT}
 
 test-unit: clean build
-	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)
+	$(TEST_ENVVAR) go test --test.short -race ./... $(FLAGS)
 
 docker-build:
 ifndef REGISTRY


### PR DESCRIPTION
`admission-controller` and `updater` were still using `godep` and they
didn't work. `recommender` tried to run tests with `-race` flag, wich
failed with

`go test: -race requires cgo; enable cgo by setting CGO_ENABLED=1`