### PR TITLE
VPA: Configurable container limit scaling

### DIFF
--- a/vertical-pod-autoscaler/e2e/go.mod
+++ b/vertical-pod-autoscaler/e2e/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/prometheus/procfs v0.0.6 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea // indirect
 	google.golang.org/appengine v1.6.5 // indirect
@@ -26,7 +25,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
-	k8s.io/autoscaler/vertical-pod-autoscaler v0.0.0-20200207133143-e7988a6dd041
+	k8s.io/autoscaler/vertical-pod-autoscaler v0.0.0-20200605154545-936eea18fb1d
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/component-base v0.0.0
 	k8s.io/klog v1.0.0

--- a/vertical-pod-autoscaler/e2e/go.sum
+++ b/vertical-pod-autoscaler/e2e/go.sum
@@ -545,8 +545,6 @@ golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
-golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/vertical-pod-autoscaler/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/e2e/v1/admission_controller.go
@@ -166,6 +166,44 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 		}
 	})
 
+	ginkgo.It("keeps limits unchanged when container controlled values is requests only", func() {
+		d := NewHamsterDeploymentWithResourcesAndLimits(f,
+			ParseQuantityOrDie("100m") /*cpu request*/, ParseQuantityOrDie("100Mi"), /*memory request*/
+			ParseQuantityOrDie("500m") /*cpu limit*/, ParseQuantityOrDie("500Mi") /*memory limit*/)
+
+		ginkgo.By("Setting up a VPA CRD")
+		vpaCRD := NewVPA(f, "hamster-vpa", hamsterTargetRef)
+		vpaCRD.Status.Recommendation = &vpa_types.RecommendedPodResources{
+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{{
+				ContainerName: "hamster",
+				Target: apiv1.ResourceList{
+					apiv1.ResourceCPU:    ParseQuantityOrDie("250m"),
+					apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+				},
+			}},
+		}
+		containerControlledValuesRequestsOnly := vpa_types.ContainerControlledValuesRequestsOnly
+		vpaCRD.Spec.ResourcePolicy = &vpa_types.PodResourcePolicy{
+			ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+				ContainerName:    "hamster",
+				ControlledValues: &containerControlledValuesRequestsOnly,
+			}},
+		}
+		InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Setting up a hamster deployment")
+		podList := startDeploymentPods(f, d)
+
+		// Originally Pods had 100m CPU, 100Mi of memory, but admission controller
+		// should change it to 250m CPU and 200Mi of memory. Limits should stay unchanged.
+		for _, pod := range podList.Items {
+			gomega.Expect(*pod.Spec.Containers[0].Resources.Requests.Cpu()).To(gomega.Equal(ParseQuantityOrDie("250m")))
+			gomega.Expect(*pod.Spec.Containers[0].Resources.Requests.Memory()).To(gomega.Equal(ParseQuantityOrDie("200Mi")))
+			gomega.Expect(*pod.Spec.Containers[0].Resources.Limits.Cpu()).To(gomega.Equal(ParseQuantityOrDie("500m")))
+			gomega.Expect(*pod.Spec.Containers[0].Resources.Limits.Memory()).To(gomega.Equal(ParseQuantityOrDie("500Mi")))
+		}
+	})
+
 	ginkgo.It("caps request according to container max limit set in LimitRange", func() {
 		startCpuRequest := ParseQuantityOrDie("100m")
 		startCpuLimit := ParseQuantityOrDie("150m")

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -147,6 +147,16 @@ type ContainerResourcePolicy struct {
 	// for the container. The default is no maximum.
 	// +optional
 	MaxAllowed v1.ResourceList `json:"maxAllowed,omitempty" protobuf:"bytes,4,rep,name=maxAllowed,casttype=ResourceList,castkey=ResourceName"`
+
+	// Specifies the type of recommendations that will be computed
+	// (and possibly applied) by VPA.
+	// If not specified, the default of [ResourceCPU, ResourceMemory] will be used.
+	ControlledResources *[]v1.ResourceName `json:"controlledResources,omitempty" patchStrategy:"merge" protobuf:"bytes,5,rep,name=controlledResources"`
+
+	// Specifies which resource values should be controlled.
+	// The default is "RequestsAndLimits".
+	// +optional
+	ControlledValues *ContainerControlledValues `json:"controlledValues,omitempty" protobuf:"bytes,6,rep,name=controlledValues"`
 }
 
 const (
@@ -164,6 +174,17 @@ const (
 	ContainerScalingModeAuto ContainerScalingMode = "Auto"
 	// ContainerScalingModeOff means autoscaling is disabled for a container.
 	ContainerScalingModeOff ContainerScalingMode = "Off"
+)
+
+// ContainerControlledValues controls which resource value should be autoscaled.
+type ContainerControlledValues string
+
+const (
+	// ContainerControlledValuesRequestsAndLimits means resource request and limits
+	// are scaled automatically. The limit is scaled proportionally to the request.
+	ContainerControlledValuesRequestsAndLimits ContainerControlledValues = "RequestsAndLimits"
+	// ContainerControlledValuesRequestsOnly means only requested resource is autoscaled.
+	ContainerControlledValuesRequestsOnly ContainerControlledValues = "RequestsOnly"
 )
 
 // VerticalPodAutoscalerStatus describes the runtime state of the autoscaler.

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -48,6 +48,20 @@ func (in *ContainerResourcePolicy) DeepCopyInto(out *ContainerResourcePolicy) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.ControlledResources != nil {
+		in, out := &in.ControlledResources, &out.ControlledResources
+		*out = new([]corev1.ResourceName)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]corev1.ResourceName, len(*in))
+			copy(*out, *in)
+		}
+	}
+	if in.ControlledValues != nil {
+		in, out := &in.ControlledValues, &out.ControlledValues
+		*out = new(ContainerControlledValues)
+		**out = **in
+	}
 	return
 }
 
