### PR TITLE
full vpa e2e - bumping up cpu request tolerance

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -101,7 +101,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("900m"))
+			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
@@ -101,7 +101,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("900m"))
+			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 


### PR DESCRIPTION
Bumping up upper limit for cpu recommendation in "Pods under VPA have cpu requests growing with usage" test case.

/fixes #3249