### PR TITLE
Remove docker -it flag from addon-resizer Makefile

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -48,7 +48,7 @@ container: .container-$(ARCH)
 	cp -r * $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
-	docker run --rm -it -v $(TEMP_DIR):$(TEMP_DIR):Z -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
+	docker run --rm -v $(TEMP_DIR):$(TEMP_DIR):Z -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
         golang:${GOLANG_VERSION} \
         /bin/bash -c "\
             go get github.com/tools/godep && \
@@ -63,7 +63,7 @@ ifeq ($(ARCH), amd64)
 endif
 
 test:
-	docker run --rm -it -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
+	docker run --rm -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
 	golang:${GOLANG_VERSION} \
         /bin/bash -c "\
             go get github.com/tools/godep && \


### PR DESCRIPTION
Having interactive tty flag breaks non-interactive CI builds, as they will error out with `the input device is not a TTY`