### PR TITLE
cluster-autoscaler: Allow Azure Rate Limit Defaults to be set from the environment

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -260,12 +260,12 @@ The new version of [Azure client][] supports rate limit and back-off retries whe
 | CloudProviderBackoffDuration | 5 | BACKOFF_DURATION | cloudProviderBackoffDuration |
 | CloudProviderBackoffJitter | 1.0 | BACKOFF_JITTER | cloudProviderBackoffJitter |
 | CloudProviderRateLimit * | false | CLOUD_PROVIDER_RATE_LIMIT | cloudProviderRateLimit |
-| CloudProviderRateLimitQPS * | 1 | | cloudProviderRateLimitQPS |
-| CloudProviderRateLimitBucket * | 5 | | cloudProviderRateLimitBucket |
-| CloudProviderRateLimitQPSWrite * | 1 | | cloudProviderRateLimitQPSWrite |
-| CloudProviderRateLimitBucketWrite * | 5 | | cloudProviderRateLimitBucketWrite |
+| CloudProviderRateLimitQPS * | 1 | RATE_LIMIT_READ_QPS | cloudProviderRateLimitQPS |
+| CloudProviderRateLimitBucket * | 5 | RATE_LIMIT_READ_BUCKETS | cloudProviderRateLimitBucket |
+| CloudProviderRateLimitQPSWrite * | 1 | RATE_LIMIT_WRITE_QPS | cloudProviderRateLimitQPSWrite |
+| CloudProviderRateLimitBucketWrite * | 5 | RATE_LIMIT_WRITE_BUCKETS | cloudProviderRateLimitBucketWrite |
 
-> **_NOTE_**: * These rate limit configs can be set per-client. Customizing  `QPS` and `Bucket` through environment variables is not supported.
+> **_NOTE_**: * These rate limit configs can be set per-client. Customizing `QPS` and `Bucket` through environment variables per client is not supported.
 
 [AKS]: https://docs.microsoft.com/azure/aks/
 [AKS autoscaler documentation]: https://docs.microsoft.com/azure/aks/autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -66,8 +66,12 @@ const (
 	backoffJitterDefault   = 1.0
 
 	// rate limit
-	rateLimitQPSDefault    = 1.0
+	rateLimitQPSDefault float32 = 1.0
 	rateLimitBucketDefault = 5
