### PR TITLE
CA-Chart - Move from helm chart-releaser-action to scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+
       - name: Configure Git
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
+
+      - name: Package
+        shell: bash
+        run: hack/helm-release-chart.sh
+
+      - name: Create Pull Request branch
+        run: |
+          git checkout -b gh-pages-pull-request
+
+      # Note that this will fail if branch already exists - i.e. we can only have one bot raised PR at a time
+      - name: Push Git Branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages-pull-request
+
+      # Note that this will silently fail if the PR already exists
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: gh-pages-pull-request
+          destination_branch: gh-pages
+          pr_title: "Helm Chart: Update Helm repository"
+          pr_body: "Automatically created from Helm Release workflow."
+
 name: Release Charts
 on:
   push:

--- a/hack/helm-release-chart.sh
+++ b/hack/helm-release-chart.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Taken with light modifications from https://raw.githubusercontent.com/kubernetes/dashboard/9ddb951f8aca579727f3923518659235f38e278d/aio/scripts/helm-release-chart.sh
+
+# This script takes an argument: the tag name ("v1.2.3") to release from.
+
+# Exit on error.
+set -e
+
+# Declare variables.
+HELM_CHART_DIR="charts/cluster-autoscaler-chart"
+
+function release-helm-chart {
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "Git working tree not clean, aborting."
+    exit 1
+  fi
+  echo "Generating Helm Chart package for new version."
+  echo "Please note that your gh-pages branch, if it locally exists, should be up-to-date."
+  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  helm dependency build "$HELM_CHART_DIR"
+  helm package "$HELM_CHART_DIR"
+  rm -rf "$HELM_CHART_DIR/charts/"
+  echo "Switching git branch to gh-pages so that we can commit package along the previous versions."
+  git checkout gh-pages
+  echo "Generating new Helm index, containing all existing versions in gh-pages (previous ones + new one)."
+  helm repo index .
+  echo "Commit new package and index."
+  git add -A "./cluster-autoscaler-*.tgz" ./index.yaml && git commit -m "Update Helm repository from CI."
+  echo "If you are happy with the changes, please manually push to the gh-pages branch. No force should be needed."
+  echo "Assuming upstream is your remote, please run: git push upstream gh-pages."
+}
+
+# Execute script.
+release-helm-chart


### PR DESCRIPTION
Moves away from the helm chart-releaser-action to scripts due to `gh-pages` branch being protected.

Post merging of #3393 the attempted publish action failed due to the branch protection on the `gh-pages` branch.

Unfortunately due to the issues documented by https://github.com/helm/chart-releaser-action/issues/33 we can't use the official chart-releaser action currently as it relies on the ability to push directly to the `gh-pages` branch.

This workflow and the associated script are lifted liberally from the kubernetes/dashboard repo's flow for publishing their helm charts: https://github.com/kubernetes/dashboard/blob/master/.github/workflows/cd-helm-workflow.yml albeit changing some regex and custom functions.

I'm hopeful that this will be a short term fix until the official action resolves this issue.

### Questions still to be addressed


- [ ] How to clean up the branch created for raising PRs `gh-pages-pull-request` as this existing will block further raising of PRs - I briefly considered randomly generating the branch names, but that just puts the problem off and we'd end up with many stale branches, not ideal, would prefer this to be automated if at all possible
It looks like the maintainers of the dashboard repo are currently manually cleaning this up post merging - not ideal.

- [ ] Whether the script should be made more generic now to handle possible extension of charts hosted in this repo - I'm hopeful that the official action should address the issue raised above and as such we won't need to use this long term

- [ ] Whether branch protection will automatically be stuck on the new `gh-pages-pull-request` branch preventing a push to it - I don't think this should be the case looking at `kubernetes/dashboard`, but worth checking

