### PR TITLE
Properly propagate scale-up failures in scale sets

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -39,6 +39,8 @@ type VirtualMachineScaleSetsClient interface {
 	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (resp *http.Response, err error)
 	DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error)
+	CreateOrUpdateSync(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error)
+	WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error)
 	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error)
 }
 
@@ -105,6 +107,20 @@ func (az *azVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, r
 		return future.Response(), err
 	}
 
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
+	return future.Response(), err
+}
+
+func (az *azVirtualMachineScaleSetsClient) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+	klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): start", resourceGroupName, VMScaleSetName)
+	defer func() {
+		klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): end", resourceGroupName, VMScaleSetName)
+	}()
+
+	return az.client.CreateOrUpdate(ctx, resourceGroupName, VMScaleSetName, parameters)
+}
+
+func (az *azVirtualMachineScaleSetsClient) WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error) {
 	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -76,13 +76,8 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdate(ctx context.Cont
 func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
-
-	if _, ok := client.FakeStore[resourceGroupName]; !ok {
-		client.FakeStore[resourceGroupName] = make(map[string]compute.VirtualMachineScaleSet)
-	}
-	client.FakeStore[resourceGroupName][VMScaleSetName] = parameters
-
-	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, nil
+	args := client.Called(resourceGroupName, VMScaleSetName, parameters)
+	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, args.Error(1)
 }
 
 // WaitForCreateOrUpdate returns a successful result

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -72,6 +72,26 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdate(ctx context.Cont
 	}, nil
 }
 
+// CreateOrUpdateSync creates or updates the VirtualMachineScaleSet and returns the future
+func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+
+	if _, ok := client.FakeStore[resourceGroupName]; !ok {
+		client.FakeStore[resourceGroupName] = make(map[string]compute.VirtualMachineScaleSet)
+	}
+	client.FakeStore[resourceGroupName][VMScaleSetName] = parameters
+
+	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, nil
+}
+
+// WaitForCreateOrUpdate returns a successful result
+func (client *VirtualMachineScaleSetsClientMock) WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
 // DeleteInstances deletes a set of instances for specified VirtualMachineScaleSet.
 func (client *VirtualMachineScaleSetsClientMock) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error) {
 	args := client.Called(resourceGroupName, vmScaleSetName, vmInstanceIDs)


### PR DESCRIPTION
The following splits the scale-up operation into two parts:

- Synchronous short lived call that returns a future. This allows capturing quota failures and other early failures and properly propagate those tocore autoscaler so that the nodegroup can be backed-off. Otherwise, in the case of quota failures for example, retries will occur in every autoscaler loop leading to throttling.

- Asynchronous part that waits on the future and logs those failures.

/area provider/azure