@@ -256,7 +270,7 @@ func (in *VerticalPodAutoscalerCheckpoint) DeepCopyObject() runtime.Object {
 func (in *VerticalPodAutoscalerCheckpointList) DeepCopyInto(out *VerticalPodAutoscalerCheckpointList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscalerCheckpoint, len(*in))
@@ -343,7 +357,7 @@ func (in *VerticalPodAutoscalerCondition) DeepCopy() *VerticalPodAutoscalerCondi
 func (in *VerticalPodAutoscalerList) DeepCopyInto(out *VerticalPodAutoscalerList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscaler, len(*in))

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/zz_generated.deepcopy.go
@@ -256,7 +256,7 @@ func (in *VerticalPodAutoscalerCheckpoint) DeepCopyObject() runtime.Object {
 func (in *VerticalPodAutoscalerCheckpointList) DeepCopyInto(out *VerticalPodAutoscalerCheckpointList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscalerCheckpoint, len(*in))
@@ -343,7 +343,7 @@ func (in *VerticalPodAutoscalerCondition) DeepCopy() *VerticalPodAutoscalerCondi
 func (in *VerticalPodAutoscalerList) DeepCopyInto(out *VerticalPodAutoscalerList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscaler, len(*in))

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -256,7 +256,7 @@ func (in *VerticalPodAutoscalerCheckpoint) DeepCopyObject() runtime.Object {
 func (in *VerticalPodAutoscalerCheckpointList) DeepCopyInto(out *VerticalPodAutoscalerCheckpointList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscalerCheckpoint, len(*in))
@@ -343,7 +343,7 @@ func (in *VerticalPodAutoscalerCondition) DeepCopy() *VerticalPodAutoscalerCondi
 func (in *VerticalPodAutoscalerList) DeepCopyInto(out *VerticalPodAutoscalerList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscaler, len(*in))

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1/zz_generated.deepcopy.go
@@ -249,7 +249,7 @@ func (in *VerticalPodAutoscalerCheckpoint) DeepCopyObject() runtime.Object {
 func (in *VerticalPodAutoscalerCheckpointList) DeepCopyInto(out *VerticalPodAutoscalerCheckpointList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscalerCheckpoint, len(*in))
@@ -336,7 +336,7 @@ func (in *VerticalPodAutoscalerCondition) DeepCopy() *VerticalPodAutoscalerCondi
 func (in *VerticalPodAutoscalerList) DeepCopyInto(out *VerticalPodAutoscalerList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]VerticalPodAutoscaler, len(*in))

--- a/vertical-pod-autoscaler/e2e/vendor/modules.txt
+++ b/vertical-pod-autoscaler/e2e/vendor/modules.txt
@@ -925,7 +925,7 @@ k8s.io/apiserver/pkg/util/webhook
 k8s.io/apiserver/pkg/util/wsstream
 k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 k8s.io/apiserver/plugin/pkg/authorizer/webhook
-# k8s.io/autoscaler/vertical-pod-autoscaler v0.0.0-20200207133143-e7988a6dd041 => ../
+# k8s.io/autoscaler/vertical-pod-autoscaler v0.0.0-20200605154545-936eea18fb1d => ../
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -134,6 +134,12 @@ func validateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 					return fmt.Errorf("max resource for %v is lower than min", resource)
 				}
 			}
+			ControlledValues := policy.ControlledValues
+			if mode != nil && ControlledValues != nil {
+				if *mode == vpa_types.ContainerScalingModeOff && *ControlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
+					return fmt.Errorf("ControlledValues shouldn't be specified if container scaling mode is off.")
+				}
+			}
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -36,6 +36,8 @@ func TestValidateVPA(t *testing.T) {
 	validUpdateMode := vpa_types.UpdateModeOff
 	badScalingMode := vpa_types.ContainerScalingMode("bad")
 	validScalingMode := vpa_types.ContainerScalingModeAuto
+	scalingModeOff := vpa_types.ContainerScalingModeOff
+	controlledValuesRequestsAndLimits := vpa_types.ContainerControlledValuesRequestsAndLimits
 	tests := []struct {
 		name        string
 		vpa         vpa_types.VerticalPodAutoscaler
@@ -119,6 +121,23 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			expectError: fmt.Errorf("max resource for cpu is lower than min"),
+		},
+		{
+			name: "scaling off with controlled values requests and limits",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName:    "loot box",
+								Mode:             &scalingModeOff,
+								ControlledValues: &controlledValuesRequestsAndLimits,
+							},
+						},
+					},
+				},
+			},
+			expectError: fmt.Errorf("ControlledValues shouldn't be specified if container scaling mode is off."),
 		},
 		{
 			name: "all valid",

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -152,6 +152,11 @@ type ContainerResourcePolicy struct {
 	// (and possibly applied) by VPA.
 	// If not specified, the default of [ResourceCPU, ResourceMemory] will be used.
 	ControlledResources *[]v1.ResourceName `json:"controlledResources,omitempty" patchStrategy:"merge" protobuf:"bytes,5,rep,name=controlledResources"`
+
+	// Specifies which resource values should be controlled.
+	// The default is "RequestsAndLimits".
+	// +optional
+	ControlledValues *ContainerControlledValues `json:"controlledValues,omitempty" protobuf:"bytes,6,rep,name=controlledValues"`
 }
 
 const (
@@ -169,6 +174,17 @@ const (
 	ContainerScalingModeAuto ContainerScalingMode = "Auto"
 	// ContainerScalingModeOff means autoscaling is disabled for a container.
 	ContainerScalingModeOff ContainerScalingMode = "Off"
+)
+
+// ContainerControlledValues controls which resource value should be autoscaled.
+type ContainerControlledValues string
+
+const (
+	// ContainerControlledValuesRequestsAndLimits means resource request and limits
+	// are scaled automatically. The limit is scaled proportionally to the request.
+	ContainerControlledValuesRequestsAndLimits ContainerControlledValues = "RequestsAndLimits"
+	// ContainerControlledValuesRequestsOnly means only requested resource is autoscaled.
+	ContainerControlledValuesRequestsOnly ContainerControlledValues = "RequestsOnly"
 )
 
 // VerticalPodAutoscalerStatus describes the runtime state of the autoscaler.

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -57,6 +57,11 @@ func (in *ContainerResourcePolicy) DeepCopyInto(out *ContainerResourcePolicy) {
 			copy(*out, *in)
 		}
 	}
+	if in.ControlledValues != nil {
+		in, out := &in.ControlledValues, &out.ControlledValues
+		*out = new(ContainerControlledValues)
+		**out = **in
+	}
 	return
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -37,6 +37,7 @@ type cappingAction string
 var (
 	cappedToMinAllowed             cappingAction = "capped to minAllowed"
 	cappedToMaxAllowed             cappingAction = "capped to maxAllowed"
+	cappedToLimit                  cappingAction = "capped to container limit"
 	cappedProportionallyToMaxLimit cappingAction = "capped to fit Max in container LimitRange"
 	cappedProportionallyToMinLimit cappingAction = "capped to fit Min in container LimitRange"
 )
@@ -121,6 +122,11 @@ func getCappedRecommendationForContainer(
 			cappingAnnotations = append(cappingAnnotations, limitAnnotations...)
 			cappingAnnotations = append(cappingAnnotations, annotations...)
 		}
+		// TODO: If limits and policy are conflicting, set some condition on the VPA.
+		annotations = capRecommendationToContainerLimit(recommendation, container)
+		if genAnnotations {
+			cappingAnnotations = append(cappingAnnotations, annotations...)
+		}
 	}
 
 	process(cappedRecommendations.Target, true)
