### PR TITLE
Provider/Azure: Update vm, storageaccount, interface and disk client.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -148,7 +148,7 @@ func (m *asgCache) FindForInstance(instance *azureRef, vmType string) (cloudprov
 	}
 
 	// Look up caches for the instance.
-	klog.V(4).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instanceToAsg)
+	klog.V(6).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instanceToAsg)
 	if asg := m.getInstanceFromCache(inst.Name); asg != nil {
 		klog.V(4).Infof("FindForInstance: found asg %s in cache", asg.Id())
 		return asg, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -23,9 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
 	"github.com/Azure/go-autorest/autorest"
@@ -33,21 +31,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"k8s.io/klog"
+	"k8s.io/legacy-cloud-providers/azure/clients/diskclient"
+	"k8s.io/legacy-cloud-providers/azure/clients/interfaceclient"
+	"k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient"
+	"k8s.io/legacy-cloud-providers/azure/clients/vmclient"
 	"k8s.io/legacy-cloud-providers/azure/clients/vmssclient"
 	"k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient"
 )
-
-// VirtualMachinesClient defines needed functions for azure compute.VirtualMachinesClient.
-type VirtualMachinesClient interface {
-	Get(ctx context.Context, resourceGroupName string, VMName string, expand compute.InstanceViewTypes) (result compute.VirtualMachine, err error)
-	Delete(ctx context.Context, resourceGroupName string, VMName string) (resp *http.Response, err error)
-	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachine, err error)
-}
-
-// InterfacesClient defines needed functions for azure network.InterfacesClient.
-type InterfacesClient interface {
-	Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (resp *http.Response, err error)
-}
 
 // DeploymentsClient defines needed functions for azure network.DeploymentsClient.
 type DeploymentsClient interface {
@@ -56,111 +46,6 @@ type DeploymentsClient interface {
 	ExportTemplate(ctx context.Context, resourceGroupName string, deploymentName string) (result resources.DeploymentExportResult, err error)
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, deploymentName string, parameters resources.Deployment) (resp *http.Response, err error)
 	Delete(ctx context.Context, resourceGroupName string, deploymentName string) (resp *http.Response, err error)
-}
-
-// DisksClient defines needed functions for azure disk.DisksClient.
-type DisksClient interface {
-	Delete(ctx context.Context, resourceGroupName string, diskName string) (resp *http.Response, err error)
-}
-
-// AccountsClient defines needed functions for azure storage.AccountsClient.
-type AccountsClient interface {
-	ListKeys(ctx context.Context, resourceGroupName string, accountName string) (result storage.AccountListKeysResult, err error)
-}
-
-// azVirtualMachinesClient implements VirtualMachinesClient.
-type azVirtualMachinesClient struct {
-	client compute.VirtualMachinesClient
-}
-
-func newAzVirtualMachinesClient(subscriptionID, endpoint string, servicePrincipalToken *adal.ServicePrincipalToken) *azVirtualMachinesClient {
-	virtualMachinesClient := compute.NewVirtualMachinesClient(subscriptionID)
-	virtualMachinesClient.BaseURI = endpoint
-	virtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
-	virtualMachinesClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&virtualMachinesClient.Client)
-
-	return &azVirtualMachinesClient{
-		client: virtualMachinesClient,
-	}
-}
-
-func (az *azVirtualMachinesClient) Get(ctx context.Context, resourceGroupName string, VMName string, expand compute.InstanceViewTypes) (result compute.VirtualMachine, err error) {
-	klog.V(10).Infof("azVirtualMachinesClient.Get(%q,%q,%q): start", resourceGroupName, VMName, expand)
-	defer func() {
-		klog.V(10).Infof("azVirtualMachinesClient.Get(%q,%q,%q): end", resourceGroupName, VMName, expand)
-	}()
-
-	return az.client.Get(ctx, resourceGroupName, VMName, expand)
-}
-
-func (az *azVirtualMachinesClient) Delete(ctx context.Context, resourceGroupName string, VMName string) (resp *http.Response, err error) {
-	klog.V(10).Infof("azVirtualMachinesClient.Delete(%q,%q): start", resourceGroupName, VMName)
-	defer func() {
-		klog.V(10).Infof("azVirtualMachinesClient.Delete(%q,%q): end", resourceGroupName, VMName)
-	}()
-
-	future, err := az.client.Delete(ctx, resourceGroupName, VMName)
-	if err != nil {
-		return future.Response(), err
-	}
-
-	err = future.WaitForCompletionRef(ctx, az.client.Client)
-	return future.Response(), err
-}
-
-func (az *azVirtualMachinesClient) List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachine, err error) {
-	klog.V(10).Infof("azVirtualMachinesClient.List(%q): start", resourceGroupName)
-	defer func() {
-		klog.V(10).Infof("azVirtualMachinesClient.List(%q): end", resourceGroupName)
-	}()
-
-	iterator, err := az.client.ListComplete(ctx, resourceGroupName)
-	if err != nil {
-		return nil, err
-	}
-
-	result = make([]compute.VirtualMachine, 0)
-	for ; iterator.NotDone(); err = iterator.Next() {
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, iterator.Value())
-	}
-
-	return result, nil
-}
-
-type azInterfacesClient struct {
-	client network.InterfacesClient
-}
-
-func newAzInterfacesClient(subscriptionID, endpoint string, servicePrincipalToken *adal.ServicePrincipalToken) *azInterfacesClient {
-	interfacesClient := network.NewInterfacesClient(subscriptionID)
-	interfacesClient.BaseURI = endpoint
-	interfacesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
-	interfacesClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&interfacesClient.Client)
-
-	return &azInterfacesClient{
-		client: interfacesClient,
-	}
-}
-
-func (az *azInterfacesClient) Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (resp *http.Response, err error) {
-	klog.V(10).Infof("azInterfacesClient.Delete(%q,%q): start", resourceGroupName, networkInterfaceName)
-	defer func() {
-		klog.V(10).Infof("azInterfacesClient.Delete(%q,%q): end", resourceGroupName, networkInterfaceName)
-	}()
-
-	future, err := az.client.Delete(ctx, resourceGroupName, networkInterfaceName)
-	if err != nil {
-		return future.Response(), err
-	}
-
-	err = future.WaitForCompletionRef(ctx, az.client.Client)
-	return future.Response(), err
 }
 
 type azDeploymentsClient struct {
@@ -250,70 +135,18 @@ func (az *azDeploymentsClient) Delete(ctx context.Context, resourceGroupName, de
 	return future.Response(), err
 }
 
-type azDisksClient struct {
-	client compute.DisksClient
-}
-
-func newAzDisksClient(subscriptionID, endpoint string, servicePrincipalToken *adal.ServicePrincipalToken) *azDisksClient {
-	disksClient := compute.NewDisksClient(subscriptionID)
-	disksClient.BaseURI = endpoint
-	disksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
-	disksClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&disksClient.Client)
-
-	return &azDisksClient{
-		client: disksClient,
-	}
-}
-
-func (az *azDisksClient) Delete(ctx context.Context, resourceGroupName string, diskName string) (resp *http.Response, err error) {
-	klog.V(10).Infof("azDisksClient.Delete(%q,%q): start", resourceGroupName, diskName)
-	defer func() {
-		klog.V(10).Infof("azDisksClient.Delete(%q,%q): end", resourceGroupName, diskName)
-	}()
-
-	future, err := az.client.Delete(ctx, resourceGroupName, diskName)
-	if err != nil {
-		return future.Response(), err
-	}
-
-	err = future.WaitForCompletionRef(ctx, az.client.Client)
-	return future.Response(), err
-}
-
 type azAccountsClient struct {
 	client storage.AccountsClient
-}
-
-func newAzAccountsClient(subscriptionID, endpoint string, servicePrincipalToken *adal.ServicePrincipalToken) *azAccountsClient {
-	accountsClient := storage.NewAccountsClient(subscriptionID)
-	accountsClient.BaseURI = endpoint
-	accountsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
-	accountsClient.PollingDelay = 5 * time.Second
-	configureUserAgent(&accountsClient.Client)
-
-	return &azAccountsClient{
-		client: accountsClient,
-	}
-}
-
-func (az *azAccountsClient) ListKeys(ctx context.Context, resourceGroupName string, accountName string) (result storage.AccountListKeysResult, err error) {
-	klog.V(10).Infof("azAccountsClient.ListKeys(%q,%q): start", resourceGroupName, accountName)
-	defer func() {
-		klog.V(10).Infof("azAccountsClient.ListKeys(%q,%q): end", resourceGroupName, accountName)
-	}()
-
-	return az.client.ListKeys(ctx, resourceGroupName, accountName)
 }
 
 type azClient struct {
 	virtualMachineScaleSetsClient   vmssclient.Interface
 	virtualMachineScaleSetVMsClient vmssvmclient.Interface
-	virtualMachinesClient           VirtualMachinesClient
+	virtualMachinesClient           vmclient.Interface
 	deploymentsClient               DeploymentsClient
-	interfacesClient                InterfacesClient
-	disksClient                     DisksClient
-	storageAccountsClient           AccountsClient
+	interfacesClient                interfaceclient.Interface
+	disksClient                     diskclient.Interface
+	storageAccountsClient           storageaccountclient.Interface
 	containerServicesClient         containerservice.ContainerServicesClient
 	managedContainerServicesClient  containerservice.ManagedClustersClient
 }
