### PR TITLE
CA - AWS CloudProvider - Static Instance List update

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -322,6 +322,66 @@ var InstanceTypes = map[string]*InstanceType{
 		MemoryMb:     10752,
 		GPU:          0,
 	},
+	"c6g": {
+		InstanceType: "c6g",
+		VCPU:         64,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"c6g.12xlarge": {
+		InstanceType: "c6g.12xlarge",
+		VCPU:         48,
+		MemoryMb:     98304,
+		GPU:          0,
+	},
+	"c6g.16xlarge": {
+		InstanceType: "c6g.16xlarge",
+		VCPU:         64,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"c6g.2xlarge": {
+		InstanceType: "c6g.2xlarge",
+		VCPU:         8,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"c6g.4xlarge": {
+		InstanceType: "c6g.4xlarge",
+		VCPU:         16,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"c6g.8xlarge": {
+		InstanceType: "c6g.8xlarge",
+		VCPU:         32,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"c6g.large": {
+		InstanceType: "c6g.large",
+		VCPU:         2,
+		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"c6g.medium": {
+		InstanceType: "c6g.medium",
+		VCPU:         1,
+		MemoryMb:     2048,
+		GPU:          0,
+	},
+	"c6g.metal": {
+		InstanceType: "c6g.metal",
+		VCPU:         64,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"c6g.xlarge": {
+		InstanceType: "c6g.xlarge",
+		VCPU:         4,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
 	"cc2.8xlarge": {
 		InstanceType: "cc2.8xlarge",
 		VCPU:         32,
@@ -516,7 +576,7 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"hs1.8xlarge": {
 		InstanceType: "hs1.8xlarge",
-		VCPU:         17,
+		VCPU:         16,
 		MemoryMb:     119808,
 		GPU:          0,
 	},
@@ -588,7 +648,7 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"i3.metal": {
 		InstanceType: "i3.metal",
-		VCPU:         72,
+		VCPU:         64,
 		MemoryMb:     524288,
 		GPU:          0,
 	},
@@ -600,7 +660,7 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"i3en": {
 		InstanceType: "i3en",
-		VCPU:         64,
+		VCPU:         96,
 		MemoryMb:     0,
 		GPU:          0,
 	},
@@ -650,6 +710,12 @@ var InstanceTypes = map[string]*InstanceType{
 		InstanceType: "i3en.xlarge",
 		VCPU:         4,
 		MemoryMb:     32768,
+		GPU:          0,
+	},
+	"i3p.16xlarge": {
+		InstanceType: "i3p.16xlarge",
+		VCPU:         64,
+		MemoryMb:     499712,
 		GPU:          0,
 	},
 	"inf1.24xlarge": {
@@ -1126,6 +1192,12 @@ var InstanceTypes = map[string]*InstanceType{
 		MemoryMb:     16384,
 		GPU:          0,
 	},
+	"m6g": {
+		InstanceType: "m6g",
+		VCPU:         64,
+		MemoryMb:     0,
+		GPU:          0,
+	},
 	"m6g.12xlarge": {
 		InstanceType: "m6g.12xlarge",
 		VCPU:         48,
@@ -1166,6 +1238,12 @@ var InstanceTypes = map[string]*InstanceType{
 		InstanceType: "m6g.medium",
 		VCPU:         1,
 		MemoryMb:     4096,
+		GPU:          0,
+	},
+	"m6g.metal": {
+		InstanceType: "m6g.metal",
+		VCPU:         64,
+		MemoryMb:     262144,
 		GPU:          0,
 	},
 	"m6g.xlarge": {
@@ -1225,7 +1303,7 @@ var InstanceTypes = map[string]*InstanceType{
 	"p3dn": {
 		InstanceType: "p3dn",
 		VCPU:         96,
-		MemoryMb:     786432,
+		MemoryMb:     0,
 		GPU:          8,
 	},
 	"p3dn.24xlarge": {
@@ -1648,6 +1726,66 @@ var InstanceTypes = map[string]*InstanceType{
 		MemoryMb:     32768,
 		GPU:          0,
 	},
+	"r6g": {
+		InstanceType: "r6g",
+		VCPU:         64,
+		MemoryMb:     0,
+		GPU:          0,
+	},
+	"r6g.12xlarge": {
+		InstanceType: "r6g.12xlarge",
+		VCPU:         48,
+		MemoryMb:     393216,
+		GPU:          0,
+	},
+	"r6g.16xlarge": {
+		InstanceType: "r6g.16xlarge",
+		VCPU:         64,
+		MemoryMb:     524288,
+		GPU:          0,
+	},
+	"r6g.2xlarge": {
+		InstanceType: "r6g.2xlarge",
+		VCPU:         8,
+		MemoryMb:     65536,
+		GPU:          0,
+	},
+	"r6g.4xlarge": {
+		InstanceType: "r6g.4xlarge",
+		VCPU:         16,
+		MemoryMb:     131072,
+		GPU:          0,
+	},
+	"r6g.8xlarge": {
+		InstanceType: "r6g.8xlarge",
+		VCPU:         32,
+		MemoryMb:     262144,
+		GPU:          0,
+	},
+	"r6g.large": {
+		InstanceType: "r6g.large",
+		VCPU:         2,
+		MemoryMb:     16384,
+		GPU:          0,
+	},
+	"r6g.medium": {
+		InstanceType: "r6g.medium",
+		VCPU:         1,
+		MemoryMb:     8192,
+		GPU:          0,
+	},
+	"r6g.metal": {
+		InstanceType: "r6g.metal",
+		VCPU:         64,
+		MemoryMb:     524288,
+		GPU:          0,
+	},
+	"r6g.xlarge": {
+		InstanceType: "r6g.xlarge",
+		VCPU:         4,
+		MemoryMb:     32768,
+		GPU:          0,
+	},
 	"t1.micro": {
 		InstanceType: "t1.micro",
 		VCPU:         1,
@@ -1786,6 +1924,12 @@ var InstanceTypes = map[string]*InstanceType{
 		MemoryMb:     0,
 		GPU:          0,
 	},
+	"u-12tb1.metal": {
+		InstanceType: "u-12tb1.metal",
+		VCPU:         448,
+		MemoryMb:     12582912,
+		GPU:          0,
+	},
 	"u-18tb1": {
 		InstanceType: "u-18tb1",
 		VCPU:         448,
@@ -1816,10 +1960,22 @@ var InstanceTypes = map[string]*InstanceType{
 		MemoryMb:     0,
 		GPU:          0,
 	},
+	"u-6tb1.metal": {
+		InstanceType: "u-6tb1.metal",
+		VCPU:         448,
+		MemoryMb:     6291456,
+		GPU:          0,
+	},
 	"u-9tb1": {
 		InstanceType: "u-9tb1",
 		VCPU:         448,
 		MemoryMb:     0,
+		GPU:          0,
+	},
+	"u-9tb1.metal": {
+		InstanceType: "u-9tb1.metal",
+		VCPU:         448,
+		MemoryMb:     9437184,
 		GPU:          0,
 	},
 	"x1": {


### PR DESCRIPTION
Adds a number of new instance types/families to the static list

Doesn't include the `c5a` family as #3259 already exists, however does include the `r6g` family as #3250 seems to miss the smaller instance types in this family.

Also brings in the new `c6g` family [announced last month](https://aws.amazon.com/ec2/instance-types/c6/).