### PR TITLE
VPA: Allow limiting VPA deployment to a namespace

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -106,8 +106,8 @@ func main() {
 	}
 
 	statusNamespace := status.AdmissionControllerStatusNamespace
-	if *vpaObjectNamespace != "" {
-		statusNamespace = *vpaObjectNamespace
+	if namespace != "" {
+		statusNamespace = namespace
 	}
 	stopCh := make(chan struct{})
 	statusUpdater := status.NewUpdater(

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -113,7 +113,7 @@ func NewClusterStateFeeder(config *rest.Config, clusterState *model.ClusterState
 		PodLister:           podLister,
 		OOMObserver:         oomObserver,
 		KubeClient:          kubeClient,
-		MetricsClient:       newMetricsClient(config),
+		MetricsClient:       newMetricsClient(config, namespace),
 		VpaCheckpointClient: vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
 		VpaLister:           vpa_api_util.NewVpasLister(vpa_clientset.NewForConfigOrDie(config), make(chan struct{}), namespace),
 		ClusterState:        clusterState,
@@ -123,9 +123,9 @@ func NewClusterStateFeeder(config *rest.Config, clusterState *model.ClusterState
 	}.Make()
 }
 
-func newMetricsClient(config *rest.Config) metrics.MetricsClient {
+func newMetricsClient(config *rest.Config, namespace string) metrics.MetricsClient {
 	metricsGetter := resourceclient.NewForConfigOrDie(config)
-	return metrics.NewMetricsClient(metricsGetter)
+	return metrics.NewMetricsClient(metricsGetter, namespace)
 }
 
 // WatchEvictionEventsWithRetries watches new Events with reason=Evicted and passes them to the observer.

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -32,9 +32,11 @@ import (
 )
 
 const (
-	cpuQuery    = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[30s])"
-	memoryQuery = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}"
-	labelsQuery = "up{job=\"kubernetes-pods\"}"
+	cpuQuery              = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[30s])"
+	memoryQuery           = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}"
+	labelsQuery           = "up{job=\"kubernetes-pods\"}"
+	cpuNamespacedQuery    = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}[30s])"
+	memoryNamespacedQuery = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}"
 )
 
 func getDefaultPrometheusHistoryProviderConfigForTest() PrometheusHistoryProviderConfig {
@@ -60,39 +62,51 @@ type mockPrometheusAPI struct {
 func (m mockPrometheusAPI) AlertManagers(ctx context.Context) (prometheusv1.AlertManagersResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Alerts(ctx context.Context) (prometheusv1.AlertsResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) CleanTombstones(ctx context.Context) error {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Config(ctx context.Context) (prometheusv1.ConfigResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Flags(ctx context.Context) (prometheusv1.FlagsResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) LabelNames(ctx context.Context) ([]string, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) LabelValues(ctx context.Context, label string) (prommodel.LabelValues, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]prommodel.LabelSet, api.Warnings, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Rules(ctx context.Context) (prometheusv1.RulesResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (prometheusv1.SnapshotResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) Targets(ctx context.Context) (prometheusv1.TargetsResult, error) {
 	panic("not implemented")
 }
+
 func (m mockPrometheusAPI) TargetsMetadata(ctx context.Context, _, _, _ string) ([]prometheusv1.MetricMetadata, error) {
 	panic("not implemented")
 }
@@ -119,7 +133,8 @@ func TestGetEmptyClusterHistory(t *testing.T) {
 	mockClient := mockPrometheusAPI{}
 	historyProvider := prometheusHistoryProvider{
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
-		prometheusClient: &mockClient}
+		prometheusClient: &mockClient,
+	}
 	mockClient.On("Query", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Times(1).Return(
 		prommodel.Matrix{}, nil)
 	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(2).Return(
@@ -134,7 +149,8 @@ func TestPrometheusError(t *testing.T) {
 	mockClient := mockPrometheusAPI{}
 	historyProvider := prometheusHistoryProvider{
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
-		prometheusClient: &mockClient}
+		prometheusClient: &mockClient,
+	}
 	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(2).Return(
 		nil, fmt.Errorf("bla"))
 	_, err := historyProvider.GetClusterHistory()
@@ -145,7 +161,8 @@ func TestGetCPUSamples(t *testing.T) {
 	mockClient := mockPrometheusAPI{}
 	historyProvider := prometheusHistoryProvider{
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
-		prometheusClient: &mockClient}
+		prometheusClient: &mockClient,
+	}
 	mockClient.On("QueryRange", mock.Anything, cpuQuery, mock.AnythingOfType("v1.Range")).Return().Return(
 		prommodel.Matrix{
 			{
@@ -171,7 +188,9 @@ func TestGetCPUSamples(t *testing.T) {
 		Samples: map[string][]model.ContainerUsageSample{"container": {{
 			MeasureStart: time.Unix(1, 0),
 			Usage:        model.CPUAmountFromCores(5.5),
-			Resource:     model.ResourceCPU}}}}
+			Resource:     model.ResourceCPU,
+		}}},
+	}
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
 	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
@@ -181,7 +200,8 @@ func TestGetMemorySamples(t *testing.T) {
 	mockClient := mockPrometheusAPI{}
 	historyProvider := prometheusHistoryProvider{
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
-		prometheusClient: &mockClient}
+		prometheusClient: &mockClient,
+	}
 	mockClient.On("QueryRange", mock.Anything, cpuQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(
 		prommodel.Matrix{
@@ -206,7 +226,50 @@ func TestGetMemorySamples(t *testing.T) {
 		Samples: map[string][]model.ContainerUsageSample{"container": {{
 			MeasureStart: time.Unix(1, 0),
 			Usage:        model.MemoryAmountFromBytes(12345),
-			Resource:     model.ResourceMemory}}}}
+			Resource:     model.ResourceMemory,
+		}}},
+	}
+	histories, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
+}
+
+func TestGetNamespacedMemorySamples(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.Namespace = "kube-system"
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, cpuNamespacedQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, memoryNamespacedQuery, mock.AnythingOfType("v1.Range")).Return().Return(
+		prommodel.Matrix{
+			{
+				Metric: map[prommodel.LabelName]prommodel.LabelValue{
+					"namespace": "kube-system",
+					"pod_name":  "pod",
+					"name":      "container",
+				},
+				Values: []prommodel.SamplePair{
+					{
+						Timestamp: prommodel.TimeFromUnix(1),
+						Value:     12345,
+					},
+				},
+			},
+		}, nil)
+	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	podID := model.PodID{Namespace: "kube-system", PodName: "pod"}
+	podHistory := &PodHistory{
+		LastLabels: map[string]string{},
+		Samples: map[string][]model.ContainerUsageSample{"container": {{
+			MeasureStart: time.Unix(1, 0),
+			Usage:        model.MemoryAmountFromBytes(12345),
+			Resource:     model.ResourceMemory,
+		}}},
+	}
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
 	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
@@ -216,7 +279,8 @@ func TestGetLabels(t *testing.T) {
 	mockClient := mockPrometheusAPI{}
 	historyProvider := prometheusHistoryProvider{
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
-		prometheusClient: &mockClient}
+		prometheusClient: &mockClient,
+	}
 	mockClient.On("QueryRange", mock.Anything, cpuQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(
@@ -252,7 +316,8 @@ func TestGetLabels(t *testing.T) {
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{"x": "z"},
 		LastSeen:   time.Unix(20, 0),
-		Samples:    map[string][]model.ContainerUsageSample{}}
+		Samples:    map[string][]model.ContainerUsageSample{},
+	}
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
 	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -49,20 +49,23 @@ type MetricsClient interface {
 
 type metricsClient struct {
 	metricsGetter resourceclient.PodMetricsesGetter
+	namespace     string
 }
 
 // NewMetricsClient creates new instance of MetricsClient, which is used by recommender.
 // It requires an instance of PodMetricsesGetter, which is used for underlying communication with metrics server.
-func NewMetricsClient(metricsGetter resourceclient.PodMetricsesGetter) MetricsClient {
+// namespace limits queries to particular namespace, empty strings means all namespaces.
+func NewMetricsClient(metricsGetter resourceclient.PodMetricsesGetter, namespace string) MetricsClient {
 	return &metricsClient{
 		metricsGetter: metricsGetter,
+		namespace:     namespace,
 	}
 }
 
 func (c *metricsClient) GetContainersMetrics() ([]*ContainerMetricsSnapshot, error) {
 	var metricsSnapshots []*ContainerMetricsSnapshot
 
-	podMetricsInterface := c.metricsGetter.PodMetricses(k8sapiv1.NamespaceAll)
+	podMetricsInterface := c.metricsGetter.PodMetricses(c.namespace)
 	podMetricsList, err := podMetricsInterface.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -54,7 +54,7 @@ type metricsClient struct {
 
 // NewMetricsClient creates new instance of MetricsClient, which is used by recommender.
 // It requires an instance of PodMetricsesGetter, which is used for underlying communication with metrics server.
-// namespace limits queries to particular namespace, empty strings means all namespaces.
+// namespace limits queries to particular namespace, use k8sapiv1.NamespaceAll to select all namespaces.
 func NewMetricsClient(metricsGetter resourceclient.PodMetricsesGetter, namespace string) MetricsClient {
 	return &metricsClient{
 		metricsGetter: metricsGetter,

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -22,7 +22,7 @@ import (
 
 	k8sapiv1 "k8s.io/api/core/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -84,7 +84,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1())
+	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
@@ -53,6 +54,7 @@ var (
 	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
+	vpaNamespace        = flag.String("namespace", apiv1.NamespaceAll, "Namespace to search for pod stats and VPA objects. Empty means all namespaces will be used.")
 )
 
 // Aggregation configuration flags
@@ -78,7 +80,7 @@ func main() {
 	metrics_quality.Register()
 
 	useCheckpoints := *storage != "prometheus"
-	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints)
+	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaNamespace)
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {
@@ -101,6 +103,7 @@ func main() {
 			CtrPodNameLabel:        *ctrPodNameLabel,
 			CtrNameLabel:           *ctrNameLabel,
 			CadvisorMetricsJobName: *prometheusJobName,
+			Namespace:              *vpaNamespace,
 		}
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {
@@ -114,7 +117,6 @@ func main() {
 		recommender.RunOnce()
 		healthCheck.UpdateLastActivity()
 	}
-
 }
 
 func createKubeConfig(kubeApiQps float32, kubeApiBurst int) *rest.Config {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -54,7 +54,7 @@ var (
 	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
-	vpaNamespace        = flag.String("namespace", apiv1.NamespaceAll, "Namespace to search for pod stats and VPA objects. Empty means all namespaces will be used.")
+	vpaObjectNamespace  = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects and pod stats. Empty means all namespaces will be used.")
 )
 
 // Aggregation configuration flags
@@ -80,7 +80,7 @@ func main() {
 	metrics_quality.Register()
 
 	useCheckpoints := *storage != "prometheus"
-	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaNamespace)
+	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace)
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {
@@ -103,7 +103,7 @@ func main() {
 			CtrPodNameLabel:        *ctrPodNameLabel,
 			CtrNameLabel:           *ctrNameLabel,
 			CadvisorMetricsJobName: *prometheusJobName,
-			Namespace:              *vpaNamespace,
+			Namespace:              *vpaObjectNamespace,
 		}
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -34,10 +34,8 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	// AggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
-	AggregateContainerStateGCInterval = 1 * time.Hour
-)
+// AggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
+const AggregateContainerStateGCInterval = 1 * time.Hour
 
 var (
 	checkpointsWriteTimeout = flag.Duration("checkpoints-timeout", time.Minute, `Timeout for writing checkpoints since the start of the recommender's main loop`)
@@ -91,7 +89,8 @@ func (r *recommender) UpdateVPAs() {
 	for _, observedVpa := range r.clusterState.ObservedVpas {
 		key := model.VpaID{
 			Namespace: observedVpa.Namespace,
-			VpaName:   observedVpa.Name}
+			VpaName:   observedVpa.Name,
+		}
 
 		vpa, found := r.clusterState.Vpas[key]
 		if !found {
@@ -164,7 +163,6 @@ func (r *recommender) MaintainCheckpoints(ctx context.Context, minCheckpointsPer
 			r.clusterStateFeeder.GarbageCollectCheckpoints()
 		}
 	}
-
 }
 
 func (r *recommender) GarbageCollect() {
@@ -240,11 +238,11 @@ func (c RecommenderFactory) Make() Recommender {
 // NewRecommender creates a new recommender instance.
 // Dependencies are created automatically.
 // Deprecated; use RecommenderFactory instead.
-func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, useCheckpoints bool) Recommender {
+func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, useCheckpoints bool, namespace string) Recommender {
 	clusterState := model.NewClusterState()
 	return RecommenderFactory{
 		ClusterState:           clusterState,
-		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState, *memorySaver),
+		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState, *memorySaver, namespace),
 		CheckpointWriter:       checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
 		VpaClient:              vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
 		PodResourceRecommender: logic.CreatePodResourceRecommender(),

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -76,7 +76,8 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 	return nil, nil
 }
 
-// NewVpasLister returns VerticalPodAutoscalerLister configured to fetch all VPA objects from namespace.
+// NewVpasLister returns VerticalPodAutoscalerLister configured to fetch all VPA objects from namespace,
+// set namespace to k8sapiv1.NamespaceAll to select all namespaces.
 // The method blocks until vpaLister is initially populated.
 func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}, namespace string) vpa_lister.VerticalPodAutoscalerLister {
 	vpaListWatch := cache.NewListWatchFromClient(vpaClient.AutoscalingV1().RESTClient(), "verticalpodautoscalers", namespace, fields.Everything())

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -76,10 +76,10 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 	return nil, nil
 }
 
-// NewAllVpasLister returns VerticalPodAutoscalerLister configured to fetch all VPA objects.
+// NewVpasLister returns VerticalPodAutoscalerLister configured to fetch all VPA objects from namespace.
 // The method blocks until vpaLister is initially populated.
-func NewAllVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}) vpa_lister.VerticalPodAutoscalerLister {
-	vpaListWatch := cache.NewListWatchFromClient(vpaClient.AutoscalingV1().RESTClient(), "verticalpodautoscalers", core.NamespaceAll, fields.Everything())
+func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}, namespace string) vpa_lister.VerticalPodAutoscalerLister {
+	vpaListWatch := cache.NewListWatchFromClient(vpaClient.AutoscalingV1().RESTClient(), "verticalpodautoscalers", namespace, fields.Everything())
 	indexer, controller := cache.NewIndexerInformer(vpaListWatch,
 		&vpa_types.VerticalPodAutoscaler{},
 		1*time.Hour,


### PR DESCRIPTION
Allows running multiple VPA deployments, each deployment looking at only it's namespace, update it's lease in that namespace, etc.

Also for Prometheus it would limit queries to that namespace.

Fixes #3010

We are currently running this and it works great!

docker images available:
```
# Image runs https://github.com/kubernetes/autoscaler/pull/3227/files
  - name: vpa-updater
    newName: quay.io/utilitywarehouse/vpa-updater
    newTag: dev
  - name: vpa-admission-controller
    newName: quay.io/utilitywarehouse/vpa-admission-controller
    newTag: dev
  - name: vpa-recommender
    newName: quay.io/utilitywarehouse/vpa-recommender
    newTag: dev
```

Role bindings:
<details>
<pre>
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: vpa-actor
  namespace: telecom
rules:
  - apiGroups:
      - ""
    resources:
      - pods
      - limitranges
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - ""
    resources:
      - events
    verbs:
      - get
      - list
      - watch
      - create
  - apiGroups:
      - "poc.autoscaling.k8s.io"
    resources:
      - verticalpodautoscalers
    verbs:
      - get
      - list
      - watch
      - patch
  - apiGroups:
      - "autoscaling.k8s.io"
    resources:
      - verticalpodautoscalers
    verbs:
      - get
      - list
      - watch
      - patch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: evictioner
  namespace: telecom
rules:
  - apiGroups:
      - "apps"
      - "extensions"
    resources:
      - replicasets
    verbs:
      - get
  - apiGroups:
      - ""
    resources:
      - pods/eviction
    verbs:
      - create
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: vpa-actor
  namespace: telecom
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: vpa-actor
subjects:
  - kind: ServiceAccount
    name: vpa-recommender
    namespace: telecom
  - kind: ServiceAccount
    name: vpa-updater
    namespace: telecom
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: vpa-target-reader
  namespace: telecom
rules:
  - apiGroups:
      - ""
    resources:
      - replicationcontrollers
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - apps
    resources:
      - daemonsets
      - deployments
      - replicasets
      - statefulsets
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - batch
    resources:
      - jobs
      - cronjobs
    verbs:
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: vpa-target-reader-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: vpa-target-reader
subjects:
  - kind: ServiceAccount
    name: vpa-recommender
    namespace: telecom
  - kind: ServiceAccount
    name: vpa-admission-controller
    namespace: telecom
  - kind: ServiceAccount
    name: vpa-updater
    namespace: telecom
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: vpa-evictioner-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: evictioner
subjects:
  - kind: ServiceAccount
    name: vpa-updater
    namespace: telecom
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vpa-admission-controller
  namespace: telecom
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: vpa-admission-controller
  namespace: telecom
rules:
  - apiGroups:
      - ""
    resources:
      - pods
      - configmaps
      - nodes
      - limitranges
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - "poc.autoscaling.k8s.io"
    resources:
      - verticalpodautoscalers
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - "autoscaling.k8s.io"
    resources:
      - verticalpodautoscalers
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - "coordination.k8s.io"
    resources:
      - leases
    verbs:
      - create
      - update
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: vpa-admission-controller
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: vpa-admission-controller
subjects:
  - kind: ServiceAccount
    name: vpa-admission-controller
    namespace: telecom
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: vpa-status-reader
rules:
  - apiGroups:
      - "coordination.k8s.io"
    resources:
      - leases
    verbs:
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: vpa-status-reader-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: vpa-status-reader
subjects:
  - kind: ServiceAccount
    name: vpa-updater
    namespace: telecom
```
</pre>
</details>