### PR TITLE
Add missing daemonsets and replicasets to ALI example cluster role

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-standard.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets"]
+  resources: ["statefulsets", "replicasets", "daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
The ALI examples appear to be missing the daemonsets and replicasets resource under the apps apiGroups 

**Which issue(s) this PR fixes:**
#3085
