### PR TITLE
backport #2171: ignore azure agentpool label when comparing nodegroups for similarity

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -99,6 +99,7 @@ func IsNodeInfoSimilar(n1, n2 *schedulernodeinfo.NodeInfo) bool {
 		"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
 		"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
 		"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
+		"agentpool":                           true, // this is a label used in Azure clusters deployed with aks-engine or AKS. Each node has an "agentpool" label that identifies this nodepool.
 	}
 
 	labels := make(map[string][]string)

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
@@ -120,6 +120,11 @@ func TestNodesSimilarVariousLabels(t *testing.T) {
 	n2.ObjectMeta.Labels[apiv1.LabelZoneFailureDomain] = "us-houston1-a"
 	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, true)
 
+	// Different agentpool labels shouldn't matter
+	n1.ObjectMeta.Labels["agentpool"] = "pool1"
+	n2.ObjectMeta.Labels["agentpool"] = "pool2"
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, true)
+
 	// Different beta.kubernetes.io/fluentd-ds-ready should not matter
 	n1.ObjectMeta.Labels["beta.kubernetes.io/fluentd-ds-ready"] = "true"
 	n2.ObjectMeta.Labels["beta.kubernetes.io/fluentd-ds-ready"] = "false"


### PR DESCRIPTION
This backports the changes in #2171 to 1.15 so that balancing nodegroups works properly. It's not a clean cherry-pick because the PR introduces nodegroupsets per cloud-provider where this ignored label logic lives. 

I've noticed the label for eksctl added so wondering if we could do the same for 1.15.

/area provider/azure