### PR TITLE
chore: add kustomize support

### DIFF
--- a/vertical-pod-autoscaler/deploy/kustomization.yaml
+++ b/vertical-pod-autoscaler/deploy/kustomization.yaml
@@ -3,6 +3,4 @@ resources:
 - recommender-deployment.yaml
 - updater-deployment.yaml
 - vpa-rbac.yaml
-
-crds:
 - vpa-v1-crd.yaml

--- a/vertical-pod-autoscaler/deploy/kustomization.yaml
+++ b/vertical-pod-autoscaler/deploy/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- admission-controller-deployment.yaml
+- recommender-deployment.yaml
+- updater-deployment.yaml
+- vpa-rbac.yaml
+
+crds:
+- vpa-v1-crd.yaml


### PR DESCRIPTION
This will allow the use of kustomizes [base](https://kubectl.docs.kubernetes.io/pages/app_customization/bases_and_variants.html) feature.

This will allow to retrieve and update manifest like so:

```
# cat kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: kube-system

bases:
- github.com/estahn/autoscaler//vertical-pod-autoscaler/deploy/?ref=patch-1

commonLabels:
 app.kubernetes.io/name: vertical-pod-autoscaler

patchesStrategicMerge:
- patches.yaml
```

```
# cat patches.yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: vpa-recommender
  namespace: kube-system
spec:
  template:
    spec:
      containers:
      - name: recommender
        command: ['./recommender']
        args:
        - --v=4
        - --stderrthreshold=info
        - --storage=prometheus
        - --prometheus-address=http://prometheus-operator-prometheus.devops.svc:9090
        - --prometheus-cadvisor-job-name=kubelet
        - --pod-namespace-label=namespace
        - --pod-name-label=pod
        - --pod-label-prefix=""
        - --container-name-label=container
        - --container-namespace-label=namespace
        - --container-pod-name-label=pod
        - --history-length=4h
        - --memory-saver
        resources:
          limits:
            cpu: 200m
            memory: 2000Mi
          requests:
            cpu: 50m
            memory: 1500Mi
```