### PR TITLE
[CA-1.18] #3034 cherry-pick: Improve delete node mechanisms for cluster-api autoscaler provider #3034

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
@@ -105,12 +105,8 @@ func (r machineDeploymentScalableResource) UnmarkMachineForDeletion(machine *Mac
 
 func (r machineDeploymentScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	u = u.DeepCopy()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
@@ -99,6 +99,10 @@ func (r machineDeploymentScalableResource) SetSize(nreplicas int32) error {
 	return updateErr
 }
 
+func (r machineDeploymentScalableResource) UnmarkMachineForDeletion(machine *Machine) error {
+	return unmarkMachineForDeletion(r.controller, machine)
+}
+
 func (r machineDeploymentScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -107,6 +107,10 @@ func (r machineSetScalableResource) MarkMachineForDeletion(machine *Machine) err
 	return updateErr
 }
 
+func (r machineSetScalableResource) UnmarkMachineForDeletion(machine *Machine) error {
+	return unmarkMachineForDeletion(r.controller, machine)
+}
+
 func newMachineSetScalableResource(controller *machineController, machineSet *MachineSet) (*machineSetScalableResource, error) {
 	minSize, maxSize, err := parseScalingBounds(machineSet.Annotations)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -86,12 +86,8 @@ func (r machineSetScalableResource) SetSize(nreplicas int32) error {
 
 func (r machineSetScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	u = u.DeepCopy()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -139,6 +139,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		}
 
 		if err := ng.scalableResource.SetSize(replicas - 1); err != nil {
+			nodeGroup.scalableResource.UnmarkMachineForDeletion(machine)
 			return err
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
@@ -18,7 +18,6 @@ package clusterapi
 
 import (
 	"context"
-	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -60,12 +59,8 @@ type scalableResource interface {
 
 func unmarkMachineForDeletion(controller *machineController, machine *Machine) error {
 	u, err := controller.dynamicclient.Resource(*controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	annotations := u.GetAnnotations()


### PR DESCRIPTION
Backports #3034 to cluster-autoscaler-release-1.18:

From the original PR:
> This change is being proposed to improve the mechanism for applying and removing deletion annotations. In some situations it is possible for the CAPI provider to leave unwanted deletion annotations after a scale down to the minimum size. The two commits in this patch add a mechanism for unmarking scalable resources and an additional check for reducing a node group below minimum size.