### PR TITLE
Fix priority expander falling back to random although higher priority matches

### DIFF
--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -148,7 +148,6 @@ func (p *priority) BestOption(expansionOptions []expander.Option, nodeInfo map[s
 			}
 			best = append(best, option)
 			found = true
-			break
 		}
 		if !found {
 			msg := fmt.Sprintf("Priority expander: node group %s not found in priority expander configuration. "+

--- a/cluster-autoscaler/expander/priority/priority_test.go
+++ b/cluster-autoscaler/expander/priority/priority_test.go
@@ -62,6 +62,13 @@ var (
 10: 
   - ".*t\\.large.*"
 `
+	wildcardMatchConfig = `
+5:
+  - ".*"
+10:
+  - ".t2\\.large.*"
+`
+
 	eoT2Micro = expander.Option{
 		Debug:     "t2.micro",
 		NodeGroup: test.NewTestNodeGroup("my-asg.t2.micro", 10, 1, 1, true, false, "t2.micro", nil, nil),
@@ -107,6 +114,14 @@ func TestPriorityExpanderCorrecltySelectsSingleMatchingOptionOutOfMany(t *testin
 	s, _, _, _ := getStrategyInstance(t, config)
 	ret := s.BestOption([]expander.Option{eoT2Large, eoM44XLarge}, nil)
 	assert.Equal(t, *ret, eoM44XLarge)
+}
+
+func TestPriorityExpanderDoesNotFallBackToRandomWhenHigherPriorityMatches(t *testing.T) {
+	s, _, _, _ := getStrategyInstance(t, wildcardMatchConfig)
+	for i := 0; i < 10; i++ {
+		ret := s.BestOption([]expander.Option{eoT2Large, eoT2Micro}, nil)
+		assert.Equal(t, *ret, eoT2Large)
+	}
 }
 
 func TestPriorityExpanderCorrecltySelectsOneOfTwoMatchingOptionsOutOfMany(t *testing.T) {


### PR DESCRIPTION
When an option matches in a low priority together with another option both get added to the `best` list where the random expander fallback strategy finally selects one option randomly although one of the options also matches in a higher priority.
This PR ensures all priorities are evaluated for an option and higher ones take precedence by removing the `break` in the loop. The root cause is that the map of priorities is unordered and therefore we have to walk to the end