### PR TITLE
Cherry-pick onto 1.18: Backoff needs retries

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -250,7 +250,7 @@ Please see the [AKS autoscaler documentation][] for details.
 
 ## Rate limit and back-off retries
 
-The new version of [Azure client][] supports rate limit and back-off retries when the cluster hits the throttling issue. These can be set by environment variables or cloud config file.
+The new version of [Azure client][] supports rate limit and back-off retries when the cluster hits the throttling issue. These can be set by either environment variables, or cloud config file. With config file, defaults values are false or 0.
 
 | Config Name | Default | Environment Variable | Cloud Config File |
 | ----------- | ------- | -------------------- | ----------------- |

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -559,6 +559,10 @@ func validateConfig(cfg *Config) error {
 		return fmt.Errorf("ARM Client ID not set")
 	}
 
+	if cfg.CloudProviderBackoff && cfg.CloudProviderBackoffRetries == 0 {
+		return fmt.Errorf("Cloud provider backoff is enabled but retries are not set")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry-pick #3449 onto `cluster-autoscaler-release-1.18`