### PR TITLE
Refactor admission controller patch logic

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	metrics_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
@@ -39,13 +40,13 @@ type AdmissionServer struct {
 }
 
 // NewAdmissionServer constructs new AdmissionServer
-func NewAdmissionServer(recommendationProvider pod.RecommendationProvider,
-	podPreProcessor pod.PreProcessor,
+func NewAdmissionServer(podPreProcessor pod.PreProcessor,
 	vpaPreProcessor vpa.PreProcessor,
 	limitsChecker limitrange.LimitRangeCalculator,
-	vpaMatcher vpa.Matcher) *AdmissionServer {
+	vpaMatcher vpa.Matcher,
+	patchCalculators []patch.Calculator) *AdmissionServer {
 	as := &AdmissionServer{limitsChecker, map[metav1.GroupResource]resource.Handler{}}
-	as.RegisterResourceHandler(pod.NewResourceHandler(podPreProcessor, recommendationProvider, vpaMatcher))
+	as.RegisterResourceHandler(pod.NewResourceHandler(podPreProcessor, vpaMatcher, patchCalculators))
 	as.RegisterResourceHandler(vpa.NewResourceHandler(vpaPreProcessor))
 	return as
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/logic"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
@@ -92,7 +94,7 @@ func main() {
 		klog.Errorf("Failed to create limitRangeCalculator, falling back to not checking limits. Error message: %s", err)
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
-	recommendationProvider := pod.NewRecommendationProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
 	vpaMatcher := vpa.NewMatcher(vpaLister, targetSelectorFetcher)
 
 	hostname, err := os.Hostname()
@@ -109,7 +111,8 @@ func main() {
 	)
 	defer close(stopCh)
 
-	as := logic.NewAdmissionServer(recommendationProvider, podPreprocessor, vpaPreprocessor, limitRangeCalculator, vpaMatcher)
+	calculators := []patch.Calculator{patch.NewResourceUpdatesCalculator(recommendationProvider), patch.NewObservedContainersCalculator()}
+	as := logic.NewAdmissionServer(podPreprocessor, vpaPreprocessor, limitRangeCalculator, vpaMatcher, calculators)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		as.Serve(w, r)
 		healthCheck.UpdateLastActivity()

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/calculator.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/calculator.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	core "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// Calculator is capable of calculating required patches for pod.
+type Calculator interface {
+	CalculatePatches(pod *core.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource.PatchRecord, error)
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/observed_containers.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/observed_containers.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	core "k8s.io/api/core/v1"
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+)
+
+type observedContainers struct{}
+
+func (*observedContainers) CalculatePatches(pod *core.Pod, _ *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
+	vpaObservedContainersValue := annotations.GetVpaObservedContainersValue(pod)
+	return []resource_admission.PatchRecord{GetAddAnnotationPatch(annotations.VpaObservedContainersLabel, vpaObservedContainersValue)}, nil
+}
+
+// NewObservedContainersCalculator returns calculator for
+// observed containers patches.
+func NewObservedContainersCalculator() Calculator {
+	return &observedContainers{}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+	"strings"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+const (
+	// ResourceUpdatesAnnotation is the name of annotation
+	// containing resource updates performed by VPA.
+	ResourceUpdatesAnnotation = "vpaUpdates"
+)
+
+type resourcesUpdatesPatchCalculator struct {
+	recommendationProvider recommendation.Provider
+}
+
+// NewResourceUpdatesCalculator returns a calculator for
+// resource update patches.
+func NewResourceUpdatesCalculator(recommendationProvider recommendation.Provider) Calculator {
+	return &resourcesUpdatesPatchCalculator{
+		recommendationProvider: recommendationProvider,
+	}
+}
+
+func (c *resourcesUpdatesPatchCalculator) CalculatePatches(pod *core.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
+	result := []resource_admission.PatchRecord{}
+
+	containersResources, annotationsPerContainer, err := c.recommendationProvider.GetContainersResourcesForPod(pod, vpa)
+	if err != nil {
+		return []resource_admission.PatchRecord{}, fmt.Errorf("Failed to calculate resource patch for pod %v/%v: %v", pod.Namespace, pod.Name, err)
+	}
+
+	if annotationsPerContainer == nil {
+		annotationsPerContainer = vpa_api_util.ContainerToAnnotationsMap{}
+	}
+
+	updatesAnnotation := []string{}
+	for i, containerResources := range containersResources {
+		newPatches, newUpdatesAnnotation := getContainerPatch(pod, i, annotationsPerContainer, containerResources)
+		result = append(result, newPatches...)
+		updatesAnnotation = append(updatesAnnotation, newUpdatesAnnotation)
+	}
+
+	if len(updatesAnnotation) > 0 {
+		vpaAnnotationValue := fmt.Sprintf("Pod resources updated by %s: %s", vpa.Name, strings.Join(updatesAnnotation, "; "))
+		result = append(result, GetAddAnnotationPatch(ResourceUpdatesAnnotation, vpaAnnotationValue))
+	}
+	return result, nil
+}
+
+func getContainerPatch(pod *core.Pod, i int, annotationsPerContainer vpa_api_util.ContainerToAnnotationsMap, containerResources vpa_api_util.ContainerResources) ([]resource_admission.PatchRecord, string) {
+	var patches []resource_admission.PatchRecord
+	// Add empty resources object if missing.
+	if pod.Spec.Containers[i].Resources.Limits == nil &&
+		pod.Spec.Containers[i].Resources.Requests == nil {
+		patches = append(patches, getPatchInitializingEmptyResources(i))
+	}
+
+	annotations, found := annotationsPerContainer[pod.Spec.Containers[i].Name]
+	if !found {
+		annotations = make([]string, 0)
+	}
+
+	patches, annotations = appendPatchesAndAnnotations(patches, annotations, pod.Spec.Containers[i].Resources.Requests, i, containerResources.Requests, "requests", "request")
+	patches, annotations = appendPatchesAndAnnotations(patches, annotations, pod.Spec.Containers[i].Resources.Limits, i, containerResources.Limits, "limits", "limit")
+
+	updatesAnnotation := fmt.Sprintf("container %d: ", i) + strings.Join(annotations, ", ")
+	return patches, updatesAnnotation
+}
+
+func appendPatchesAndAnnotations(patches []resource_admission.PatchRecord, annotations []string, current core.ResourceList, containerIndex int, resources core.ResourceList, fieldName, resourceName string) ([]resource_admission.PatchRecord, []string) {
+	// Add empty object if it's missing and we're about to fill it.
+	if current == nil && len(resources) > 0 {
+		patches = append(patches, getPatchInitializingEmptyResourcesSubfield(containerIndex, fieldName))
+	}
+	for resource, request := range resources {
+		patches = append(patches, getAddResourceRequirementValuePatch(containerIndex, fieldName, resource, request))
+		annotations = append(annotations, fmt.Sprintf("%s %s", resource, resourceName))
+	}
+	return patches, annotations
+}
+
+func getAddResourceRequirementValuePatch(i int, kind string, resource core.ResourceName, quantity resource.Quantity) resource_admission.PatchRecord {
+	return resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, resource),
+		Value: quantity.String()}
+}
+
+func getPatchInitializingEmptyResources(i int) resource_admission.PatchRecord {
+	return resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources", i),
+		Value: core.ResourceRequirements{},
+	}
+}
+
+func getPatchInitializingEmptyResourcesSubfield(i int, kind string) resource_admission.PatchRecord {
+	return resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s", i, kind),
+		Value: core.ResourceList{},
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+)
+
+// GetAddEmptyAnnotationsPatch returns a patch initializing empty annotations.
+func GetAddEmptyAnnotationsPatch() resource_admission.PatchRecord {
+	return resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  "/metadata/annotations",
+		Value: map[string]string{},
+	}
+}
+
+// GetAddAnnotationPatch returns a patch for an annotation.
+func GetAddAnnotationPatch(annotationName, annotationValue string) resource_admission.PatchRecord {
+	return resource_admission.PatchRecord{
+		Op:    "add",
+		Path:  fmt.Sprintf("/metadata/annotations/%s", annotationName),
+		Value: annotationValue,
+	}
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package recommendation
 
 import (
 	"fmt"
@@ -26,8 +26,8 @@ import (
 	"k8s.io/klog"
 )
 
-// RecommendationProvider gets current recommendation, annotations and vpaName for the given pod.
-type RecommendationProvider interface {
+// Provider gets current recommendation, annotations and vpaName for the given pod.
+type Provider interface {
 	GetContainersResourcesForPod(pod *core.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, error)
 }
 
@@ -36,8 +36,8 @@ type recommendationProvider struct {
 	recommendationProcessor vpa_api_util.RecommendationProcessor
 }
 
-// NewRecommendationProvider constructs the recommendation provider that can be used to determine recommendations for pods.
-func NewRecommendationProvider(calculator limitrange.LimitRangeCalculator,
+// NewProvider constructs the recommendation provider that can be used to determine recommendations for pods.
+func NewProvider(calculator limitrange.LimitRangeCalculator,
 	recommendationProcessor vpa_api_util.RecommendationProcessor) *recommendationProvider {
 	return &recommendationProvider{
 		limitsRangeCalculator:   calculator,

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package recommendation
 
 import (
 	"fmt"


### PR DESCRIPTION
Only actual change that happens here is that empty annotations patch comes before any other patch.
Other than that, this only moves code around. 
I'm doing a restructuring of tests in followup PR.