### PR TITLE
fix vpa yamls

### DIFF
--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-recommender
-  namespace: kube-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-updater
-  namespace: kube-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -1,3 +1,9 @@
+--- ## rbac for vpa-recommender only
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-recommender
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,6 +18,121 @@ rules:
       - get
       - list
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-checkpoint-actor
+rules:
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-checkpoint-actor-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-checkpoint-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---  ## rbac for vpa-updater only
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-updater
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:evictioner
+rules:
+  - apiGroups:
+      - "apps"
+      - "extensions"
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-evictionter-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:evictioner
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-reader
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-reader
+subjects:
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
+---  ## rbac for both vpa-recommender and vpa-updater
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -37,15 +158,6 @@ rules:
       - watch
       - create
   - apiGroups:
-      - "poc.autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-  - apiGroups:
       - "autoscaling.k8s.io"
     resources:
       - verticalpodautoscalers
@@ -56,76 +168,9 @@ rules:
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:vpa-checkpoint-actor
-rules:
-  - apiGroups:
-      - "poc.autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalercheckpoints
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - patch
-      - delete
-  - apiGroups:
-      - "autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalercheckpoints
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:evictioner
-rules:
-  - apiGroups:
-      - "apps"
-      - "extensions"
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
-      - pods/eviction
-    verbs:
-      - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:metrics-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:metrics-reader
-subjects:
-  - kind: ServiceAccount
-    name: vpa-recommender
-    namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:vpa-actor
+  name: system:vpa-actor-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -137,20 +182,70 @@ subjects:
   - kind: ServiceAccount
     name: vpa-updater
     namespace: kube-system
+--- ## rbac only for vpa-admission-controller
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-admission-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - nodes
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-checkpoint-actor
+  name: system:vpa-admission-controller-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-checkpoint-actor
+  name: system:vpa-admission-controller
 subjects:
   - kind: ServiceAccount
-    name: vpa-recommender
+    name: vpa-admission-controller
     namespace: kube-system
----
+--- ## rbac for all three vpa-recommender, vpa-updater, vpa-admission-controller
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -200,117 +295,6 @@ subjects:
   - kind: ServiceAccount
     name: vpa-admission-controller
     namespace: kube-system
-  - kind: ServiceAccount
-    name: vpa-updater
-    namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:vpa-evictionter-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:evictioner
-subjects:
-  - kind: ServiceAccount
-    name: vpa-updater
-    namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-admission-controller
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:vpa-admission-controller
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - configmaps
-      - nodes
-      - limitranges
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "admissionregistration.k8s.io"
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-  - apiGroups:
-      - "poc.autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - leases
-    verbs:
-      - create
-      - update
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:vpa-admission-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:vpa-admission-controller
-subjects:
-  - kind: ServiceAccount
-    name: vpa-admission-controller
-    namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:vpa-status-reader
-rules:
-  - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:vpa-status-reader-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:vpa-status-reader
-subjects:
   - kind: ServiceAccount
     name: vpa-updater
     namespace: kube-system

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -73,10 +73,10 @@ for i in ${COMPONENTS}; do
   make --directory ${SCRIPT_ROOT}/pkg/${i} release
 done
 
-kubectl create -f ${SCRIPT_ROOT}/deploy/vpa-v1-crd.yaml
-kubectl create -f ${SCRIPT_ROOT}/deploy/vpa-rbac.yaml
+kubectl apply -f ${SCRIPT_ROOT}/deploy/vpa-v1-crd.yaml
+kubectl apply -f ${SCRIPT_ROOT}/deploy/vpa-rbac.yaml
 
 for i in ${COMPONENTS}; do
-  ${SCRIPT_ROOT}/hack/vpa-process-yaml.sh  ${SCRIPT_ROOT}/deploy/${i}-deployment.yaml | kubectl create -f -
+  ${SCRIPT_ROOT}/hack/vpa-process-yaml.sh  ${SCRIPT_ROOT}/deploy/${i}-deployment.yaml | kubectl apply -f -
 done
 

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -22,7 +22,7 @@ SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
 function print_help {
   echo "ERROR! Usage: vpa-process-yamls.sh <action> [<component>]"
-  echo "<action> should be either 'create' or 'delete'."
+  echo "<action> should be either 'apply' or 'delete'."
   echo "<component> might be one of 'admission-controller', 'updater', 'recommender'."
   echo "If <component> is set, only the deployment of that component will be processed,"
   echo "otherwise all components and configs will be processed."
@@ -39,9 +39,9 @@ if [ $# -gt 2 ]; then
 fi
 
 ACTION=$1
-COMPONENTS="vpa-beta2-crd vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
+COMPONENTS="vpa-v1-crd vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
 if [ ${ACTION} == delete ]; then
-  COMPONENTS+=" vpa-beta2-crd"
+  COMPONENTS+=" vpa-v1-crd"
 fi
 
 if [ $# -gt 1 ]; then
@@ -50,7 +50,7 @@ fi
 
 for i in $COMPONENTS; do
   if [ $i == admission-controller-deployment ] ; then
-    if [ ${ACTION} == create ] ; then
+    if [ ${ACTION} == apply ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/gencerts.sh || true)
     elif [ ${ACTION} == delete ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/rmcerts.sh || true)

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -20,4 +20,4 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
-$SCRIPT_ROOT/hack/vpa-process-yamls.sh create $*
+$SCRIPT_ROOT/hack/vpa-process-yamls.sh apply $*


### PR DESCRIPTION
- [X] use vpa v1 crd
- [X] use `apply` instead of `create`
- [X] remove `poc.autoscaling.k8s.io` group permissions from rbac
- [X] organize rbac into groupings per recommender, updater and admission controller