### PR TITLE
VPA Add controlledValues to CRD

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
@@ -51,6 +51,9 @@ spec:
                     properties:
                       containerName:
                         type: string
+                      controlledValues:
+                        type: string
+                        enum: ["RequestsAndLimits", "RequestsOnly"]
                       mode:
                         type: string
                         enum: ["Auto", "Off"]


### PR DESCRIPTION
This was missed in https://github.com/kubernetes/autoscaler/pull/3028.

I updated the CRD definition manually, not sure whether there is a better way.