### PR TITLE
Add scale down protection for containers

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
 	yaml "gopkg.in/yaml.v2"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
 )
 
 // Client is an interface that expects a Get method similar to http.Get. This

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination/linked.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination/linked.go
@@ -40,7 +40,7 @@ func (current LinkedPageBase) NextPageURL() (string, error) {
 	}
 
 	for {
-		key, path = path[0], path[1:len(path)]
+		key, path = path[0], path[1:]
 
 		value, ok := submap[key]
 		if !ok {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
@@ -58,7 +58,9 @@ func (c *fakePatchCalculator) CalculatePatches(_ *apiv1.Pod, _ *vpa_types.Vertic
 }
 
 func TestGetPatches(t *testing.T) {
-	testVpa := test.VerticalPodAutoscaler().WithName("name").WithContainer("testy-container").Get()
+	testVpa := test.VerticalPodAutoscaler().WithName("name").
+		AppendRecommendation(test.Recommendation().WithContainer("testy-container").GetContainerResources()).
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("testy-container").Get()).Get()
 	testPatchRecord := resource_admission.PatchRecord{
 		Op:    "add",
 		Path:  "some/path",

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
@@ -102,7 +102,7 @@ func addAnnotationRequest(updateResources [][]string, kind string) resource_admi
 	return GetAddAnnotationPatch(ResourceUpdatesAnnotation, vpaUpdates)
 }
 
-func TestClalculatePatches_ResourceUpdates(t *testing.T) {
+func TestCalculatePatches_ResourceUpdates(t *testing.T) {
 	tests := []struct {
 		name                 string
 		pod                  *core.Pod
@@ -253,7 +253,10 @@ func TestClalculatePatches_ResourceUpdates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			frp := fakeRecommendationProvider{tc.recommendResources, tc.recommendAnnotations, tc.recommendError}
 			c := NewResourceUpdatesCalculator(&frp)
-			patches, err := c.CalculatePatches(tc.pod, test.VerticalPodAutoscaler().WithContainer("test").WithName("name").Get())
+			patches, err := c.CalculatePatches(tc.pod, test.VerticalPodAutoscaler().
+				AppendRecommendation(test.Recommendation().WithContainer("test").GetContainerResources()).WithName("name").
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test").Get()).
+				Get())
 			if tc.expectError == nil {
 				assert.NoError(t, err)
 			} else {
@@ -295,7 +298,9 @@ func TestGetPatches_TwoReplacementResources(t *testing.T) {
 	recommendAnnotations := vpa_api_util.ContainerToAnnotationsMap{}
 	frp := fakeRecommendationProvider{recommendResources, recommendAnnotations, nil}
 	c := NewResourceUpdatesCalculator(&frp)
-	patches, err := c.CalculatePatches(pod, test.VerticalPodAutoscaler().WithName("name").WithContainer("test").Get())
+	patches, err := c.CalculatePatches(pod, test.VerticalPodAutoscaler().WithName("name").
+		AppendRecommendation(test.Recommendation().WithContainer("test").GetContainerResources()).
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test").Get()).Get())
 	assert.NoError(t, err)
 	// Order of updates for cpu and unobtanium depends on order of iterating a map, both possible results are valid.
 	if assert.Len(t, patches, 3, "unexpected number of patches") {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -320,7 +320,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name:             "PreventScaleDown container scales up",
+			name:             "prevent scale down container scales up",
 			pod:              initialized,
 			vpa:              vpaHighTargetAndPreventScaleDown,
 			expectedAction:   true,
@@ -328,7 +328,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			expectedMem:      resource.MustParse("500Mi"),
 		},
 		{
-			name:             "PreventScaleDown container does not scale down",
+			name:             "prevent scale down container does not scale down",
 			pod:              initialized,
 			vpa:              vpaLowTargetAndPreventScaleDown,
 			expectedAction:   true,
@@ -336,7 +336,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			expectedMem:      resource.MustParse("100Mi"),
 		},
 		{
-			name:             "PreventScaleDown container one resource scales up",
+			name:             "prevent scale down container one resource scales up",
 			pod:              initialized,
 			vpa:              vpaMixedTargetAndPreventScaleDown,
 			expectedAction:   true,

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -320,28 +320,28 @@ func TestUpdateResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name:             "prevent scale down container scales up",
-			pod:              initialized,
-			vpa:              vpaHighTargetAndPreventScaleDown,
-			expectedAction:   true,
-			expectedCPU:      resource.MustParse("3"),
-			expectedMem:      resource.MustParse("500Mi"),
+			name:           "prevent scale down container scales up",
+			pod:            initialized,
+			vpa:            vpaHighTargetAndPreventScaleDown,
+			expectedAction: true,
+			expectedCPU:    resource.MustParse("3"),
+			expectedMem:    resource.MustParse("500Mi"),
 		},
 		{
-			name:             "prevent scale down container does not scale down",
-			pod:              initialized,
-			vpa:              vpaLowTargetAndPreventScaleDown,
-			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("100Mi"),
+			name:           "prevent scale down container does not scale down",
+			pod:            initialized,
+			vpa:            vpaLowTargetAndPreventScaleDown,
+			expectedAction: true,
+			expectedCPU:    resource.MustParse("2"),
+			expectedMem:    resource.MustParse("100Mi"),
 		},
 		{
-			name:             "prevent scale down container one resource scales up",
-			pod:              initialized,
-			vpa:              vpaMixedTargetAndPreventScaleDown,
-			expectedAction:   true,
-			expectedCPU:      resource.MustParse("2"),
-			expectedMem:      resource.MustParse("200Mi"),
+			name:           "prevent scale down container one resource scales up",
+			pod:            initialized,
+			vpa:            vpaMixedTargetAndPreventScaleDown,
+			expectedAction: true,
+			expectedCPU:    resource.MustParse("2"),
+			expectedMem:    resource.MustParse("200Mi"),
 		},
 	}
 
@@ -410,4 +410,3 @@ func TestUpdateResourceRequests(t *testing.T) {
 
 	}
 }
-

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -39,7 +39,8 @@ func parseLabelSelector(selector string) labels.Selector {
 func TestGetMatchingVpa(t *testing.T) {
 	podBuilder := test.Pod().WithName("test-pod").WithLabels(map[string]string{"app": "test"}).
 		AddContainer(test.Container().WithName("i-am-container").Get())
-	vpaBuilder := test.VerticalPodAutoscaler().WithContainer("i-am-container")
+	vpaBuilder := test.VerticalPodAutoscaler().
+		AppendRecommendation(test.Recommendation().WithContainer("i-am-container").GetContainerResources())
 	testCases := []struct {
 		name            string
 		pod             *core.Pod

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -157,6 +157,10 @@ type ContainerResourcePolicy struct {
 	// The default is "RequestsAndLimits".
 	// +optional
 	ControlledValues *ContainerControlledValues `json:"controlledValues,omitempty" protobuf:"bytes,6,rep,name=controlledValues"`
+
+	// Specifies whether this container should only ever scale up its resources
+	// +optional
+	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,7,opt,name=PreventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -160,7 +160,7 @@ type ContainerResourcePolicy struct {
 
 	// Specifies whether this container should only ever scale up its resources
 	// +optional
-	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,7,opt,name=PreventScaleDown"`
+	PreventScaleDown bool `json:"preventScaleDown,omitempty" protobuf:"bytes,7,opt,name=preventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/types.go
@@ -138,7 +138,7 @@ type ContainerResourcePolicy struct {
 	MaxAllowed v1.ResourceList `json:"maxAllowed,omitempty" protobuf:"bytes,4,rep,name=maxAllowed,casttype=ResourceList,castkey=ResourceName"`
 	// Specifies whether this container should only ever scale up its resources
 	// +optional
-	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,5,opt,name=PreventScaleDown"`
+	PreventScaleDown bool `json:"preventScaleDown,omitempty" protobuf:"bytes,5,opt,name=preventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/types.go
@@ -136,6 +136,9 @@ type ContainerResourcePolicy struct {
 	// for the container. The default is no maximum.
 	// +optional
 	MaxAllowed v1.ResourceList `json:"maxAllowed,omitempty" protobuf:"bytes,4,rep,name=maxAllowed,casttype=ResourceList,castkey=ResourceName"`
+	// Specifies whether this container should only ever scale up its resources
+	// +optional
+	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,5,opt,name=PreventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -149,7 +149,7 @@ type ContainerResourcePolicy struct {
 	MaxAllowed v1.ResourceList `json:"maxAllowed,omitempty" protobuf:"bytes,4,rep,name=maxAllowed,casttype=ResourceList,castkey=ResourceName"`
 	// Specifies whether this container should only ever scale up its resources
 	// +optional
-	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,5,opt,name=PreventScaleDown"`
+	PreventScaleDown bool `json:"preventScaleDown,omitempty" protobuf:"bytes,5,opt,name=preventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -147,6 +147,9 @@ type ContainerResourcePolicy struct {
 	// for the container. The default is no maximum.
 	// +optional
 	MaxAllowed v1.ResourceList `json:"maxAllowed,omitempty" protobuf:"bytes,4,rep,name=maxAllowed,casttype=ResourceList,castkey=ResourceName"`
+	// Specifies whether this container should only ever scale up its resources
+	// +optional
+	PreventScaleDown bool `json:"PreventScaleDown,omitempty" protobuf:"bytes,5,opt,name=PreventScaleDown"`
 }
 
 const (

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -200,7 +200,9 @@ func TestLoadPods(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			vpa := test.VerticalPodAutoscaler().WithName("testVpa").WithContainer("container").WithNamespace("testNamespace").WithTargetRef(tc.targetRef).Get()
+			vpa := test.VerticalPodAutoscaler().WithName("testVpa").WithNamespace("testNamespace").WithTargetRef(tc.targetRef).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("container").Get()).Get()
+
 			vpaLister := &test.VerticalPodAutoscalerListerMock{}
 			vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -238,7 +238,10 @@ func TestMissingKeys(t *testing.T) {
 
 func addVpa(cluster *ClusterState, id VpaID, annotations vpaAnnotationsMap, selector string) *Vpa {
 	apiObject := test.VerticalPodAutoscaler().WithNamespace(id.Namespace).
-		WithName(id.VpaName).WithContainer(testContainerID.ContainerName).WithAnnotations(annotations).Get()
+		WithName(id.VpaName).WithAnnotations(annotations).
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(testContainerID.ContainerName).Get()).
+		Get()
+
 	return addVpaObject(cluster, id, apiObject, selector)
 }
 
@@ -347,7 +350,9 @@ func TestUpdatePodSelector(t *testing.T) {
 // Test setting ResourcePolicy and UpdatePolicy on adding or updating VPA object
 func TestAddOrUpdateVPAPolicies(t *testing.T) {
 	testVpaBuilder := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).
-		WithNamespace(testVpaID.Namespace).WithContainer(testContainerID.ContainerName)
+		WithNamespace(testVpaID.Namespace).
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(testContainerID.ContainerName).Get())
+
 	updateModeAuto := vpa_types.UpdateModeAuto
 	updateModeOff := vpa_types.UpdateModeOff
 	scalingModeAuto := vpa_types.ContainerScalingModeAuto

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -160,10 +160,8 @@ func testRunOnceBase(
 	podLister.On("List").Return(pods, nil)
 
 	vpaObj := test.VerticalPodAutoscaler().
-		WithContainer(containerName).
-		WithTarget("2", "200M").
-		WithMinAllowed("1", "100M").
-		WithMaxAllowed("3", "1G").
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithMinAllowed("1", "100M").WithMaxAllowed("3", "1G").Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "200M").GetContainerResources()).
 		Get()
 	vpaObj.Spec.UpdatePolicy = &vpa_types.PodUpdatePolicy{UpdateMode: &updateMode}
 	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
@@ -75,7 +75,7 @@ func (*defaultPriorityProcessor) GetUpdatePriority(pod *apiv1.Pod, vpa *vpa_type
 				// If container is PreventScaleDown, then flag as 'outside recommended range' only if the request is
 				// below the lower bound. Requests above the upper bound for these containers is fine.
 				if crp.PreventScaleDown {
-					if (hasLowerBound && request.Cmp(lowerBound) < 0) {
+					if hasLowerBound && request.Cmp(lowerBound) < 0 {
 						outsideRecommendedRange = true
 					}
 				} else if (hasLowerBound && request.Cmp(lowerBound) < 0) ||

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
@@ -40,11 +40,6 @@ func NewProcessor() PriorityProcessor {
 type defaultPriorityProcessor struct {
 }
 
-type ContainerScaling struct {
-	outsideRecommendedRange bool
-	scaleUp bool
-}
-
 func (*defaultPriorityProcessor) GetUpdatePriority(pod *apiv1.Pod, vpa *vpa_types.VerticalPodAutoscaler,
 	recommendation *vpa_types.RecommendedPodResources) PodPriority {
 	outsideRecommendedRange := false

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -236,7 +236,7 @@ func TestGetUpdatePriority(t *testing.T) {
 				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
-				ResourceDiff:            (10.0 - 4) / 4.0,  // |(total request - total recommended)| / total request
+				ResourceDiff:            (10.0 - 4) / 4.0, // |(total request - total recommended)| / total request
 				ScaleUp:                 true,
 			},
 		}, {
@@ -248,12 +248,12 @@ func TestGetUpdatePriority(t *testing.T) {
 				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            (16.0 - 10.0) / 16.0,  // (total request - total recommended) / total request
+				ResourceDiff:            (16.0 - 10.0) / 16.0, // (total request - total recommended) / total request
 				ScaleUp:                 false,
 			},
 		}, {
 			name: "one PreventScaleDown container above upper bound and one normal container above upper bound",
-			pod:  test.Pod().WithName("POD1").
+			pod: test.Pod().WithName("POD1").
 				AddContainer(test.BuildTestContainer(containerName, "16", "")).
 				AddContainer(test.BuildTestContainer("test-container-2", "18", "")).Get(),
 			vpa: test.VerticalPodAutoscaler().
@@ -264,12 +264,12 @@ func TestGetUpdatePriority(t *testing.T) {
 				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
-				ResourceDiff:            (34.0 - 20.0) / 34.0,  // (total request - total recommended) / total request
+				ResourceDiff:            (34.0 - 20.0) / 34.0, // (total request - total recommended) / total request
 				ScaleUp:                 false,
 			},
 		}, {
 			name: "one PreventScaleDown container above upper bound and one normal container below lower bound",
-			pod:  test.Pod().WithName("POD1").
+			pod: test.Pod().WithName("POD1").
 				AddContainer(test.BuildTestContainer(containerName, "16", "")).
 				AddContainer(test.BuildTestContainer("test-container-2", "4", "")).Get(),
 			vpa: test.VerticalPodAutoscaler().
@@ -280,7 +280,7 @@ func TestGetUpdatePriority(t *testing.T) {
 				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
-				ResourceDiff:            (20.0 - 20.0) / 20.0,  // (total request - total recommended) / total request
+				ResourceDiff:            (20.0 - 20.0) / 20.0, // (total request - total recommended) / total request
 				ScaleUp:                 true,
 			},
 		},

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -38,7 +38,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		{
 			name: "simple scale up",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("10", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            4.0,
@@ -47,7 +50,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "simple scale down",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            0.5,
@@ -56,7 +62,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "no resource diff",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            0.0,
@@ -65,7 +74,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "scale up on milliquanitites",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "10m", "")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("900m", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("900m", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            89.0,
@@ -74,10 +86,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "scale up outside recommended range",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("10", "").
-				WithLowerBound("6", "").
-				WithUpperBound("14", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("10", "").WithLowerBound("6", "").WithUpperBound("14", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
 				ResourceDiff:            1.5,
@@ -86,10 +98,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "scale down outside recommended range",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "8", "")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("2", "").
-				WithLowerBound("1", "").
-				WithUpperBound("3", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "").WithLowerBound("1", "").WithUpperBound("3", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
 				ResourceDiff:            0.75,
@@ -98,7 +110,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "scale up with multiple quantities",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("10", "").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            4.0,
@@ -107,7 +122,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "multiple resources, both scale up",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "10M")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("6", "20M").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("6", "20M").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            1.0 + 1.0, // summed relative diffs for resources
@@ -116,7 +134,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "multiple resources, only one scale up",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "10M")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "20M").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "20M").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            1.5 + 0.0, // summed relative diffs for resources
@@ -125,7 +146,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "multiple resources, both scale down",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
-			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "10M").Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "10M").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            0.5 + 0.5, // summed relative diffs for resources
@@ -134,10 +158,10 @@ func TestGetUpdatePriority(t *testing.T) {
 		}, {
 			name: "multiple resources, one outside recommended range",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("2", "10M").
-				WithLowerBound("1", "5M").
-				WithUpperBound("3", "30M").Get(),
+			vpa: test.VerticalPodAutoscaler().AppendContainerResourcePolicy(
+				test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "10M").WithLowerBound("1", "5M").WithUpperBound("3", "30M").GetContainerResources()).
+				Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
 				ResourceDiff:            0.5 + 0.5, // summed relative diffs for resources
@@ -147,11 +171,11 @@ func TestGetUpdatePriority(t *testing.T) {
 			name: "multiple containers, both scale up",
 			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
 				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("4", "").AppendRecommendation(
-				test.Recommendation().
-					WithContainer("test-container-2").
-					WithTarget("8", "").GetContainerResources()).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("4", "").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithTarget("8", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            3.0, // relative diff between summed requests and summed recommendations
@@ -161,11 +185,11 @@ func TestGetUpdatePriority(t *testing.T) {
 			name: "multiple containers, both scale down",
 			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "")).
 				AddContainer(test.BuildTestContainer("test-container-2", "7", "")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("1", "").AppendRecommendation(
-				test.Recommendation().
-					WithContainer("test-container-2").
-					WithTarget("2", "").GetContainerResources()).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("1", "").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithTarget("2", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				ResourceDiff:            0.7, // relative diff between summed requests and summed recommendations
@@ -175,14 +199,11 @@ func TestGetUpdatePriority(t *testing.T) {
 			name: "multiple containers, both scale up, one outside range",
 			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
 				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("4", "").
-				WithLowerBound("1", "").AppendRecommendation(
-				test.Recommendation().
-					WithContainer("test-container-2").
-					WithTarget("8", "").
-					WithLowerBound("3", "").
-					WithUpperBound("10", "").GetContainerResources()).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("4", "").WithLowerBound("1", "").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithTarget("8", "").WithLowerBound("3", "").WithUpperBound("10", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
 				ResourceDiff:            3.0, // relative diff between summed requests and summed recommendations
@@ -195,16 +216,72 @@ func TestGetUpdatePriority(t *testing.T) {
 			//   total:      request={10 CPU, 40 MB}, recommended={15 CPU, 50 MB}
 			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "6", "10M")).
 				AddContainer(test.BuildTestContainer("test-container-2", "4", "30M")).Get(),
-			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("8", "20M").AppendRecommendation(
-				test.Recommendation().
-					WithContainer("test-container-2").
-					WithTarget("7", "30M").GetContainerResources()).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("8", "20M").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithTarget("7", "30M").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
 				// relative diff between summed requests and summed recommendations, summed over resources
 				ResourceDiff: 0.5 + 0.25,
 				ScaleUp:      true,
+			},
+		}, {
+			name: "one PreventScaleDown container below lower bound so scales up",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithPreventScaleDown(true).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				Get(),
+			expectedPrio: PodPriority{
+				OutsideRecommendedRange: true,
+				ResourceDiff:            (10.0 - 4) / 4.0,  // |(total request - total recommended)| / total request
+				ScaleUp:                 true,
+			},
+		}, {
+			name: "one PreventScaleDown container above upper bound but doesn't show as outside recommended range",
+			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "16", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithPreventScaleDown(true).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				Get(),
+			expectedPrio: PodPriority{
+				OutsideRecommendedRange: false,
+				ResourceDiff:            (16.0 - 10.0) / 16.0,  // (total request - total recommended) / total request
+				ScaleUp:                 false,
+			},
+		}, {
+			name: "one PreventScaleDown container above upper bound and one normal container above upper bound",
+			pod:  test.Pod().WithName("POD1").
+				AddContainer(test.BuildTestContainer(containerName, "16", "")).
+				AddContainer(test.BuildTestContainer("test-container-2", "18", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithPreventScaleDown(true).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				Get(),
+			expectedPrio: PodPriority{
+				OutsideRecommendedRange: true,
+				ResourceDiff:            (34.0 - 20.0) / 34.0,  // (total request - total recommended) / total request
+				ScaleUp:                 false,
+			},
+		}, {
+			name: "one PreventScaleDown container above upper bound and one normal container below lower bound",
+			pod:  test.Pod().WithName("POD1").
+				AddContainer(test.BuildTestContainer(containerName, "16", "")).
+				AddContainer(test.BuildTestContainer("test-container-2", "4", "")).Get(),
+			vpa: test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithPreventScaleDown(true).Get()).
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer("test-container-2").Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				AppendRecommendation(test.Recommendation().WithContainer("test-container-2").WithLowerBound("6", "").WithTarget("10", "").WithUpperBound("14", "").GetContainerResources()).
+				Get(),
+			expectedPrio: PodPriority{
+				OutsideRecommendedRange: true,
+				ResourceDiff:            (20.0 - 20.0) / 20.0,  // (total request - total recommended) / total request
+				ScaleUp:                 true,
 			},
 		},
 	}
@@ -222,7 +299,8 @@ func TestGetUpdatePriority(t *testing.T) {
 func TestGetUpdatePriority_NoRecommendationForContainer(t *testing.T) {
 	p := NewProcessor()
 	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer("test-container", "5", "10")).Get()
-	vpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithContainer("test-container").Get()
+	vpa := test.VerticalPodAutoscaler().WithName("test-vpa").AppendContainerResourcePolicy(
+		test.ContainerResourcePolicy().WithContainer("test-container").Get()).Get()
 	result := p.GetUpdatePriority(pod, vpa, nil)
 	assert.NotNil(t, result)
 }
@@ -236,7 +314,8 @@ func TestGetUpdatePriority_VpaObservedContainers(t *testing.T) {
 		// and the container is not listed in.
 		optedOutContainerDiff = 0
 	)
-	testVpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithContainer(containerName).Get()
+	testVpa := test.VerticalPodAutoscaler().WithName("test-vpa").AppendContainerResourcePolicy(
+		test.ContainerResourcePolicy().WithContainer(containerName).Get()).Get()
 	tests := []struct {
 		name           string
 		pod            *corev1.Pod

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -42,7 +42,10 @@ func TestSortPriority(t *testing.T) {
 	pod3 := test.Pod().WithName("POD3").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get()
 	pod4 := test.Pod().WithName("POD4").AddContainer(test.BuildTestContainer(containerName, "3", "")).Get()
 
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("10", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ResourceDiff: 4.0},
@@ -67,7 +70,10 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.BuildTestContainer(containerName, "8", "")).Get()
 	pod3 := test.Pod().WithName("POD3").AddContainer(test.BuildTestContainer(containerName, "10", "")).Get()
 
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("5", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ScaleUp: true, ResourceDiff: 0.25},
@@ -91,7 +97,10 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 
 func TestUpdateNotRequired(t *testing.T) {
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get()
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("4", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("4", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{"POD1": {
 		ResourceDiff: 0.0,
@@ -112,7 +121,10 @@ func TestUseProcessor(t *testing.T) {
 	recommendationProcessor := &test.RecommendationProcessorMock{}
 	recommendationProcessor.On("Apply").Return(processedRecommendation, nil)
 
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("5", "5M").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "5M").GetContainerResources()).
+		Get()
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "10M")).Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
@@ -140,10 +152,10 @@ func TestUpdateLonglivedPods(t *testing.T) {
 	}
 
 	// Both pods are within the recommended range.
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-		WithTarget("5", "").
-		WithLowerBound("1", "").
-		WithUpperBound("6", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {OutsideRecommendedRange: false, ScaleUp: true, ResourceDiff: 0.25},
@@ -174,10 +186,10 @@ func TestUpdateShortlivedPods(t *testing.T) {
 	}
 
 	// Pods 1 and 2 are within the recommended range.
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-		WithTarget("5", "").
-		WithLowerBound("1", "").
-		WithUpperBound("6", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {OutsideRecommendedRange: false, ScaleUp: true, ResourceDiff: 0.25},
@@ -216,10 +228,10 @@ func TestUpdatePodWithQuickOOM(t *testing.T) {
 	}
 
 	// Pod is within the recommended range.
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-		WithTarget("5", "").
-		WithLowerBound("1", "").
-		WithUpperBound("6", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ScaleUp: true, ResourceDiff: 0.25},
@@ -252,10 +264,10 @@ func TestDontUpdatePodWithQuickOOMNoResourceChange(t *testing.T) {
 	}
 
 	// Pod is within the recommended range.
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-		WithTarget("4", "8Gi").
-		WithLowerBound("2", "5Gi").
-		WithUpperBound("5", "10Gi").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("4", "8Gi").WithLowerBound("2", "5Gi").WithUpperBound("5", "10Gi").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ScaleUp: true, ResourceDiff: 0.0},
@@ -288,10 +300,10 @@ func TestDontUpdatePodWithOOMAfterLongRun(t *testing.T) {
 	}
 
 	// Pod is within the recommended range.
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-		WithTarget("5", "").
-		WithLowerBound("1", "").
-		WithUpperBound("6", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ScaleUp: true, ResourceDiff: 0.0},
@@ -350,10 +362,10 @@ func TestQuickOOM_VpaOvservedContainers(t *testing.T) {
 			}
 
 			// Pod is within the recommended range.
-			vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("5", "").
-				WithLowerBound("1", "").
-				WithUpperBound("6", "").Get()
+			vpa := test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+				Get()
 
 			priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 				"POD1": {ScaleUp: true, ResourceDiff: 0.25}})
@@ -435,10 +447,10 @@ func TestQuickOOM_ContainerResourcePolicy(t *testing.T) {
 			}
 
 			// Pod is within the recommended range.
-			vpa := test.VerticalPodAutoscaler().WithContainer(containerName).
-				WithTarget("5", "").
-				WithLowerBound("1", "").
-				WithUpperBound("6", "").Get()
+			vpa := test.VerticalPodAutoscaler().
+				AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+				AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("5", "").WithLowerBound("1", "").WithUpperBound("6", "").GetContainerResources()).
+				Get()
 
 			vpa.Spec.ResourcePolicy = &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
@@ -480,7 +492,10 @@ func TestAdmission(t *testing.T) {
 	pod3 := test.Pod().WithName("POD3").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get()
 	pod4 := test.Pod().WithName("POD4").AddContainer(test.BuildTestContainer(containerName, "3", "")).Get()
 
-	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get()
+	vpa := test.VerticalPodAutoscaler().
+		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get()).
+		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("10", "").GetContainerResources()).
+		Get()
 
 	priorityProcessor := NewFakeProcessor(map[string]PodPriority{
 		"POD1": {ScaleUp: true, ResourceDiff: 4.0},

--- a/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	core "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// RecommendationBuilder helps building test instances of RecommendedPodResources.
+type ContainerResourcePolicyBuilder interface {
+	WithContainer(containerName string) ContainerResourcePolicyBuilder
+	WithMinAllowed(cpu, memory string) ContainerResourcePolicyBuilder
+	WithMaxAllowed(cpu, memory string) ContainerResourcePolicyBuilder
+	WithControlledValues(mode vpa_types.ContainerControlledValues) ContainerResourcePolicyBuilder
+	WithPreventScaleDown(PreventScaleDown bool) ContainerResourcePolicyBuilder
+
+	Get() vpa_types.ContainerResourcePolicy
+}
+
+// Recommendation returns a new ContainerResourcePolicyBuilder.
+func ContainerResourcePolicy() ContainerResourcePolicyBuilder {
+	return &containerResourcePolicyBuilder{}
+}
+
+type containerResourcePolicyBuilder struct {
+	containerName    string
+	minAllowed       core.ResourceList
+	maxAllowed       core.ResourceList
+	ControlledValues *vpa_types.ContainerControlledValues
+	PreventScaleDown      bool
+}
+
+func (b *containerResourcePolicyBuilder) WithContainer(containerName string) ContainerResourcePolicyBuilder {
+	c := *b
+	c.containerName = containerName
+	return &c
+}
+
+func (b *containerResourcePolicyBuilder) WithMinAllowed(cpu, memory string) ContainerResourcePolicyBuilder {
+	c := *b
+	c.minAllowed = Resources(cpu, memory)
+	return &c
+}
+
+func (b *containerResourcePolicyBuilder) WithMaxAllowed(cpu, memory string) ContainerResourcePolicyBuilder {
+	c := *b
+	c.maxAllowed = Resources(cpu, memory)
+	return &c
+}
+
+func (b *containerResourcePolicyBuilder) WithControlledValues(mode vpa_types.ContainerControlledValues) ContainerResourcePolicyBuilder {
+	c := *b
+	c.ControlledValues = &mode
+	return &c
+}
+
+func (b *containerResourcePolicyBuilder) WithPreventScaleDown(PreventScaleDown bool) ContainerResourcePolicyBuilder {
+	c := *b
+	c.PreventScaleDown = PreventScaleDown
+	return &c
+}
+
+func (b *containerResourcePolicyBuilder) Get() vpa_types.ContainerResourcePolicy {
+	if b.containerName == "" {
+		panic("Must call WithContainer() before Get()")
+	}
+	return vpa_types.ContainerResourcePolicy{
+		ContainerName:    b.containerName,
+		MinAllowed:       b.minAllowed,
+		MaxAllowed:       b.maxAllowed,
+		ControlledValues: b.ControlledValues,
+		PreventScaleDown:      b.PreventScaleDown,
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
@@ -21,7 +21,7 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
-// RecommendationBuilder helps building test instances of RecommendedPodResources.
+// ContainerResourcePolicyBuilder helps building test instances of ContainerResourcePolicy.
 type ContainerResourcePolicyBuilder interface {
 	WithContainer(containerName string) ContainerResourcePolicyBuilder
 	WithMinAllowed(cpu, memory string) ContainerResourcePolicyBuilder
@@ -32,7 +32,7 @@ type ContainerResourcePolicyBuilder interface {
 	Get() vpa_types.ContainerResourcePolicy
 }
 
-// Recommendation returns a new ContainerResourcePolicyBuilder.
+// ContainerResourcePolicy returns a new ContainerResourcePolicyBuilder.
 func ContainerResourcePolicy() ContainerResourcePolicyBuilder {
 	return &containerResourcePolicyBuilder{}
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_container_resource_policy.go
@@ -42,7 +42,7 @@ type containerResourcePolicyBuilder struct {
 	minAllowed       core.ResourceList
 	maxAllowed       core.ResourceList
 	ControlledValues *vpa_types.ContainerControlledValues
-	PreventScaleDown      bool
+	PreventScaleDown bool
 }
 
 func (b *containerResourcePolicyBuilder) WithContainer(containerName string) ContainerResourcePolicyBuilder {
@@ -84,6 +84,6 @@ func (b *containerResourcePolicyBuilder) Get() vpa_types.ContainerResourcePolicy
 		MinAllowed:       b.minAllowed,
 		MaxAllowed:       b.maxAllowed,
 		ControlledValues: b.ControlledValues,
-		PreventScaleDown:      b.PreventScaleDown,
+		PreventScaleDown: b.PreventScaleDown,
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -147,7 +147,7 @@ func (b *verticalPodAutoscalerBuilder) Get() *vpa_types.VerticalPodAutoscaler {
 			Recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: b.recommendedContainerResources,
 			},
-			Conditions:     b.conditions,
+			Conditions: b.conditions,
 		},
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -59,8 +59,7 @@ func TestUpdateVpaIfNeeded(t *testing.T) {
 	observedVpaBuilder := test.VerticalPodAutoscaler().WithName("vpa").WithNamespace("test").
 		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).Get())
 
-
-		testCases := []struct {
+	testCases := []struct {
 		caseName       string
 		updatedVpa     *vpa_types.VerticalPodAutoscaler
 		observedVpa    *vpa_types.VerticalPodAutoscaler
@@ -126,7 +125,6 @@ func TestPodMatchesVPA(t *testing.T) {
 	vpaBuilder := test.VerticalPodAutoscaler().
 		AppendContainerResourcePolicy(test.ContainerResourcePolicy().WithContainer(containerName).WithMinAllowed("1", "100M").WithMaxAllowed("3", "1G").Get()).
 		AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("2", "200M").GetContainerResources())
-
 
 	vpa := vpaBuilder.Get()
 	otherNamespaceVPA := vpaBuilder.WithNamespace("other").Get()

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -40,7 +40,7 @@ var (
 	cappedToLimit                  cappingAction = "capped to container limit"
 	cappedProportionallyToMaxLimit cappingAction = "capped to fit Max in container LimitRange"
 	cappedProportionallyToMinLimit cappingAction = "capped to fit Min in container LimitRange"
-	cappedToPreventScaleDown            cappingAction = "capped to prevent scale down of PreventScaleDown container"
+	cappedToPreventScaleDown       cappingAction = "capped to prevent scale down of PreventScaleDown container"
 )
 
 func toCappingAnnotation(resourceName apiv1.ResourceName, action cappingAction) string {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -209,9 +209,15 @@ func applyVPAPolicyForContainer(containerName string,
 		}
 	}
 
-	process(cappedRecommendations.Target, oldContainerRecommendation.Target)
-	process(cappedRecommendations.LowerBound, oldContainerRecommendation.LowerBound)
-	process(cappedRecommendations.UpperBound, oldContainerRecommendation.UpperBound)
+	if oldContainerRecommendation != nil {
+		process(cappedRecommendations.Target, oldContainerRecommendation.Target)
+		process(cappedRecommendations.LowerBound, oldContainerRecommendation.LowerBound)
+		process(cappedRecommendations.UpperBound, oldContainerRecommendation.UpperBound)
+	} else {
+		process(cappedRecommendations.Target, nil)
+		process(cappedRecommendations.LowerBound, nil)
+		process(cappedRecommendations.UpperBound, nil)
+	}
 
 	return cappedRecommendations, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -201,8 +201,11 @@ func applyVPAPolicyForContainer(containerName string,
 			recommendation[resourceName] = cappedToMin
 			cappedToMax, _ := maybeCapToPolicyMax(cappedToMin, resourceName, containerPolicy)
 			recommendation[resourceName] = cappedToMax
-			cappedToPreventScaleDown, _ := maybeCapToPreventScaleDown(recommended, oldRecommendation[resourceName], containerPolicy)
-			recommendation[resourceName] = cappedToPreventScaleDown
+
+			if oldContainerRecommendation != nil {
+				cappedToPreventScaleDown, _ := maybeCapToPreventScaleDown(recommended, oldRecommendation[resourceName], containerPolicy)
+				recommendation[resourceName] = cappedToPreventScaleDown
+			}
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -294,8 +294,7 @@ func TestApplyVpa(t *testing.T) {
 		},
 	}
 
-	// We set the old recommendation to same as the current since it's unimportant for this test
-	res, err := ApplyVPAPolicy(&podRecommendation, &podRecommendation, &policy)
+	res, err := ApplyVPAPolicy(&podRecommendation, nil, &policy)
 	assert.Nil(t, err)
 	assert.Equal(t, apiv1.ResourceList{
 		apiv1.ResourceCPU:    *resource.NewScaledQuantity(40, 1),

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -222,6 +222,7 @@ var podRecommendation *vpa_types.RecommendedPodResources = &vpa_types.Recommende
 		},
 	},
 }
+
 var applyTestCases = []struct {
 	PodRecommendation         *vpa_types.RecommendedPodResources
 	Policy                    *vpa_types.PodResourcePolicy


### PR DESCRIPTION
At Monzo, we use the VPA on many of our microservices, which are pods containing a service container and an envoy sidecar.  In the vast majority of cases, the VPA works as expected and the requests are set to sensible values.  

![image](https://user-images.githubusercontent.com/6616412/89070156-6a34df00-d36c-11ea-847c-1e3ce130a38b.png)

We do however see cases where pods which typically see very little load, receive a surge in traffic, and the behaviour of the VPA results in all pods in the deployment being evicted in quick succession (each yellow line below is an eviction). Typically this happens when the request is close to the lower bound, and a small uptick in resource usage causes the recommender to suggest marginally higher resources. After the event which generated load, the VPA gradually decreases the requests until the next time.

![image](https://user-images.githubusercontent.com/6616412/89121732-59de4a80-d4b9-11ea-85ef-0a07519bbec5.png)

Historically, we've relied on manually increasing the lower bound for the VPA recommendation to prevent these kind of pods from being sized too small and evicted under load, but with 1800+ independent microservices, we'd like the VPA to be able to increase the size of the containers only. 

To address this we've introduced an additional flag on the ContainerResourcePolicy - `PreventScaleDown` - which can be used to prevent the resources of a container from being reduced. The flag is used by:
- the Updater to prevent it evicting pods if the resulting change would mean scaling down
- the Admission Controller to ensure the requests are only set the recommended values if doing so would increase them
- the Recommender to prevent it reducing the recommendation values for these containers

> The overall behaviour is that a container with this flag will get the higher of it's static request, or the highest recommendation that has been produced over its lifetime.

## Example VPA Spec
```
apiVersion: autoscaling.k8s.io/v1beta2
kind: VerticalPodAutoscaler
metadata:
  labels:
    app: foo
  name: foo
spec:
  resourcePolicy:
    containerPolicies:
    - containerName: '*'
      maxAllowed:
        cpu: 1
        memory: 1Gi
      minAllowed:
        cpu: 10m
        memory: 50Mi
      preventScaleDown: true   # 👈 This is new!
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: foo
  updatePolicy:
    updateMode: Auto
```

## Change Details
- Adds `PreventScaleDown` as an option on a container resource policy.  This allows the scale down protection to be applied on specific containers in a pod.
- Updates the recommender capping behaviour to prevent recommendations from being reduced for containers with `PreventScaleDown` enabled.  This ensures the recommended resources will remain static or increase over time.
- Updates the VPA Updater priority calculator so it doesn't flag a `PreventScaleDown` container which is requesting more than the upper bound as outside the recommended range. It is acceptable for these containers to request more resources than the VPA recommends. 
- Updates the capping behaviour in the admission controller to prevent the requests of any containers with `PreventScaleDown` from being reduced.  This prevents the 

### Testing changes
- Updates the VPABuilder test harness to make the setup of Recommendations and ContainerResourcePolicies explicit rather than implicit (previously, many of the `With` commands on the VPA builder were creating recommendations as side effects) The change aimed to make this more explicit and support multi-container testing more easily.
- Adds a new `ContainerResourcePolicyBuilder` to support adding these explicitly to tests.

## Remaining Work
- The documentation for this setting is missing.  If the approach is agreed, I'll write it before merging.