@@ -390,19 +223,23 @@ func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
 	scaleSetVMsClient := vmssvmclient.New(vmssVMClientConfig)
 	klog.V(5).Infof("Created scale set vm client with authorizer: %v", scaleSetVMsClient)
 
-	virtualMachinesClient := newAzVirtualMachinesClient(cfg.SubscriptionID, env.ResourceManagerEndpoint, spt)
+	vmClientConfig := azClientConfig.WithRateLimiter(cfg.VirtualMachineRateLimit)
+	virtualMachinesClient := vmclient.New(vmClientConfig)
 	klog.V(5).Infof("Created vm client with authorizer: %v", virtualMachinesClient)
 
 	deploymentsClient := newAzDeploymentsClient(cfg.SubscriptionID, env.ResourceManagerEndpoint, spt)
 	klog.V(5).Infof("Created deployments client with authorizer: %v", deploymentsClient)
 
-	interfacesClient := newAzInterfacesClient(cfg.SubscriptionID, env.ResourceManagerEndpoint, spt)
+	interfaceClientConfig := azClientConfig.WithRateLimiter(cfg.InterfaceRateLimit)
+	interfacesClient := interfaceclient.New(interfaceClientConfig)
 	klog.V(5).Infof("Created interfaces client with authorizer: %v", interfacesClient)
 