@@ -128,6 +134,21 @@ func getCappedRecommendationForContainer(
 	process(cappedRecommendations.UpperBound, false)
 
 	return cappedRecommendations, cappingAnnotations, nil
+}
+
+// capRecommendationToContainerLimit makes sure recommendation is not above current limit for the container.
+// If this function makes adjustments appropriate annotations are returned.
+func capRecommendationToContainerLimit(recommendation apiv1.ResourceList, container apiv1.Container) []string {
+	annotations := make([]string, 0)
+	// Iterate over limits set in the container. Unset means Infinite limit.
+	for resourceName, limit := range container.Resources.Limits {
+		recommendedValue, found := recommendation[resourceName]
+		if found && recommendedValue.MilliValue() > limit.MilliValue() {
+			recommendation[resourceName] = limit
+			annotations = append(annotations, toCappingAnnotation(resourceName, cappedToLimit))
+		}
+	}
+	return annotations
 }
 
 // applyVPAPolicy updates recommendation if recommended resources are outside of limits defined in VPA resources policy


### PR DESCRIPTION
Make the proportional limit scaling configurable.

Follow up of https://github.com/kubernetes/autoscaler/issues/2359, https://github.com/kubernetes/autoscaler/pull/2362 and https://github.com/kubernetes/autoscaler/issues/2387

I'm happy to update the generated files and add tests if the approach looks acceptable.

//cc @Avanpourm @bskiba