### PR TITLE
[WIP] Assign result of InstanceType creation on initialisation when dynamic

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -368,7 +368,9 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 			keys = append(keys, key)
 		}
 
-		klog.Infof("Successfully load %d EC2 Instance Types %s", len(keys), keys)
+		klog.Infof("Successfully loaded %d EC2 Instance Types %s", len(keys), keys)
+		// TODO: Move away from global variable
+		InstanceTypes = instanceTypes
 	}
 
 	manager, err := CreateAwsManager(config, do)


### PR DESCRIPTION
* Resolves #3109

* Still to add tests before ready to merge

This isn't currently the best approach I think. It's highlighted the that the `instanceTypes` of the `awsCloudProvider` doesn't actually appear to be used anywhere currently.