### PR TITLE
cluster-autoscaler: use generated instance types

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -49,16 +49,13 @@ var (
 type awsCloudProvider struct {
 	awsManager      *AwsManager
 	resourceLimiter *cloudprovider.ResourceLimiter
-	// InstanceTypes is a map of ec2 resources
-	instanceTypes map[string]*InstanceType
 }
 
 // BuildAwsCloudProvider builds CloudProvider implementation for AWS.
-func BuildAwsCloudProvider(awsManager *AwsManager, instanceTypes map[string]*InstanceType, resourceLimiter *cloudprovider.ResourceLimiter) (cloudprovider.CloudProvider, error) {
+func BuildAwsCloudProvider(awsManager *AwsManager, resourceLimiter *cloudprovider.ResourceLimiter) (cloudprovider.CloudProvider, error) {
 	aws := &awsCloudProvider{
 		awsManager:      awsManager,
 		resourceLimiter: resourceLimiter,
-		instanceTypes:   instanceTypes,
 	}
 	return aws, nil
 }
@@ -347,10 +344,8 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	}
 
 	// Generate EC2 list
-	var instanceTypes map[string]*InstanceType
-	var lastUpdateTime string
+	instanceTypes, lastUpdateTime := GetStaticEC2InstanceTypes()
 	if opts.AWSUseStaticInstanceList {
-		instanceTypes, lastUpdateTime = GetStaticEC2InstanceTypes()
 		klog.Warningf("Use static EC2 Instance Types and list could be outdated. Last update time: %s", lastUpdateTime)
 	} else {
 		region, err := GetCurrentAwsRegion()
@@ -358,10 +353,21 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 			klog.Fatalf("Failed to get AWS Region: %v", err)
 		}
 
-		instanceTypes, err = GenerateEC2InstanceTypes(region)
+		generatedInstanceTypes, err := GenerateEC2InstanceTypes(region)
 		if err != nil {
 			klog.Fatalf("Failed to generate AWS EC2 Instance Types: %v", err)
 		}
+		// fallback on the static list if we miss any instance types in the generated output
+		// credits to: https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/80
+		for k, v := range instanceTypes {
+			_, ok := generatedInstanceTypes[k]
+			if ok {
+				continue
+			}
+			klog.Infof("Using static instance type %s", k)
+			generatedInstanceTypes[k] = v
+		}
+		instanceTypes = generatedInstanceTypes
 
 		keys := make([]string, 0, len(instanceTypes))
 		for key := range instanceTypes {
@@ -371,12 +377,12 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		klog.Infof("Successfully load %d EC2 Instance Types %s", len(keys), keys)
 	}
 
-	manager, err := CreateAwsManager(config, do)
+	manager, err := CreateAwsManager(config, do, instanceTypes)
 	if err != nil {
 		klog.Fatalf("Failed to create AWS Manager: %v", err)
 	}
 
-	provider, err := BuildAwsCloudProvider(manager, instanceTypes, rl)
+	provider, err := BuildAwsCloudProvider(manager, rl)
 	if err != nil {
 		klog.Fatalf("Failed to create AWS cloud provider: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -61,6 +61,7 @@ type AwsManager struct {
 	ec2Service         ec2Wrapper
 	asgCache           *asgCache
 	lastRefresh        time.Time
+	instanceTypes      map[string]*InstanceType
 }
 
 type asgTemplate struct {
@@ -174,6 +175,7 @@ func createAWSManagerInternal(
 	discoveryOpts cloudprovider.NodeGroupDiscoveryOptions,
 	autoScalingService *autoScalingWrapper,
 	ec2Service *ec2Wrapper,
+	instanceTypes map[string]*InstanceType,
 ) (*AwsManager, error) {
 
 	cfg, err := readAWSCloudConfig(configReader)
@@ -219,6 +221,7 @@ func createAWSManagerInternal(
 		autoScalingService: *autoScalingService,
 		ec2Service:         *ec2Service,
 		asgCache:           cache,
+		instanceTypes:      instanceTypes,
 	}
 
 	if err := manager.forceRefresh(); err != nil {
@@ -244,8 +247,8 @@ func readAWSCloudConfig(config io.Reader) (*provider_aws.CloudConfig, error) {
 }
 
 // CreateAwsManager constructs awsManager object.
-func CreateAwsManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*AwsManager, error) {
-	return createAWSManagerInternal(configReader, discoveryOpts, nil, nil)
+func CreateAwsManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, instanceTypes map[string]*InstanceType) (*AwsManager, error) {
+	return createAWSManagerInternal(configReader, discoveryOpts, nil, nil, instanceTypes)
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
@@ -317,7 +320,7 @@ func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 		return nil, err
 	}
 
-	if t, ok := InstanceTypes[instanceTypeName]; ok {
+	if t, ok := m.instanceTypes[instanceTypeName]; ok {
 		return &asgTemplate{
 			InstanceType: t,
 			Region:       region,


### PR DESCRIPTION
I refactored the way we use the generated instance types.

From what I understood in the code, we can, behind an option:
* use a generated list of instance types with a http query to the pricing endpoint `https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/${region}/index.json`
* use the statically generated map in `cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go.
` which is a templated go files from the process just described above.

I didn't see in the code where we actually uses the generated instance types as we still use the global and static map regardless if we set to `--aws-use-static-instance-list=false` (which is also the default).

So I moved the instance types where it seems more convenient to use, in the `AwsManager`.

This component is documented as follow:
```go
// AwsManager is handles aws communication and data caching.
type AwsManager struct
```

I added an additional safety with the live generated instance types list: In case we miss any keys in the static list, we add it, this idea comes from https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/80 but related to a `DescribeInstanceTypesInput` failure/side-effect.