### PR TITLE
Add api-approved label to the Vertical Pod Autoscaler API

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalers.autoscaling.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
 spec:
   group: autoscaling.k8s.io
   scope: Namespaced
@@ -66,6 +68,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
 spec:
   group: autoscaling.k8s.io
   scope: Namespaced


### PR DESCRIPTION
Resources are part of verticalpodautoscalers.autoscaling.k8s.io
- VerticalPodAutoscaler is an api resource for configuring vertical autoscaling for pods.
- VerticalPodAutoscalerCheckpoint is an API resource used internally by the Vertical Pod Autoscaler to store its additional state.

The API was discussed and approved in https://github.com/kubernetes/kubernetes/pull/63797
The design itself was discussed and approved in https://github.com/kubernetes/community/pull/338

Fixes #3069 