### PR TITLE
Bypass comparing node group resources if the hardware config is the same

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -247,6 +247,10 @@ This does not guarantee similar node groups will have exactly the same sizes:
   same set of pending pods. If you run pods that can only go to a single node group
   (for example due to nodeSelector on zone label) CA will only add nodes to
   this particular node group.
+* On AWS, node groups that have at least one provisioned instance may be preferred
+ over node groups that have none. This can lead to all nodes being provisioned in a
+ single AZ. To work around this, add the `cluster-autoscaler.kubernetes.io/hardware-configuration-id`
+ label to all similar nodes and specify the same value
 
 You can opt-out a node group from being automatically balanced with other node
 groups using the same instance type by giving it any custom label.

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups_test.go
@@ -96,6 +96,44 @@ func TestNodesSimilarVariousRequirementsAndPods(t *testing.T) {
 	checkNodesSimilarWithPods(t, n1, n4, []*apiv1.Pod{p1}, []*apiv1.Pod{p4}, IsNodeInfoSimilar, true)
 }
 
+func TestNodesSimilarHardwareConfigurationLabels(t *testing.T) {
+	nodeGroupHwConfigLabel := "node.kubernetes.io/autoscaler-hardware-configuration-id"
+
+	n1 := BuildTestNode("node1", 1000, 2000)
+	n1.ObjectMeta.Labels["test-label"] = "test-value"
+	n1.ObjectMeta.Labels["character"] = "winnie the pooh"
+	n2 := BuildTestNode("node2", 1000, 2000)
+	n2.ObjectMeta.Labels["test-label"] = "test-value"
+
+	// No hardware-configuration-id labels
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, false)
+
+	// Empty hardware-configuration-id labels
+	n1.ObjectMeta.Labels[nodeGroupHwConfigLabel] = ""
+	n2.ObjectMeta.Labels[nodeGroupHwConfigLabel] = ""
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, false)
+
+	// Only one hardware-configuration-id non empty
+	n1.ObjectMeta.Labels[nodeGroupHwConfigLabel] = ""
+	n2.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah"
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, false)
+
+	// Only one hardware-configuration-id present
+	delete(n1.ObjectMeta.Labels, nodeGroupHwConfigLabel)
+	n2.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah"
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, false)
+
+	// Different vales for hardware-configuration-id
+	n1.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah1"
+	n2.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah2"
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, false)
+
+	// Same values for hardware-configuration-id
+	n1.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah"
+	n2.ObjectMeta.Labels[nodeGroupHwConfigLabel] = "blah"
+	checkNodesSimilar(t, n1, n2, IsNodeInfoSimilar, true)
+ }
+
 func TestNodesSimilarVariousMemoryRequirements(t *testing.T) {
 	n1 := BuildTestNode("node1", 1000, 1000)
 


### PR DESCRIPTION
https://github.com/Leadfeeder/autoscaler/pull/1 for Autoscaler 1.17.3