### PR TITLE
CLI flags for VPA recommender aggregations config.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -73,7 +73,7 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 			"Current peak was not excluded from the aggregation.")
 	}
 	// Verify that an old peak is not excluded from the aggregation.
-	timeNow = timeNow.Add(model.MemoryAggregationInterval)
+	timeNow = timeNow.Add(model.GetAggregationsConfig().MemoryAggregationInterval)
 	aggregateContainerStateMap = buildAggregateContainerStateMap(vpa, cluster, timeNow)
 	if assert.Contains(t, aggregateContainerStateMap, "container-1") {
 		assert.False(t, aggregateContainerStateMap["container-1"].AggregateMemoryPeaks.IsEmpty(),

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -36,13 +36,14 @@ var (
 // Verifies that the PercentileEstimator returns requested percentiles of CPU
 // and memory peaks distributions.
 func TestPercentileEstimator(t *testing.T) {
+	config := model.GetAggregationsConfig()
 	// Create a sample CPU histogram.
-	cpuHistogram := util.NewHistogram(model.CPUHistogramOptions)
+	cpuHistogram := util.NewHistogram(config.CPUHistogramOptions)
 	cpuHistogram.AddSample(1.0, 1.0, anyTime)
 	cpuHistogram.AddSample(2.0, 1.0, anyTime)
 	cpuHistogram.AddSample(3.0, 1.0, anyTime)
 	// Create a sample memory histogram.
-	memoryPeaksHistogram := util.NewHistogram(model.MemoryHistogramOptions)
+	memoryPeaksHistogram := util.NewHistogram(config.MemoryHistogramOptions)
 	memoryPeaksHistogram.AddSample(1e9, 1.0, anyTime)
 	memoryPeaksHistogram.AddSample(2e9, 1.0, anyTime)
 	memoryPeaksHistogram.AddSample(3e9, 1.0, anyTime)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -43,18 +43,22 @@ var (
 
 	storage = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	// prometheus history provider configs
-	historyLength                        = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
-	podLabelPrefix                       = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
-	podLabelsMetricName                  = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
-	podNamespaceLabel                    = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for container names`)
-	podNameLabel                         = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for container names`)
-	ctrNamespaceLabel                    = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
-	ctrPodNameLabel                      = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
-	ctrNameLabel                         = flag.String("container-name-label", "name", `Label name to look for container names`)
-	memoryAggregationInterval            = flag.Duration("memory-aggregation-interval", model.DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)`)
-	memoryAggregationWindowIntervalCount = flag.Int64("memory-aggregation-window-interval-count", model.DefaultMemoryAggregationWindowIntervalCount, `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-window-interval-count.`)
-	memoryHistogramDecayHalfLife         = flag.Duration("memory-histogram-decay-half-life", model.DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
-	cpuHistogramDecayHalfLife            = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
+	historyLength       = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
+	podLabelPrefix      = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
+	podLabelsMetricName = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
+	podNamespaceLabel   = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for container names`)
+	podNameLabel        = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for container names`)
+	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
+	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
+	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
+)
+
+// Aggregation configuration flags
+var (
+	memoryAggregationInterval      = flag.Duration("memory-aggregation-interval", model.DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)`)
+	memoryAggregationIntervalCount = flag.Int64("memory-aggregation-interval-count", model.DefaultMemoryAggregationIntervalCount, `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count.`)
+	memoryHistogramDecayHalfLife   = flag.Duration("memory-histogram-decay-half-life", model.DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
+	cpuHistogramDecayHalfLife      = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
 )
 
 func main() {
@@ -64,7 +68,7 @@ func main() {
 
 	config := createKubeConfig(float32(*kubeApiQps), int(*kubeApiBurst))
 
-	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationWindowIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife))
+	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife))
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
+	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
-	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
@@ -43,14 +43,18 @@ var (
 
 	storage = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	// prometheus history provider configs
-	historyLength       = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
-	podLabelPrefix      = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
-	podLabelsMetricName = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
-	podNamespaceLabel   = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for container names`)
-	podNameLabel        = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for container names`)
-	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
-	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
-	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
+	historyLength                        = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
+	podLabelPrefix                       = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
+	podLabelsMetricName                  = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
+	podNamespaceLabel                    = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for container names`)
+	podNameLabel                         = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for container names`)
+	ctrNamespaceLabel                    = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
+	ctrPodNameLabel                      = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
+	ctrNameLabel                         = flag.String("container-name-label", "name", `Label name to look for container names`)
+	memoryAggregationInterval            = flag.Duration("memory-aggregation-interval", model.DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)`)
+	memoryAggregationWindowIntervalCount = flag.Int64("memory-aggregation-window-interval-count", model.DefaultMemoryAggregationWindowIntervalCount, `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-window-interval-count.`)
+	memoryHistogramDecayHalfLife         = flag.Duration("memory-histogram-decay-half-life", model.DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
+	cpuHistogramDecayHalfLife            = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
 )
 
 func main() {
@@ -59,6 +63,8 @@ func main() {
 	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender", common.VerticalPodAutoscalerVersion)
 
 	config := createKubeConfig(float32(*kubeApiQps), int(*kubeApiBurst))
+
+	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationWindowIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife))
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -170,9 +170,10 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 
 // NewAggregateContainerState returns a new, empty AggregateContainerState.
 func NewAggregateContainerState() *AggregateContainerState {
+	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:    util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks: util.NewDecayingHistogram(MemoryHistogramOptions, MemoryHistogramDecayHalfLife),
+		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
 		CreationTime:         time.Now(),
 	}
 }
@@ -263,9 +264,9 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 
 func (a *AggregateContainerState) isExpired(now time.Time) bool {
 	if a.isEmpty() {
-		return now.Sub(a.CreationTime) >= MemoryAggregationWindowLength
+		return now.Sub(a.CreationTime) >= GetAggregationsConfig().GetMemoryAggregationWindowLength()
 	}
-	return now.Sub(a.LastSampleStart) >= MemoryAggregationWindowLength
+	return now.Sub(a.LastSampleStart) >= GetAggregationsConfig().GetMemoryAggregationWindowLength()
 }
 
 func (a *AggregateContainerState) isEmpty() bool {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -110,13 +110,14 @@ func TestAggregateStateByContainerName(t *testing.T) {
 	assert.Equal(t, 1, aggregateResources["app-B"].TotalSamplesCount)
 	assert.Equal(t, 1, aggregateResources["app-C"].TotalSamplesCount)
 
+	config := GetAggregationsConfig()
 	// Compute the expected histograms for the "app-A" containers.
-	expectedCPUHistogram := util.NewDecayingHistogram(CPUHistogramOptions, CPUHistogramDecayHalfLife)
+	expectedCPUHistogram := util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife)
 	expectedCPUHistogram.Merge(cluster.findOrCreateAggregateContainerState(containers[0]).AggregateCPUUsage)
 	expectedCPUHistogram.Merge(cluster.findOrCreateAggregateContainerState(containers[2]).AggregateCPUUsage)
 	actualCPUHistogram := aggregateResources["app-A"].AggregateCPUUsage
 
-	expectedMemoryHistogram := util.NewDecayingHistogram(MemoryHistogramOptions, MemoryHistogramDecayHalfLife)
+	expectedMemoryHistogram := util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife)
 	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).WindowEnd)
 	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).WindowEnd)
 	actualMemoryHistogram := aggregateResources["app-A"].AggregateMemoryPeaks

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"flag"
 	"time"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util"
@@ -24,15 +25,15 @@ import (
 
 var (
 	// MemoryAggregationWindowLength is the length of the memory usage history
-	// aggregated by VPA, which is 8 days.
-	MemoryAggregationWindowLength = time.Hour * 8 * 24
+	// aggregated by VPA.
+	MemoryAggregationWindowLength = DefaultMemoryAggregationWindowLength
 	// MemoryAggregationInterval is the length of a single interval, for
 	// which the peak memory usage is computed.
 	// Memory usage peaks are aggregated in daily intervals. In other words
 	// there is one memory usage sample per day (the maximum usage over that
 	// day).
 	// Note: AggregationWindowLength must be integrally divisible by this value.
-	MemoryAggregationInterval = time.Hour * 24
+	MemoryAggregationInterval = DefaultMemoryAggregationInterval
 	// CPUHistogramOptions are options to be used by histograms that store
 	// CPU measures expressed in cores.
 	CPUHistogramOptions = cpuHistogramOptions()
@@ -46,10 +47,10 @@ var (
 	// memory usage sample to lose half of its weight. In other words, a fresh
 	// usage sample is twice as 'important' as one with age equal to the half
 	// life period.
-	MemoryHistogramDecayHalfLife = time.Hour * 24
+	MemoryHistogramDecayHalfLife = DefaultMemoryHistogramDecayHalfLife
 	// CPUHistogramDecayHalfLife is the amount of time it takes a historical
 	// CPU usage sample to lose half of its weight.
-	CPUHistogramDecayHalfLife = time.Hour * 24
+	CPUHistogramDecayHalfLife = DefaultCPUHistogramDecayHalfLife
 )
 
 const (
@@ -58,6 +59,16 @@ const (
 	// epsilon is the minimal weight kept in histograms, it should be small enough that old samples
 	// (just inside MemoryAggregationWindowLength) added with minSampleWeight are still kept
 	epsilon = 0.001 * minSampleWeight
+	// DefaultMemoryAggregationWindowLength is the default value for MemoryAggregationWindowLength.
+	DefaultMemoryAggregationWindowLength = time.Hour * 8 * 24
+	// DefaultMemoryAggregationInterval is the default value for MemoryAggregationInterval.
+	// which the peak memory usage is computed.
+	DefaultMemoryAggregationInterval = time.Hour * 24
+	// DefaultMemoryHistogramDecayHalfLife is the default value for MemoryHistogramDecayHalfLife.
+	DefaultMemoryHistogramDecayHalfLife = time.Hour * 24
+	// DefaultCPUHistogramDecayHalfLife is the default value for CPUHistogramDecayHalfLife.
+	// CPU usage sample to lose half of its weight.
+	DefaultCPUHistogramDecayHalfLife = time.Hour * 24
 )
 
 func cpuHistogramOptions() util.HistogramOptions {
@@ -82,4 +93,11 @@ func memoryHistogramOptions() util.HistogramOptions {
 		panic("Invalid memory histogram options") // Should not happen.
 	}
 	return options
+}
+
+func init() {
+	flag.DurationVar(&MemoryAggregationWindowLength, "memory-aggregation-window-length", DefaultMemoryAggregationWindowLength, `The length of the memory usage history aggregated by VPA.`)
+	flag.DurationVar(&MemoryAggregationInterval, "memory-aggregation-interval", DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in daily intervals. In other words there is one memory usage sample per day (the maximum usage over that day). Note: AggregationWindowLength must be integrally divisible by this value.`)
+	flag.DurationVar(&MemoryHistogramDecayHalfLife, "memory-histogram-decay-half-life", DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
+	flag.DurationVar(&CPUHistogramDecayHalfLife, "cpu-histogram-decay-half-life", DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -17,41 +17,41 @@ limitations under the License.
 package model
 
 import (
-	"flag"
 	"time"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util"
 )
 
-var (
-	// MemoryAggregationWindowLength is the length of the memory usage history
-	// aggregated by VPA.
-	MemoryAggregationWindowLength = DefaultMemoryAggregationWindowLength
+// AggregationsConfig is used to configure aggregation behaviour.
+type AggregationsConfig struct {
 	// MemoryAggregationInterval is the length of a single interval, for
 	// which the peak memory usage is computed.
-	// Memory usage peaks are aggregated in daily intervals. In other words
-	// there is one memory usage sample per day (the maximum usage over that
-	// day).
-	// Note: AggregationWindowLength must be integrally divisible by this value.
-	MemoryAggregationInterval = DefaultMemoryAggregationInterval
+	// Memory usage peaks are aggregated in multiples of this interval. In other words
+	// there is one memory usage sample per interval (the maximum usage over that
+	// interval).
+	MemoryAggregationInterval time.Duration
+	// MemoryAggregationWindowIntervalCount is the number of consecutive MemoryAggregationIntervals
+	// which make up the MemoryAggregationWindowLength which in turn is the period for memory
+	// usage aggregation by VPA.
+	MemoryAggregationWindowIntervalCount int64
 	// CPUHistogramOptions are options to be used by histograms that store
 	// CPU measures expressed in cores.
-	CPUHistogramOptions = cpuHistogramOptions()
+	CPUHistogramOptions util.HistogramOptions
 	// MemoryHistogramOptions are options to be used by histograms that
 	// store memory measures expressed in bytes.
-	MemoryHistogramOptions = memoryHistogramOptions()
+	MemoryHistogramOptions util.HistogramOptions
 	// HistogramBucketSizeGrowth defines the growth rate of the histogram buckets.
 	// Each bucket is wider than the previous one by this fraction.
-	HistogramBucketSizeGrowth = 0.05 // Make each bucket 5% larger than the previous one.
+	HistogramBucketSizeGrowth float64
 	// MemoryHistogramDecayHalfLife is the amount of time it takes a historical
 	// memory usage sample to lose half of its weight. In other words, a fresh
 	// usage sample is twice as 'important' as one with age equal to the half
 	// life period.
-	MemoryHistogramDecayHalfLife = DefaultMemoryHistogramDecayHalfLife
+	MemoryHistogramDecayHalfLife time.Duration
 	// CPUHistogramDecayHalfLife is the amount of time it takes a historical
 	// CPU usage sample to lose half of its weight.
-	CPUHistogramDecayHalfLife = DefaultCPUHistogramDecayHalfLife
-)
+	CPUHistogramDecayHalfLife time.Duration
+}
 
 const (
 	// minSampleWeight is the minimal weight of any sample (prior to including decaying factor)
@@ -59,11 +59,13 @@ const (
 	// epsilon is the minimal weight kept in histograms, it should be small enough that old samples
 	// (just inside MemoryAggregationWindowLength) added with minSampleWeight are still kept
 	epsilon = 0.001 * minSampleWeight
-	// DefaultMemoryAggregationWindowLength is the default value for MemoryAggregationWindowLength.
-	DefaultMemoryAggregationWindowLength = time.Hour * 8 * 24
+	// DefaultMemoryAggregationWindowIntervalCount is the default value for MemoryAggregationWindowIntevalCount.
+	DefaultMemoryAggregationWindowIntervalCount = 8
 	// DefaultMemoryAggregationInterval is the default value for MemoryAggregationInterval.
 	// which the peak memory usage is computed.
 	DefaultMemoryAggregationInterval = time.Hour * 24
+	// DefaultHistogramBucketSizeGrowth is the default value for HistogramBucketSizeGrowth.
+	DefaultHistogramBucketSizeGrowth = 0.05 // Make each bucket 5% larger than the previous one.
 	// DefaultMemoryHistogramDecayHalfLife is the default value for MemoryHistogramDecayHalfLife.
 	DefaultMemoryHistogramDecayHalfLife = time.Hour * 24
 	// DefaultCPUHistogramDecayHalfLife is the default value for CPUHistogramDecayHalfLife.
@@ -71,33 +73,61 @@ const (
 	DefaultCPUHistogramDecayHalfLife = time.Hour * 24
 )
 
-func cpuHistogramOptions() util.HistogramOptions {
+// GetMemoryAggregationWindowLength returns the total length of the memory usage history aggregated by VPA.
+func (a *AggregationsConfig) GetMemoryAggregationWindowLength() time.Duration {
+	return a.MemoryAggregationInterval * time.Duration(a.MemoryAggregationWindowIntervalCount)
+}
+
+func (a *AggregationsConfig) cpuHistogramOptions() util.HistogramOptions {
 	// CPU histograms use exponential bucketing scheme with the smallest bucket
 	// size of 0.01 core, max of 1000.0 cores and the relative error of HistogramRelativeError.
 	//
 	// When parameters below are changed SupportedCheckpointVersion has to be bumped.
-	options, err := util.NewExponentialHistogramOptions(1000.0, 0.01, 1.+HistogramBucketSizeGrowth, epsilon)
+	options, err := util.NewExponentialHistogramOptions(1000.0, 0.01, 1.+a.HistogramBucketSizeGrowth, epsilon)
 	if err != nil {
 		panic("Invalid CPU histogram options") // Should not happen.
 	}
 	return options
 }
 
-func memoryHistogramOptions() util.HistogramOptions {
+func (a *AggregationsConfig) memoryHistogramOptions() util.HistogramOptions {
 	// Memory histograms use exponential bucketing scheme with the smallest
 	// bucket size of 10MB, max of 1TB and the relative error of HistogramRelativeError.
 	//
 	// When parameters below are changed SupportedCheckpointVersion has to be bumped.
-	options, err := util.NewExponentialHistogramOptions(1e12, 1e7, 1.+HistogramBucketSizeGrowth, epsilon)
+	options, err := util.NewExponentialHistogramOptions(1e12, 1e7, 1.+a.HistogramBucketSizeGrowth, epsilon)
 	if err != nil {
 		panic("Invalid memory histogram options") // Should not happen.
 	}
 	return options
 }
 
-func init() {
-	flag.DurationVar(&MemoryAggregationWindowLength, "memory-aggregation-window-length", DefaultMemoryAggregationWindowLength, `The length of the memory usage history aggregated by VPA.`)
-	flag.DurationVar(&MemoryAggregationInterval, "memory-aggregation-interval", DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in daily intervals. In other words there is one memory usage sample per day (the maximum usage over that day). Note: AggregationWindowLength must be integrally divisible by this value.`)
-	flag.DurationVar(&MemoryHistogramDecayHalfLife, "memory-histogram-decay-half-life", DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
-	flag.DurationVar(&CPUHistogramDecayHalfLife, "cpu-histogram-decay-half-life", DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
+// NewAggregationsConfig creates a new AggregationsConfig based on the supplied parameters and default values.
+func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationWindowIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration) *AggregationsConfig {
+	a := &AggregationsConfig{
+		MemoryAggregationInterval:            memoryAggregationInterval,
+		MemoryAggregationWindowIntervalCount: memoryAggregationWindowIntervalCount,
+		HistogramBucketSizeGrowth:            DefaultHistogramBucketSizeGrowth,
+		MemoryHistogramDecayHalfLife:         memoryHistogramDecayHalfLife,
+		CPUHistogramDecayHalfLife:            cpuHistogramDecayHalfLife,
+	}
+	a.CPUHistogramOptions = a.cpuHistogramOptions()
+	a.MemoryHistogramOptions = a.memoryHistogramOptions()
+	return a
+}
+
+var aggregationsConfig *AggregationsConfig
+
+// GetAggregationsConfig gets the aggregations config. Initializes to default values if not initialized already.
+func GetAggregationsConfig() *AggregationsConfig {
+	if aggregationsConfig == nil {
+		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationWindowIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife)
+	}
+
+	return aggregationsConfig
+}
+
+// InitializeAggregationsConfig initializes the global aggregations configuration. Not thread-safe.
+func InitializeAggregationsConfig(config *AggregationsConfig) {
+	aggregationsConfig = config
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -33,7 +33,7 @@ type AggregationsConfig struct {
 	// MemoryAggregationWindowIntervalCount is the number of consecutive MemoryAggregationIntervals
 	// which make up the MemoryAggregationWindowLength which in turn is the period for memory
 	// usage aggregation by VPA.
-	MemoryAggregationWindowIntervalCount int64
+	MemoryAggregationIntervalCount int64
 	// CPUHistogramOptions are options to be used by histograms that store
 	// CPU measures expressed in cores.
 	CPUHistogramOptions util.HistogramOptions
@@ -59,8 +59,8 @@ const (
 	// epsilon is the minimal weight kept in histograms, it should be small enough that old samples
 	// (just inside MemoryAggregationWindowLength) added with minSampleWeight are still kept
 	epsilon = 0.001 * minSampleWeight
-	// DefaultMemoryAggregationWindowIntervalCount is the default value for MemoryAggregationWindowIntevalCount.
-	DefaultMemoryAggregationWindowIntervalCount = 8
+	// DefaultMemoryAggregationIntervalCount is the default value for MemoryAggregationIntevalCount.
+	DefaultMemoryAggregationIntervalCount = 8
 	// DefaultMemoryAggregationInterval is the default value for MemoryAggregationInterval.
 	// which the peak memory usage is computed.
 	DefaultMemoryAggregationInterval = time.Hour * 24
@@ -75,7 +75,7 @@ const (
 
 // GetMemoryAggregationWindowLength returns the total length of the memory usage history aggregated by VPA.
 func (a *AggregationsConfig) GetMemoryAggregationWindowLength() time.Duration {
-	return a.MemoryAggregationInterval * time.Duration(a.MemoryAggregationWindowIntervalCount)
+	return a.MemoryAggregationInterval * time.Duration(a.MemoryAggregationIntervalCount)
 }
 
 func (a *AggregationsConfig) cpuHistogramOptions() util.HistogramOptions {
@@ -103,13 +103,13 @@ func (a *AggregationsConfig) memoryHistogramOptions() util.HistogramOptions {
 }
 
 // NewAggregationsConfig creates a new AggregationsConfig based on the supplied parameters and default values.
-func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationWindowIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration) *AggregationsConfig {
+func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration) *AggregationsConfig {
 	a := &AggregationsConfig{
-		MemoryAggregationInterval:            memoryAggregationInterval,
-		MemoryAggregationWindowIntervalCount: memoryAggregationWindowIntervalCount,
-		HistogramBucketSizeGrowth:            DefaultHistogramBucketSizeGrowth,
-		MemoryHistogramDecayHalfLife:         memoryHistogramDecayHalfLife,
-		CPUHistogramDecayHalfLife:            cpuHistogramDecayHalfLife,
+		MemoryAggregationInterval:      memoryAggregationInterval,
+		MemoryAggregationIntervalCount: memoryAggregationIntervalCount,
+		HistogramBucketSizeGrowth:      DefaultHistogramBucketSizeGrowth,
+		MemoryHistogramDecayHalfLife:   memoryHistogramDecayHalfLife,
+		CPUHistogramDecayHalfLife:      cpuHistogramDecayHalfLife,
 	}
 	a.CPUHistogramOptions = a.cpuHistogramOptions()
 	a.MemoryHistogramOptions = a.memoryHistogramOptions()
@@ -121,7 +121,7 @@ var aggregationsConfig *AggregationsConfig
 // GetAggregationsConfig gets the aggregations config. Initializes to default values if not initialized already.
 func GetAggregationsConfig() *AggregationsConfig {
 	if aggregationsConfig == nil {
-		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationWindowIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife)
+		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife)
 	}
 
 	return aggregationsConfig

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -164,7 +164,8 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 		}
 	} else {
 		// Shift the memory aggregation window to the next interval.
-		shift := truncate(ts.Sub(container.WindowEnd), MemoryAggregationInterval) + MemoryAggregationInterval
+		memoryAggregationInterval := GetAggregationsConfig().MemoryAggregationInterval
+		shift := truncate(ts.Sub(container.WindowEnd), memoryAggregationInterval) + memoryAggregationInterval
 		container.WindowEnd = container.WindowEnd.Add(shift)
 		container.memoryPeak = 0
 		container.oomPeak = 0
@@ -191,7 +192,7 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 // RecordOOM adds info regarding OOM event in the model as an artificial memory sample.
 func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory ResourceAmount) error {
 	// Discard old OOM
-	if timestamp.Before(container.WindowEnd.Add(-1 * MemoryAggregationInterval)) {
+	if timestamp.Before(container.WindowEnd.Add(-1 * GetAggregationsConfig().MemoryAggregationInterval)) {
 		return fmt.Errorf("OOM event will be discarded - it is too old (%v)", timestamp)
 	}
 	// Get max of the request and the recent usage-based memory peak.


### PR DESCRIPTION
This PR exposes some of the aggregations configuration of VPA recommender as command-line flags in the VPA recommender. This can help change the default behaviour of the VPA recommender for different workload use-cases. The pre-existing constant values have been retained as the default values.