### PR TITLE
Azure: Delete containerServicesClient in provider azure.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -147,7 +147,6 @@ type azClient struct {
 	interfacesClient                interfaceclient.Interface
 	disksClient                     diskclient.Interface
 	storageAccountsClient           storageaccountclient.Interface
-	containerServicesClient         containerservice.ContainerServicesClient
 	managedContainerServicesClient  containerservice.ManagedClustersClient
 }
 
@@ -242,13 +241,6 @@ func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
 	disksClient := diskclient.New(diskClientConfig)
 	klog.V(5).Infof("Created disks client with authorizer: %v", disksClient)
 
-	containerServicesClient := containerservice.NewContainerServicesClient(cfg.SubscriptionID)
-	containerServicesClient.BaseURI = env.ResourceManagerEndpoint
-	containerServicesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	containerServicesClient.PollingDelay = 5 * time.Second
-	containerServicesClient.Sender = autorest.CreateSender()
-	klog.V(5).Infof("Created Container services client with authorizer: %v", containerServicesClient)
-
 	managedContainerServicesClient := containerservice.NewManagedClustersClient(cfg.SubscriptionID)
 	managedContainerServicesClient.BaseURI = env.ResourceManagerEndpoint
 	managedContainerServicesClient.Authorizer = autorest.NewBearerAuthorizer(spt)
@@ -264,7 +256,6 @@ func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
 		deploymentsClient:               deploymentsClient,
 		virtualMachinesClient:           virtualMachinesClient,
 		storageAccountsClient:           storageAccountsClient,
-		containerServicesClient:         containerServicesClient,
 		managedContainerServicesClient:  managedContainerServicesClient,
 	}, nil
 }


### PR DESCRIPTION
Delete containerServicesClient in provider azure since it is useless.

/kind cleanup
/area provider/azure