### PR TITLE
Add HuaweiCloud info link to FAQ/Documentation section in CA main readme

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -16,6 +16,7 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [Azure](./cloudprovider/azure/README.md)
 * [AWS](./cloudprovider/aws/README.md)
 * [BaiduCloud](./cloudprovider/baiducloud/README.md)
+* [HuaweiCloud](./cloudprovider/huaweicloud/README.md)
 
 # Releases
 


### PR DESCRIPTION
Add HuaweiCloud info link to FAQ/Documentation section in CA main readme. It is currently missing the link and prevent from navigating to Huawei cloud provider readme.md from the main page.