### PR TITLE
Cherry-pick #2207 add kops instance group label to ignore list for similar node group identification.

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -44,7 +44,8 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
-	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
+	"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -44,6 +44,7 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups


### PR DESCRIPTION
Cherry-picking ignored labels that were lost from [1.15.5 to 1.16](https://github.com/kubernetes/autoscaler/blob/c6929a2fa9632eb10eaad71621096f35eee7a736/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go#L100). 

The MaxCapacityMemoryDifferenceRatio changes were needed to correct balance-similar-node-groups behavior on AWS but the removal of the labels prevents it working properly with kops. I don't think BalancingExtraIgnoredLabels is available into 1.19 so we are stuck with this unless that gets backported.

I didn't add tests for the labels to keep this as just a cherry-pick of existing commits. 