### PR TITLE
Decrease the number of GCE Read Requests when node deletion.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -97,7 +97,7 @@ func NewAutoscalingGceClientV1(client *http.Client, projectId string) (*autoscal
 // NewCustomAutoscalingGceClientV1 creates a new client using custom server url and timeouts
 // for communicating with GCE v1 API.
 func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl string,
-		waitTimeout, pollInterval time.Duration, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
+	waitTimeout, pollInterval time.Duration, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
 	gceService, err := gce.New(client)
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -73,7 +73,7 @@ func TestWaitForOp(t *testing.T) {
 
 	operation := &gce_api.Operation{Name: "operation-1505728466148-d16f5197"}
 
-	err := g.waitForOp(operation, projectId, zoneB)
+	err := g.waitForOp(operation, projectId, zoneB, false)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -94,6 +94,6 @@ func TestWaitForOpTimeout(t *testing.T) {
 
 	operation := &gce_api.Operation{Name: "operation-1505728466148-d16f5197"}
 
-	err := g.waitForOp(operation, projectId, zoneB)
+	err := g.waitForOp(operation, projectId, zoneB, false)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This change should substantially decrease the number of GCE Read Requests when Node Deletion takes place. As Read Requests take place for each node, for large node cluster this is impact-ful.