### PR TITLE
Cherry-pick #3019: Correct cloudprovider/azure's GPULabel to "accelerator"

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -34,7 +34,7 @@ const (
 	ProviderName = "azure"
 
 	// GPULabel is the label added to nodes with GPU resource.
-	GPULabel = "cloud.google.com/gke-accelerator"
+	GPULabel = "accelerator"
 )
 
 var (


### PR DESCRIPTION
#3019 