### PR TITLE
Azure: Add test cases for azure_agent_pool.go.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -18,28 +18,91 @@ package azure
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient"
 	"k8s.io/legacy-cloud-providers/azure/clients/vmclient/mockvmclient"
+	"k8s.io/legacy-cloud-providers/azure/retry"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	rerrTooManyReqs       = retry.Error{HTTPStatusCode: http.StatusTooManyRequests}
+	rerrInternalErr       = retry.Error{HTTPStatusCode: http.StatusInternalServerError}
+	testValidProviderID0  = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/as-vm-0"
+	testValidProviderID1  = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/as-vm-1"
+	testInvalidProviderID = "/subscriptions/sub/resourceGroups/rg/providers/provider/virtualMachines/as-vm-0/"
+)
+
 func newTestAgentPool(manager *AzureManager, name string) *AgentPool {
+	virtualMachinesStatusCache.lastRefresh = make(map[string]time.Time)
+
 	return &AgentPool{
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager: manager,
-		minSize: 1,
-		maxSize: 5,
+		manager:    manager,
+		minSize:    1,
+		maxSize:    5,
+		parameters: make(map[string]interface{}),
+		template:   make(map[string]interface{}),
 	}
+}
+
+func getExpectedVMs() []compute.VirtualMachine {
+	expectedVMs := []compute.VirtualMachine{
+		{
+			Name: to.StringPtr("000-0-00000000-0"),
+			ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/provider/0"),
+			Tags: map[string]*string{"poolName": to.StringPtr("as")},
+			VirtualMachineProperties: &compute.VirtualMachineProperties{
+				StorageProfile: &compute.StorageProfile{
+					OsDisk: &compute.OSDisk{
+						OsType: compute.Linux,
+						Vhd:    &compute.VirtualHardDisk{URI: to.StringPtr("https://foo.blob/vhds/bar.vhd")},
+					},
+				},
+				NetworkProfile: &compute.NetworkProfile{
+					NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+						{},
+					},
+				},
+			},
+		},
+		{
+			Name: to.StringPtr("00000000001"),
+			ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/provider/0"),
+			Tags: map[string]*string{"poolName": to.StringPtr("as")},
+			VirtualMachineProperties: &compute.VirtualMachineProperties{
+				StorageProfile: &compute.StorageProfile{
+					OsDisk: &compute.OSDisk{OsType: compute.Windows},
+				},
+			},
+		},
+	}
+
+	return expectedVMs
+}
+
+func TestInitialize(t *testing.T) {
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+
+	err := as.initialize()
+	assert.NoError(t, err)
+	assert.NotNil(t, as.template)
 }
 
 func TestDeleteOutdatedDeployments(t *testing.T) {
@@ -122,10 +185,364 @@ func TestGetVirtualMachinesFromCache(t *testing.T) {
 	}
 
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
-	mockVMClient.EXPECT().List(gomock.Any(), testAS.manager.config.ResourceGroup).Return(expectedVMs, nil)
 	testAS.manager.azClient.virtualMachinesClient = mockVMClient
 
+	mockVMClient.EXPECT().List(gomock.Any(), testAS.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrTooManyReqs)
 	vms, err := testAS.getVirtualMachinesFromCache()
+	assert.NoError(t, err)
+	assert.Empty(t, vms)
+
+	mockVMClient.EXPECT().List(gomock.Any(), testAS.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	vms, err = testAS.getVirtualMachinesFromCache()
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+	assert.Empty(t, vms)
+
+	mockVMClient.EXPECT().List(gomock.Any(), testAS.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	vms, err = testAS.getVirtualMachinesFromCache()
 	assert.Equal(t, 1, len(vms))
 	assert.NoError(t, err)
+
+	vms, err = testAS.getVirtualMachinesFromCache()
+	assert.Equal(t, 1, len(vms))
+	assert.NoError(t, err)
+}
+
+func TestInvalidateVMCache(t *testing.T) {
+	virtualMachinesStatusCache.lastRefresh = make(map[string]time.Time)
+	virtualMachinesStatusCache.lastRefresh["test"] = time.Now()
+	invalidateVMCache("test")
+	assert.True(t, virtualMachinesStatusCache.lastRefresh["test"].Add(vmInstancesRefreshPeriod).Before(time.Now()))
+}
+
+func TestGetVMIndexes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	expectedVMs := getExpectedVMs()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	sortedIndexes, indexToVM, err := as.GetVMIndexes()
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, sortedIndexes)
+	assert.Nil(t, indexToVM)
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	sortedIndexes, indexToVM, err = as.GetVMIndexes()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(sortedIndexes))
+	assert.Equal(t, 2, len(indexToVM))
+
+	invalidateVMCache("as")
+	expectedVMs[0].ID = to.StringPtr("foo")
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	sortedIndexes, indexToVM, err = as.GetVMIndexes()
+	expectedErr = fmt.Errorf("\"azure://foo\" isn't in Azure resource ID format")
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, sortedIndexes)
+	assert.Nil(t, indexToVM)
+
+	invalidateVMCache("as")
+	expectedVMs[0].Name = to.StringPtr("foo")
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	sortedIndexes, indexToVM, err = as.GetVMIndexes()
+	expectedErr = fmt.Errorf("resource name was missing from identifier")
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, sortedIndexes)
+	assert.Nil(t, indexToVM)
+}
+
+func TestGetCurSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.curSize = 1
+	expectedVMs := getExpectedVMs()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	as.lastRefresh = time.Now()
+	curSize, err := as.getCurSize()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), curSize)
+
+	invalidateVMCache("as")
+	as.lastRefresh = time.Now().Add(-1 * 15 * time.Second)
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	curSize, err = as.getCurSize()
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+	assert.Zero(t, curSize)
+
+	invalidateVMCache("as")
+	as.lastRefresh = time.Now().Add(-1 * 15 * time.Second)
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	curSize, err = as.getCurSize()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), curSize)
+}
+
+func TestAgentPoolTargetSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+	expectedVMs := getExpectedVMs()
+
+	invalidateVMCache("as")
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	size, err := as.getCurSize()
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+	assert.Zero(t, size)
+
+	invalidateVMCache("as")
+	as.lastRefresh = time.Now().Add(-1 * 15 * time.Second)
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	size, err = as.getCurSize()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), size)
+}
+
+func TestAgentPoolIncreaseSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+	expectedVMs := getExpectedVMs()
+
+	err := as.IncreaseSize(-1)
+	expectedErr := fmt.Errorf("size increase must be positive")
+	assert.Equal(t, expectedErr, err)
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil).MaxTimes(2)
+	err = as.IncreaseSize(4)
+	expectedErr = fmt.Errorf("size increase too large - desired:6 max:5")
+
+	err = as.IncreaseSize(2)
+	assert.NoError(t, err)
+}
+
+func TestDecreaseTargetSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.curSize = 3
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+	expectedVMs := getExpectedVMs()
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	err := as.DecreaseTargetSize(-1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), as.curSize)
+
+	err = as.DecreaseTargetSize(-1)
+	expectedErr := fmt.Errorf("attempt to delete existing nodes targetSize:2 delta:-1 existingNodes: 2")
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestAgentPoolBelongs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as
+
+	flag, err := as.Belongs(&apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: testValidProviderID0}})
+	assert.NoError(t, err)
+	assert.True(t, flag)
+
+	flag, err = as.Belongs(&apiv1.Node{
+		Spec:       apiv1.NodeSpec{ProviderID: testInvalidProviderID},
+		ObjectMeta: v1.ObjectMeta{Name: "node"},
+	})
+	expectedErr := fmt.Errorf("node doesn't belong to a known agent pool")
+	assert.Equal(t, expectedErr, err)
+	assert.False(t, flag)
+
+	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
+	as1.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as
+	flag, err = as1.Belongs(&apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: testValidProviderID0}})
+	assert.NoError(t, err)
+	assert.False(t, flag)
+}
+
+func TestDeleteInstances(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID1}] = as1
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testInvalidProviderID}] = as
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	mockSAClient := mockstorageaccountclient.NewMockInterface(ctrl)
+	as.manager.azClient.storageAccountsClient = mockSAClient
+
+	err := as.DeleteInstances([]*azureRef{})
+	assert.NoError(t, err)
+
+	instances := []*azureRef{
+		{Name: "foo"},
+	}
+	err = as.DeleteInstances(instances)
+	expectedErr := fmt.Errorf("\"foo\" isn't in Azure resource ID format")
+	assert.Equal(t, expectedErr, err)
+
+	instances = []*azureRef{
+		{Name: testValidProviderID0},
+		{Name: "foo"},
+	}
+	err = as.DeleteInstances(instances)
+	assert.Equal(t, expectedErr, err)
+
+	instances = []*azureRef{
+		{Name: testInvalidProviderID},
+	}
+	err = as.DeleteInstances(instances)
+	expectedErr = fmt.Errorf("resource name was missing from identifier")
+	assert.Equal(t, expectedErr, err)
+
+	instances = []*azureRef{
+		{Name: testValidProviderID0},
+		{Name: testValidProviderID1},
+	}
+
+	err = as.DeleteInstances(instances)
+	expectedErr = fmt.Errorf("cannot delete instance (%s) which don't belong to the same node pool (\"as\")", testValidProviderID1)
+	assert.Equal(t, expectedErr, err)
+
+	instances = []*azureRef{
+		{Name: testValidProviderID0},
+	}
+	mockVMClient.EXPECT().Get(gomock.Any(), as.manager.config.ResourceGroup, "as-vm-0", gomock.Any()).Return(getExpectedVMs()[0], nil)
+	mockVMClient.EXPECT().Delete(gomock.Any(), as.manager.config.ResourceGroup, "as-vm-0").Return(nil)
+	mockSAClient.EXPECT().ListKeys(gomock.Any(), as.manager.config.ResourceGroup, "foo").Return(storage.AccountListKeysResult{
+		Keys: &[]storage.AccountKey{
+			{Value: to.StringPtr("dmFsdWUK")},
+		},
+	}, nil)
+	err = as.DeleteInstances(instances)
+	expectedErrStr := "The specified account is disabled."
+	assert.True(t, strings.Contains(err.Error(), expectedErrStr))
+}
+
+func TestAgentPoolDeleteNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as
+	expectedVMs := getExpectedVMs()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+	mockSAClient := mockstorageaccountclient.NewMockInterface(ctrl)
+	as.manager.azClient.storageAccountsClient = mockSAClient
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	err := as.DeleteNodes([]*apiv1.Node{})
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil).Times(2)
+	err = as.DeleteNodes([]*apiv1.Node{
+		{
+			Spec:       apiv1.NodeSpec{ProviderID: testInvalidProviderID},
+			ObjectMeta: v1.ObjectMeta{Name: "node"},
+		},
+	})
+	expectedErr = fmt.Errorf("node doesn't belong to a known agent pool")
+	assert.Equal(t, expectedErr, err)
+
+	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as1
+	err = as.DeleteNodes([]*apiv1.Node{
+		{
+			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
+			ObjectMeta: v1.ObjectMeta{Name: "node"},
+		},
+	})
+	expectedErr = fmt.Errorf("node belongs to a different asg than as")
+	assert.Equal(t, expectedErr, err)
+
+	as.manager.asgCache.instanceToAsg[azureRef{Name: testValidProviderID0}] = as
+	mockVMClient.EXPECT().Get(gomock.Any(), as.manager.config.ResourceGroup, "as-vm-0", gomock.Any()).Return(getExpectedVMs()[0], nil)
+	mockVMClient.EXPECT().Delete(gomock.Any(), as.manager.config.ResourceGroup, "as-vm-0").Return(nil)
+	mockSAClient.EXPECT().ListKeys(gomock.Any(), as.manager.config.ResourceGroup, "foo").Return(storage.AccountListKeysResult{
+		Keys: &[]storage.AccountKey{
+			{Value: to.StringPtr("dmFsdWUK")},
+		},
+	}, nil)
+	err = as.DeleteNodes([]*apiv1.Node{
+		{
+			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
+			ObjectMeta: v1.ObjectMeta{Name: "node"},
+		},
+	})
+	expectedErrStr := "The specified account is disabled."
+	assert.True(t, strings.Contains(err.Error(), expectedErrStr))
+
+	as.minSize = 3
+	err = as.DeleteNodes([]*apiv1.Node{})
+	expectedErr = fmt.Errorf("min size reached, nodes will not be deleted")
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestAgentPoolNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	expectedVMs := []compute.VirtualMachine{
+		{
+			Tags: map[string]*string{"poolName": to.StringPtr("as")},
+			ID:   to.StringPtr(""),
+		},
+		{
+			Tags: map[string]*string{"poolName": to.StringPtr("as")},
+			ID:   &testValidProviderID0,
+		},
+	}
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, &rerrInternalErr)
+	nodes, err := as.Nodes()
+	expectedErr := fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>")
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, nodes)
+
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	nodes, err = as.Nodes()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(nodes))
+
+	expectedVMs = []compute.VirtualMachine{
+		{
+			Tags: map[string]*string{"poolName": to.StringPtr("as")},
+			ID:   to.StringPtr("foo"),
+		},
+	}
+	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
+	invalidateVMCache("as")
+	nodes, err = as.Nodes()
+	expectedErr = fmt.Errorf("\"azure://foo\" isn't in Azure resource ID format")
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, nodes)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,11 +39,26 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 			ResourceGroup:       "test",
 			VMType:              vmTypeVMSS,
 			MaxDeploymentsCount: 2,
