### PR TITLE
VPA: Ignore admission hook failures

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -76,6 +76,7 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace,
 		RegisterClientConfig.URL = &url
 	}
 	sideEffects := admissionregistration.SideEffectClassNone
+	failurePolicy := admissionregistration.Ignore
 	RegisterClientConfig.CABundle = caCert
 	webhookConfig := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,8 +104,9 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace,
 						},
 					},
 				},
-				ClientConfig: RegisterClientConfig,
-				SideEffects:  &sideEffects,
+				FailurePolicy: &failurePolicy,
+				ClientConfig:  RegisterClientConfig,
+				SideEffects:   &sideEffects,
 			},
 		},
 	}


### PR DESCRIPTION
When switching the VPA admission controller to the v1 admissionregistration API, the FailurePolicy was changed from Ignore to Fail.

[v1beta1 type](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go#L212-L215) vs [v1 type](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/admissionregistration/v1/types.go#L194-L197) (the change is the "Defaults to")

Using Fail makes pod creation depend on VPA and can cause a deadlock when the admission controller pod itself can't be scheduled again.