### PR TITLE
[CA-1.18] #2934 cherry-pick: Fixes 2932: let the capi version to be discovered

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -146,12 +147,17 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 		klog.Fatalf("could not generate dynamic client for config")
 	}
 
-	kubeclient, err := kubernetes.NewForConfig(externalConfig)
+	kubeClient, err := kubernetes.NewForConfig(externalConfig)
 	if err != nil {
 		klog.Fatalf("create kube clientset failed: %v", err)
 	}
 
-	controller, err := newMachineController(dc, kubeclient)
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(externalConfig)
+	if err != nil {
+		klog.Fatalf("create discovery client failed: %v", err)
+	}
+
+	controller, err := newMachineController(dc, kubeClient, discoveryClient)
 	if err != nil {
 		klog.Fatal(err)
 	}


### PR DESCRIPTION
This PR proposes to cherry-pick #2934 to the `cluster-autoscaler-release-1.18` branch.

With Cluster Autoscaler v1.18.0, it's possible to use the Cluster-API provider. However, there is a bug that makes the provider unusable for some users.

The provider supports all Cluster-API groups and versions, but in the original PR, the group and version are hardcoded. Users that are not using v1alpha2 have two options, which are not optimal:
* Wait for Cluster Autoscaler v1.19.0, which will come up with K8s 1.19.0. The problem is that it's somewhere in August, so that could be a bit long to wait
* Build the image which includes the fix manually, which is not the greatest approach.

The PR (#2934) that fixes this could be looked at as a bugfix and it doesn't introduce any behavior changes (the default group is still `cluster.x-k8s.io` and version will be auto-discovered). I believe that it would make sense to cherry-pick it to the release-1.18 branch, so the bugfix is included in the next patch release. That would make the provider useful for all users, regardless of the group and version they are using.

Original PR description:
```
…API version.
This change adds detection for an environment variable to specify the group for the clusterapi resources. If the environment
variable `CAPI_GROUP` is specified, then it will
be used instead of the default.
This also decouples the API group from the version and let the latter to be discovered dynamically.
```

cc @elmiko 