### PR TITLE
Use shallow clone in update-vendor.sh

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -80,12 +80,13 @@ set +o errexit
 
   if [ ! -d ${K8S_REPO} ]; then
     echo "Cloning ${K8S_FORK} into ${K8S_REPO}"
-    git clone ${K8S_FORK} ${K8S_REPO} >&${BASH_XTRACEFD} 2>&1
+    git clone --depth 1 ${K8S_FORK} ${K8S_REPO} >&${BASH_XTRACEFD} 2>&1
   fi
 
   pushd ${K8S_REPO} >/dev/null
-  git checkout ${K8S_REV} >&${BASH_XTRACEFD} 2>&1
-  K8S_REV_PARSED=$(git rev-parse ${K8S_REV})
+  git fetch --depth 1 origin ${K8S_REV} >&${BASH_XTRACEFD} 2>&1
+  git checkout FETCH_HEAD >&${BASH_XTRACEFD} 2>&1
+  K8S_REV_PARSED=$(git rev-parse FETCH_HEAD)
   popd >/dev/null
 
 


### PR DESCRIPTION
Pulling the complete kubernetes/kubernetes repo can take a while especially on a slow connection.

Instead of pulling everything, this change pulls only the tip of the master branch and then fetches the single revision that is requested, checking it out using `FETCH_HEAD`.

It works with `--k8srev=branch-name`, `--k8srev=tags/tag-name` and `--k8srev=commit-sha`, which should be all the ways this could already be used.

The total download size is reduced from ~750MB to ~50MB. The disk space used by the cloned kubernetes repo is also reduced from 950MB to 250MB.