### PR TITLE
VPA - Adding altName to e2e webhook cert

### DIFF
--- a/vertical-pod-autoscaler/e2e/utils/certs.go
+++ b/vertical-pod-autoscaler/e2e/utils/certs.go
@@ -65,6 +65,7 @@ func SetupWebhookCert(namespaceName string) *certContext {
 	signedCert, err := utils.NewSignedCert(
 		&cert.Config{
 			CommonName: WebhookServiceName + "." + namespaceName + ".svc",
+			AltNames:   cert.AltNames{DNSNames: []string{WebhookServiceName + "." + namespaceName + ".svc"}},
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
 		key, signingCert, signingKey,


### PR DESCRIPTION
/fixes #3377

Adds now-required altName to e2e webhook certificate.