### PR TITLE
Let the controller move on if machineDeployments are not available

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -86,9 +86,31 @@ func mustCreateTestController(t *testing.T, testConfigs ...*testConfig) (*machin
 			Resources: []*v1.APIResourceList{
 				{
 					GroupVersion: fmt.Sprintf("%s/v1beta1", customCAPIGroup),
+					APIResources: []v1.APIResource{
+						{
+							Name: resourceNameMachineDeployment,
+						},
+						{
+							Name: resourceNameMachineSet,
+						},
+						{
+							Name: resourceNameMachine,
+						},
+					},
 				},
 				{
 					GroupVersion: fmt.Sprintf("%s/v1alpha3", defaultCAPIGroup),
+					APIResources: []v1.APIResource{
+						{
+							Name: resourceNameMachineDeployment,
+						},
+						{
+							Name: resourceNameMachineSet,
+						},
+						{
+							Name: resourceNameMachine,
+						},
+					},
 				},
 			},
 		},
@@ -1122,6 +1144,70 @@ func TestGetAPIGroupPreferredVersion(t *testing.T) {
 			}
 			if version != tc.preferredVersion {
 				t.Errorf("expected %v, got: %v", tc.preferredVersion, version)
+			}
+		})
+	}
+}
+
+func TestGroupVersionHasResource(t *testing.T) {
+	testCases := []struct {
+		description  string
+		APIGroup     string
+		resourceName string
+		expected     bool
+		error        bool
+	}{
+		{
+			description:  "true when it finds resource",
+			resourceName: resourceNameMachineDeployment,
+			APIGroup:     fmt.Sprintf("%s/v1alpha3", defaultCAPIGroup),
+			expected:     true,
+			error:        false,
+		},
+		{
+			description:  "false when it does not find resource",
+			resourceName: "resourceDoesNotExist",
+			APIGroup:     fmt.Sprintf("%s/v1alpha3", defaultCAPIGroup),
+			expected:     false,
+			error:        false,
+		},
+		{
+			description:  "error when invalid groupVersion",
+			resourceName: resourceNameMachineDeployment,
+			APIGroup:     "APIGroupDoesNotExist",
+			expected:     false,
+			error:        true,
+		},
+	}
+
+	discoveryClient := &fakediscovery.FakeDiscovery{
+		Fake: &clientgotesting.Fake{
+			Resources: []*v1.APIResourceList{
+				{
+					GroupVersion: fmt.Sprintf("%s/v1alpha3", defaultCAPIGroup),
+					APIResources: []v1.APIResource{
+						{
+							Name: resourceNameMachineDeployment,
+						},
+						{
+							Name: resourceNameMachineSet,
+						},
+						{
+							Name: resourceNameMachine,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := groupVersionHasResource(discoveryClient, tc.APIGroup, tc.resourceName)
+			if (err != nil) != tc.error {
+				t.Errorf("expected to have error: %t. Had an error: %t", tc.error, err != nil)
+			}
+			if got != tc.expected {
+				t.Errorf("expected %v, got: %v", tc.expected, got)
 			}
 		})
 	}


### PR DESCRIPTION
There might be adhoc environments where machineDeployments might not necessarily be available. This let the controller to remain functional for such scenarios.

/area provider/cluster-api