### PR TITLE
[cluster-autoscaler] Fixes to Kubemark integration.

### DIFF
--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -23,7 +23,6 @@ package kubemark
 
 import (
 	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubemark"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"os"
 
 	klog "k8s.io/klog/v2"
 )
@@ -197,7 +197,7 @@ func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 		return instances, err
 	}
 	for _, node := range nodes {
-		instances = append(instances, cloudprovider.Instance{Id: ":////" + node})
+		instances = append(instances, cloudprovider.Instance{Id: "kubemark://" + node})
 	}
 	return instances, nil
 }
@@ -313,9 +313,13 @@ func BuildKubemark(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 		klog.Fatalf("Failed to get kubeclient config for external cluster: %v", err)
 	}
 
-	kubemarkConfig, err := clientcmd.BuildConfigFromFlags("", "/kubeconfig/cluster_autoscaler.kubeconfig")
-	if err != nil {
-		klog.Fatalf("Failed to get kubeclient config for kubemark cluster: %v", err)
+	// Use provided kubeconfig or fallback to InClusterConfig
+	kubemarkConfig := externalConfig
+	kubemarkConfigPath := "/kubeconfig/cluster_autoscaler.kubeconfig"
+	if _, err := os.Stat(kubemarkConfigPath); !os.IsNotExist(err) {
+		if kubemarkConfig, err = clientcmd.BuildConfigFromFlags("", kubemarkConfigPath); err != nil {
+			klog.Fatalf("Failed to get kubeclient config for kubemark cluster: %v", err)
+		}
 	}
 
 	stop := make(chan struct{})


### PR DESCRIPTION
- Correctly sets providerID
- Enables Kubemark to run in the same cluster as CA.