### PR TITLE
Configure user agent properly for azure clients

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -213,6 +213,7 @@ func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
 	}
 
 	azClientConfig := cfg.getAzureClientConfig(spt, env)
+	azClientConfig.UserAgent = getUserAgentExtension()
 
 	vmssClientConfig := azClientConfig.WithRateLimiter(cfg.VirtualMachineScaleSetRateLimit)
 	scaleSetsClient := vmssclient.New(vmssClientConfig)

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -230,12 +230,12 @@ func decodePkcs12(pkcs []byte, password string) (*x509.Certificate, *rsa.Private
 	return certificate, rsaPrivateKey, nil
 }
 
-// configureUserAgent configures the autorest client with a user agent that
-// includes "autoscaler" and the full client version string
-// example:
-// Azure-SDK-for-Go/7.0.1-beta arm-network/2016-09-01; cluster-autoscaler/v1.7.0-alpha.2.711+a2fadef8170bb0-dirty;
+func getUserAgentExtension() string {
+	return fmt.Sprintf("cluster-autoscaler/v%s", version.ClusterAutoscalerVersion)
+}
+
 func configureUserAgent(client *autorest.Client) {
-	client.UserAgent = fmt.Sprintf("%s; cluster-autoscaler/v%s", client.UserAgent, version.ClusterAutoscalerVersion)
+	client.UserAgent = fmt.Sprintf("%s; %s", client.UserAgent, getUserAgentExtension())
 }
 
 // normalizeForK8sVMASScalingUp takes a template and removes elements that are unwanted in a K8s VMAS scale up/down case


### PR DESCRIPTION
Since the clients are using the vendored cloud-provider ones - we need to configure the user agent to not use the cloud-provider one.

/area provider/azure
