### PR TITLE
Scalability: Switch to deltaClusterSnapshot

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
@@ -293,6 +294,7 @@ func buildAutoscaler() (core.Autoscaler, error) {
 
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions: autoscalingOptions,
+		ClusterSnapshot:    simulator.NewDeltaClusterSnapshot(),
 		KubeClient:         kubeClient,
 		EventsKubeClient:   eventsKubeClient,
 	}


### PR DESCRIPTION
This massively speeds up checking predicates.