### PR TITLE
Decrement curSize by the number of instances to be deleted

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"fmt"
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -94,7 +95,7 @@ func TestNodeGroupForNode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedVMSSVMs := newTestVMSSVMList()
+	expectedVMSSVMs := newTestVMSSVMList(3)
 	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
 
 	provider := newTestProvider(t)
@@ -112,7 +113,7 @@ func TestNodeGroupForNode(t *testing.T) {
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fakeVirtualMachineScaleSetVMID,
+			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
 		},
 	}
 	// refresh cache

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/0"
+	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/%d"
 )
 
 // DeploymentsClientMock mocks for DeploymentsClient.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -598,7 +598,7 @@ func TestFetchExplicitAsgs(t *testing.T) {
 	}
 
 	manager := newTestAzureManager(t)
-	expectedVMSSVMs := newTestVMSSVMList()
+	expectedVMSSVMs := newTestVMSSVMList(3)
 	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
 
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
@@ -889,7 +889,7 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 	}
 
 	expectedScaleSets := []compute.VirtualMachineScaleSet{fakeVMSSWithTags(vmssName, map[string]*string{vmssTag: &vmssTagValue, "min": &minString, "max": &maxString})}
-	expectedVMSSVMs := newTestVMSSVMList()
+	expectedVMSSVMs := newTestVMSSVMList(1)
 
 	manager := newTestAzureManager(t)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -452,7 +452,7 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef) error {
 	// Proactively decrement scale set size so that we don't
 	// go below minimum node count if cache data is stale
 	scaleSet.sizeMutex.Lock()
-	scaleSet.curSize--
+	scaleSet.curSize -= int64(len(instanceIDs))
 	scaleSet.sizeMutex.Unlock()
 
 	go scaleSet.waitForDeleteInstances(future, requiredIds)


### PR DESCRIPTION
DeleteInstances can take in an array of instances to delete so we should decrement by the length of instances to be deleted.

Note: It's not really an issue now because all code paths used in CA send a single instance to Delete (except `deleteCreatedNodesWithErrors` which isn't used by the Azure provider) but just in case the signatures change in the future

/area provider/azure