### PR TITLE
Switch VPA default deployment to 0.8.0

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
         - name: admission-controller
-          image: k8s.gcr.io/vpa-admission-controller:0.6.3
+          image: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller:0.8.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: vpa-recommender
       containers:
       - name: recommender
-        image: k8s.gcr.io/vpa-recommender:0.6.3
+        image: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender:0.8.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: vpa-updater
       containers:
         - name: updater
-          image: k8s.gcr.io/vpa-updater:0.6.3
+          image: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater:0.8.0
           imagePullPolicy: Always
           resources:
             limits:

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -31,8 +31,8 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-DEFAULT_REGISTRY="k8s.gcr.io"
-DEFAULT_TAG="0.6.3"
+DEFAULT_REGISTRY="us.gcr.io/k8s-artifacts-prod/autoscaling"
+DEFAULT_TAG="0.8.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -39,7 +39,7 @@ if [ $# -gt 2 ]; then
 fi
 
 ACTION=$1
-COMPONENTS="vpa-beta2-crd vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
+COMPONENTS="vpa-v1-crd vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
 if [ ${ACTION} == delete ]; then
   COMPONENTS+=" vpa-beta2-crd"
 fi


### PR DESCRIPTION
Includes a change to the new image repository as per k8s vanity domain flip (https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md)