### PR TITLE
Azure cloud provider: backoff needs retries

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -278,7 +278,7 @@ Please see the [AKS autoscaler documentation][] for details.
 
 ## Rate limit and back-off retries
 
-The new version of [Azure client][] supports rate limit and back-off retries when the cluster hits the throttling issue. These can be set by environment variables or cloud config file.
+The new version of [Azure client][] supports rate limit and back-off retries when the cluster hits the throttling issue. These can be set by either environment variables, or cloud config file. With config file, defaults values are false or 0.
 
 | Config Name | Default | Environment Variable | Cloud Config File |
 | ----------- | ------- | -------------------- | ----------------- |

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -560,6 +560,10 @@ func validateConfig(cfg *Config) error {
 		return fmt.Errorf("ARM Client ID not set")
 	}
 
+	if cfg.CloudProviderBackoff && cfg.CloudProviderBackoffRetries == 0 {
+		return fmt.Errorf("Cloud provider backoff is enabled but retries are not set")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When `cloudProviderBackoff` is enabled, `cloudProviderBackoffRetries` must also be set to a value `> 0`.

Otherwise cluster-autoscaler will [instantiate](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/cloudprovider/azure/azure_client.go#L215-L219) a [vmss client](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/azure_vmssclient.go#L60) with [0 Steps retries](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go#L65), which will cause the [doBackoffRetry()](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/retry/azure_retry.go#L160-L187) decorator to return a [nil response and nil error](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/retry/azure_retry.go#L187) on requests. ARM client can't cope with those; it will [dereference the nil response](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go#L118-L122) and segfault. A [PR to prevent the segfault](https://github.com/kubernetes/kubernetes/pull/94078) is discussed with ARM client's upstream: here we only try to reject wrong configs early and avoid providing bogus values in the first place.

`README.md` needed a small update, because the defaults values' documentation can be slightly misleading. Defaults don't apply (and all env variables are ignored) when the cluster-autoscaler is provided a config file, due to [env+defaults parsing being silently ignored](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.19.0/cluster-autoscaler/cloudprovider/azure/azure_manager.go#L291-L300) in that case. ie. we're using a config file, and shouldn't have counted on `cloudProviderBackoffRetries: 6` default.

Semi-related: would a follow-up PR setting the defaults in both cases (env and config file), and deep merging config file parsing over potentially provided env variables something you'd consider? I think that's the least surprise behaviour, but that's a change for those used to documented default and env being ignored when they provide a conf.