+			Deployment:          "deployment",
 		},
 
 		azClient: &azClient{
 			deploymentsClient: &DeploymentsClientMock{
-				FakeStore: make(map[string]resources.DeploymentExtended),
+				FakeStore: map[string]resources.DeploymentExtended{
+					"deployment": {
+						Name: to.StringPtr("deployment"),
+						Properties: &resources.DeploymentPropertiesExtended{Template: map[string]interface{}{
+							resourcesFieldName: []interface{}{
+								map[string]interface{}{
+									typeFieldName: nsgResourceType,
+								},
+								map[string]interface{}{
+									typeFieldName: rtResourceType,
+								},
+							},
+						}},
+					},
+				},
 			},
 		},
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -82,7 +82,7 @@ func (m *DeploymentsClientMock) CreateOrUpdate(ctx context.Context, resourceGrou
 
 	deploy.Properties.Parameters = parameters.Properties.Parameters
 	deploy.Properties.Template = parameters.Properties.Template
-	return nil, nil
+	return &http.Response{StatusCode: 200}, nil
 }
 
 // List gets all the deployments for a resource group.

--- a/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/BUILD
+++ b/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/BUILD
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "interface.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient",
+    importpath = "k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/legacy-cloud-providers/azure/retry:go_default_library",
+        "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/doc.go
+++ b/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/doc.go
@@ -1,0 +1,20 @@
+// +build !providerless
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mockstorageaccountclient implements the mock client for StorageAccounts.
+package mockstorageaccountclient // import "k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient"

