### PR TITLE
Improve Cluster API tests to work better with constrained resources

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -888,7 +888,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		// when fetched from the API
 		for _, node := range nodesToBeDeleted {
 			// Ensure the update has propogated
-			if err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+			if err := wait.PollImmediate(100*time.Millisecond, 5*time.Minute, func() (bool, error) {
 				m, err := controller.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))
 				if err != nil {
 					return false, err


### PR DESCRIPTION
This makes Cluster API provider tests for Cluster Autoscaler more resilient when running in resource constrained environments. Previously the tests were replicating operations on the informer cache stores and the fake clients, which led to duplicated resources being present in the informer cache store depending on racy behavior that manifests with increased parallelism or in resource constrained environments. With this change, rather than trying to replicate operations the test helpers poll the informer cache store for the changes to be propagated before continuing test assertions.

/assign @elmiko 