### PR TITLE
cluster-autoscaler: Move DisableScaleDownForLoop to the scaleUp loop

### DIFF
--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -77,7 +77,6 @@ func (p *filterOutSchedulablePodListProcessor) Process(
 
 	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
 		klog.V(2).Info("Schedulable pods present")
-		context.ProcessorCallbacks.DisableScaleDownForLoop()
 	} else {
 		klog.V(4).Info("No schedulable pods")
 	}


### PR DESCRIPTION
When running the autoscaler with `--max-nodes-total` set and that max is reached, downscale is *disabled* when new unschedulable pods are added.

Preventing the removal of nodes.
If pods are created very frequently by let's say by a cronjob/job, the cluster will never be able to downscale.
Despite the fact that you could have a certain amount of unneeded node that could be removed to make some space for needed nodes.

In order to fix that behavior i moved the downscale lock from the process to the actual place where scale-up happens.

