### PR TITLE
Cherry pick #2944 to 1.15: Properly propagate scale-up failures in scale sets

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -39,6 +39,8 @@ type VirtualMachineScaleSetsClient interface {
 	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (resp *http.Response, err error)
 	DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error)
+	CreateOrUpdateSync(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error)
+	WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error)
 	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error)
 }
 
@@ -105,6 +107,20 @@ func (az *azVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, r
 		return future.Response(), err
 	}
 
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
+	return future.Response(), err
+}
+
+func (az *azVirtualMachineScaleSetsClient) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+	klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): start", resourceGroupName, VMScaleSetName)
+	defer func() {
+		klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): end", resourceGroupName, VMScaleSetName)
+	}()
+
+	return az.client.CreateOrUpdate(ctx, resourceGroupName, VMScaleSetName, parameters)
+}
+
+func (az *azVirtualMachineScaleSetsClient) WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error) {
 	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -76,13 +76,8 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdate(ctx context.Cont
 func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
-
-	if _, ok := client.FakeStore[resourceGroupName]; !ok {
-		client.FakeStore[resourceGroupName] = make(map[string]compute.VirtualMachineScaleSet)
-	}
-	client.FakeStore[resourceGroupName][VMScaleSetName] = parameters
-
-	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, nil
+	args := client.Called(resourceGroupName, VMScaleSetName, parameters)
+	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, args.Error(1)
 }
 
 // WaitForCreateOrUpdate returns a successful result

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -72,6 +72,26 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdate(ctx context.Cont
 	}, nil
 }
 
+// CreateOrUpdateSync creates or updates the VirtualMachineScaleSet and returns the future
+func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+
+	if _, ok := client.FakeStore[resourceGroupName]; !ok {
+		client.FakeStore[resourceGroupName] = make(map[string]compute.VirtualMachineScaleSet)
+	}
+	client.FakeStore[resourceGroupName][VMScaleSetName] = parameters
+
+	return compute.VirtualMachineScaleSetsCreateOrUpdateFuture{}, nil
+}
+
+// WaitForCreateOrUpdate returns a successful result
+func (client *VirtualMachineScaleSetsClientMock) WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
 // DeleteInstances deletes a set of instances for specified VirtualMachineScaleSet.
 func (client *VirtualMachineScaleSetsClientMock) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error) {
 	args := client.Called(resourceGroupName, vmScaleSetName, vmInstanceIDs)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -225,10 +225,40 @@ func (scaleSet *ScaleSet) GetScaleSetSize() (int64, error) {
 }
 
 // updateVMSSCapacity invokes virtualMachineScaleSetsClient to update the capacity for VMSS.
-func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) {
+func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) error {
 	var op compute.VirtualMachineScaleSet
-	var resp *http.Response
-	var isSuccess bool
+	var err error
+
+	resourceGroup := scaleSet.manager.config.ResourceGroup
+	op, err = scaleSet.getVMSSInfo()
+	if err != nil {
+		klog.Errorf("Failed to get information for VMSS (%q): %v", scaleSet.Name, err)
+		return err
+	}
+
+	vmssSizeMutex.Lock()
+	op.Sku.Capacity = &size
+	vmssSizeMutex.Unlock()
+	op.Identity = nil
+	op.VirtualMachineScaleSetProperties.ProvisioningState = nil
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.CreateOrUpdateSync(%s)", scaleSet.Name)
+	future, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.CreateOrUpdateSync(ctx, resourceGroup, scaleSet.Name, op)
+	if err != nil {
+		klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdateSync for scale set %q failed: %v", scaleSet.Name, err)
+		return err
+	}
+
+	// Proactively set the VMSS size so autoscaler makes better decisions.
+	scaleSet.curSize = size
+	scaleSet.lastSizeRefresh = time.Now()
+
+	go scaleSet.waitForUpdateVMSSCapacity(future)
+	return nil
+}
+
+func (scaleSet *ScaleSet) waitForUpdateVMSSCapacity(future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) {
 	var err error
 
 	defer func() {
@@ -241,42 +271,26 @@ func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) {
 		}
 	}()
 
