### PR TITLE
Add a metric for observing recommendation stability & changes.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -46,8 +46,6 @@ type ClusterState struct {
 	// time we've noticed the recommendation missing or last time we logged
 	// a warning about it.
 	EmptyVPAs map[VpaID]time.Time
-	// VpaPodCount contains number of live Pods matching a given VPA object.
-	VpaPodCount map[VpaID]int
 	// Observed VPAs. Used to check if there are updates needed.
 	ObservedVpas []*vpa_types.VerticalPodAutoscaler
 
@@ -99,7 +97,6 @@ func NewClusterState() *ClusterState {
 		Pods:              make(map[PodID]*PodState),
 		Vpas:              make(map[VpaID]*Vpa),
 		EmptyVPAs:         make(map[VpaID]time.Time),
-		VpaPodCount:       make(map[VpaID]int),
 		aggregateStateMap: make(aggregateContainerStatesMap),
 		labelSetMap:       make(labelSetMap),
 	}
@@ -147,7 +144,7 @@ func (cluster *ClusterState) AddOrUpdatePod(podID PodID, newLabels labels.Set, p
 func (cluster *ClusterState) addPodToItsVpa(pod *PodState) {
 	for _, vpa := range cluster.Vpas {
 		if vpa_utils.PodLabelsMatchVPA(pod.ID.Namespace, cluster.labelSetMap[pod.labelSetKey], vpa.ID.Namespace, vpa.PodSelector) {
-			cluster.VpaPodCount[vpa.ID]++
+			vpa.PodCount++
 		}
 	}
 }
@@ -156,7 +153,7 @@ func (cluster *ClusterState) addPodToItsVpa(pod *PodState) {
 func (cluster *ClusterState) removePodFromItsVpa(pod *PodState) {
 	for _, vpa := range cluster.Vpas {
 		if vpa_utils.PodLabelsMatchVPA(pod.ID.Namespace, cluster.labelSetMap[pod.labelSetKey], vpa.ID.Namespace, vpa.PodSelector) {
-			cluster.VpaPodCount[vpa.ID]--
+			vpa.PodCount--
 		}
 	}
 }
@@ -268,7 +265,7 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 		for aggregationKey, aggregation := range cluster.aggregateStateMap {
 			vpa.UseAggregationIfMatching(aggregationKey, aggregation)
 		}
-		cluster.VpaPodCount[vpaID] = len(cluster.GetMatchingPods(vpa))
+		vpa.PodCount = len(cluster.GetMatchingPods(vpa))
 	}
 	vpa.TargetRef = apiObject.Spec.TargetRef
 	vpa.Annotations = annotationsMap
@@ -290,7 +287,6 @@ func (cluster *ClusterState) DeleteVpa(vpaID VpaID) error {
 	}
 	delete(cluster.Vpas, vpaID)
 	delete(cluster.EmptyVPAs, vpaID)
-	delete(cluster.VpaPodCount, vpaID)
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -768,7 +768,7 @@ func TestVPAWithMatchingPods(t *testing.T) {
 				containerID := ContainerID{testPodID, "foo"}
 				assert.NoError(t, cluster.AddOrUpdateContainer(containerID, testRequest))
 			}
-			assert.Equal(t, tc.expectedMatch, cluster.VpaPodCount[vpa.ID])
+			assert.Equal(t, tc.expectedMatch, cluster.Vpas[vpa.ID].PodCount)
 		})
 	}
 	// Run with adding Pods first
@@ -781,7 +781,7 @@ func TestVPAWithMatchingPods(t *testing.T) {
 				assert.NoError(t, cluster.AddOrUpdateContainer(containerID, testRequest))
 			}
 			vpa := addVpa(cluster, testVpaID, testAnnotations, tc.vpaSelector)
