### PR TITLE
Update aggregatedContainerState from containerResourcePolicy

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
@@ -32,6 +32,7 @@ func GetContainerNameToAggregateStateMap(vpa *model.Vpa) model.ContainerNameToAg
 		autoscalingDisabled := containerResourcePolicy != nil && containerResourcePolicy.Mode != nil &&
 			*containerResourcePolicy.Mode == vpa_types.ContainerScalingModeOff
 		if !autoscalingDisabled && aggregatedContainerState.TotalSamplesCount > 0 {
+			aggregatedContainerState.UpdateFromPolicy(containerResourcePolicy)
 			filteredContainerNameToAggregateStateMap[containerName] = aggregatedContainerState
 		}
 	}


### PR DESCRIPTION
This is needed for map containerName: aggregatedState to contain
complete information (not only samples, but also resource policy), which
can be later processed downstream. In particular, it is needed for VPA
controlled resources.