### PR TITLE
CA 1.18: Remove checking for VMSS provisioningState before scaling

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -40,7 +40,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 var (
@@ -268,17 +267,9 @@ func (scaleSet *ScaleSet) SetScaleSetSize(size int64) error {
 		return rerr.Error()
 	}
 
-	// Abort scaling to avoid concurrent VMSS scaling if the VMSS is still under updating.
-	// Note that the VMSS provisioning state would be updated per scaleSet.sizeRefreshPeriod.
-	if vmssInfo.VirtualMachineScaleSetProperties != nil && strings.EqualFold(to.String(vmssInfo.VirtualMachineScaleSetProperties.ProvisioningState), string(compute.ProvisioningStateUpdating)) {
-		klog.Errorf("VMSS %q is still under updating, waiting for it finishes before scaling", scaleSet.Name)
-		return fmt.Errorf("VMSS %q is still under updating", scaleSet.Name)
-	}
-
 	// Update the new capacity to cache.
 	vmssSizeMutex.Lock()
 	vmssInfo.Sku.Capacity = &size
-	vmssInfo.VirtualMachineScaleSetProperties.ProvisioningState = to.StringPtr(string(compute.ProvisioningStateUpdating))
 	vmssSizeMutex.Unlock()
 
 	// Compose a new VMSS for updating.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest"
@@ -126,29 +125,9 @@ func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
 	provider, err := BuildAzureCloudProvider(manager, nil)
 	assert.NoError(t, err)
 
-	// Scaling should fail because VMSS is still under updating.
+	// Scaling should continue even VMSS is under updating.
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
-	err = scaleSet.IncreaseSize(1)
-	assert.Equal(t, fmt.Errorf("VMSS %q is still under updating", scaleSet.Name), err)
-
-	// Scaling should succeed after VMSS ProvisioningState changed to succeeded.
-	scaleSetClient.FakeStore = map[string]map[string]compute.VirtualMachineScaleSet{
-		"test": {
-			vmssName: {
-				Name: &vmssName,
-				Sku: &compute.Sku{
-					Capacity: &vmssCapacity,
-				},
-				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-					ProvisioningState: to.StringPtr(string(compute.ProvisioningStateSucceeded)),
-				},
-			},
-		},
-	}
-	scaleSetStatusCache.mutex.Lock()
-	scaleSetStatusCache.lastRefresh = time.Now().Add(-1 * scaleSet.sizeRefreshPeriod)
-	scaleSetStatusCache.mutex.Unlock()
 	err = scaleSet.IncreaseSize(1)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
cherry pick #3037 to CA 1.18: Remove checking for VMSS provisioningState before scaling.

/kind bug
/area provider/azure
/cc @marwanad