### PR TITLE
[CA-1.18] #3177 cherry-pick: Fix stale replicas issue with cluster-autoscaler CAPI provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,7 @@ type machineController struct {
 	machineSetResource        *schema.GroupVersionResource
 	machineResource           *schema.GroupVersionResource
 	machineDeploymentResource *schema.GroupVersionResource
+	accessLock                sync.Mutex
 }
 
 type machineSetFilterFunc func(machineSet *MachineSet) error

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -60,8 +61,23 @@ func (r machineSetScalableResource) Nodes() ([]string, error) {
 	return r.controller.machineSetProviderIDs(r.machineSet)
 }
 
-func (r machineSetScalableResource) Replicas() int32 {
-	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, 0)
+func (r machineSetScalableResource) Replicas() (int32, error) {
+	freshMachineSet, err := r.controller.getMachineSet(r.machineSet.Namespace, r.machineSet.Name, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	if freshMachineSet == nil {
+		return 0, fmt.Errorf("unknown machineSet %s", r.machineSet.Name)
+	}
+
+	if freshMachineSet.Spec.Replicas == nil {
+		klog.Warningf("MachineSet %q has nil spec.replicas. This is unsupported behaviour. Falling back to status.replicas.", r.machineSet.Name)
+	}
+
+	// If no value for replicas on the MachineSet spec, fallback to the status
+	// TODO: Remove this fallback once defaulting is implemented for MachineSet Replicas
+	return pointer.Int32PtrDerefOr(freshMachineSet.Spec.Replicas, freshMachineSet.Status.Replicas), nil
 }
 
 func (r machineSetScalableResource) SetSize(nreplicas int32) error {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterapi
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSetSize(t *testing.T) {
+	initialReplicas := int32(1)
+	updatedReplicas := int32(5)
+
+	testConfig := createMachineSetTestConfig(testNamespace, int(initialReplicas), nil)
+	controller, stop := mustCreateTestController(t, testConfig)
+	defer stop()
+
+	sr, err := newMachineSetScalableResource(controller, testConfig.machineSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = sr.SetSize(updatedReplicas)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch machineSet
+	u, err := sr.controller.dynamicclient.Resource(*sr.controller.machineSetResource).Namespace(testConfig.machineSet.Namespace).
+		Get(context.TODO(), testConfig.machineSet.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replicas, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("spec.replicas not found")
+	}
+
+	got := int32(replicas)
+	if got != updatedReplicas {
+		t.Errorf("expected %v, got: %v", updatedReplicas, got)
+	}
+}
+
+func TestReplicas(t *testing.T) {
+	initialReplicas := int32(1)
+	updatedReplicas := int32(5)
+
+	testConfig := createMachineSetTestConfig(testNamespace, int(initialReplicas), nil)
+	controller, stop := mustCreateTestController(t, testConfig)
+	defer stop()
+
+	sr, err := newMachineSetScalableResource(controller, testConfig.machineSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i, err := sr.Replicas()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != initialReplicas {
+		t.Errorf("expected %v, got: %v", initialReplicas, i)
+	}
+
+	// fetch and update machineSet
+	u, err := sr.controller.dynamicclient.Resource(*sr.controller.machineSetResource).Namespace(testConfig.machineSet.Namespace).
+		Get(context.TODO(), testConfig.machineSet.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unstructured.SetNestedField(u.Object, int64(updatedReplicas), "spec", "replicas"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = sr.controller.dynamicclient.Resource(*sr.controller.machineSetResource).Namespace(u.GetNamespace()).
+		Update(context.TODO(), u, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i, err = sr.Replicas()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != updatedReplicas {
+		t.Errorf("expected %v, got: %v", updatedReplicas, i)
+	}
+}
+
+func TestSetSizeAndReplicas(t *testing.T) {
+	initialReplicas := int32(1)
+	updatedReplicas := int32(5)
+
+	testConfig := createMachineSetTestConfig(testNamespace, int(initialReplicas), nil)
+	controller, stop := mustCreateTestController(t, testConfig)
+	defer stop()
+
+	sr, err := newMachineSetScalableResource(controller, testConfig.machineSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i, err := sr.Replicas()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != initialReplicas {
+		t.Errorf("expected %v, got: %v", initialReplicas, i)
+	}
+
+	err = sr.SetSize(updatedReplicas)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i, err = sr.Replicas()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != updatedReplicas {
+		t.Errorf("expected %v, got: %v", updatedReplicas, i)
+	}
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -82,6 +82,9 @@ func (ng *nodegroup) IncreaseSize(delta int) error {
 // group. This function should wait until node group size is updated.
 // Implementation required.
 func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
+	ng.machineController.accessLock.Lock()
+	defer ng.machineController.accessLock.Unlock()
+
 	// Step 1: Verify all nodes belong to this node group.
 	for _, node := range nodes {
 		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
@@ -42,7 +42,7 @@ type scalableResource interface {
 	SetSize(nreplicas int32) error
 
 	// Replicas returns the current replica count of the resource
-	Replicas() int32
+	Replicas() (int32, error)
 
 	// MarkMachineForDeletion marks machine for deletion
 	MarkMachineForDeletion(machine *Machine) error

--- a/cluster-autoscaler/cloudprovider/clusterapi/machinedeployment_types.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/machinedeployment_types.go
@@ -36,7 +36,11 @@ type MachineDeploymentSpec struct {
 }
 
 // MachineDeploymentStatus is the internal autoscaler Schema for MachineDeploymentStatus
-type MachineDeploymentStatus struct{}
+type MachineDeploymentStatus struct {
+	// Number of desired machines. Defaults to 1.
+	// This is a pointer to distinguish between explicit zero and not specified.
+	Replicas int32 `json:"replicas,omitempty"`
+}
 
 // MachineDeployment is the internal autoscaler Schema for MachineDeployment
 type MachineDeployment struct {

--- a/cluster-autoscaler/cloudprovider/clusterapi/machineset_types.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/machineset_types.go
@@ -68,7 +68,10 @@ type MachineTemplateSpec struct {
 }
 
 // MachineSetStatus is the internal autoscaler Schema for MachineSetStatus
-type MachineSetStatus struct{}
+type MachineSetStatus struct {
+	// Replicas is the most recently observed number of replicas.
+	Replicas int32 `json:"replicas"`
+}
 
 // MachineSetList is the internal autoscaler Schema for MachineSetList
 type MachineSetList struct {


### PR DESCRIPTION
Backports #3177 to cluster-autoscaler-release-1.18:

From the original PR:
> This change brings in a series of patches to remediate the issues with MachineSet and MachineDeployment replicas becoming stale. These changes add protection around the deletion mechanisms by adding a mutex to this operation and also changing the check versus 0 to use the minimum size for that group. Additionally, the operations to get the replicas are now using API server calls to ensure that the freshest information is available during replica count checks. Lastly, a minor change to the unit tests is added to address the underlying changes with respect to API server queries for replicas.