### PR TITLE
Ignore AWS NodeWithImpairedVolumes taint

### DIFF
--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -17,11 +17,11 @@ limitations under the License.
 package taints
 
 import (
-	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	"k8s.io/klog"
@@ -34,6 +34,9 @@ const (
 	IgnoreTaintPrefix = "ignore-taint.cluster-autoscaler.kubernetes.io/"
 
 	gkeNodeTerminationHandlerTaint = "cloud.google.com/impending-node-termination"
+
+	// AWS: Indicates that a node has volumes stuck in attaching state and hence it is not fit for scheduling more pods
+	awsNodeWithImpairedVolumesTaint = "NodeWithImpairedVolumes"
 )
 
 // TaintKeySet is a set of taint key
@@ -52,6 +55,7 @@ var (
 		cloudproviderapi.TaintExternalCloudProvider: true,
 		cloudproviderapi.TaintNodeShutdown:          true,
 		gkeNodeTerminationHandlerTaint:              true,
+		awsNodeWithImpairedVolumesTaint:             true,
 	}
 )
 


### PR DESCRIPTION
The `NodeWithImpairedVolumes` taint is applied to node on AWS when a volume is stuck in attaching state for too long.

The taint was introduced in k8s a while ago https://github.com/kubernetes/kubernetes/pull/55558

Add it to the ignored node condition taints.