### PR TITLE
Update golang version used in docker builds

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.5
+FROM golang:1.14
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/


### PR DESCRIPTION
This is a minor cleanup after https://github.com/kubernetes/autoscaler/pull/3267 to fix building in docker.