### PR TITLE
Added a make target to support immutable images when developing

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -1,6 +1,7 @@
 all: build
 
-TAG?=dev
+DATE:=${shell date +'%y%m%d-%H%M%S'}
+TAG?=dev-${DATE}
 FLAGS=
 LDFLAGS?=-s
 ENVVAR=CGO_ENABLED=0 GO111MODULE=off
@@ -33,6 +34,9 @@ test-unit: clean deps build
 
 dev-release: build-binary execute-release
 	@echo "Release ${TAG}${FOR_PROVIDER} completed"
+
+dev-deploy: dev-release
+	kubectl patch deployment cluster-autoscaler -n kube-system --type=json -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"'${REGISTRY}'/cluster-autoscaler:'${TAG}'"}]'
 
 make-image:
 ifdef BASEIMAGE


### PR DESCRIPTION
Added a basic make target that automatically dates and patches images while developing.

1) Some repositories recommend immutable tags. Requiring a fixed tag like "dev" creates eventual consistency challenges with remote storage. 
2) Automatically patches cluster autoscaler with the new image.