### PR TITLE
use contexts with timeouts in scale set GET calls

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -174,7 +174,7 @@ func (scaleSet *ScaleSet) getVMSSInfo() (compute.VirtualMachineScaleSet, *retry.
 }
 
 func (scaleSet *ScaleSet) getAllVMSSInfo() ([]compute.VirtualMachineScaleSet, *retry.Error) {
-	ctx, cancel := getContextWithCancel()
+	ctx, cancel := getContextWithTimeout(3 * time.Minute)
 	defer cancel()
 
 	resourceGroup := scaleSet.manager.config.ResourceGroup
@@ -339,7 +339,7 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // GetScaleSetVms returns list of nodes for the given scale set.
 func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, *retry.Error) {
 	klog.V(4).Infof("GetScaleSetVms: starts")
-	ctx, cancel := getContextWithCancel()
+	ctx, cancel := getContextWithTimeout(3 * time.Minute)
 	defer cancel()
 
 	resourceGroup := scaleSet.manager.config.ResourceGroup

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -595,6 +596,10 @@ func readDeploymentParameters(paramFilePath string) (map[string]interface{}, err
 
 func getContextWithCancel() (context.Context, context.CancelFunc) {
 	return context.WithCancel(context.Background())
+}
+
+func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 // checkExistsFromError inspects an error and returns a true if err is nil,


### PR DESCRIPTION
We don't set any timeouts on the contexts used with the azure clients. In some cases, this can be dangerous because we can block the autoscaler main loop in the paths that depend on `cloudprovider.Nodes()` call. This can possibly lead to lock contention and halting the entire progress.

Here's an example of a List VMs call that blocked the main loop for 10 minutes:

```
I0703 06:38:34.812256       1 azure_client.go:202] azVirtualMachineScaleSetVMsClient.List("mc_","aks-nodepool1-11559524-vmss",""): start
I0703 06:48:04.815605       1 azure_client.go:204] azVirtualMachineScaleSetVMsClient.List("mc_","aks-nodepool1-11559524-vmss",""): end
E0703 06:48:04.815662       1 azure_scale_set.go:349] VirtualMachineScaleSetVMsClient.List failed for aks-nodepool1-11559524-vmss: compute.VirtualMachineScaleSetVMsClient#List: Failure sending request: StatusCode=0 -- Original Error: Get https://management.azure.com/subscriptions/{}/aks-nodepool1-11559524-vmss/virtualMachines?api-version=2018-10-01: dial tcp 13.73.240.225:443: i/o timeout
```

This sets a context timeout of 3 minutes on those calls. We should also have proper timeouts for the mutating calls but this isn't much of a concern because they're non-blocking and don't hold locks. They also tend to vary largely with SKU types, capacity request, etc.

/area provider/azure