### PR TITLE
Fix module path in local gophercloud copy

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/.zuul.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/.zuul.yaml
@@ -76,16 +76,6 @@
       global_env:
         OS_BRANCH: stable/newton
 
-- job:
-    name: gophercloud-acceptance-test-mitaka
-    parent: gophercloud-acceptance-test
-    description: |
-      Run gophercloud acceptance test on mitaka branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/mitaka
-    nodeset: ubuntu-trusty
-
 - project:
     name: gophercloud/gophercloud
     check:
@@ -93,9 +83,6 @@
         - gophercloud-unittest
         - gophercloud-acceptance-test
         - gophercloud-acceptance-test-ironic
-    recheck-mitaka:
-      jobs:
-        - gophercloud-acceptance-test-mitaka
     recheck-newton:
       jobs:
         - gophercloud-acceptance-test-newton

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/CHANGELOG.md
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.8.0 (Unreleased)
+## 0.9.0 (Unreleased)
+
+## 0.8.0 (February 8, 2020)
+
+UPGRADE NOTES
+
+* The behavior of `keymanager/v1/acls.SetOpts` has changed. Instead of a struct, it is now `[]SetOpt`. See [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816) for implementation details.
 
 IMPROVEMENTS
 
@@ -8,6 +14,32 @@ IMPROVEMENTS
 * Added `compute/v2/extensions/shelveunshelve.Unshelve` [GH-1799](https://github.com/gophercloud/gophercloud/pull/1799)
 * Added `containerinfra/v1/nodegroups.Get` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
 * Added `containerinfra/v1/nodegroups.List` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
+* Added `orchestration/v1/resourcetypes.List` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GetSchema` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GenerateTemplate` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `keymanager/v1/acls.SetOpt` and changed `keymanager/v1/acls.SetOpts` to `[]SetOpt` [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816)
+* Added `blockstorage/apiversions.List` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `blockstorage/apiversions.Get` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `StatusCodeError` interface and `GetStatusCode` convenience method [GH-1820](https://github.com/gophercloud/gophercloud/pull/1820)
+* Added pagination support to `compute/v2/extensions/usage.SingleTenant` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added pagination support to `compute/v2/extensions/usage.AllTenants` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added `placement/v1/resourceproviders.List` [GH-1815](https://github.com/gophercloud/gophercloud/pull/1815)
+* Allow `CreateMemberOptsBuilder` to be passed in `loadbalancer/v2/pools.Create` [GH-1822](https://github.com/gophercloud/gophercloud/pull/1822)
+* Added `Backup` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorAddress` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorPort` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Changed `Impersonation` to a non-required field in `identity/v3/extensions/trusts.CreateOpts` [GH-1818](https://github.com/gophercloud/gophercloud/pull/1818)
+* Added `InsertHeaders` to `loadbalancer/v2/listeners.UpdateOpts` [GH-1835]
+* Added `NUMATopology` to `baremetalintrospection/v1/introspection.Data` [GH-1842](https://github.com/gophercloud/gophercloud/pull/1842)
+* Added `placement/v1/resourceproviders.Create` [GH-1841](https://github.com/gophercloud/gophercloud/pull/1841)
+
+BUG FIXES
+
+* Changed `sort_key` to `sort_keys` in ` workflow/v2/crontriggers.ListOpts` [GH-1809](https://github.com/gophercloud/gophercloud/pull/1809)
+* Allow `blockstorage/extensions/schedulerstats.Capabilities.MaxOverSubscriptionRatio` to accept both string and int/float responses [GH-1817](https://github.com/gophercloud/gophercloud/pull/1817)
+* Fixed bug in `NewLoadBalancerV2` for situations when the LBaaS service was advertised without a `/v2.0` endpoint [GH-1829](https://github.com/gophercloud/gophercloud/pull/1829)
+* Fixed JSON tags in `baremetal/v1/ports.UpdateOperation` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
+* Fixed JSON tags in `networking/v2/extensions/lbaas/vips.commonResult.Extract()` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
 
 ## 0.7.0 (December 3, 2019)
 

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/errors.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/errors.go
@@ -92,6 +92,23 @@ func (e ErrUnexpectedResponseCode) Error() string {
 	return e.choseErrString()
 }
 
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// StatusCodeError is a convenience interface to easily allow access to the
+// status code field of the various ErrDefault* types.
+//
+// By using this interface, you only have to make a single type cast of
+// the returned error to err.(StatusCodeError) and then call GetStatusCode()
+// instead of having a large switch statement checking for each of the
+// ErrDefault* types.
+type StatusCodeError interface {
+	Error() string
+	GetStatusCode() int
+}
+
 // ErrDefault400 is the default error type returned on a 400 HTTP response code.
 type ErrDefault400 struct {
 	ErrUnexpectedResponseCode

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/go.mod
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/go.mod
@@ -1,4 +1,4 @@
-module github.com/gophercloud/gophercloud
+module k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud
 
 require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
@@ -11,3 +11,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.7
 )
+

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/client.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
 	tokens2 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v2/tokens"
@@ -432,7 +433,11 @@ func NewImageServiceV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // load balancer service.
 func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "load-balancer")
-	sc.ResourceBase = sc.Endpoint + "v2.0/"
+
+	// Fixes edge case having an OpenStack lb endpoint with trailing version number.
+	endpoint := strings.Replace(sc.Endpoint, "v2.0/", "", -1)
+
+	sc.ResourceBase = endpoint + "v2.0/"
 	return sc, err
 }
 
@@ -472,4 +477,9 @@ func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.Endp
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "workflowv2")
+}
+
+// NewPlacementV1 creates a ServiceClient that may be used with the placement package.
+func NewPlacementV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "placement")
 }

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts/doc.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts/doc.go
@@ -38,7 +38,7 @@ Example to Create a Trust
         },
         TrusteeUserID: "ecb37e88cc86431c99d0332208cb6fbf",
         TrustorUserID: "959ed913a32c4ec88c041c98e61cbbc3",
-	}
+    }
 
     trust, err := trusts.Create(identityClient, createOpts).Extract()
     if err != nil {

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts/requests.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts/requests.go
@@ -52,7 +52,7 @@ type CreateOptsBuilder interface {
 // CreateOpts provides options used to create a new trust.
 type CreateOpts struct {
 	// Impersonation allows the trustee to impersonate the trustor.
-	Impersonation bool `json:"impersonation" required:"true"`
+	Impersonation bool `json:"impersonation"`
 
 	// TrusteeUserID is a user who is capable of consuming the trust.
 	TrusteeUserID string `json:"trustee_user_id" required:"true"`


### PR DESCRIPTION
Fixes #3414

This path was missed in go.mod when replacing
import paths because it was filtering for *.go files.

This commit also changes the gophercloud version to
exactly v0.8.0, instead of being vendored immediately
after nodegroup support was added.