### PR TITLE
a misspelling

### DIFF
--- a/vertical-pod-autoscaler/e2e/vendor/github.com/evanphx/json-patch/README.md
+++ b/vertical-pod-autoscaler/e2e/vendor/github.com/evanphx/json-patch/README.md
@@ -1,5 +1,5 @@
 # JSON-Patch
-`jsonpatch` is a library which provides functionallity for both applying
+`jsonpatch` is a library which provides functionality for both applying
 [RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against documents, as
 well as for calculating & applying [RFC7396 JSON merge patches](https://tools.ietf.org/html/rfc7396).
 


### PR DESCRIPTION
functionallity->functionality
There is one 'l'
From https://dictionary.cambridge.org/spellcheck/english-chinese-simplified/?q=functionallity