### PR TITLE
digitalocean: fix min size bug

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -144,7 +144,7 @@ func (n *NodeGroup) DecreaseTargetSize(delta int) error {
 	}
 
 	targetSize := n.nodePool.Count + delta
-	if targetSize <= n.MinSize() {
+	if targetSize < n.MinSize() {
 		return fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
 			n.nodePool.Count, targetSize, n.MinSize())
 	}

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -182,6 +182,34 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("successful decrease to minimum", func(t *testing.T) {
+		client := &doClientMock{}
+		ng := testNodeGroup(client, &godo.KubernetesNodePool{
+			Count:     2,
+			AutoScale: true,
+			MinNodes:  1,
+			MaxNodes:  5,
+		})
+
+		delta := -1
+		newCount := ng.nodePool.Count + delta
+		client.On("UpdateNodePool",
+			ctx,
+			ng.clusterID,
+			ng.id,
+			&godo.KubernetesNodePoolUpdateRequest{
+				Count: &newCount,
+			},
+		).Return(
+			&godo.KubernetesNodePool{Count: newCount},
+			&godo.Response{},
+			nil,
+		).Once()
+
+		err := ng.DecreaseTargetSize(delta)
+		assert.NoError(t, err)
+	})
+
 	t.Run("positive decrease", func(t *testing.T) {
 		numberOfNodes := 5
 		client := &doClientMock{}
@@ -216,7 +244,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		client := &doClientMock{}
 		ng := testNodeGroup(client, &godo.KubernetesNodePool{
 			Count:    numberOfNodes,
-			MinNodes: 1,
+			MinNodes: 2,
 			MaxNodes: 5,
 		})
 


### PR DESCRIPTION
Previously we were rejecting decreases down to the min size due to a logic error -- use of `<=` where we should have been using `<`.