### PR TITLE
Allow max size to be zero when fetching from VMSS tags

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -643,9 +643,6 @@ func (m *AzureManager) listScaleSets(filter []labelAutoDiscoveryConfig) ([]cloud
 		} else {
 			return asgs, fmt.Errorf("no maximum size specified for vmss: %s", *scaleSet.Name)
 		}
-		if spec.MaxSize < 1 {
-			return asgs, fmt.Errorf("maximum size must be greater than 1 node")
-		}
 		if spec.MaxSize < spec.MinSize {
 			return asgs, fmt.Errorf("maximum size must be greater than minimum size")
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -247,11 +247,6 @@ func TestListScalesets(t *testing.T) {
 			expectedErrString: fmt.Sprintf("no maximum size specified for vmss: %s", vmssName),
 		},
 		{
-			name:              "MaxLessThanOne",
-			specs:             map[string]string{"min": "5", "max": "-5"},
-			expectedErrString: "maximum size must be greater than 1 node",
-		},
-		{
 			name:              "MinLessThanZero",
 			specs:             map[string]string{"min": "-4", "max": "20"},
 			expectedErrString: fmt.Sprintf("minimum size must be a non-negative number of nodes"),


### PR DESCRIPTION
The max size should allow to be zero when min size is zero too.