### PR TITLE
Cherry-pick #3261: Reduce instance lock scope in scale sets

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -392,9 +392,6 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef) error {
 		return err
 	}
 
-	scaleSet.instanceMutex.Lock()
-	defer scaleSet.instanceMutex.Unlock()
-
 	instanceIDs := []string{}
 	for _, instance := range instances {
 		asg, err := scaleSet.manager.GetAsgForInstance(instance)
@@ -406,10 +403,12 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef) error {
 			return fmt.Errorf("cannot delete instance (%s) which don't belong to the same Scale Set (%q)", instance.Name, commonAsg)
 		}
 
+		scaleSet.instanceMutex.Lock()
 		if cpi, found := scaleSet.getInstanceByProviderID(instance.Name); found && cpi.Status != nil && cpi.Status.State == cloudprovider.InstanceDeleting {
 			klog.V(3).Infof("Skipping deleting instance %s as its current state is deleting", instance.Name)
 			continue
 		}
+		scaleSet.instanceMutex.Unlock()
 
 		instanceID, err := getLastSegment(instance.Name)
 		if err != nil {


### PR DESCRIPTION
Cherry-pick #3261

Currently, DeleteInstances can take a lock on instanceMutex and get blocked on GetAsgForInstance if a manager.regenerate call happens and grab the azure_cache mutex lock. Both DeleteInstances and Nodes will then be deadlocked.

/area provider/azure