-	resourceGroup := scaleSet.manager.config.ResourceGroup
-	op, err = scaleSet.getVMSSInfo()
-	if err != nil {
-		klog.Errorf("Failed to get information for VMSS (%q): %v", scaleSet.Name, err)
-		return
-	}
-
-	vmssSizeMutex.Lock()
-	op.Sku.Capacity = &size
-	vmssSizeMutex.Unlock()
-	op.Identity = nil
-	op.VirtualMachineScaleSetProperties.ProvisioningState = nil
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.CreateOrUpdate(%s)", scaleSet.Name)
-	resp, err = scaleSet.manager.azClient.virtualMachineScaleSetsClient.CreateOrUpdate(ctx, resourceGroup, scaleSet.Name, op)
-	isSuccess, err = isSuccessHTTPResponse(resp, err)
+
+	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.WaitForCreateOrUpdate(%s)", scaleSet.Name)
+	resp, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.WaitForCreateOrUpdate(ctx, future)
+	isSuccess, err := isSuccessHTTPResponse(resp, err)
 	if isSuccess {
-		klog.V(3).Infof("virtualMachineScaleSetsClient.CreateOrUpdate(%s) success", scaleSet.Name)
+		klog.V(3).Infof("virtualMachineScaleSetsClient.WaitForCreateOrUpdate(%s) success", scaleSet.Name)
 		scaleSet.invalidateInstanceCache()
 		return
 	}
-
-	klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
-	return
+	klog.Errorf("virtualMachineScaleSetsClient.WaitForCreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
 }
 
 // SetScaleSetSize sets ScaleSet size.
-func (scaleSet *ScaleSet) SetScaleSetSize(size int64) {
+func (scaleSet *ScaleSet) SetScaleSetSize(size int64) error {
 	scaleSet.sizeMutex.Lock()
 	defer scaleSet.sizeMutex.Unlock()
 
-	// Proactively set the VMSS size so autoscaler makes better decisions.
-	scaleSet.curSize = size
-	scaleSet.lastSizeRefresh = time.Now()
-	go scaleSet.updateVMSSCapacity(size)
+	return scaleSet.updateVMSSCapacity(size)
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
@@ -301,8 +315,7 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
 	}
 
-	scaleSet.SetScaleSetSize(size + int64(delta))
-	return nil
+	return scaleSet.SetScaleSetSize(size + int64(delta))
 }
 
 // GetScaleSetVms returns list of nodes for the given scale set.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -95,6 +96,37 @@ func TestIncreaseSize(t *testing.T) {
 	targetSize, err = provider.NodeGroups()[0].TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 5, targetSize)
+}
+
+func TestIncreaseSizeFailure(t *testing.T) {
+	provider := newTestProvider(t)
+	manager := newTestAzureManager(t)
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	scaleSetClient := &VirtualMachineScaleSetsClientMock{
+		FakeStore: map[string]map[string]compute.VirtualMachineScaleSet{
+			"test": {
+				"test-asg": {
+					Name: &vmssName,
+					Sku: &compute.Sku{
+						Capacity: &vmssCapacity,
+					},
+					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{},
+				},
+			},
+		},
+	}
+	scaleSetClient.On("CreateOrUpdateSync", "test", "test-asg", mock.Anything).Return(nil, errors.New("autorest/azure: service returned an error"))
+	manager.azClient.virtualMachineScaleSetsClient = scaleSetClient
+	provider.azureManager = manager
+
+	registered := provider.azureManager.RegisterAsg(newTestScaleSet(provider.azureManager, "test-asg"))
+	assert.True(t, registered)
+	assert.Equal(t, len(provider.NodeGroups()), 1)
+
+	// Increase Size by 2 nodes
+	err := provider.NodeGroups()[0].IncreaseSize(2)
+	assert.Error(t, err)
 }
 
 func TestBelongs(t *testing.T) {


### PR DESCRIPTION
The following splits the scale-up operation into two parts:

Synchronous short lived call that returns a future. This allows capturing quota failures and other early failures and properly propagate those tocore autoscaler so that the nodegroup can be backed-off. Otherwise, in the case of quota failures for example, retries will occur in every autoscaler loop leading to throttling.

Asynchronous part that waits on the future and logs those failures.

/area provider/azure