### PR TITLE
Ignore CloudFormation labels for ASG balancing

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -25,6 +25,8 @@ func IsAwsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 	awsIgnoredLabels := map[string]bool{
 		"alpha.eksctl.io/instance-id":    true, // this is a label used by eksctl to identify instances.
 		"alpha.eksctl.io/nodegroup-name": true, // this is a label used by eksctl to identify "node group" names.
+		"aws:cloudformation:stack-id":    true, // this label is used by cloudformation to identify what stack a "nodegroup" came from.
+		"aws:cloudformation:stack-name":  true, // this label is used by cloudformation to identify what stack a "nodegroup" came from.
 		"eks.amazonaws.com/nodegroup":    true, // this is a label used by eks to identify "node group".
 		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
 		"lifecycle":                      true, // this is a label used by the AWS for spot.


### PR DESCRIPTION
Node groups (auto-scaling groups) created by `eksctl` via CloudFormation will have two un-removable labels added to them that break the `--balance-similar-node-groups` feature.

CloudFormation adds two labels that will be unique across stacks:
- `aws:cloudformation:stack-id` containing the AWS stack ID
- `aws:cloudformation:stack-name` containing the human stack name

**Desired use-case:**
Per-AZ ASGs created by `eksctl` that will actually balance properly.

**Current behavior:**
Four identical ASGs spread across four different AZs will be treated as different because of the two CloudFormation labels (with all other labels being equal), and thus not balanced.

**Logs of issue:**
(with each node-group starting at 1 node)
```
I0312 21:43:35.322944       1 flags.go:52] FLAG: --balance-similar-node-groups="true"
<snip>
I0312 21:44:07.679489       1 waste.go:57] Expanding Node Group eksctl-staging-us-east-1-nodegroup-app-v6-spot-1a-NodeGroup-1H9QC72Z3W3II would waste 18.75% CPU, 60.01% Memory, 39.38% Blended
I0312 21:44:07.679520       1 waste.go:57] Expanding Node Group eksctl-staging-us-east-1-nodegroup-app-v6-spot-1b-NodeGroup-799Y4MIG8Q9C would waste 18.75% CPU, 69.63% Memory, 44.19% Blended
I0312 21:44:07.679530       1 waste.go:57] Expanding Node Group eksctl-staging-us-east-1-nodegroup-app-v6-spot-1c-NodeGroup-71VCPZAHE90F would waste 18.75% CPU, 69.63% Memory, 44.19% Blended
I0312 21:44:07.679540       1 waste.go:57] Expanding Node Group eksctl-staging-us-east-1-nodegroup-app-v6-spot-1d-NodeGroup-1B8QGTKTH3OJ3 would waste 18.75% CPU, 69.63% Memory, 44.19% Blended
I0312 21:44:07.679555       1 scale_up.go:427] Best option to resize: eksctl-staging-us-east-1-nodegroup-app-v6-spot-1a-NodeGroup-1H9QC72Z3W3II
I0312 21:44:07.679563       1 scale_up.go:431] Estimated 3 nodes needed in eksctl-staging-us-east-1-nodegroup-app-v6-spot-1a-NodeGroup-1H9QC72Z3W3II
I0312 21:44:07.679651       1 scale_up.go:533] Final scale-up plan: [{eksctl-staging-us-east-1-nodegroup-app-v6-spot-1a-NodeGroup-1H9QC72Z3W3II 1->4 (max: 10)}]
I0312 21:44:07.679672       1 scale_up.go:699] Scale-up: setting group eksctl-staging-us-east-1-nodegroup-app-v6-spot-1a-NodeGroup-1H9QC72Z3W3II size to 4
```