### PR TITLE
VPA: fix nil pointer in getBoundaryRecommendation when no limits set

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
@@ -97,7 +97,7 @@ func GetBoundaryRequest(originalRequest, originalLimit, boundaryLimit, defaultLi
 	}
 	// originalLimit not set, no boundary
 	if originalLimit == nil || originalLimit.Value() == 0 {
-		return nil
+		return &resource.Quantity{}
 	}
 	// originalLimit set but originalRequest not set - K8s will treat the pod as if they were equal
 	if originalRequest == nil || originalRequest.Value() == 0 {


### PR DESCRIPTION
If you have a pod with no Limits for either CPU or Memory and no Default Limits you get a panic in the `updater` when it's calculating the boundary.
e.g
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1269d03]

goroutine 1 [running]:
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.getBoundaryRecommendation(0xc0018af8c0, 0xc001822aa0, 0x12, 0xc002f5f4d0, 0x25, 0xc008bd3c00, 0x11, 0x20, 0x0, 0x0, ...)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:317 +0x8f3
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.getMinAllowedRecommendation(0xc0018af8c0, 0xc001822aa0, 0x12, 0xc002f5f4d0, 0x25, 0xc008bd3c00, 0x11, 0x20, 0x0, 0x0, ...)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:294 +0x99
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.applyContainerLimitRange(0xc0018af8c0, 0xc001822aa0, 0x12, 0xc002f5f4d0, 0x25, 0xc008bd3c00, 0x11, 0x20, 0x0, 0x0, ...)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:263 +0x150
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.getCappedRecommendationForContainer.func1(0xc0018af8c0, 0x1)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:118 +0xc2
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.getCappedRecommendationForContainer(0xc001822aa0, 0x12, 0xc002f5f4d0, 0x25, 0xc008bd3c00, 0x11, 0x20, 0x0, 0x0, 0x0, ...)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:126 +0x260
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa.(*cappingRecommendationProcessor).Apply(0xc003132950, 0xc000959c60, 0xc000959c40, 0xc00361baa0, 0x1, 0x1, 0xc0038712a0, 0x1418c40, 0xc001035880, 0x44619f, ...)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa/capping.go:86 +0x2a0
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority.(*UpdatePriorityCalculator).AddPod(0xc001035aa8, 0xc0038712a0, 0xbfbdc6bd2e543112, 0xd23f9b68ff, 0x25b9880)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go:86 +0x98
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/logic.(*updater).getPodsUpdateOrder(0xc00569cb40, 0xc003a77580, 0x2, 0x2, 0xc00698ec60, 0xc003a77580, 0x2, 0x2)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/logic/updater.go:225 +0x193
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/logic.(*updater).RunOnce(0xc00569cb40, 0x1883d20, 0xc0012b2360)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/logic/updater.go:182 +0xe54
main.main()
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/main.go:110 +0x5e3
``` 
This is due to the function `GetBoundaryRequest` returning a `nil` value which then causes a panic as you've got a pointer to a nil value if `cpuMaxRequest` or `memMaxRequest` are nil.
```golang
return apiv1.ResourceList{
		apiv1.ResourceCPU:    *cpuMaxRequest,
		apiv1.ResourceMemory: *memMaxRequest,
	}
```

This PR changes the return value to be `&resource.Quantity{}` instead if no limits are found.