### PR TITLE
add CAPI prerequisites section to cluster-autoscaler README

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -10,6 +10,14 @@ cluster.
 The cluster-api provider requires Kubernetes v1.16 or greater to run the
 v1alpha3 version of the API.
 
+## Cluster API Prerequisites
+
+Please be aware that currently the cluster autoscaler only supports CAPI
+clusters that have joined their management and workload clusters into a single
+cluster. For more information about this please see the
+[Cluster API Concepts documentations](https://cluster-api.sigs.k8s.io/user/concepts.html)
+and the [`clusterctl move` command documentaion](https://cluster-api.sigs.k8s.io/user/concepts.html).
+
 ## Starting the Autoscaler
 
 To enable the Cluster API provider, you must first specify it in the command


### PR DESCRIPTION
This change adds a section to the cluster-autoscaler CAPI provider
README which details the required prerequisites for using the
autoscaler. It is being added to help inform users about the
restrictions that are currently in place with regards to using this
provider.

/area provider/cluster-api
/kind documentation
