### PR TITLE
Update repository references for the Vanity Domain Flip

### DIFF
--- a/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
@@ -723,7 +723,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.
@@ -4704,4 +4704,3 @@ message WeightedPodAffinityTerm {
   // Required. A pod affinity term, associated with the corresponding weight.
   optional PodAffinityTerm podAffinityTerm = 2;
 }
-

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types.go
@@ -3993,7 +3993,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -340,7 +340,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 
@@ -1633,7 +1633,7 @@ func (PreferredSchedulingTerm) SwaggerDoc() map[string]string {
 }
 
 var map_Probe = map[string]string{
-	"": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+	"":                    "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
 	"initialDelaySeconds": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
 	"timeoutSeconds":      "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
 	"periodSeconds":       "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
@@ -2197,7 +2197,7 @@ func (TopologySelectorLabelRequirement) SwaggerDoc() map[string]string {
 }
 
 var map_TopologySelectorTerm = map[string]string{
-	"": "A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.",
+	"":                      "A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.",
 	"matchLabelExpressions": "A list of topology selector requirements by labels.",
 }
 
@@ -2270,23 +2270,23 @@ var map_VolumeSource = map[string]string{
 	"iscsi":                 "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md",
 	"glusterfs":             "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
 	"persistentVolumeClaim": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-	"rbd":                  "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
-	"flexVolume":           "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
-	"cinder":               "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-	"cephfs":               "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
-	"flocker":              "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
-	"downwardAPI":          "DownwardAPI represents downward API about the pod that should populate this volume",
-	"fc":                   "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-	"azureFile":            "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-	"configMap":            "ConfigMap represents a configMap that should populate this volume",
-	"vsphereVolume":        "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
-	"quobyte":              "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
-	"azureDisk":            "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-	"photonPersistentDisk": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
-	"projected":            "Items for all in one resources secrets, configmaps, and downward API",
-	"portworxVolume":       "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
-	"scaleIO":              "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
-	"storageos":            "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+	"rbd":                   "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
+	"flexVolume":            "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+	"cinder":                "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+	"cephfs":                "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+	"flocker":               "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+	"downwardAPI":           "DownwardAPI represents downward API about the pod that should populate this volume",
+	"fc":                    "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+	"azureFile":             "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+	"configMap":             "ConfigMap represents a configMap that should populate this volume",
+	"vsphereVolume":         "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+	"quobyte":               "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+	"azureDisk":             "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+	"photonPersistentDisk":  "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+	"projected":             "Items for all in one resources secrets, configmaps, and downward API",
+	"portworxVolume":        "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+	"scaleIO":               "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+	"storageos":             "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
 }
 
 func (VolumeSource) SwaggerDoc() map[string]string {

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -397,7 +397,7 @@ spec:
       priorityClassName: overprovisioning
       containers:
       - name: reserve-resources
-        image: k8s.gcr.io/pause
+        image: us.gcr.io/k8s-artifacts-prod/pause
         resources:
           requests:
             cpu: "200m"
@@ -420,7 +420,7 @@ spec:
         app: overprovisioning-autoscaler
     spec:
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - ./cluster-proportional-autoscaler
@@ -950,5 +950,3 @@ Caveats:
    in `kubernetes/kubernetes` revision against which revendoring is done.
  - `update-vendor.sh` automatically runs unit tests as part of verification process. If one needs to suppress that, it can be done by overriding `VERIFY_COMMAND` variable (`VERIFY_COMMAND=true ./hack/update-vendor.sh ...`)
  - If one wants to only add new libraries to `go.mod-extra`, but not change the base `go.mod`, `-r` should be used with kubernetes/kubernets revision, which was used last time `update-vendor.sh` was called. One can determine that revision by looking at `git log` in Cluster Autoscaler repository. Following command will do the trick `git log | grep "Updating vendor against"`.
-
-

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -138,7 +138,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:v1.14.7
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -138,7 +138,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:v1.14.7
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -138,7 +138,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:v1.14.7
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml
@@ -145,7 +145,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:v1.14.7
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-aks.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-aks.yaml
@@ -153,7 +153,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
@@ -187,7 +187,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+          image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-master.yaml
@@ -203,7 +203,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+          image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
@@ -188,7 +188,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+          image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
@@ -196,7 +196,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+          image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-master.yaml
@@ -158,7 +158,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           command:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
@@ -156,7 +156,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           command:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
@@ -151,7 +151,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        - image: us.gcr.io/k8s-artifacts-prod/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/vendor/k8s.io/api/core/v1/generated.proto
+++ b/cluster-autoscaler/vendor/k8s.io/api/core/v1/generated.proto
@@ -783,7 +783,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.
@@ -5329,4 +5329,3 @@ message WindowsSecurityContextOptions {
   // +optional
   optional string runAsUserName = 3;
 }
-

--- a/cluster-autoscaler/vendor/k8s.io/api/core/v1/types.go
+++ b/cluster-autoscaler/vendor/k8s.io/api/core/v1/types.go
@@ -4534,7 +4534,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/cluster-autoscaler/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/cluster-autoscaler/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -356,7 +356,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/node.yaml
+++ b/cluster-autoscaler/vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/node.yaml
@@ -131,8 +131,8 @@ status:
     - grafana/grafana:4.4.2
     sizeBytes: 287008013
   - names:
-    - k8s.gcr.io/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b
-    - k8s.gcr.io/node-problem-detector:v0.4.1
+    - us.gcr.io/k8s-artifacts-prod/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b
+    - us.gcr.io/k8s-artifacts-prod/node-problem-detector:v0.4.1
     sizeBytes: 286572743
   - names:
     - grafana/grafana@sha256:7ff7f9b2501a5d55b55ce3f58d21771b1c5af1f2a4ab7dbf11bef7142aae7033
@@ -151,76 +151,76 @@ status:
     - nginx:1.10.1
     sizeBytes: 180708613
   - names:
-    - k8s.gcr.io/fluentd-elasticsearch@sha256:b8c94527b489fb61d3d81ce5ad7f3ddbb7be71e9620a3a36e2bede2f2e487d73
-    - k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    - us.gcr.io/k8s-artifacts-prod/fluentd-elasticsearch@sha256:b8c94527b489fb61d3d81ce5ad7f3ddbb7be71e9620a3a36e2bede2f2e487d73
+    - us.gcr.io/k8s-artifacts-prod/fluentd-elasticsearch:v2.0.4
     sizeBytes: 135716379
   - names:
     - nginx@sha256:00be67d6ba53d5318cd91c57771530f5251cfbe028b7be2c4b70526f988cfc9f
     - nginx:latest
     sizeBytes: 109357355
   - names:
-    - k8s.gcr.io/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0
-    - k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3
+    - us.gcr.io/k8s-artifacts-prod/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0
+    - us.gcr.io/k8s-artifacts-prod/kubernetes-dashboard-amd64:v1.8.3
     sizeBytes: 102319441
   - names:
     - gcr.io/google_containers/kube-proxy:v1.11.10-gke.5
-    - k8s.gcr.io/kube-proxy:v1.11.10-gke.5
+    - us.gcr.io/k8s-artifacts-prod/kube-proxy:v1.11.10-gke.5
     sizeBytes: 102279340
   - names:
-    - k8s.gcr.io/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516
-    - k8s.gcr.io/event-exporter:v0.2.3
+    - us.gcr.io/k8s-artifacts-prod/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516
+    - us.gcr.io/k8s-artifacts-prod/event-exporter:v0.2.3
     sizeBytes: 94171943
   - names:
-    - k8s.gcr.io/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662
-    - k8s.gcr.io/prometheus-to-sd:v0.3.1
+    - us.gcr.io/k8s-artifacts-prod/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662
+    - us.gcr.io/k8s-artifacts-prod/prometheus-to-sd:v0.3.1
     sizeBytes: 88077694
   - names:
-    - k8s.gcr.io/fluentd-gcp-scaler@sha256:a5ace7506d393c4ed65eb2cbb6312c64ab357fcea16dff76b9055bc6e498e5ff
-    - k8s.gcr.io/fluentd-gcp-scaler:0.5.1
+    - us.gcr.io/k8s-artifacts-prod/fluentd-gcp-scaler@sha256:a5ace7506d393c4ed65eb2cbb6312c64ab357fcea16dff76b9055bc6e498e5ff
+    - us.gcr.io/k8s-artifacts-prod/fluentd-gcp-scaler:0.5.1
     sizeBytes: 86637208
   - names:
-    - k8s.gcr.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521
-    - k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+    - us.gcr.io/k8s-artifacts-prod/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521
+    - us.gcr.io/k8s-artifacts-prod/heapster-amd64:v1.6.0-beta.1
     sizeBytes: 76016169
   - names:
-    - k8s.gcr.io/ingress-glbc-amd64@sha256:31d36bbd9c44caffa135fc78cf0737266fcf25e3cf0cd1c2fcbfbc4f7309cc52
-    - k8s.gcr.io/ingress-glbc-amd64:v1.1.1
+    - us.gcr.io/k8s-artifacts-prod/ingress-glbc-amd64@sha256:31d36bbd9c44caffa135fc78cf0737266fcf25e3cf0cd1c2fcbfbc4f7309cc52
+    - us.gcr.io/k8s-artifacts-prod/ingress-glbc-amd64:v1.1.1
     sizeBytes: 67801919
   - names:
-    - k8s.gcr.io/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09
-    - k8s.gcr.io/kube-addon-manager:v8.7
+    - us.gcr.io/k8s-artifacts-prod/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09
+    - us.gcr.io/k8s-artifacts-prod/kube-addon-manager:v8.7
     sizeBytes: 63322109
   - names:
     - nginx@sha256:4aacdcf186934dcb02f642579314075910f1855590fd3039d8fa4c9f96e48315
     - nginx:1.10-alpine
     sizeBytes: 54042627
   - names:
-    - k8s.gcr.io/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869
-    - k8s.gcr.io/cpvpa-amd64:v0.6.0
+    - us.gcr.io/k8s-artifacts-prod/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869
+    - us.gcr.io/k8s-artifacts-prod/cpvpa-amd64:v0.6.0
     sizeBytes: 51785854
   - names:
-    - k8s.gcr.io/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d
-    - k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+    - us.gcr.io/k8s-artifacts-prod/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d
+    - us.gcr.io/k8s-artifacts-prod/cluster-proportional-autoscaler-amd64:1.1.2-r2
     sizeBytes: 49648481
   - names:
-    - k8s.gcr.io/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103
-    - k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+    - us.gcr.io/k8s-artifacts-prod/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103
+    - us.gcr.io/k8s-artifacts-prod/ip-masq-agent-amd64:v2.1.1
     sizeBytes: 49612505
   - names:
-    - k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:b99fc3eee2a9f052f7eb4cc00f15eb12fc405fa41019baa2d6b79847ae7284a8
-    - k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
+    - us.gcr.io/k8s-artifacts-prod/k8s-dns-kube-dns-amd64@sha256:b99fc3eee2a9f052f7eb4cc00f15eb12fc405fa41019baa2d6b79847ae7284a8
+    - us.gcr.io/k8s-artifacts-prod/k8s-dns-kube-dns-amd64:1.14.10
     sizeBytes: 49549457
   - names:
-    - k8s.gcr.io/rescheduler@sha256:156cfbfd05a5a815206fd2eeb6cbdaf1596d71ea4b415d3a6c43071dd7b99450
-    - k8s.gcr.io/rescheduler:v0.4.0
+    - us.gcr.io/k8s-artifacts-prod/rescheduler@sha256:156cfbfd05a5a815206fd2eeb6cbdaf1596d71ea4b415d3a6c43071dd7b99450
+    - us.gcr.io/k8s-artifacts-prod/rescheduler:v0.4.0
     sizeBytes: 48973149
   - names:
-    - k8s.gcr.io/event-exporter@sha256:16ca66e2b5dc7a1ce6a5aafcb21d0885828b75cdfc08135430480f7ad2364adc
-    - k8s.gcr.io/event-exporter:v0.2.4
+    - us.gcr.io/k8s-artifacts-prod/event-exporter@sha256:16ca66e2b5dc7a1ce6a5aafcb21d0885828b75cdfc08135430480f7ad2364adc
+    - us.gcr.io/k8s-artifacts-prod/event-exporter:v0.2.4
     sizeBytes: 47261019
   - names:
-    - k8s.gcr.io/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
-    - k8s.gcr.io/coredns:1.1.3
+    - us.gcr.io/k8s-artifacts-prod/coredns@sha256:db2bf53126ed1c761d5a41f24a1b82a461c85f736ff6e90542e9522be4757848
+    - us.gcr.io/k8s-artifacts-prod/coredns:1.1.3
     sizeBytes: 45587362
   - names:
     - prom/prometheus@sha256:483f4c9d7733699ba79facca9f8bcce1cef1af43dfc3e7c5a1882aa85f53cb74

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// When these values are updated, also update test/utils/image/manifest.go
-	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
+	defaultPodSandboxImageName    = "us.gcr.io/k8s-artifacts-prod/pause"
 	defaultPodSandboxImageVersion = "3.2"
 )
 

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "k8s.gcr.io/pause:3.2"
+	defaultSandboxImage = "us.gcr.io/k8s-artifacts-prod/pause:3.2"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
@@ -533,7 +533,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: k8s.gcr.io/test-webserver
+	//     - image: us.gcr.io/k8s-artifacts-prod/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd
@@ -571,7 +571,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: k8s.gcr.io/test-webserver
+	//     - image: us.gcr.io/k8s-artifacts-prod/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/test/utils/runners.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/test/utils/runners.go
@@ -1308,7 +1308,7 @@ func MakePodSpec() v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
 			Name:  "pause",
-			Image: "k8s.gcr.io/pause:3.2",
+			Image: "us.gcr.io/k8s-artifacts-prod/pause:3.2",
 			Ports: []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -1726,7 +1726,7 @@ type DaemonConfig struct {
 
 func (config *DaemonConfig) Run() error {
 	if config.Image == "" {
-		config.Image = "k8s.gcr.io/pause:3.2"
+		config.Image = "us.gcr.io/k8s-artifacts-prod/pause:3.2"
 	}
 	nameLabel := map[string]string{
 		"name": config.Name + "-daemon",

--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -286,7 +286,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 			// TODO(krzysied): Update the image url when the agnhost:2.10 image
 			// is promoted to the k8s-e2e-test-images repository.
 			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
-			sidecarParam  = "--sidecar-image=k8s.gcr.io/pause:3.1"
+			sidecarParam  = "--sidecar-image=us.gcr.io/k8s-artifacts-prod/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)
 			containerPort = int32(8444)
@@ -468,7 +468,7 @@ func setupHamsterController(f *framework.Framework, controllerKind, cpu, memory 
 
 func setupHamsterReplicationController(f *framework.Framework, cpu, memory string, replicas int32) {
 	hamsterContainer := SetupHamsterContainer(cpu, memory)
-	rc := framework.RcByNameContainer("hamster-rc", replicas, "k8s.gcr.io/ubuntu-slim:0.1",
+	rc := framework.RcByNameContainer("hamster-rc", replicas, "us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1",
 		hamsterLabels, hamsterContainer, nil)
 
 	rc.Namespace = f.Namespace.Name

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -140,12 +140,12 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		panic("container count should be greater than 0")
 	}
 	d := framework_deployment.NewDeployment(
-		"hamster-deployment",                       /*deploymentName*/
-		defaultHamsterReplicas,                     /*replicas*/
-		hamsterLabels,                              /*podLabels*/
-		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"k8s.gcr.io/ubuntu-slim:0.1",               /*image*/
-		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
+		"hamster-deployment",                           /*deploymentName*/
+		defaultHamsterReplicas,                         /*replicas*/
+		hamsterLabels,                                  /*podLabels*/
+		GetHamsterContainerNameByIndex(0),              /*imageName*/
+		"us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1", /*image*/
+		appsv1.RollingUpdateDeploymentStrategyType,     /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
@@ -279,7 +279,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "k8s.gcr.io/ubuntu-slim:0.1",
+		Image: "us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
@@ -286,7 +286,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 			// TODO(krzysied): Update the image url when the agnhost:2.10 image
 			// is promoted to the k8s-e2e-test-images repository.
 			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
-			sidecarParam  = "--sidecar-image=k8s.gcr.io/pause:3.1"
+			sidecarParam  = "--sidecar-image=us.gcr.io/k8s-artifacts-prod/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)
 			containerPort = int32(8444)
@@ -468,7 +468,7 @@ func setupHamsterController(f *framework.Framework, controllerKind, cpu, memory 
 
 func setupHamsterReplicationController(f *framework.Framework, cpu, memory string, replicas int32) {
 	hamsterContainer := SetupHamsterContainer(cpu, memory)
-	rc := framework.RcByNameContainer("hamster-rc", replicas, "k8s.gcr.io/ubuntu-slim:0.1",
+	rc := framework.RcByNameContainer("hamster-rc", replicas, "us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1",
 		hamsterLabels, hamsterContainer, nil)
 
 	rc.Namespace = f.Namespace.Name

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -140,12 +140,12 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		panic("container count should be greater than 0")
 	}
 	d := framework_deployment.NewDeployment(
-		"hamster-deployment",                       /*deploymentName*/
-		defaultHamsterReplicas,                     /*replicas*/
-		hamsterLabels,                              /*podLabels*/
-		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"k8s.gcr.io/ubuntu-slim:0.1",               /*image*/
-		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
+		"hamster-deployment",                           /*deploymentName*/
+		defaultHamsterReplicas,                         /*replicas*/
+		hamsterLabels,                                  /*podLabels*/
+		GetHamsterContainerNameByIndex(0),              /*imageName*/
+		"us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1", /*image*/
+		appsv1.RollingUpdateDeploymentStrategyType,     /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
@@ -279,7 +279,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "k8s.gcr.io/ubuntu-slim:0.1",
+		Image: "us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/generated.proto
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/generated.proto
@@ -776,7 +776,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.
@@ -5253,4 +5253,3 @@ message WindowsSecurityContextOptions {
   // +optional
   optional string runAsUserName = 3;
 }
-

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/types.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/types.go
@@ -4471,7 +4471,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -355,7 +355,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// When these values are updated, also update test/e2e/framework/util.go
-	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
+	defaultPodSandboxImageName    = "us.gcr.io/k8s-artifacts-prod/pause"
 	defaultPodSandboxImageVersion = "3.1"
 )
 

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "k8s.gcr.io/pause:3.1"
+	defaultSandboxImage = "us.gcr.io/k8s-artifacts-prod/pause:3.1"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
@@ -480,7 +480,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: k8s.gcr.io/test-webserver
+	//     - image: us.gcr.io/k8s-artifacts-prod/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd
@@ -518,7 +518,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: k8s.gcr.io/test-webserver
+	//     - image: us.gcr.io/k8s-artifacts-prod/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/test/utils/runners.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/kubernetes/test/utils/runners.go
@@ -1251,7 +1251,7 @@ func MakePodSpec() v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
 			Name:  "pause",
-			Image: "k8s.gcr.io/pause:3.1",
+			Image: "us.gcr.io/k8s-artifacts-prod/pause:3.1",
 			Ports: []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -1601,7 +1601,7 @@ type DaemonConfig struct {
 
 func (config *DaemonConfig) Run() error {
 	if config.Image == "" {
-		config.Image = "k8s.gcr.io/pause:3.1"
+		config.Image = "us.gcr.io/k8s-artifacts-prod/pause:3.1"
 	}
 	nameLabel := map[string]string{
 		"name": config.Name + "-daemon",

--- a/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: hamster
-          image: k8s.gcr.io/ubuntu-slim:0.1
+          image: us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: hamster
-          image: k8s.gcr.io/ubuntu-slim:0.1
+          image: us.gcr.io/k8s-artifacts-prod/ubuntu-slim:0.1
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/redis-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/redis-deprecated.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: k8s.gcr.io/redis:e2e  # or just image: redis
+          image: us.gcr.io/k8s-artifacts-prod/redis:e2e  # or just image: redis
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/redis.yaml
+++ b/vertical-pod-autoscaler/examples/redis.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: k8s.gcr.io/redis:e2e  # or just image: redis
+          image: us.gcr.io/k8s-artifacts-prod/redis:e2e  # or just image: redis
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/generated.proto
+++ b/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/generated.proto
@@ -776,7 +776,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.
@@ -5261,4 +5261,3 @@ message WindowsSecurityContextOptions {
   // +optional
   optional string runAsUserName = 3;
 }
-

--- a/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/types.go
+++ b/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/types.go
@@ -4470,7 +4470,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/vertical-pod-autoscaler/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -355,7 +355,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"us.gcr.io/k8s-artifacts-prod/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 


### PR DESCRIPTION
Update all repository references to prepare for the great [Vanity Domain Flip](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md) that is currently taking place.  This will help prevent broken references later.

In addition, there was a bunch of bad `godoc` formatting so I fixed that too (actually, VS Code kindly did it on our behalf).  You can ignore it in your diff output by appending `?w=1` to the GitHub URL.