### PR TITLE
Fix AWS CA tests for InstanceType generation changes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -134,8 +134,7 @@ func testProvider(t *testing.T, m *AwsManager) *awsCloudProvider {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	instanceTypes, _ := GetStaticEC2InstanceTypes()
-	provider, err := BuildAwsCloudProvider(m, instanceTypes, resourceLimiter)
+	provider, err := BuildAwsCloudProvider(m, resourceLimiter)
 	assert.NoError(t, err)
 	return provider.(*awsCloudProvider)
 }
@@ -145,8 +144,7 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
-	instanceTypes, _ := GetStaticEC2InstanceTypes()
-	_, err := BuildAwsCloudProvider(testAwsManager, instanceTypes, resourceLimiter)
+	_, err := BuildAwsCloudProvider(testAwsManager, resourceLimiter)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Updates the AWS Cloudprovider tests to match the updates to call signatures from #3185 

Renamed a couple of variables for instance type overrides to be more explicitly named in the tests at the same time.