### PR TITLE
[cluster-autoscaler] Skip nodes that are not Kubemark nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -23,6 +23,9 @@ package kubemark
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -35,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubemark"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-	"os"
 
 	klog "k8s.io/klog/v2"
 )
@@ -120,6 +122,10 @@ func (kubemark *KubemarkCloudProvider) Pricing() (cloudprovider.PricingModel, er
 
 // NodeGroupForNode returns the node group for the given node.
 func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	// Skip nodes that are not managed by Kubemark Cloud Provider.
+	if !strings.HasPrefix(node.Spec.ProviderID, ProviderName) {
+		return nil, nil
+	}
 	nodeGroupName, err := kubemark.kubemarkController.GetNodeGroupForNode(node.ObjectMeta.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For clusters with both real and hollow nodes, CA fails at static_autoscaler.go:268: "core_utils.GetNodeInfosForGroups(" since the Kubemark Cloud Provider doesn't know how to find pods for real nodes. This change will simply skip nodes that are not Kubemark nodes, as they cannot be scaled by CA's Kubemark implementation anyways.