### PR TITLE
CA: fix integer to string conversion

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers/signer_ecs_ram_role.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers/signer_ecs_ram_role.go
@@ -19,13 +19,14 @@ package signers
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/jmespath/go-jmespath"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/requests"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/responses"
-	"net/http"
-	"strings"
-	"time"
 )
 
 // EcsRamRoleSigner is kind of signer
@@ -123,7 +124,7 @@ func (signer *EcsRamRoleSigner) refreshApi(request *requests.CommonRequest) (res
 
 func (signer *EcsRamRoleSigner) refreshCredential(response *responses.CommonResponse) (err error) {
 	if response.GetHttpStatus() != http.StatusOK {
-		fmt.Println("refresh Ecs sts token err, httpStatus: " + string(response.GetHttpStatus()) + ", message = " + response.GetHttpContentString())
+		fmt.Printf("refresh Ecs sts token err, httpStatus: %d, message = %s\n", response.GetHttpStatus(), response.GetHttpContentString())
 		return
 	}
 	var data interface{}

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/errors.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huawei-cloud-sdk-go/errors.go
@@ -162,7 +162,7 @@ func (e UnifiedError) ErrorCode() string {
 	}
 
 	if i, ok := e.ErrCode.(int); ok {
-		return string(i)
+		return fmt.Sprint(i)
 	}
 
 	return ""


### PR DESCRIPTION
Fixes bug reported by go vet check stringintconv. In go casting an
integer to string does not result in the string representation of
the number, instead the result is a rune representing
the codepoint of that number.

Fixes #3472