### PR TITLE
Support arbitrary custom resource building template

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -366,8 +366,8 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(template.InstanceType.MemoryMb*1024*1024, resource.DecimalSI)
 
 	resourcesFromTags := extractAllocatableResourcesFromAsg(template.Tags)
-	if val, ok := resourcesFromTags["ephemeral-storage"]; ok {
-		node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *val
+	for resourceName, val := range resourcesFromTags {
+		node.Status.Capacity[apiv1.ResourceName(resourceName)] = *val
 	}
 
 	// TODO: use proper allocatable!!


### PR DESCRIPTION
Scale from 0 need to build node template from ASG tags. Currently, we only support `ephemeral -storage`. We'd like to extend to arbitrary custom resources. 

Resolves 
#2927 -> node level devices
#2888 -> EKS Windows IP resource. 


Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>