### PR TITLE
Ensure VMSS is not under updating before scaling out

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -80,7 +80,7 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateAsync(ctx context
 
 // WaitForAsyncOperationResult waits for the response of the request
 func (client *VirtualMachineScaleSetsClientMock) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error) {
-	return nil, nil
+	return &http.Response{StatusCode: http.StatusOK}, nil
 }
 
 // DeleteInstances deletes a set of instances for specified VirtualMachineScaleSet.


### PR DESCRIPTION
Because of various reasons, the VM provisioning may need a long period and hence VMSS scaling requests would time out.

On such cases, the following scaling requests should check the provisioning state and only continue to scale after it has been finished. If the VMSS is still under updating, then CA should log an error and abort the current scaling step.

Fix #3018 

/kind bug
/area provider/azure

