### PR TITLE
Make VPA Crds compliant with OpenAPIV3

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-beta-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-beta-crd.yaml
@@ -16,21 +16,27 @@ spec:
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           required:
             - selector
           properties:
             selector:
               type: object
             updatePolicy:
+              type: object
               properties:
                 updateMode:
                   type: string
             resourcePolicy:
+              type: object
               properties:
                 containerPolicies:
                   type: array
+                  items:
+                    type: object
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
@@ -23,6 +23,7 @@ spec:
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object

--- a/vertical-pod-autoscaler/deploy/vpa-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-crd.yaml
@@ -16,21 +16,27 @@ spec:
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           required:
             - selector
           properties:
             selector:
               type: object
             updatePolicy:
+              type: object
               properties:
                 updateMode:
                   type: string
             resourcePolicy:
+              type: object
               properties:
                 containerPolicies:
                   type: array
+                  items:
+                    type: object
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
@@ -26,6 +26,7 @@ spec:
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           type: object


### PR DESCRIPTION
Resolves issue #2859 

Make CRDS compliant with OpenAPIV3 so it won't get NonStructuralSchema Validation Error