### PR TITLE
Count live Pods per VPA

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -126,20 +126,18 @@ func NewVpa(id VpaID, selector labels.Selector, created time.Time) *Vpa {
 }
 
 // UseAggregationIfMatching checks if the given aggregation matches (contributes to) this VPA
-// and adds it to the set of VPA's aggregations if that is the case. Returns true
-// if the aggregation matches VPA.
-func (vpa *Vpa) UseAggregationIfMatching(aggregationKey AggregateStateKey, aggregation *AggregateContainerState) bool {
+// and adds it to the set of VPA's aggregations if that is the case.
+func (vpa *Vpa) UseAggregationIfMatching(aggregationKey AggregateStateKey, aggregation *AggregateContainerState) {
 	if vpa.UsesAggregation(aggregationKey) {
-		return true
+		// Already linked, we can return quickly.
+		return
 	}
 	if vpa.matchesAggregation(aggregationKey) {
 		vpa.aggregateContainerStates[aggregationKey] = aggregation
 		aggregation.IsUnderVPA = true
 		aggregation.UpdateMode = vpa.UpdateMode
 		aggregation.UpdateFromPolicy(vpa_api_util.GetContainerResourcePolicy(aggregationKey.ContainerName(), vpa.ResourcePolicy))
-		return true
 	}
-	return false
 }
 
 // UpdateRecommendation updates the recommended resources in the VPA and its

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -231,7 +231,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 		updateMode                  *vpa_types.UpdateMode
 		container                   string
 		containerLabels             map[string]string
-		expectedMatching            bool
 		expectedUpdateMode          *vpa_types.UpdateMode
 		expectedNeedsRecommendation map[string]bool
 	}{
@@ -242,7 +241,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeOff,
 			container:                   "test-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"test-container": true},
 			expectedUpdateMode:          &modeOff,
 		}, {
@@ -252,7 +250,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"test-container": true, "second-container": true},
 			expectedUpdateMode:          &modeAuto,
 		}, {
@@ -262,7 +259,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeOff,
 			container:                   "test-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"test-container": true},
 			expectedUpdateMode:          &modeOff,
 		}, {
@@ -272,7 +268,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             map[string]string{"different": "labels"},
-			expectedMatching:            false,
 			expectedNeedsRecommendation: map[string]bool{"test-container": true},
 			expectedUpdateMode:          nil,
 		}, {
@@ -290,7 +285,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": true},
 			expectedUpdateMode:          &modeAuto,
 		}, {
@@ -308,7 +302,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": false},
 			expectedUpdateMode:          &modeAuto,
 		}, {
@@ -330,7 +323,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": true},
 			expectedUpdateMode:          &modeAuto,
 		}, {
@@ -352,7 +344,6 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			updateMode:                  &modeAuto,
 			container:                   "second-container",
 			containerLabels:             testLabels,
-			expectedMatching:            true,
 			expectedNeedsRecommendation: map[string]bool{"second-container": true, "test-container": false},
 			expectedUpdateMode:          &modeAuto,
 		},
@@ -381,8 +372,7 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			}
 			vpa.SetResourcePolicy(tc.resourcePolicy)
 
-			matching := vpa.UseAggregationIfMatching(key, aggregationUnderTest)
-			assert.Equal(t, tc.expectedMatching, matching, "Unexpected assessment of aggregation matching")
+			vpa.UseAggregationIfMatching(key, aggregationUnderTest)
 			assert.Len(t, vpa.aggregateContainerStates, len(tc.expectedNeedsRecommendation), "AggregateContainerStates has unexpected size")
 			for container, expectedNeedsRecommendation := range tc.expectedNeedsRecommendation {
 				found := false

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -103,17 +103,19 @@ func (r *recommender) UpdateVPAs() {
 		if vpa.HasRecommendation() && !had {
 			metrics_recommender.ObserveRecommendationLatency(vpa.Created)
 		}
-		hasMatchingPods := r.clusterState.VpasWithMatchingPods[vpa.ID]
+		hasMatchingPods := r.clusterState.VpaPodCount[vpa.ID] > 0
 		vpa.UpdateConditions(hasMatchingPods)
 		if err := r.clusterState.RecordRecommendation(vpa, time.Now()); err != nil {
 			klog.Warningf("%v", err)
 			klog.V(4).Infof("VPA dump")
 			klog.V(4).Infof("%+v", vpa)
 			klog.V(4).Infof("HasMatchingPods: %v", hasMatchingPods)
+			podCount := r.clusterState.VpaPodCount[vpa.ID]
+			klog.V(4).Infof("VpaPodCount: %v", podCount)
 			pods := r.clusterState.GetMatchingPods(vpa)
 			klog.V(4).Infof("MatchingPods: %+v", pods)
-			if len(pods) > 0 != hasMatchingPods {
-				klog.Errorf("Aggregated states and matching pods disagree for vpa %v/%v", vpa.ID.Namespace, vpa.ID.VpaName)
+			if len(pods) != podCount {
+				klog.Errorf("ClusterState pod count and matching pods disagree for vpa %v/%v", vpa.ID.Namespace, vpa.ID.VpaName)
 			}
 		}
 		cnt.Add(vpa)


### PR DESCRIPTION
Replaces a map of bools which were computed based on aggregated states with a map of ints, computed based on raw data.

One potentially heavy operation is a full scan of Pods whenever new VPA object is created, apart from that I don't see any major performance impact.
The full scan is in-memory only, we have all the necessary data already fetched.