### PR TITLE
Bump addon-resizer to 1.8.11

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -26,7 +26,7 @@ REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.10
+TAG = 1.8.11
 
 BASEIMAGE?=gcr.io/distroless/static:latest
 


### PR DESCRIPTION
This is to roll-out https://github.com/kubernetes/autoscaler/pull/3298 - reverting golang version to 1.12.1