### PR TITLE
Add bunch of metrics to monitor VPA Updater impact in a cluster

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/README.md
+++ b/vertical-pod-autoscaler/pkg/updater/README.md
@@ -29,4 +29,3 @@ before pod with 20% memory increase and no change in cpu).
 
 # Missing parts
 * Recommendation API for fetching data from Vertical Pod Autoscaler Recommender.
-* Monitoring.

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -24,7 +24,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metrics_updater "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/updater"
 	appsinformer "k8s.io/client-go/informers/apps/v1"
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	kube_client "k8s.io/client-go/kubernetes"
@@ -141,7 +140,6 @@ func (e *podsEvictionRestrictionImpl) Evict(podToEvict *apiv1.Pod, eventRecorder
 	}
 	eventRecorder.Event(podToEvict, apiv1.EventTypeNormal, "EvictedByVPA",
 		"Pod was evicted by VPA Updater to apply resource recommendation.")
-	metrics_updater.AddEvictedPod()
 
 	if podToEvict.Status.Phase != apiv1.PodPending {
 		singleGroupStats, present := e.creatorToSingleGroupStatsMap[cr]

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -189,6 +189,8 @@ func (u *updater) RunOnce(ctx context.Context) {
 	defer vpasWithEvictablePodsCounter.Observe()
 	defer vpasWithEvictedPodsCounter.Observe()
 
+	// NOTE: this loop assumes that controlledPods are filtered
+	// to contain only Pods controlled by a VPA in auto or recreate mode
 	for vpa, livePods := range controlledPods {
 		vpaSize := len(livePods)
 		controlledPodsCounter.Add(vpaSize, vpaSize)


### PR DESCRIPTION
New metrics to measure how VPA Updater impacts workloads controlled by VPA:
* number of Pods that are considered by the Updater,
* number of Pods that can be evicted,
* number of VPA objects with at least one Pod that can be evicted,
* number of VPA objects with at least one evicted Pod.

Additionally changes the existing metric (number of evicted Pods) by adding a label.

TODO: Manual testing.

