### PR TITLE
Cherry-pick #3036: Proactively decrement scale set count during deletion operations

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -206,8 +206,20 @@ func TestDeleteNodes(t *testing.T) {
 	}
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
+
+	targetSize, err := scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 5, targetSize)
+
+	// Perform the delete operation
 	err = scaleSet.DeleteNodes([]*apiv1.Node{node})
 	assert.NoError(t, err)
+
+	// Ensure the the cached size has been proactively decremented
+	targetSize, err = scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, targetSize)
+
 	scaleSetClient.AssertNumberOfCalls(t, "DeleteInstances", 1)
 }
 


### PR DESCRIPTION
This is to avoid stale cache reads which might deem a node deletable and cause the scale-down operation to below minimum node count.

/area provider/azure
/kind bug