### PR TITLE
Cherry pick of #2908 to 1.15: Provider/Azure: Fix the bug of vm cache that multiple agentpools share the same cache.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -41,9 +41,9 @@ var (
 )
 
 var virtualMachinesStatusCache struct {
-	lastRefresh     time.Time
+	lastRefresh     map[string]time.Time
 	mutex           sync.Mutex
-	virtualMachines []compute.VirtualMachine
+	virtualMachines map[string][]compute.VirtualMachine
 }
 
 // AgentPool implements NodeGroup interface for agent pools deployed by aks-engine.
@@ -130,22 +130,36 @@ func (as *AgentPool) MaxSize() int {
 func (as *AgentPool) getVirtualMachinesFromCache() ([]compute.VirtualMachine, error) {
 	virtualMachinesStatusCache.mutex.Lock()
 	defer virtualMachinesStatusCache.mutex.Unlock()
+	klog.V(4).Infof("getVirtualMachinesFromCache: starts for %+v", as)
 
-	if virtualMachinesStatusCache.lastRefresh.Add(vmInstancesRefreshPeriod).After(time.Now()) {
-		return virtualMachinesStatusCache.virtualMachines, nil
+	if virtualMachinesStatusCache.virtualMachines == nil {
+		klog.V(4).Infof("getVirtualMachinesFromCache: initialize vm cache")
+		virtualMachinesStatusCache.virtualMachines = make(map[string][]compute.VirtualMachine)
+	}
+	if virtualMachinesStatusCache.lastRefresh == nil {
+		klog.V(4).Infof("getVirtualMachinesFromCache: initialize last refresh time cache")
+		virtualMachinesStatusCache.lastRefresh = make(map[string]time.Time)
 	}
 
+	if virtualMachinesStatusCache.lastRefresh[as.Id()].Add(vmInstancesRefreshPeriod).After(time.Now()) {
+		klog.V(4).Infof("getVirtualMachinesFromCache: get vms from cache")
+		return virtualMachinesStatusCache.virtualMachines[as.Id()], nil
+	}
+	klog.V(4).Infof("getVirtualMachinesFromCache: get vms from API")
 	vms, err := as.GetVirtualMachines()
+	klog.V(4).Infof("getVirtualMachinesFromCache: got vms from API %+v", vms)
+
 	if err != nil {
 		if isAzureRequestsThrottled(err) {
 			klog.Warningf("getAllVirtualMachines: throttling with message %v, would return the cached vms", err)
-			return virtualMachinesStatusCache.virtualMachines, nil
+			return virtualMachinesStatusCache.virtualMachines[as.Id()], nil
 		}
 
 		return []compute.VirtualMachine{}, err
 	}
-	virtualMachinesStatusCache.virtualMachines = vms
-	virtualMachinesStatusCache.lastRefresh = time.Now()
+
+	virtualMachinesStatusCache.virtualMachines[as.Id()] = vms
+	virtualMachinesStatusCache.lastRefresh[as.Id()] = time.Now()
 
 	return vms, err
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -171,10 +171,12 @@ func (m *asgCache) regenerate() error {
 	newCache := make(map[azureRef]cloudprovider.NodeGroup)
 
 	for _, nsg := range m.registeredAsgs {
+		klog.V(6).Infof("regenerate: finding nodes for nsg %+v", nsg)
 		instances, err := nsg.Nodes()
 		if err != nil {
 			return err
 		}
+		klog.V(6).Infof("regenerate: found nodes for nsg %v: %+v", nsg, instances)
 
 		for _, instance := range instances {
 			ref := azureRef{Name: instance.Id}


### PR DESCRIPTION
Fix the bug of vm cache that multiple agentpools share the same cache.

/kind bug
/area provider/azure