### PR TITLE
VPA: Fix recommender's Prometheus CPU history

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -80,6 +80,7 @@ func main() {
 			CtrPodNameLabel:        *ctrPodNameLabel,
 			CtrNameLabel:           *ctrNameLabel,
 			CadvisorMetricsJobName: *prometheusJobName,
+			MetricsFetchInterval:   *metricsFetcherInterval,
 		}
 		recommender.GetClusterStateFeeder().InitFromHistoryProvider(history.NewPrometheusHistoryProvider(config))
 	}


### PR DESCRIPTION
There are some WIP pull requests that are quite large in scope. What if we use a subquery syntax to fix the issue with historical CPU metrics?

https://github.com/kubernetes/autoscaler/pull/2549
https://github.com/kubernetes/autoscaler/pull/2551
https://github.com/kubernetes/autoscaler/issues/2543

fixes https://github.com/kubernetes/autoscaler/issues/2508