### PR TITLE
Ignore the label of aws instance id when comparing nodegroups

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -99,6 +99,7 @@ func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 		"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
 		"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
 		"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
+		"alpha.eksctl.io/instance-id":         true, // this is a label used by eksctl to identify instances.
 	}
 
 	labels := make(map[string][]string)


### PR DESCRIPTION
Currently, aws eks version is 1.14. 
We configured 3 nodegroups those have same instance type but different AZs. And we enabled `balance-similar-node-groups` option. 
However, when CA is auto-scaling, the desired counts of nodegroups are not similar. We found the reason is that CA did not ignore the `alpha.eksctl.io/instance-id` label on the node when comparing similar nodegroups