### PR TITLE
Revert "Use golang1.14.3 to compile AddonResizer"

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -21,7 +21,7 @@ ALL_ARCH = amd64 arm arm64 ppc64le s390x
 ARCH ?= amd64
 
 GOARM=7
-GOLANG_VERSION = 1.14.3
+GOLANG_VERSION = 1.12.1
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)


### PR DESCRIPTION
This is required due to #3294

This reverts commit 0410b57dd0e556581d91d1685ae0e2e8331257a6.