--- a/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/interface.go
+++ b/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/mockstorageaccountclient/interface.go
@@ -1,0 +1,123 @@
+// +build !providerless
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockstorageaccountclient
+
+import (
+	context "context"
+	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	gomock "github.com/golang/mock/gomock"
+	retry "k8s.io/legacy-cloud-providers/azure/retry"
+	reflect "reflect"
+)
+
+// MockInterface is a mock of Interface interface
+type MockInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockInterfaceMockRecorder
+}
+
+// MockInterfaceMockRecorder is the mock recorder for MockInterface
+type MockInterfaceMockRecorder struct {
+	mock *MockInterface
+}
+
+// NewMockInterface creates a new mock instance
+func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
+	mock := &MockInterface{ctrl: ctrl}
+	mock.recorder = &MockInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
+	return m.recorder
+}
+
+// Create mocks base method
+func (m *MockInterface) Create(ctx context.Context, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, accountName, parameters)
+	ret0, _ := ret[0].(*retry.Error)
+	return ret0
+}
+
+// Create indicates an expected call of Create
+func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, accountName, parameters)
+}
+
+// Delete mocks base method
+func (m *MockInterface) Delete(ctx context.Context, resourceGroupName, accountName string) *retry.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, resourceGroupName, accountName)
+	ret0, _ := ret[0].(*retry.Error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, accountName)
+}
+
+// ListKeys mocks base method
+func (m *MockInterface) ListKeys(ctx context.Context, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListKeys", ctx, resourceGroupName, accountName)
+	ret0, _ := ret[0].(storage.AccountListKeysResult)
+	ret1, _ := ret[1].(*retry.Error)
+	return ret0, ret1
+}
+
+// ListKeys indicates an expected call of ListKeys
+func (mr *MockInterfaceMockRecorder) ListKeys(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeys", reflect.TypeOf((*MockInterface)(nil).ListKeys), ctx, resourceGroupName, accountName)
+}
+
+// ListByResourceGroup mocks base method
+func (m *MockInterface) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]storage.Account, *retry.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByResourceGroup", ctx, resourceGroupName)
+	ret0, _ := ret[0].([]storage.Account)
+	ret1, _ := ret[1].(*retry.Error)
+	return ret0, ret1
+}
+
+// ListByResourceGroup indicates an expected call of ListByResourceGroup
+func (mr *MockInterfaceMockRecorder) ListByResourceGroup(ctx, resourceGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByResourceGroup", reflect.TypeOf((*MockInterface)(nil).ListByResourceGroup), ctx, resourceGroupName)
+}
+
+// GetProperties mocks base method
+func (m *MockInterface) GetProperties(ctx context.Context, resourceGroupName, accountName string) (storage.Account, *retry.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProperties", ctx, resourceGroupName, accountName)
+	ret0, _ := ret[0].(storage.Account)
+	ret1, _ := ret[1].(*retry.Error)
+	return ret0, ret1
+}
+
+// GetProperties indicates an expected call of GetProperties
+func (mr *MockInterfaceMockRecorder) GetProperties(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperties", reflect.TypeOf((*MockInterface)(nil).GetProperties), ctx, resourceGroupName, accountName)
+}


### PR DESCRIPTION
Add test cases for azure_agent_pool.go. We update the vendor because we need packages that don't exist in `vendor/`.

/kind cleanup
/area provider/azure