### PR TITLE
Add huaweicloud autoscaler owners file.

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/OWNERS
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- kevin-wangzefeng
+- RainbowMango
+reviewers:
+- kevin-wangzefeng
+- RainbowMango


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR just added the OWNERS file under HUAWEICLOUD autoscaler directory.

I'm the maintainer of [cloud-provider-huaweicloud](github.com/kubernetes-sigs/cloud-provider-huaweicloud), and I'll take the responsibility of autoscaler in the future.

/cc @feiskyer 