### PR TITLE
Reduce instance lock scope in scale sets

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -228,14 +228,6 @@ func (scaleSet *ScaleSet) GetScaleSetSize() (int64, error) {
 }
 
 func (scaleSet *ScaleSet) waitForDeleteInstances(future *azure.Future, requiredIds *compute.VirtualMachineScaleSetVMInstanceRequiredIDs) {
-	var err error
-
-	defer func() {
-		if err != nil {
-			klog.Errorf("Failed to delete instances %v", requiredIds.InstanceIds)
-		}
-	}()
-
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 


### PR DESCRIPTION
Currently, `DeleteInstances` can take a lock on `instanceMutex` and get blocked on `GetAsgForInstance` if a `manager.regenerate` call happens and grab the `azure_cache` mutex lock. Both `DeleteInstances` and `Nodes` will then be deadlocked.

/area provider/azure