### PR TITLE
Cherry-pick #1982: Allow Azure VMSS to scale from 0 with taints and labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -25,6 +25,12 @@ az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<subscrip
 
 This will create a new [service principal][] with "Contributor" role scoped to your subscription. Save the JSON output, because it will be needed to configure the cluster autoscaler deployment in the next step.
 
+## Scaling a node group to and from 0
+
+If you are using `nodeSelector`, you need to tag the VMSS  with a node-template key `"k8s.io|cluster-autoscaler|node-template|label|"` for using labels and and `"k8s.io|cluster-autoscaler|node-template|taint|"` if you are using taints.
+
+> Note that these tags use the pipe `|` character compared to a forward slash due to [Azure tag name restrictions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-using-tags).
+
 ## Deployment manifests
 
 Cluster autoscaler supports four Kubernetes cluster options on Azure:

--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -25,11 +25,25 @@ az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<subscrip
 
 This will create a new [service principal][] with "Contributor" role scoped to your subscription. Save the JSON output, because it will be needed to configure the cluster autoscaler deployment in the next step.
 
-## Scaling a node group to and from 0
+## Scaling a VMSS node group to and from 0
 
-If you are using `nodeSelector`, you need to tag the VMSS  with a node-template key `"k8s.io|cluster-autoscaler|node-template|label|"` for using labels and and `"k8s.io|cluster-autoscaler|node-template|taint|"` if you are using taints.
+If you are using `nodeSelector`, you need to tag the VMSS  with a node-template key `"k8s.io_cluster-autoscaler_node-template_label_"` for using labels and `"k8s.io_cluster-autoscaler_node-template_taint_"` if you are using taints.
 
-> Note that these tags use the pipe `|` character compared to a forward slash due to [Azure tag name restrictions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-using-tags).
+> Note that these tags use the pipe `_` character compared to a forward slash due to [Azure tag name restrictions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-using-tags).
+
+### Examples
+
+#### Labels
+
+To add the label of `foo=bar` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_label_foo: bar`.
+
+You can also use forward slashes in the labels by setting them as an underscore in the tag name. For example to add the label of `k8s.io/foo=bar` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_label_k8s.io_foo: bar`
+
+#### Taints
+
+To add the taint of `foo=bar:NoSchedule` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_taint_foo: bar:NoSchedule`.
+
+You can also use forward slashes in taints by setting them as an underscore in the tag name. For example to add the taint of `k8s.io/foo=bar:NoSchedule` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_taint_k8s.io_foo: bar:NoSchedule`
 
 ## Deployment manifests
 