-	storageAccountsClient := newAzAccountsClient(cfg.SubscriptionID, env.ResourceManagerEndpoint, spt)
+	accountClientConfig := azClientConfig.WithRateLimiter(cfg.StorageAccountRateLimit)
+	storageAccountsClient := storageaccountclient.New(accountClientConfig)
 	klog.V(5).Infof("Created storage accounts client with authorizer: %v", storageAccountsClient)
 
-	disksClient := newAzDisksClient(cfg.SubscriptionID, env.ResourceManagerEndpoint, spt)
+	diskClientConfig := azClientConfig.WithRateLimiter(cfg.DiskRateLimit)
+	disksClient := diskclient.New(diskClientConfig)
 	klog.V(5).Infof("Created disks client with authorizer: %v", disksClient)
 
 	containerServicesClient := containerservice.NewContainerServicesClient(cfg.SubscriptionID)

--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
@@ -177,9 +177,9 @@ func (agentPool *AKSAgentPool) GetName(providerID string) (string, error) {
 	providerID = strings.TrimPrefix(providerID, "azure://")
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	vms, err := agentPool.manager.azClient.virtualMachinesClient.List(ctx, agentPool.nodeResourceGroup)
-	if err != nil {
-		return "", err
+	vms, rerr := agentPool.manager.azClient.virtualMachinesClient.List(ctx, agentPool.nodeResourceGroup)
+	if rerr != nil {
+		return "", rerr.Error()
 	}
 	for _, vm := range vms {
 		if strings.EqualFold(*vm.ID, providerID) {
@@ -336,10 +336,10 @@ func (agentPool *AKSAgentPool) IsAKSNode(tags map[string]*string) bool {
 func (agentPool *AKSAgentPool) GetNodes() ([]string, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	vmList, err := agentPool.manager.azClient.virtualMachinesClient.List(ctx, agentPool.nodeResourceGroup)
-	if err != nil {
-		klog.Errorf("Azure client list vm error : %v", err)
-		return nil, err
+	vmList, rerr := agentPool.manager.azClient.virtualMachinesClient.List(ctx, agentPool.nodeResourceGroup)
+	if rerr != nil {
+		klog.Errorf("Azure client list vm error : %v", rerr.Error())
+		return nil, rerr.Error()
 	}
 	var nodeArray []string
 	for _, node := range vmList {

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -39,6 +39,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/version"
 	"k8s.io/klog"
+	"k8s.io/legacy-cloud-providers/azure/retry"
 )
 
 const (
@@ -99,9 +100,9 @@ func (util *AzUtil) DeleteBlob(accountName, vhdContainer, vhdBlob string) error 
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	storageKeysResult, err := util.manager.azClient.storageAccountsClient.ListKeys(ctx, util.manager.config.ResourceGroup, accountName)
-	if err != nil {
-		return err
+	storageKeysResult, rerr := util.manager.azClient.storageAccountsClient.ListKeys(ctx, util.manager.config.ResourceGroup, accountName)
+	if rerr != nil {
+		return rerr.Error()
 	}
 
 	keys := *storageKeysResult.Keys
@@ -122,15 +123,15 @@ func (util *AzUtil) DeleteVirtualMachine(rg string, name string) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	vm, err := util.manager.azClient.virtualMachinesClient.Get(ctx, rg, name, "")
-	if err != nil {
-		if exists, _ := checkResourceExistsFromError(err); !exists {
+	vm, rerr := util.manager.azClient.virtualMachinesClient.Get(ctx, rg, name, "")
+	if rerr != nil {
+		if exists, _ := checkResourceExistsFromRetryError(rerr); !exists {
 			klog.V(2).Infof("VirtualMachine %s/%s has already been removed", rg, name)
 			return nil
 		}
 
-		klog.Errorf("failed to get VM: %s/%s: %s", rg, name, err.Error())
-		return err
+		klog.Errorf("failed to get VM: %s/%s: %s", rg, name, rerr.Error())
+		return rerr.Error()
 	}
 
 	vhd := vm.VirtualMachineProperties.StorageProfile.OsDisk.Vhd
@@ -146,7 +147,7 @@ func (util *AzUtil) DeleteVirtualMachine(rg string, name string) error {
 	if nicID == nil {
 		klog.Warningf("NIC ID is not set for VM (%s/%s)", rg, name)
 	} else {
-		nicName, err = resourceName(*nicID)
+		nicName, err := resourceName(*nicID)
 		if err != nil {
 			return err
 		}
@@ -158,8 +159,8 @@ func (util *AzUtil) DeleteVirtualMachine(rg string, name string) error {
 	defer deleteCancel()
 
 	klog.Infof("waiting for VirtualMachine deletion: %s/%s", rg, name)
-	_, err = util.manager.azClient.virtualMachinesClient.Delete(deleteCtx, rg, name)
-	_, realErr := checkResourceExistsFromError(err)
+	rerr = util.manager.azClient.virtualMachinesClient.Delete(deleteCtx, rg, name)
+	_, realErr := checkResourceExistsFromRetryError(rerr)
 	if realErr != nil {
 		return realErr
 	}
@@ -170,8 +171,8 @@ func (util *AzUtil) DeleteVirtualMachine(rg string, name string) error {
 		interfaceCtx, interfaceCancel := getContextWithCancel()
 		defer interfaceCancel()
 		klog.Infof("waiting for nic deletion: %s/%s", rg, nicName)
-		_, nicErr := util.manager.azClient.interfacesClient.Delete(interfaceCtx, rg, nicName)
-		_, realErr := checkResourceExistsFromError(nicErr)
+		nicErr := util.manager.azClient.interfacesClient.Delete(interfaceCtx, rg, nicName)
+		_, realErr := checkResourceExistsFromRetryError(nicErr)
 		if realErr != nil {
 			return realErr
 		}
@@ -201,8 +202,8 @@ func (util *AzUtil) DeleteVirtualMachine(rg string, name string) error {
 			klog.Infof("deleting managed disk: %s/%s", rg, *osDiskName)
 			disksCtx, disksCancel := getContextWithCancel()
 			defer disksCancel()
-			_, diskErr := util.manager.azClient.disksClient.Delete(disksCtx, rg, *osDiskName)
-			_, realErr := checkResourceExistsFromError(diskErr)
+			diskErr := util.manager.azClient.disksClient.Delete(disksCtx, rg, *osDiskName)
+			_, realErr := checkResourceExistsFromRetryError(diskErr)
 			if realErr != nil {
 				return realErr
 			}
@@ -613,6 +614,16 @@ func checkResourceExistsFromError(err error) (bool, error) {
 	return false, v
 }
 
+func checkResourceExistsFromRetryError(err *retry.Error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	if err.HTTPStatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, err.Error()
+}
+
 // isSuccessHTTPResponse determines if the response from an HTTP request suggests success
 func isSuccessHTTPResponse(resp *http.Response, err error) (isSuccess bool, realError error) {
 	if err != nil {
@@ -644,19 +655,11 @@ func convertResourceGroupNameToLower(resourceID string) (string, error) {
 }
 
 // isAzureRequestsThrottled returns true when the err is http.StatusTooManyRequests (429).
-func isAzureRequestsThrottled(err error) bool {
-	if err == nil {
+func isAzureRequestsThrottled(rerr *retry.Error) bool {
+	klog.V(6).Infof("isAzureRequestsThrottled: starts for error %v", rerr)
+	if rerr == nil {
 		return false
 	}
 
-	v, ok := err.(autorest.DetailedError)
-	if !ok {
-		return false
-	}
-
-	if v.StatusCode == http.StatusTooManyRequests {
-		return true
-	}
-
-	return false
+	return rerr.HTTPStatusCode == http.StatusTooManyRequests
 }


### PR DESCRIPTION
This PR updates the rest of the azure clients to the latest version in cloud provider azure after https://github.com/kubernetes/autoscaler/pull/2902.

Fixes #2898.

/kind feature
/area provider/azure