### PR TITLE
Cherry-pick #3221, #3284 - Async Deletions and 409 Conflicts

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -42,6 +42,8 @@ type VirtualMachineScaleSetsClient interface {
 	CreateOrUpdateSync(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error)
 	WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error)
 	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error)
+	DeleteInstancesAsync(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (result compute.VirtualMachineScaleSetsDeleteInstancesFuture, err error)
+	WaitForDeleteInstances(ctx context.Context, future compute.VirtualMachineScaleSetsDeleteInstancesFuture) (resp *http.Response, err error)
 }
 
 // VirtualMachineScaleSetVMsClient defines needed functions for azure compute.VirtualMachineScaleSetVMsClient.
@@ -168,6 +170,19 @@ func (az *azVirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, 
 		return future.Response(), err
 	}
 
+	err = future.WaitForCompletionRef(ctx, az.client.Client)
+	return future.Response(), err
+}
+
+func (az *azVirtualMachineScaleSetsClient) DeleteInstancesAsync(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (result compute.VirtualMachineScaleSetsDeleteInstancesFuture, err error) {
+	klog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstancesAsync(%q,%q,%v): start", resourceGroupName, vmScaleSetName, vmInstanceIDs.InstanceIds)
+	defer func() {
+		klog.V(10).Infof("azVirtualMachineScaleSetsClient.DeleteInstancesAsync(%q,%q,%v): end", resourceGroupName, vmScaleSetName, vmInstanceIDs.InstanceIds)
+	}()
+	return az.client.DeleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
+}
+
+func (az *azVirtualMachineScaleSetsClient) WaitForDeleteInstances(ctx context.Context, future compute.VirtualMachineScaleSetsDeleteInstancesFuture) (resp *http.Response, err error) {
 	err = future.WaitForCompletionRef(ctx, az.client.Client)
 	return future.Response(), err
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -39,7 +39,7 @@ type VirtualMachineScaleSetsClient interface {
 	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (resp *http.Response, err error)
 	DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (resp *http.Response, err error)
-	CreateOrUpdateSync(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error)
+	CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, name string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error)
 	WaitForCreateOrUpdate(ctx context.Context, future compute.VirtualMachineScaleSetsCreateOrUpdateFuture) (resp *http.Response, err error)
 	List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error)
 	DeleteInstancesAsync(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (result compute.VirtualMachineScaleSetsDeleteInstancesFuture, err error)
@@ -113,10 +113,10 @@ func (az *azVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, r
 	return future.Response(), err
 }
 
-func (az *azVirtualMachineScaleSetsClient) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
-	klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): start", resourceGroupName, VMScaleSetName)
+func (az *azVirtualMachineScaleSetsClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+	klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateAsync(%q,%q): start", resourceGroupName, VMScaleSetName)
 	defer func() {
-		klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateSync(%q,%q): end", resourceGroupName, VMScaleSetName)
+		klog.V(10).Infof("azVirtualMachineScaleSetsClient.CreateOrUpdateAsync(%q,%q): end", resourceGroupName, VMScaleSetName)
 	}()
 
 	return az.client.CreateOrUpdate(ctx, resourceGroupName, VMScaleSetName, parameters)

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -52,7 +52,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 		},
 	}
 
