### PR TITLE
Don't fetch nodes

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
@@ -353,6 +353,31 @@ func TestControllerFetcher(t *testing.T) {
 				Name: "iCanScale", Kind: "Scale", Namespace: "test-namesapce"}, ApiVersion: "Foo/Foo"}, // Parent supports scale subresource"
 			expectedError: nil,
 		},
+		{
+			name: "pod, parent is node",
+			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
+			objects: []runtime.Object{&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namesapce",
+					// Parent is a node
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Controller: &trueVar,
+							Kind:       "Node",
+							Name:       "node",
+						},
+					},
+				},
+			}},
+			expectedKey:   nil,
+			expectedError: fmt.Errorf("Unhandled targetRef v1 / Node / node, last error node is not a valid owner"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := simpleControllerFetcher()

--- a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
@@ -107,25 +107,29 @@ func addController(controller *controllerFetcher, obj runtime.Object) {
 
 func TestControllerFetcher(t *testing.T) {
 	type testCase struct {
+		name          string
 		apiVersion    string
 		key           *ControllerKeyWithAPIVersion
 		objects       []runtime.Object
 		expectedKey   *ControllerKeyWithAPIVersion
 		expectedError error
 	}
-	for i, tc := range []testCase{
+	for _, tc := range []testCase{
 		{
+			name:          "nils",
 			key:           nil,
 			expectedKey:   nil,
 			expectedError: nil,
 		},
 		{
+			name: "deployment doesn't exist",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
 			expectedKey:   nil,
 			expectedError: fmt.Errorf("Deployment test-namesapce/test-deployment does not exist"),
 		},
 		{
+			name: "deployment no parent",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.Deployment{
@@ -142,6 +146,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "deployment with parent",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-rs", Kind: "ReplicaSet", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.Deployment{
@@ -173,6 +178,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "StatefulSet",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-statefulset", Kind: "StatefulSet", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.StatefulSet{
@@ -189,6 +195,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "DaemonSet",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-daemonset", Kind: "DaemonSet", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.DaemonSet{
@@ -205,6 +212,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "CronJob",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-job", Kind: "Job", Namespace: "test-namespace"}},
 			objects: []runtime.Object{&batchv1.Job{
@@ -236,6 +244,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "CronJob no parent",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-cronjob", Kind: "CronJob", Namespace: "test-namespace"}},
 			objects: []runtime.Object{&batchv1beta1.CronJob{
@@ -252,6 +261,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "rc no parent",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-rc", Kind: "ReplicationController", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&corev1.ReplicationController{
@@ -268,6 +278,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "deployment cycle in ownership",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.Deployment{
@@ -291,6 +302,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: fmt.Errorf("Cycle detected in ownership chain"),
 		},
 		{
+			name: "deployment, parent with no scale subresource",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.Deployment{
@@ -316,6 +328,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "deployment, parent not well known with scale subresource",
 			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
 				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
 			objects: []runtime.Object{&appsv1.Deployment{
@@ -341,7 +354,7 @@ func TestControllerFetcher(t *testing.T) {
 			expectedError: nil,
 		},
 	} {
-		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			f := simpleControllerFetcher()
 			for _, obj := range tc.objects {
 				addController(f, obj)


### PR DESCRIPTION
I see pods that have Nodes as their owners in K8s `1.17` and `1.18`. We shouldn't try to fetch nodes, we know it's not a controller