### PR TITLE
Cherry-pick #2841: remove unused asg cache TTL

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -73,8 +73,6 @@ Make a copy of [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.y
 
 > **_NOTE_**: Use a command such as `echo $CLIENT_ID | base64` to encode each of the fields above.
 
-> **_NOTE_** (optional) to specify the TTL of VMSS ASG cache to prevent throttling issue, please provide the env `AZURE_ASG_CACHE_TTL` in seconds which is set to one hour by default.
-
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
 
 Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and VMSS name. For example, if node pool "k8s-nodepool-1-vmss" should scale from 1 to 10 nodes:
@@ -120,7 +118,7 @@ Make a copy of [cluster-autoscaler-standard-master.yaml](examples/cluster-autosc
 
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
 
-Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and node pool name (tips: node pool name is NOT availability set name, e.g., the corresponding node pool name of the availability set 
+Below that, in the `command:` section, update the `--nodes=` arguments to reference your node limits and node pool name (tips: node pool name is NOT availability set name, e.g., the corresponding node pool name of the availability set
 `agentpool1-availabilitySet-xxxxxxxx` would be `agentpool1`). For example, if node pool "k8s-nodepool-1" should scale from 1 to 10 nodes:
 
 ```yaml

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -97,7 +97,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 		},
 	}
 
-	cache, error := newAsgCache(int64(defaultAsgCacheTTL))
+	cache, error := newAsgCache()
 	assert.NoError(t, error)
 
 	manager.asgCache = cache

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -81,9 +81,6 @@ type Config struct {
 	//Config only for AKS
 	NodeResourceGroup string `json:"nodeResourceGroup" yaml:"nodeResourceGroup"`
 
-	// ASG cache TTL in seconds
-	AsgCacheTTL int64 `json:"asgCacheTTL" yaml:"asgCacheTTL"`
-
 	// VMSS metadata cache TTL in seconds, only applies for vmss type
 	VmssCacheTTL int64 `json:"vmssCacheTTL" yaml:"vmssCacheTTL"`
 }
@@ -140,13 +137,6 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 			}
 		}
 
-		if asgCacheTTL := os.Getenv("AZURE_ASG_CACHE_TTL"); asgCacheTTL != "" {
-			cfg.AsgCacheTTL, err = strconv.ParseInt(asgCacheTTL, 10, 0)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse AZURE_ASG_CACHE_TTL %q: %v", asgCacheTTL, err)
-			}
-		}
-
 		if vmssCacheTTL := os.Getenv("AZURE_VMSS_CACHE_TTL"); vmssCacheTTL != "" {
 			cfg.VmssCacheTTL, err = strconv.ParseInt(vmssCacheTTL, 10, 0)
 			if err != nil {
@@ -170,10 +160,6 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		}
 
 		cfg.DeploymentParameters = parameters
-	}
-
-	if cfg.AsgCacheTTL == 0 {
-		cfg.AsgCacheTTL = int64(defaultAsgCacheTTL)
 	}
 
 	// Defaulting env to Azure Public Cloud.
@@ -204,7 +190,7 @@ func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.Node
 		explicitlyConfigured: make(map[string]bool),
 	}
 
-	cache, err := newAsgCache(cfg.AsgCacheTTL)
+	cache, err := newAsgCache()
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -37,7 +37,6 @@ const validAzureCfg = `{
 	"vnetName": "fakeName",
 	"routeTableName": "fakeName",
 	"primaryAvailabilitySetName": "fakeName",
-	"asgCacheTTL": 900,
 	"vmssCacheTTL": 60}`
 
 const invalidAzureCfg = `{{}"cloud": "AzurePublicCloud",}`
@@ -53,7 +52,6 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		VMType:          "vmss",
 		AADClientID:     "fakeId",
 		AADClientSecret: "fakeId",
-		AsgCacheTTL:     900,
 		VmssCacheTTL:    60,
 	}
 


### PR DESCRIPTION
The cache TTL isn't really applicable and the goroutine running can do more harm than good in some cases given the lock it acquires.