-	scaleSetsClient.On("CreateOrUpdateSync", mock.Anything, mock.Anything, mock.Anything).Run(
+	scaleSetsClient.On("CreateOrUpdateAsync", mock.Anything, mock.Anything, mock.Anything).Run(
 		func(args mock.Arguments) {
 			resourceGroupName := args.Get(0).(string)
 			vmssName := args.Get(1).(string)

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -93,6 +93,21 @@ func (client *VirtualMachineScaleSetsClientMock) DeleteInstances(ctx context.Con
 	return nil, args.Error(1)
 }
 
+// DeleteInstancesAsync deletes a set of instances for specified VirtualMachineScaleSet and returns the future
+func (client *VirtualMachineScaleSetsClientMock) DeleteInstancesAsync(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) (result compute.VirtualMachineScaleSetsDeleteInstancesFuture, err error) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	args := client.Called(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+	return compute.VirtualMachineScaleSetsDeleteInstancesFuture{}, args.Error(1)
+}
+
+// WaitForDeleteInstances returns a successful result
+func (client *VirtualMachineScaleSetsClientMock) WaitForDeleteInstances(ctx context.Context, future compute.VirtualMachineScaleSetsDeleteInstancesFuture) (resp *http.Response, err error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
 // List gets a list of VirtualMachineScaleSets.
 func (client *VirtualMachineScaleSetsClientMock) List(ctx context.Context, resourceGroupName string) (result []compute.VirtualMachineScaleSet, err error) {
 	client.mutex.Lock()

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -72,8 +72,8 @@ func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdate(ctx context.Cont
 	}, nil
 }
 
-// CreateOrUpdateSync creates or updates the VirtualMachineScaleSet and returns the future
-func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateSync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
+// CreateOrUpdateAsync creates or updates the VirtualMachineScaleSet and returns the future
+func (client *VirtualMachineScaleSetsClientMock) CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (result compute.VirtualMachineScaleSetsCreateOrUpdateFuture, err error) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 	args := client.Called(resourceGroupName, VMScaleSetName, parameters)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -261,10 +261,10 @@ func (scaleSet *ScaleSet) updateVMSSCapacity(size int64) error {
 	}
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.CreateOrUpdateSync(%s)", scaleSet.Name)
-	future, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.CreateOrUpdateSync(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op)
+	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.CreateOrUpdateAsync(%s)", scaleSet.Name)
+	future, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.CreateOrUpdateAsync(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op)
 	if err != nil {
-		klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdateSync for scale set %q failed: %v", scaleSet.Name, err)
+		klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdateAsync for scale set %q failed: %v", scaleSet.Name, err)
 		return err
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -444,13 +444,14 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef) error {
 	defer cancel()
 	resourceGroup := scaleSet.manager.config.ResourceGroup
 
+	scaleSet.instanceMutex.Lock()
 	klog.V(3).Infof("Calling virtualMachineScaleSetsClient.DeleteInstancesAsync(%v)", requiredIds.InstanceIds)
-
 	future, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.DeleteInstancesAsync(ctx, resourceGroup, commonAsg.Id(), *requiredIds)
 	if err != nil {
 		klog.Errorf("virtualMachineScaleSetsClient.DeleteInstancesAsync for instances %v failed: %v", requiredIds.InstanceIds, err)
 		return err
 	}
+	scaleSet.instanceMutex.Unlock()
 
 	// Proactively decrement scale set size so that we don't
 	// go below minimum node count if cache data is stale

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -115,7 +115,7 @@ func TestIncreaseSizeFailure(t *testing.T) {
 			},
 		},
 	}
-	scaleSetClient.On("CreateOrUpdateSync", "test", "test-asg", mock.Anything).Return(nil, errors.New("autorest/azure: service returned an error"))
+	scaleSetClient.On("CreateOrUpdateAsync", "test", "test-asg", mock.Anything).Return(nil, errors.New("autorest/azure: service returned an error"))
 	manager.azClient.virtualMachineScaleSetsClient = scaleSetClient
 	provider.azureManager = manager
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -179,7 +179,7 @@ func TestDeleteNodes(t *testing.T) {
 			Status: "OK",
 		},
 	}
-	scaleSetClient.On("DeleteInstances", mock.Anything, "test-asg", mock.Anything, mock.Anything).Return(response, nil)
+	scaleSetClient.On("DeleteInstancesAsync", mock.Anything, "test-asg", mock.Anything, mock.Anything).Return(response, nil)
 	manager.azClient.virtualMachineScaleSetsClient = scaleSetClient
 	// TODO: this should call manager.Refresh() once the fetchAutoASG
 	// logic is refactored out
@@ -219,7 +219,7 @@ func TestDeleteNodes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 4, targetSize)
 
-	scaleSetClient.AssertNumberOfCalls(t, "DeleteInstances", 1)
+	scaleSetClient.AssertNumberOfCalls(t, "DeleteInstancesAsync", 1)
 }
 
 func TestDeleteNoConflictRequest(t *testing.T) {


### PR DESCRIPTION
Cherry-pick #3221 - Async deletions without waiting on future
Cherry-pick #3284 - Synchronize deletions to avoid 409 Conflict errors
Rename method for consistency with the vendored azure clients