### PR TITLE
Squashed commits reverting #3016

### DIFF
--- a/vertical-pod-autoscaler/e2e/utils/ooming_resource_consumer/Dockerfile
+++ b/vertical-pod-autoscaler/e2e/utils/ooming_resource_consumer/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google-containers/stress:v1
+ENTRYPOINT ["/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "8000"]

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -192,12 +192,17 @@ func NewHamsterDeploymentWithResourcesAndLimits(f *framework.Framework, cpuQuant
 	return d
 }
 
+func getPodSelectorExcludingDonePodsOrDie() string {
+	stringSelector := "status.phase!=" + string(apiv1.PodSucceeded) +
+		",status.phase!=" + string(apiv1.PodFailed)
+	selector := fields.ParseSelectorOrDie(stringSelector)
+	return selector.String()
+}
+
 // GetHamsterPods returns running hamster pods (matched by hamsterLabels)
 func GetHamsterPods(f *framework.Framework) (*apiv1.PodList, error) {
 	label := labels.SelectorFromSet(labels.Set(hamsterLabels))
-	selector := fields.ParseSelectorOrDie("status.phase!=" + string(apiv1.PodSucceeded) +
-		",status.phase!=" + string(apiv1.PodFailed))
-	options := metav1.ListOptions{LabelSelector: label.String(), FieldSelector: selector.String()}
+	options := metav1.ListOptions{LabelSelector: label.String(), FieldSelector: getPodSelectorExcludingDonePodsOrDie()}
 	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(options)
 }
 

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -18,6 +18,7 @@ package autoscaling
 
 import (
 	"fmt"
+	"time"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -91,14 +92,14 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	ginkgo.It("have cpu requests growing with usage", func() {
 		// initial CPU usage is low so a minimal recommendation is expected
 		err := waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// consume more CPU to get a higher recommendation
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie("500m"), ParseQuantityOrDie("900m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
@@ -106,7 +107,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	ginkgo.It("have memory requests growing with usage", func() {
 		// initial memory usage is low so a minimal recommendation is expected
 		err := waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 			ParseQuantityOrDie(minimalMemoryLowerBound), ParseQuantityOrDie(minimalMemoryUpperBound))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -114,14 +115,57 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		// NOTE: large range given due to unpredictability of actual memory usage
 		rc.ConsumeMem(1024 * replicas)
 		err = waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 			ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })
 
-func waitForPodsMatch(f *framework.Framework, listOptions metav1.ListOptions, matcher func(pod apiv1.Pod) bool) error {
-	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+var _ = FullVpaE2eDescribe("OOMing pods under VPA", func() {
+	var (
+		vpaClientSet *vpa_clientset.Clientset
+		vpaCRD       *vpa_types.VerticalPodAutoscaler
+	)
+	const replicas = 3
+
+	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
+
+	ginkgo.BeforeEach(func() {
+		ns := f.Namespace.Name
+		ginkgo.By("Setting up a hamster deployment")
+
+		runOomingReplicationController(
+			f.ClientSet,
+			ns,
+			"hamster",
+			replicas)
+		ginkgo.By("Setting up a VPA CRD")
+		config, err := framework.LoadConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		vpaCRD = NewVPA(f, "hamster-vpa", &autoscaling.CrossVersionObjectReference{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Name:       "hamster",
+		})
+
+		vpaClientSet = vpa_clientset.NewForConfigOrDie(config)
+		vpaClient := vpaClientSet.AutoscalingV1()
+		_, err = vpaClient.VerticalPodAutoscalers(ns).Create(vpaCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("have memory requests growing with OOMs", func() {
+		listOptions := metav1.ListOptions{LabelSelector: "name=hamster", FieldSelector: getPodSelectorExcludingDonePodsOrDie()}
+		err := waitForResourceRequestInRangeInPods(
+			f, 7*time.Minute, listOptions, apiv1.ResourceMemory,
+			ParseQuantityOrDie("1400Mi"), ParseQuantityOrDie("10000Mi"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})
+
+func waitForPodsMatch(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, matcher func(pod apiv1.Pod) bool) error {
+	return wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 
 		ns := f.Namespace.Name
 		c := f.ClientSet
@@ -135,18 +179,23 @@ func waitForPodsMatch(f *framework.Framework, listOptions metav1.ListOptions, ma
 			return false, nil
 		}
 
+		// Run matcher on all pods, even if we find pod that doesn't match early.
+		// This allows the matcher to write logs for all pods. This in turns makes
+		// it easier to spot some problems (for example unexpected pods in the list
+		// results).
+		result := true
 		for _, pod := range podList.Items {
 			if !matcher(pod) {
-				return false, nil
+				result = false
 			}
 		}
-		return true, nil
+		return result, nil
 
 	})
 }
 
-func waitForResourceRequestInRangeInPods(f *framework.Framework, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
-	err := waitForPodsMatch(f, listOptions,
+func waitForResourceRequestInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
+	err := waitForPodsMatch(f, timeout, listOptions,
 		func(pod apiv1.Pod) bool {
 			resourceRequest, found := pod.Spec.Containers[0].Resources.Requests[resourceName]
 			framework.Logf("Comparing %v request %v against range of (%v, %v)", resourceName, resourceRequest, lowerBound, upperBound)

--- a/vertical-pod-autoscaler/e2e/v1beta2/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/autoscaling_utils.go
@@ -60,6 +60,8 @@ const (
 	customMetricName                = "QPS"
 	serviceInitializationTimeout    = 2 * time.Minute
 	serviceInitializationInterval   = 15 * time.Second
+	// TODO(jbartosik): put the image in a VPA project
+	stressImage = "gcr.io/jbartosik-gke-dev/stress:0.10"
 )
 
 var (
@@ -426,4 +428,28 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name st
 	// Wait for endpoints to propagate for the controller service.
 	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
 		c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
+}
+
+func runOomingReplicationController(c clientset.Interface, ns, name string, replicas int) {
+	ginkgo.By(fmt.Sprintf("Running OOMing RC %s with %v replicas", name, replicas))
+
+	rcConfig := testutils.RCConfig{
+		Client:      c,
+		Image:       stressImage,
+		Name:        name,
+		Namespace:   ns,
+		Timeout:     timeoutRC,
+		Replicas:    replicas,
+		Annotations: make(map[string]string),
+		MemRequest:  1024 * 1024 * 1024,
+		MemLimit:    1024 * 1024 * 1024,
+	}
+
+	dpConfig := testutils.DeploymentConfig{
+		RCConfig: rcConfig,
+	}
+	ginkgo.By(fmt.Sprintf("Creating deployment %s in namespace %s", dpConfig.Name, dpConfig.Namespace))
+	dpConfig.NodeDumpFunc = framework.DumpNodeDebugInfo
+	dpConfig.ContainerDumpFunc = framework.LogFailedContainers
+	framework.ExpectNoError(testutils.RunDeployment(dpConfig))
 }

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -192,12 +192,17 @@ func NewHamsterDeploymentWithResourcesAndLimits(f *framework.Framework, cpuQuant
 	return d
 }
 
+func getPodSelectorExcludingDonePodsOrDie() string {
+	stringSelector := "status.phase!=" + string(apiv1.PodSucceeded) +
+		",status.phase!=" + string(apiv1.PodFailed)
+	selector := fields.ParseSelectorOrDie(stringSelector)
+	return selector.String()
+}
+
 // GetHamsterPods returns running hamster pods (matched by hamsterLabels)
 func GetHamsterPods(f *framework.Framework) (*apiv1.PodList, error) {
 	label := labels.SelectorFromSet(labels.Set(hamsterLabels))
-	selector := fields.ParseSelectorOrDie("status.phase!=" + string(apiv1.PodSucceeded) +
-		",status.phase!=" + string(apiv1.PodFailed))
-	options := metav1.ListOptions{LabelSelector: label.String(), FieldSelector: selector.String()}
+	options := metav1.ListOptions{LabelSelector: label.String(), FieldSelector: getPodSelectorExcludingDonePodsOrDie()}
 	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(options)
 }
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
@@ -18,6 +18,7 @@ package autoscaling
 
 import (
 	"fmt"
+	"time"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -91,14 +92,14 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	ginkgo.It("have cpu requests growing with usage", func() {
 		// initial CPU usage is low so a minimal recommendation is expected
 		err := waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// consume more CPU to get a higher recommendation
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie("500m"), ParseQuantityOrDie("900m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
@@ -106,7 +107,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	ginkgo.It("have memory requests growing with usage", func() {
 		// initial memory usage is low so a minimal recommendation is expected
 		err := waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 			ParseQuantityOrDie(minimalMemoryLowerBound), ParseQuantityOrDie(minimalMemoryUpperBound))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -114,14 +115,57 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		// NOTE: large range given due to unpredictability of actual memory usage
 		rc.ConsumeMem(1024 * replicas)
 		err = waitForResourceRequestInRangeInPods(
-			f, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 			ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })
 
-func waitForPodsMatch(f *framework.Framework, listOptions metav1.ListOptions, matcher func(pod apiv1.Pod) bool) error {
-	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+var _ = FullVpaE2eDescribe("OOMing pods under VPA", func() {
+	var (
+		vpaClientSet *vpa_clientset.Clientset
+		vpaCRD       *vpa_types.VerticalPodAutoscaler
+	)
+	const replicas = 3
+
+	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
+
+	ginkgo.BeforeEach(func() {
+		ns := f.Namespace.Name
+		ginkgo.By("Setting up a hamster deployment")
+
+		runOomingReplicationController(
+			f.ClientSet,
+			ns,
+			"hamster",
+			replicas)
+		ginkgo.By("Setting up a VPA CRD")
+		config, err := framework.LoadConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		vpaCRD = NewVPA(f, "hamster-vpa", &autoscaling.CrossVersionObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "hamster",
+		})
+
+		vpaClientSet = vpa_clientset.NewForConfigOrDie(config)
+		vpaClient := vpaClientSet.AutoscalingV1beta2()
+		_, err = vpaClient.VerticalPodAutoscalers(ns).Create(vpaCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("have memory requests growing with OOMs", func() {
+		listOptions := metav1.ListOptions{LabelSelector: "name=hamster", FieldSelector: getPodSelectorExcludingDonePodsOrDie()}
+		err := waitForResourceRequestInRangeInPods(
+			f, 7*time.Minute, listOptions, apiv1.ResourceMemory,
+			ParseQuantityOrDie("1400Mi"), ParseQuantityOrDie("10000Mi"))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})
+
+func waitForPodsMatch(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, matcher func(pod apiv1.Pod) bool) error {
+	return wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
 
 		ns := f.Namespace.Name
 		c := f.ClientSet
@@ -135,18 +179,23 @@ func waitForPodsMatch(f *framework.Framework, listOptions metav1.ListOptions, ma
 			return false, nil
 		}
 
+		// Run matcher on all pods, even if we find pod that doesn't match early.
+		// This allows the matcher to write logs for all pods. This in turns makes
+		// it easier to spot some problems (for example unexpected pods in the list
+		// results).
+		result := true
 		for _, pod := range podList.Items {
 			if !matcher(pod) {
-				return false, nil
+				result = false
 			}
 		}
-		return true, nil
+		return result, nil
 
 	})
 }
 
-func waitForResourceRequestInRangeInPods(f *framework.Framework, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
-	err := waitForPodsMatch(f, listOptions,
+func waitForResourceRequestInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
+	err := waitForPodsMatch(f, timeout, listOptions,
 		func(pod apiv1.Pod) bool {
 			resourceRequest, found := pod.Spec.Containers[0].Resources.Requests[resourceName]
 			framework.Logf("Comparing %v request %v against range of (%v, %v)", resourceName, resourceRequest, lowerBound, upperBound)


### PR DESCRIPTION
This reverts #3016 to add back OOM tests.

Squashed to make history shorter. The problem was with permission on the image that I use in the test. I verified that the problem is fixed by running the test on a cluster in a different project.

Messages of the squashed commits:

Revert "Revert "Add test for handling OOMing containers""

This reverts commit 644aa7a12cda8a7bc271c3c6716efcde3d8022de.

Revert "Revert "Add docekrfile for OOMing pods under VPA test""

This reverts commit 68c12d30eb8246894ee106eadbe7bb6dac1520d5.

Revert "Revert "Tweak OOM test""

This reverts commit c48f7f846c50824422fee6ef25834cdffdb203e3.

Revert "Revert "Enable tests for pods under VPA""

This reverts commit e3c38fa639179d622de1780e65530abb6e701820.