+	rateLimitReadQPSEnvVar = "RATE_LIMIT_READ_QPS"
+	rateLimitReadBucketsEnvVar = "RATE_LIMIT_READ_BUCKETS"
+	rateLimitWriteQPSEnvVar = "RATE_LIMIT_WRITE_QPS"
+	rateLimitWriteBucketsEnvVar = "RATE_LIMIT_WRITE_BUCKETS"
 )
 
 var validLabelAutoDiscovererKeys = strings.Join([]string{
@@ -155,12 +159,11 @@ func InitializeCloudProviderRateLimitConfig(config *CloudProviderRateLimitConfig
 
 	// Assign read rate limit defaults if no configuration was passed in.
 	if config.CloudProviderRateLimitQPS == 0 {
-		if rateLimitQPSFromEnv := os.Getenv("RATE_LIMIT_READ_QPS"); rateLimitQPSFromEnv != "" {
+		if rateLimitQPSFromEnv := os.Getenv(rateLimitReadQPSEnvVar); rateLimitQPSFromEnv != "" {
 			rateLimitQPS, err := strconv.ParseFloat(rateLimitQPSFromEnv, 0)
 			if err != nil {
-				return fmt.Errorf("failed to parse RATE_LIMIT_READ_QPS: %q, %v", rateLimitQPSFromEnv, err)
+				return fmt.Errorf("failed to parse %s: %q, %v", rateLimitReadQPSEnvVar, rateLimitQPSFromEnv, err)
 			}
-			klog.V(4).Infof("Set read rate limit QPS to %f", rateLimitQPS)
 			config.CloudProviderRateLimitQPS = float32(rateLimitQPS)
 		} else {
 			config.CloudProviderRateLimitQPS = rateLimitQPSDefault
@@ -168,13 +171,12 @@ func InitializeCloudProviderRateLimitConfig(config *CloudProviderRateLimitConfig
 	}
 
 	if config.CloudProviderRateLimitBucket == 0 {
-		if rateLimitBucketFromEnv := os.Getenv("RATE_LIMIT_READ_BUCKETS"); rateLimitBucketFromEnv != "" {
+		if rateLimitBucketFromEnv := os.Getenv(rateLimitReadBucketsEnvVar); rateLimitBucketFromEnv != "" {
 			rateLimitBucket, err := strconv.ParseInt(rateLimitBucketFromEnv, 10, 0)
 			if err != nil {
-				return fmt.Errorf("failed to parse RATE_LIMIT_READ_BUCKETS: %q, %v", rateLimitBucketFromEnv, err)
+				return fmt.Errorf("failed to parse %s: %q, %v", rateLimitReadBucketsEnvVar, rateLimitBucketFromEnv, err)
 			}
 			config.CloudProviderRateLimitBucket = int(rateLimitBucket)
-			klog.V(4).Infof("Set read rate limit buckets to %d", rateLimitBucket)
 		} else {
 			config.CloudProviderRateLimitBucket = rateLimitBucketDefault
 		}
@@ -182,25 +184,23 @@ func InitializeCloudProviderRateLimitConfig(config *CloudProviderRateLimitConfig
 
 	// Assign write rate limit defaults if no configuration was passed in.
 	if config.CloudProviderRateLimitQPSWrite == 0 {
-		if rateLimitQPSWriteFromEnv := os.Getenv("RATE_LIMIT_WRITE_QPS"); rateLimitQPSWriteFromEnv != "" {
+		if rateLimitQPSWriteFromEnv := os.Getenv(rateLimitWriteQPSEnvVar); rateLimitQPSWriteFromEnv != "" {
 			rateLimitQPSWrite, err := strconv.ParseFloat(rateLimitQPSWriteFromEnv, 0)
 			if err != nil {
-				return fmt.Errorf("failed to parse RATE_LIMIT_WRITE_QPS: %q, %v", rateLimitQPSWriteFromEnv, err)
+				return fmt.Errorf("failed to parse %s: %q, %v", rateLimitWriteQPSEnvVar, rateLimitQPSWriteFromEnv, err)
 			}
 			config.CloudProviderRateLimitQPSWrite = float32(rateLimitQPSWrite)
-			klog.V(4).Infof("Set write rate limit QPS to %f", rateLimitQPSWrite)
 		} else {
 			config.CloudProviderRateLimitQPSWrite = config.CloudProviderRateLimitQPS
 		}
 	}
 
 	if config.CloudProviderRateLimitBucketWrite == 0 {
-		if rateLimitBucketWriteFromEnv := os.Getenv("RATE_LIMIT_WRITE_BUCKETS"); rateLimitBucketWriteFromEnv != "" {
+		if rateLimitBucketWriteFromEnv := os.Getenv(rateLimitWriteBucketsEnvVar); rateLimitBucketWriteFromEnv != "" {
 			rateLimitBucketWrite, err := strconv.ParseInt(rateLimitBucketWriteFromEnv, 10, 0)
 			if err != nil {
-				return fmt.Errorf("failed to parse RATE_LIMIT_WRITE_BUCKET: %q, %v", rateLimitBucketWriteFromEnv, err)
+				return fmt.Errorf("failed to parse %s: %q, %v", rateLimitWriteBucketsEnvVar, rateLimitBucketWriteFromEnv, err)
 			}
-			klog.V(4).Infof("Set write rate limit buckets to %d", rateLimitBucketWrite)
 			config.CloudProviderRateLimitBucketWrite = int(rateLimitBucketWrite)
 		} else {
 			config.CloudProviderRateLimitBucketWrite = config.CloudProviderRateLimitBucket


### PR DESCRIPTION
If you're using environment variables to configure the Cluster Autoscaler, you're unable to set the Azure cloud provider's rate limit QPS or bucket size and must switch your configuration to file based to do so. This PR enables the setting of 4 environment variables which allow for the rate limit QPS or bucket size to be configured without needing to switch to file based configuration 

Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>