### PR TITLE
Allow overriding go version when updating vendor

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -326,7 +326,7 @@ number of replicas when cluster grows and decrease the number of replicas if clu
 
 Configuration of dynamic overprovisioning:
 
-1. (For 1.10, and below) Enable priority preemption in your cluster. 
+1. (For 1.10, and below) Enable priority preemption in your cluster.
 
 For GCE, it can be done by exporting following env
 variables before executing kube-up (more details [here](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)):
@@ -920,13 +920,13 @@ Cluster Autoscaler depends on `go modules` mechanism for dependency management, 
 during build process. `go.mod` file is just used to generate the `vendor` directory and further compilation
 is run against set of libraries stored in `vendor`. `vendor` directory can be regenerated using [`update-vendor.sh`](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/hack/update-vendor.sh) script.
 The `update-vendor.sh` script is responsible for autogenerating `go.mod` file used by Cluster Autoscaler. The base
-of the file is `go.mod` file coming from [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository. 
+of the file is `go.mod` file coming from [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository.
 On top of that script adds modifications as defined
-locally in [`go.mod-extra`](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/go.mod-extra) file. 
+locally in [`go.mod-extra`](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/go.mod-extra) file.
 
 Note: It is important that one should **never manually edit** `go.mod` file as it is regenerated
 on each `update-vendor.sh` call. Any extra libraries or version overrides should be put in `go.mod-extra` file (syntax of the file
-is same as syntax of `go.mod` file). 
+is same as syntax of `go.mod` file).
 
 Finally `vendor` directry is materialized and validation tests are run.
 
@@ -938,7 +938,8 @@ Execution of `update-vendor.sh` can be parametrized using command line argumets:
  - `-f` - kubernetes/kubernetes fork to use. On `master` it defaults to `git@github.com:kubernetes/kubernetes.git`
  - `-r` - revision in kubernetes/kubernetes which should be used to get base `go.mod` file
  - `-d` - specifies script workdir; useful to speed up execution if script needs to be run multiple times, because updating vendor resulted in some compilation errors on Cluster-Autoscaler side which need to be fixed
- 
+ - `-o` - overrides go version check, which may be useful if CA needs to use a different go version than the one in kubernetes go.mod file
+
 Example execution looks like this:
 ```
 ./hack/update-vendor.sh -d/tmp/ca-update-vendor.ou1l -fgit@github.com:kubernetes/kubernetes.git -rmaster

--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -21,9 +21,10 @@ K8S_REV="master"
 BATCH_MODE="false"
 TARGET_MODULE=${TARGET_MODULE:-k8s.io/autoscaler/cluster-autoscaler}
 VERIFY_COMMAND=${VERIFY_COMMAND:-"go test -mod=vendor ./..."}
+OVERRIDE_GO_VERSION="false"
 
 ARGS="$@"
-OPTS=`getopt -o f::r::d::v::b:: --long k8sfork::,k8srev::,workdir::,batch:: -n $SCRIPT_NAME -- "$@"`
+OPTS=`getopt -o f::r::d::v::b::o:: --long k8sfork::,k8srev::,workdir::,batch::,override-go-version:: -n $SCRIPT_NAME -- "$@"`
 if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 eval set -- "$OPTS"
 while true; do
@@ -32,6 +33,7 @@ while true; do
     -r | --k8srev ) K8S_REV="$2"; shift; shift ;;
     -d | --workdir ) WORK_DIR="$2"; shift; shift ;;
     -b | --batch ) BATCH_MODE="true"; shift; shift ;;
+    -o | --override-go-version) OVERRIDE_GO_VERSION="true"; shift; shift ;;
     -v ) VERBOSE=1; shift; if [[ "$1" == "v" ]]; then VERBOSE=2; shift; fi; ;;
     -- ) shift; break ;;
     * ) break ;;
@@ -109,8 +111,13 @@ set +o errexit
   REQUIRED_GO_VERSION=$(cat go.mod  |grep '^go ' |tr -s ' ' |cut -d ' '  -f 2)
   USED_GO_VERSION=$(go version |sed 's/.*go\([0-9]\+\.[0-9]\+\).*/\1/')
 
+
   if [[ "${REQUIRED_GO_VERSION}" != "${USED_GO_VERSION}" ]];then
-    err_rerun "Invalid go version ${USED_GO_VERSION}; required go version is ${REQUIRED_GO_VERSION}."
+    if [[ "${OVERRIDE_GO_VERSION}" == "false" ]]; then
+      err_rerun "Invalid go version ${USED_GO_VERSION}; required go version is ${REQUIRED_GO_VERSION}."
+    else
+      echo "Overriding go version found in go.mod file. Expected go version ${REQUIRED_GO_VERSION}, using ${USED_GO_VERSION}"
+    fi
   fi
 
   # Fix module name and staging modules links


### PR DESCRIPTION
This is required because Kubernetes 1.17 lists go1.12 in go.mod,
but it doesn't actually compile using go1.12.