### PR TITLE
Correct cloudprovider/azure's GPULabel to "accelerator"

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// GPULabel is the label added to nodes with GPU resource.
-	GPULabel = "cloud.google.com/gke-accelerator"
+	GPULabel = "accelerator"
 )
 
 var (


### PR DESCRIPTION
The node with GPU is started with the following gpu label:
```
accelerator=nvidia
```
However, [the gpu label of azure in CA](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go#L33) is ```"cloud.google.com/gke-accelerator"```.