### PR TITLE
Allow custom timeout value for webhook calls

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -57,7 +57,7 @@ func configTLS(clientset *kubernetes.Clientset, serverCert, serverKey []byte) *t
 
 // register this webhook admission controller with the kube-apiserver
 // by creating MutatingWebhookConfiguration.
-func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace, serviceName, url string, registerByURL bool) {
+func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace, serviceName, url string, registerByURL bool, timeoutSeconds int32) {
 	time.Sleep(10 * time.Second)
 	client := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	_, err := client.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -104,9 +104,10 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte, namespace,
 						},
 					},
 				},
-				FailurePolicy: &failurePolicy,
-				ClientConfig:  RegisterClientConfig,
-				SideEffects:   &sideEffects,
+				FailurePolicy:  &failurePolicy,
+				ClientConfig:   RegisterClientConfig,
+				SideEffects:    &sideEffects,
+				TimeoutSeconds: &timeoutSeconds,
 			},
 		},
 	}

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -63,6 +63,7 @@ var (
 	serviceName        = flag.String("webhook-service", "vpa-webhook", "Kubernetes service under which webhook is registered. Used when registerByURL is set to false.")
 	webhookAddress     = flag.String("webhook-address", "", "Address under which webhook is registered. Used when registerByURL is set to true.")
 	webhookPort        = flag.String("webhook-port", "", "Server Port for Webhook")
+	webhookTimeout     = flag.Int("webhook-timeout-seconds", 30, "Timeout in seconds that the API server should wait for this webhook to respond before failing.")
 	registerWebhook    = flag.Bool("register-webhook", true, "If set to true, admission webhook object will be created on start up to register with the API server.")
 	registerByURL      = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 	vpaObjectNamespace = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects. Empty means all namespaces will be used.")
@@ -133,7 +134,7 @@ func main() {
 	url := fmt.Sprintf("%v:%v", *webhookAddress, *webhookPort)
 	go func() {
 		if *registerWebhook {
-			selfRegistration(clientset, certs.caCert, namespace, *serviceName, url, *registerByURL)
+			selfRegistration(clientset, certs.caCert, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout))
 		}
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)


### PR DESCRIPTION
Because webhooks add to API request latency, they should evaluate as
quickly as possible. timeoutSeconds allows configuring how long the
API server should wait for a webhook to respond before treating the call
as a failure.

The default values from Kubernetes are, however, too large. For
admissionregistration.k8s.io/v1 the default value is 10 seconds while
for admissionregistration.k8s.io/v1beta1 is 30 seconds!

This custom/default value of 5 seconds should be more than enough for
standard installs.