### PR TITLE
Fix label selector in chart post-install notes

### DIFF
--- a/charts/cluster-autoscaler-chart/Chart.yaml
+++ b/charts/cluster-autoscaler-chart/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler-chart
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/cluster-autoscaler-chart/templates/NOTES.txt
+++ b/charts/cluster-autoscaler-chart/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 To verify that cluster-autoscaler has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "cluster-autoscaler.name" . }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "cluster-autoscaler.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
 {{- else -}}
 


### PR DESCRIPTION
Fixes the label selectors in the `kubectl get pods` command printed by the post-install notes.

The `app` and `release` labels were replaced by this commit https://github.com/helm/charts/commit/5e4e493bbb27037c54fdeeab7397de2452310d52 in the old chart location. The new labels come from

https://github.com/kubernetes/autoscaler/blob/852ea800914cae101824687a71236f7688ee653d/charts/cluster-autoscaler-chart/templates/_helpers.tpl#L36-L39

which have the same values as the old `app` and `release` labels.