### PR TITLE
Disable increaseSize when the node group is under initialilzation.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -75,6 +75,7 @@ func NewAgentPool(spec *dynamic.NodeGroupSpec, az *AzureManager) (*AgentPool, er
 		minSize: spec.MinSize,
 		maxSize: spec.MaxSize,
 		manager: az,
+		curSize: -1,
 	}
 
 	if err := as.initialize(); err != nil {
@@ -301,6 +302,10 @@ func (as *AgentPool) deleteOutdatedDeployments() (err error) {
 func (as *AgentPool) IncreaseSize(delta int) error {
 	as.mutex.Lock()
 	defer as.mutex.Unlock()
+
+	if as.curSize == -1 {
+		return fmt.Errorf("the availability set %s is under initialization, skipping IncreaseSize", as.Name)
+	}
 
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -336,6 +336,10 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 		return err
 	}
 
+	if size == -1 {
+		return fmt.Errorf("the scale set %s is under initialization, skipping IncreaseSize", scaleSet.Name)
+	}
+
 	if int(size)+delta > scaleSet.MaxSize() {
 		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
 	}


### PR DESCRIPTION
Disable increaseSize when the node group is under initialilzation.

fixes: #3240

/kind bug
/area provider/azure