### PR TITLE
Cherry pick #3437 onto 1.19 - Avoid unwanted VMSS VMs caches invalidations 

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -62,7 +61,9 @@ func (m *asgCache) Register(asg cloudprovider.NodeGroup) bool {
 
 	for i := range m.registeredAsgs {
 		if existing := m.registeredAsgs[i]; strings.EqualFold(existing.Id(), asg.Id()) {
-			if reflect.DeepEqual(existing, asg) {
+			e := existing.(*ScaleSet)
+			a := asg.(*ScaleSet)
+			if e.minSize == a.minSize && e.maxSize == a.maxSize && e.curSize == a.curSize {
 				return false
 			}
 
@@ -181,7 +182,7 @@ func (m *asgCache) regenerate() error {
 
 	m.instanceToAsg = newCache
 
-	// Incalidating unowned instance cache.
+	// Invalidating unowned instance cache.
 	m.invalidateUnownedInstanceCache()
 
 	return nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -55,27 +55,25 @@ func newAsgCache() (*asgCache, error) {
 }
 
 // Register registers a node group if it hasn't been registered.
-func (m *asgCache) Register(asg cloudprovider.NodeGroup) bool {
+func (m *asgCache) Register(newAsg cloudprovider.NodeGroup) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	for i := range m.registeredAsgs {
-		if existing := m.registeredAsgs[i]; strings.EqualFold(existing.Id(), asg.Id()) {
-			e := existing.(*ScaleSet)
-			a := asg.(*ScaleSet)
-			if e.minSize == a.minSize && e.maxSize == a.maxSize && e.curSize == a.curSize {
+		if existing := m.registeredAsgs[i]; strings.EqualFold(existing.Id(), newAsg.Id()) {
+			if existing.MinSize() == newAsg.MinSize() && existing.MaxSize() == newAsg.MaxSize() {
 				return false
 			}
 
-			m.registeredAsgs[i] = asg
-			klog.V(4).Infof("ASG %q updated", asg.Id())
+			m.registeredAsgs[i] = newAsg
+			klog.V(4).Infof("ASG %q updated", newAsg.Id())
 			m.invalidateUnownedInstanceCache()
 			return true
 		}
 	}
 
-	klog.V(4).Infof("Registering ASG %q", asg.Id())
-	m.registeredAsgs = append(m.registeredAsgs, asg)
+	klog.V(4).Infof("Registering ASG %q", newAsg.Id())
+	m.registeredAsgs = append(m.registeredAsgs, newAsg)
 	m.invalidateUnownedInstanceCache()
 	return true
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -511,7 +511,7 @@ func (m *AzureManager) buildAsgFromSpec(spec string) (cloudprovider.NodeGroup, e
 	case vmTypeStandard:
 		return NewAgentPool(s, m)
 	case vmTypeVMSS:
-		return NewScaleSet(s, m)
+		return NewScaleSet(s, m, -1)
 	case vmTypeAKS:
 		return NewAKSAgentPool(s, m)
 	default:
@@ -698,7 +698,12 @@ func (m *AzureManager) listScaleSets(filter []labelAutoDiscoveryConfig) ([]cloud
 			continue
 		}
 
-		asg, err := NewScaleSet(spec, m)
+		curSize := int64(-1)
+		if scaleSet.Sku != nil && scaleSet.Sku.Capacity != nil {
+			curSize = *scaleSet.Sku.Capacity
+		}
+
+		asg, err := NewScaleSet(spec, m, curSize)
 		if err != nil {
 			klog.Warningf("ignoring nodegroup %q %s", *scaleSet.Name, err)
 			continue

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -730,7 +730,7 @@ func TestListScalesets(t *testing.T) {
 				minSize:           5,
 				maxSize:           50,
 				manager:           manager,
-				curSize:           -1,
+				curSize:           3,
 				sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 			}},
 		},
@@ -836,7 +836,7 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 		minSize:           minVal,
 		maxSize:           maxVal,
 		manager:           manager,
-		curSize:           -1,
+		curSize:           3,
 		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
 	}}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedAsgs, asgs), "expected %#v, but found: %#v", expectedAsgs, asgs)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -89,7 +89,7 @@ type ScaleSet struct {
 }
 
 // NewScaleSet creates a new NewScaleSet.
-func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager) (*ScaleSet, error) {
+func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager, curSize int64) (*ScaleSet, error) {
 	scaleSet := &ScaleSet{
 		azureRef: azureRef{
 			Name: spec.Name,
@@ -97,7 +97,7 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager) (*ScaleSet, erro
 		minSize: spec.MinSize,
 		maxSize: spec.MaxSize,
 		manager: az,
-		curSize: -1,
+		curSize: curSize,
 	}
 
 	if az.config.VmssCacheTTL != 0 {


### PR DESCRIPTION
Cherry-pick #3437 onto 1.19