### PR TITLE
VPA min allowed test should not rely on artificial minimal recommendation

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -533,6 +533,18 @@ func WaitForRecommendationPresent(c vpa_clientset.Interface, vpa *vpa_types.Vert
 	})
 }
 
+// WaitForUncappedCPURecommendationAbove pools VPA object until uncapped recommendation is above specified value.
+// Returns polled VPA object. On timeout returns error.
+func WaitForUncappedCPURecommendationAbove(c vpa_clientset.Interface, vpa *vpa_types.VerticalPodAutoscaler, minMilliCPU int64) (*vpa_types.VerticalPodAutoscaler, error) {
+	return WaitForVPAMatch(c, vpa, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
+		if vpa.Status.Recommendation == nil || len(vpa.Status.Recommendation.ContainerRecommendations) == 0 {
+			return false
+		}
+		uncappedCpu := vpa.Status.Recommendation.ContainerRecommendations[0].UncappedTarget[apiv1.ResourceCPU]
+		return uncappedCpu.MilliValue() > minMilliCPU
+	})
+}
+
 func installLimitRange(f *framework.Framework, minCpuLimit, minMemoryLimit, maxCpuLimit, maxMemoryLimit *resource.Quantity, lrType apiv1.LimitType) {
 	lr := &apiv1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{

--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -286,15 +286,13 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		vpaCRD := createVpaCRDWithMinMaxAllowed(f, nil, maxAllowed)
 
 		ginkgo.By("Waiting for recommendation to be filled")
-		vpa, err := WaitForRecommendationPresent(vpaClientSet, vpaCRD)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		vpa, err := WaitForUncappedCPURecommendationAbove(vpaClientSet, vpaCRD, maxMilliCpu)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf(
+			"Timed out waiting for uncapped cpu recommendation above %d mCPU", maxMilliCpu))
 		gomega.Expect(vpa.Status.Recommendation.ContainerRecommendations).Should(gomega.HaveLen(1))
 		cpu := getMilliCpu(vpa.Status.Recommendation.ContainerRecommendations[0].Target)
 		gomega.Expect(cpu).Should(gomega.BeNumerically("<=", maxMilliCpu),
 			fmt.Sprintf("target cpu recommendation should be less than or equal to %dm", maxMilliCpu))
-		cpuUncapped := getMilliCpu(vpa.Status.Recommendation.ContainerRecommendations[0].UncappedTarget)
-		gomega.Expect(cpuUncapped).Should(gomega.BeNumerically(">", maxMilliCpu),
-			fmt.Sprintf("uncapped target cpu recommendation should be greater than %dm", maxMilliCpu))
 	})
 })
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -533,6 +533,18 @@ func WaitForRecommendationPresent(c vpa_clientset.Interface, vpa *vpa_types.Vert
 	})
 }
 
+// WaitForUncappedCPURecommendationAbove pools VPA object until uncapped recommendation is above specified value.
+// Returns polled VPA object. On timeout returns error.
+func WaitForUncappedCPURecommendationAbove(c vpa_clientset.Interface, vpa *vpa_types.VerticalPodAutoscaler, minMilliCPU int64) (*vpa_types.VerticalPodAutoscaler, error) {
+	return WaitForVPAMatch(c, vpa, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
+		if vpa.Status.Recommendation == nil || len(vpa.Status.Recommendation.ContainerRecommendations) == 0 {
+			return false
+		}
+		uncappedCpu := vpa.Status.Recommendation.ContainerRecommendations[0].UncappedTarget[apiv1.ResourceCPU]
+		return uncappedCpu.MilliValue() > minMilliCPU
+	})
+}
+
 func installLimitRange(f *framework.Framework, minCpuLimit, minMemoryLimit, maxCpuLimit, maxMemoryLimit *resource.Quantity, lrType apiv1.LimitType) {
 	lr := &apiv1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{

--- a/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
@@ -286,15 +286,14 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		vpaCRD := createVpaCRDWithMinMaxAllowed(f, nil, maxAllowed)
 
 		ginkgo.By("Waiting for recommendation to be filled")
-		vpa, err := WaitForRecommendationPresent(vpaClientSet, vpaCRD)
+		vpa, err := WaitForUncappedCPURecommendationAbove(vpaClientSet, vpaCRD, maxMilliCpu)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf(
+			"Timed out waiting for uncapped cpu recommendation above %d mCPU", maxMilliCpu))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(vpa.Status.Recommendation.ContainerRecommendations).Should(gomega.HaveLen(1))
 		cpu := getMilliCpu(vpa.Status.Recommendation.ContainerRecommendations[0].Target)
 		gomega.Expect(cpu).Should(gomega.BeNumerically("<=", maxMilliCpu),
 			fmt.Sprintf("target cpu recommendation should be less than or equal to %dm", maxMilliCpu))
-		cpuUncapped := getMilliCpu(vpa.Status.Recommendation.ContainerRecommendations[0].UncappedTarget)
-		gomega.Expect(cpuUncapped).Should(gomega.BeNumerically(">", maxMilliCpu),
-			fmt.Sprintf("uncapped target cpu recommendation should be greater than %dm", maxMilliCpu))
 	})
 })
 


### PR DESCRIPTION
Current implementation assumes that regardless of the workload behavior we are guaranteed to receive a recommendation that is >10mCPU.