### PR TITLE
Run as non-root for kubernetes on VPA

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app: vpa-admission-controller
     spec:
       serviceAccountName: vpa-admission-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
           image: k8s.gcr.io/vpa-admission-controller:0.6.3

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: vpa-recommender
     spec:
       serviceAccountName: vpa-recommender
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
       containers:
       - name: recommender
         image: k8s.gcr.io/vpa-recommender:0.6.3

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: vpa-updater
     spec:
       serviceAccountName: vpa-updater
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
       containers:
         - name: updater
           image: k8s.gcr.io/vpa-updater:0.6.3

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         app: hamster
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
       containers:
         - name: hamster
           image: k8s.gcr.io/ubuntu-slim:0.1


### PR DESCRIPTION
Thanks for your works !

Error with a rootless PSP 
```
  Type     Reason     Age                    From                  Message
  ----     ------     ----                   ----                  -------
  Normal   Scheduled  6m43s                  default-scheduler     Successfully assigned kube-system/vpa-recommender-654ddbd47b-xsmhw to k8s-xxx
  Normal   Pulled     5m17s (x8 over 6m40s)  kubelet, k8s-xxx  Successfully pulled image "k8s.gcr.io/vpa-recommender:0.6.3"
  Warning  Failed     5m17s (x8 over 6m40s)  kubelet, k8s-xxx  Error: container has runAsNonRoot and image will run as root
  Normal   Pulling    101s (x24 over 6m42s)  kubelet, k8s-xxx  Pulling image "k8s.gcr.io/vpa-recommender:0.6.3"
```