### PR TITLE
AWS: Use smallest instance type found in MixedInstancesPolicy

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -331,9 +331,11 @@ func (m *AwsManager) buildInstanceType(asg *asg) (string, error) {
 	} else if asg.LaunchTemplate != nil {
 		return m.ec2Service.getInstanceTypeByLT(asg.LaunchTemplate)
 	} else if asg.MixedInstancesPolicy != nil {
-		// always use first instance
-		if len(asg.MixedInstancesPolicy.instanceTypesOverrides) != 0 {
-			return asg.MixedInstancesPolicy.instanceTypesOverrides[0], nil
+		// Use smallest instance of all the instance types. Otherwise, we run
+		// the risk of launching an instance that is too small for the pending
+		// pod to actually fit in.
+		if len(asg.MixedInstancesPolicy.instanceTypesOverrides) > 0 {
+			return smallestInstanceType(asg.MixedInstancesPolicy.instanceTypesOverrides), nil
 		}
 
 		return m.ec2Service.getInstanceTypeByLT(asg.MixedInstancesPolicy.launchTemplate)

--- a/cluster-autoscaler/cloudprovider/aws/ec2.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -54,4 +55,30 @@ func (m ec2Wrapper) getInstanceTypeByLT(launchTemplate *launchTemplate) (string,
 	}
 
 	return aws.StringValue(instanceType), nil
+}
+
+// smallestInstanceType returns the smallest EC2 instance type
+// from the list of provided instance types.
+func smallestInstanceType(instanceTypes []string) (smallest string) {
+	var (
+		leastCPU int64 = math.MaxInt64
+		leastMem int64 = math.MaxInt64
+		leastGPU int64 = math.MaxInt64
+	)
+	for _, instanceType := range instanceTypes {
+		candidate := InstanceTypes[instanceType]
+		if candidate.VCPU < leastCPU {
+			smallest = candidate.InstanceType
+			leastCPU = candidate.VCPU
+		}
+		if candidate.MemoryMb < leastMem {
+			smallest = candidate.InstanceType
+			leastMem = candidate.MemoryMb
+		}
+		if candidate.GPU < leastGPU {
+			smallest = candidate.InstanceType
+			leastGPU = candidate.GPU
+		}
+	}
+	return smallest
 }

--- a/cluster-autoscaler/cloudprovider/aws/ec2_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSmallestInstanceTypeSameFamily(t *testing.T) {
+	instanceTypes := []string{
+		"c5.large",
+		"c5.xlarge",
+	}
+	smallest := smallestInstanceType(instanceTypes)
+	assert.Equal(t, smallest, "c5.large")
+}
+
+func TestSmallestInstanceTypeSameCPUDifferentMem(t *testing.T) {
+	instanceTypes := []string{
+		"c4.large",
+		"c5.large",
+	}
+	smallest := smallestInstanceType(instanceTypes)
+	assert.Equal(t, smallest, "c4.large")
+}
+
+func TestSmallestInstanceTypeSameMemDifferentCPU(t *testing.T) {
+	instanceTypes := []string{
+		"c5.xlarge",
+		"m4.large",
+	}
+	smallest := smallestInstanceType(instanceTypes)
+	assert.Equal(t, smallest, "m4.large")
+}
+
+func TestSmallestInstanceTypeSameFamilyDifferentProcessor(t *testing.T) {
+	{
+		instanceTypes := []string{
+			"m5a.large",
+			"m5.large",
+		}
+		smallest := smallestInstanceType(instanceTypes)
+		assert.Equal(t, smallest, instanceTypes[0])
+	}
+	{
+
+		instanceTypes := []string{
+			"m5.large",
+			"m5a.large",
+		}
+		smallest := smallestInstanceType(instanceTypes)
+		assert.Equal(t, smallest, instanceTypes[0])
+	}
+}
+
+func TestSmallestInstanceEqualButHasStorage(t *testing.T) {
+	{
+		instanceTypes := []string{
+			"c5d.large",
+			"c5.large",
+		}
+		smallest := smallestInstanceType(instanceTypes)
+		assert.Equal(t, smallest, instanceTypes[0])
+	}
+
+	{
+		instanceTypes := []string{
+			"c5.large",
+			"c5d.large",
+		}
+		smallest := smallestInstanceType(instanceTypes)
+		assert.Equal(t, smallest, instanceTypes[0])
+	}
+}
+
+func TestSmallestInstanceTypeCompareGPU(t *testing.T) {
+	instanceTypes := []string{
+		"p3.2xlarge",
+		"r3.2xlarge",
+	}
+	smallest := smallestInstanceType(instanceTypes)
+	assert.Equal(t, smallest, "r3.2xlarge")
+}

--- a/cluster-autoscaler/go.mod-extra
+++ b/cluster-autoscaler/go.mod-extra
@@ -3,7 +3,6 @@ go 1.12
 
 require (
   github.com/rancher/go-rancher v0.1.0
-  github.com/google/go-querystring v1.0.0
   github.com/aws/aws-sdk-go v1.23.12
 )
 

--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -17,7 +17,7 @@ fi
 
 SCRIPT_NAME=$(basename "$0")
 K8S_FORK="git@github.com:kubernetes/kubernetes.git"
-K8S_REV="master"
+K8S_REV="release-1.16"
 BATCH_MODE="false"
 TARGET_MODULE=${TARGET_MODULE:-k8s.io/autoscaler/cluster-autoscaler}
 


### PR DESCRIPTION
When determining the capacity of an Auto Scaling Group that has a Mixed Instances Policy, use the smallest instance of all the instance types in it. Otherwise, we run the risk of launching an instance that is too small for a pending pod to actually fit in.