@@ -76,8 +90,8 @@ or to autoscale multiple VM scale sets:
         - --nodes=1:10:k8s-nodepool-2-vmss
 ```
 
-Note that it doesn't mean the number of nodes in nodepool is restricted in the 
-range from 1 to 10. It means when ca is downscaling (upscaling) the nodepool, 
+Note that it doesn't mean the number of nodes in nodepool is restricted in the
+range from 1 to 10. It means when ca is downscaling (upscaling) the nodepool,
 it will never break the limit of 1 (10). If the current node pool size is lower than the specified minimum or greater than the specified maximum when you enable autoscaling, the autoscaler waits to take effect until a new node is needed in the node pool or until a node can be safely deleted from the node pool.
 
 To allow scaling similar node pools simultaneously, or when using separate node groups per zone and to keep nodes balanced across zones, use the `--balance-similar-node-groups` flag (default false). Add it to the `command` section to enable it:

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -569,6 +570,47 @@ func (scaleSet *ScaleSet) buildNodeFromTemplate(template compute.VirtualMachineS
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, buildGenericLabels(template, nodeName))
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
 	return &node, nil
+}
+
+func extractLabelsFromScaleSet(tags map[string]*string) map[string]string {
+	result := make(map[string]string)
+
+	for tagName, tagValue := range tags {
+		splits := strings.Split(tagName, nodeLabelTagName)
+		if len(splits) > 1 {
+			label := splits[1]
+			if label != "" {
+				result[label] = *tagValue
+			}
+		}
+	}
+
+	return result
+}
+
+func extractTaintsFromScaleSet(tags map[string]*string) []apiv1.Taint {
+	taints := make([]apiv1.Taint, 0)
+
+	for tagName, tagValue := range tags {
+		// The tag value must be in the format <tag>:NoSchedule
+		r, _ := regexp.Compile("(.*):(?:NoSchedule|NoExecute|PreferNoSchedule)")
+
+		if r.MatchString(*tagValue) {
+			splits := strings.Split(tagName, nodeTaintTagName)
+			if len(splits) > 1 {
+				values := strings.SplitN(*tagValue, ":", 2)
+				if len(values) > 1 {
+					taints = append(taints, apiv1.Taint{
+						Key:    splits[1],
+						Value:  values[0],
+						Effect: apiv1.TaintEffect(values[1]),
+					})
+				}
+			}
+		}
+	}
+
+	return taints
 }
 
 // TemplateNodeInfo returns a node template for this scale set.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -578,7 +578,7 @@ func extractLabelsFromScaleSet(tags map[string]*string) map[string]string {
 	for tagName, tagValue := range tags {
 		splits := strings.Split(tagName, nodeLabelTagName)
 		if len(splits) > 1 {
-			label := splits[1]
+			label := strings.Replace(splits[1], "_", "/", -1)
 			if label != "" {
 				result[label] = *tagValue
 			}
@@ -600,8 +600,9 @@ func extractTaintsFromScaleSet(tags map[string]*string) []apiv1.Taint {
 			if len(splits) > 1 {
 				values := strings.SplitN(*tagValue, ":", 2)
 				if len(values) > 1 {
+					taintKey := strings.Replace(splits[1], "_", "/", -1)
 					taints = append(taints, apiv1.Taint{
-						Key:    splits[1],
+						Key:    taintKey,
 						Value:  values[0],
 						Effect: apiv1.TaintEffect(values[1]),
 					})

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -320,9 +320,10 @@ func TestExtractTaintsFromScaleSet(t *testing.T) {
 	regularTagValue := "baz"
 
 	tags := map[string]*string{
-		fmt.Sprintf("%s%s", nodeTaintTagName, "dedicated"): &noScheduleTaintValue,
-		fmt.Sprintf("%s%s", nodeTaintTagName, "group"):     &noExecuteTaintValue,
-		fmt.Sprintf("%s%s", nodeTaintTagName, "app"):       &preferNoScheduleTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "dedicated"):                          &noScheduleTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "group"):                              &noExecuteTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "app"):                                &preferNoScheduleTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "k8s.io_testing_underscore_to_slash"): &preferNoScheduleTaintValue,
 		"bar": &regularTagValue,
 		fmt.Sprintf("%s%s", nodeTaintTagName, "blank"):   &blankTaintValue,
 		fmt.Sprintf("%s%s", nodeTaintTagName, "nosplit"): &noSplitTaintValue,
@@ -344,10 +345,15 @@ func TestExtractTaintsFromScaleSet(t *testing.T) {
 			Value:  "fizz",
 			Effect: apiv1.TaintEffectPreferNoSchedule,
 		},
+		{
+			Key:    "k8s.io/testing/underscore/to/slash",
+			Value:  "fizz",
+			Effect: apiv1.TaintEffectPreferNoSchedule,
+		},
 	}
 
 	taints := extractTaintsFromScaleSet(tags)
-	assert.Len(t, taints, 3)
+	assert.Len(t, taints, 4)
 	assert.Equal(t, makeTaintSet(expectedTaints), makeTaintSet(taints))
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -292,4 +293,68 @@ func TestTemplateNodeInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeInfo)
 	assert.NotEmpty(t, nodeInfo.Pods())
+}
+func TestExtractLabelsFromScaleSet(t *testing.T) {
+	expectedNodeLabelKey := "zip"
+	expectedNodeLabelValue := "zap"
+	extraNodeLabelValue := "buzz"
+	blankString := ""
+
+	tags := map[string]*string{
+		fmt.Sprintf("%s%s", nodeLabelTagName, expectedNodeLabelKey): &expectedNodeLabelValue,
+		"fizz": &extraNodeLabelValue,
+		"bip":  &blankString,
+	}
+
+	labels := extractLabelsFromScaleSet(tags)
+	assert.Len(t, labels, 1)
+	assert.Equal(t, expectedNodeLabelValue, labels[expectedNodeLabelKey])
+}
+
+func TestExtractTaintsFromScaleSet(t *testing.T) {
+	noScheduleTaintValue := "foo:NoSchedule"
+	noExecuteTaintValue := "bar:NoExecute"
+	preferNoScheduleTaintValue := "fizz:PreferNoSchedule"
+	noSplitTaintValue := "some_value"
+	blankTaintValue := ""
+	regularTagValue := "baz"
+
+	tags := map[string]*string{
+		fmt.Sprintf("%s%s", nodeTaintTagName, "dedicated"): &noScheduleTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "group"):     &noExecuteTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "app"):       &preferNoScheduleTaintValue,
+		"bar": &regularTagValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "blank"):   &blankTaintValue,
+		fmt.Sprintf("%s%s", nodeTaintTagName, "nosplit"): &noSplitTaintValue,
+	}
+
+	expectedTaints := []apiv1.Taint{
+		{
+			Key:    "dedicated",
+			Value:  "foo",
+			Effect: apiv1.TaintEffectNoSchedule,
+		},
+		{
+			Key:    "group",
+			Value:  "bar",
+			Effect: apiv1.TaintEffectNoExecute,
+		},
+		{
+			Key:    "app",
+			Value:  "fizz",
+			Effect: apiv1.TaintEffectPreferNoSchedule,
+		},
+	}
+
+	taints := extractTaintsFromScaleSet(tags)
+	assert.Len(t, taints, 3)
+	assert.Equal(t, makeTaintSet(expectedTaints), makeTaintSet(taints))
+}
+
+func makeTaintSet(taints []apiv1.Taint) map[apiv1.Taint]bool {
+	set := make(map[apiv1.Taint]bool)
+	for _, taint := range taints {
+		set[taint] = true
+	}
+	return set
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -76,6 +76,9 @@ const (
 	k8sWindowsVMAgentPoolPrefixIndex       = 1
 	k8sWindowsVMAgentOrchestratorNameIndex = 2
 	k8sWindowsVMAgentPoolInfoIndex         = 3
+
+	nodeLabelTagName = "k8s.io_cluster-autoscaler_node-template_label_"
+	nodeTaintTagName = "k8s.io_cluster-autoscaler_node-template_taint_"
 )
 
 var (


### PR DESCRIPTION
Add the functionality to the Azure cloud provider to enable scaling up and down from 0 with tainted and labeled VMSS

Cherry-pick #1982 

/area provider/azure