-			assert.Equal(t, tc.expectedMatch, cluster.VpaPodCount[vpa.ID])
+			assert.Equal(t, tc.expectedMatch, cluster.Vpas[vpa.ID].PodCount)
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -103,18 +103,17 @@ func (r *recommender) UpdateVPAs() {
 		if vpa.HasRecommendation() && !had {
 			metrics_recommender.ObserveRecommendationLatency(vpa.Created)
 		}
-		hasMatchingPods := r.clusterState.VpaPodCount[vpa.ID] > 0
+		hasMatchingPods := vpa.PodCount > 0
 		vpa.UpdateConditions(hasMatchingPods)
 		if err := r.clusterState.RecordRecommendation(vpa, time.Now()); err != nil {
 			klog.Warningf("%v", err)
 			klog.V(4).Infof("VPA dump")
 			klog.V(4).Infof("%+v", vpa)
 			klog.V(4).Infof("HasMatchingPods: %v", hasMatchingPods)
-			podCount := r.clusterState.VpaPodCount[vpa.ID]
-			klog.V(4).Infof("VpaPodCount: %v", podCount)
+			klog.V(4).Infof("PodCount: %v", vpa.PodCount)
 			pods := r.clusterState.GetMatchingPods(vpa)
 			klog.V(4).Infof("MatchingPods: %+v", pods)
-			if len(pods) != podCount {
+			if len(pods) != vpa.PodCount {
 				klog.Errorf("ClusterState pod count and matching pods disagree for vpa %v/%v", vpa.ID.Namespace, vpa.ID.VpaName)
 			}
 		}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	"k8s.io/klog"
@@ -38,6 +39,9 @@ var (
 	cpuBuckets = prometheus.ExponentialBuckets(0.01, 2., 17)
 	// Buckets between 1MB and 65.5 GB
 	memoryBuckets = prometheus.ExponentialBuckets(1e6, 2., 17)
+	// Buckets for relative comparisons, from -100% to x100
+	relativeBuckets = []float64{-1., -.75, -.5, -.25, -.1, -.05, -0.025, -.01, -.005, -0.0025, -.001,
+		0., .001, .0025, .005, .01, .025, .05, .1, .25, .5, .75, 1., 2.5, 5., 10., 25., 50., 100.}
 )
 
 var (
@@ -46,8 +50,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "usage_recommendation_relative_diffs",
 			Help:      "Diffs between recommendation and usage, normalized by recommendation value",
-			Buckets: []float64{-1., -.75, -.5, -.25, -.1, -.05, -0.025, -.01, -.005, -0.0025, -.001, 0.,
-				.001, .0025, .005, .01, .025, .05, .1, .25, .5, .75, 1., 2.5, 5., 10., 25., 50., 100.},
+			Buckets:   relativeBuckets,
 		}, []string{"update_mode", "resource", "is_oom"},
 	)
 	usageMissingRecommendationCounter = prometheus.NewCounterVec(
@@ -105,6 +108,14 @@ var (
 			Buckets:   memoryBuckets,
 		}, []string{"update_mode", "is_oom"},
 	)
+	relativeRecommendationChange = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "relative_recommendation_changes",
+			Help:      "Changes between consecutive recommendation values, normalized by old value",
+			Buckets:   relativeBuckets,
+		}, []string{"update_mode", "resource", "vpa_size_log2"},
+	)
 )
 
 // Register initializes all VPA quality metrics
@@ -117,6 +128,7 @@ func Register() {
 	prometheus.MustRegister(memoryRecommendationLowerOrEqualUsageDiff)
 	prometheus.MustRegister(cpuRecommendations)
 	prometheus.MustRegister(memoryRecommendations)
+	prometheus.MustRegister(relativeRecommendationChange)
 }
 
 // observeUsageRecommendationRelativeDiff records relative diff between usage and
@@ -182,6 +194,44 @@ func ObserveQualityMetrics(usage, recommendation float64, isOOM bool, resource c
 func ObserveQualityMetricsRecommendationMissing(usage float64, isOOM bool, resource corev1.ResourceName, updateMode *vpa_types.UpdateMode) {
 	observeMissingRecommendation(isOOM, resource, updateMode)
 	observeUsageRecommendationDiff(usage, 0, true, isOOM, resource, updateMode)
+}
+
+// ObserveRecommendationChange records relative_recommendation_changes metric.
+func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMode *vpa_types.UpdateMode, vpaSize int) {
+	// This will happen if there is no previous recommendation, we don't want to emit anything then.
+	if previous == nil {
+		return
+	}
+	// This is not really expected thus a warning.
+	if current == nil {
+		klog.Warningf("Cannot compare with current recommendation being nil. VPA mode: %v, size: %v", updateMode, vpaSize)
+		return
+	}
+
+	for resource, amount := range current {
+		newValue := quantityAsFloat(resource, amount)
+		oldValue := quantityAsFloat(resource, previous[resource])
+
+		if oldValue > 0.0 {
+			diff := newValue/oldValue - 1.0 // -1.0 to report decreases as negative values and keep 0.0 neutral
+			relativeRecommendationChange.WithLabelValues(updateModeToString(updateMode), string(resource), string(vpaSize)).Observe(diff)
+		} else {
+			klog.Warningf("Cannot compare as old recommendation for %v is 0. VPA mode: %v, size: %v", resource, updateMode, vpaSize)
+		}
+	}
+}
+
+// quantityAsFloat converts resource.Quantity to a float64 value, in some scale (constant per resource but unspecified)
+func quantityAsFloat(resource corev1.ResourceName, quantity resource.Quantity) float64 {
+	switch resource {
+	case corev1.ResourceCPU:
+		return float64(quantity.MilliValue())
+	case corev1.ResourceMemory:
+		return float64(quantity.Value())
+	default:
+		klog.Warningf("Unknown resource: %v", resource)
+		return 0.0
+	}
 }
 
 func updateModeToString(updateMode *vpa_types.UpdateMode) string {


### PR DESCRIPTION
The relative_recommendation_changes metric reports changes seen on any given recommendation.
This allows to observe stability vs noisiness of recommendations. Ideally the metric should report mostly zeros as we expect the recommendations to diverge with time and change only rarely.
