### PR TITLE
added a new NodeGroupDoesNotExistError in errors.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -153,7 +153,7 @@ func (client *autoscalingGceClientV1) FetchMigTargetSize(migRef GceRef) (int64, 
 	if err != nil {
 		if err, ok := err.(*googleapi.Error); ok {
 			if err.Code == http.StatusNotFound {
-				return 0, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "", err)
+				return 0, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "%s", err.Error())
 			}
 		}
 		return 0, err
@@ -347,7 +347,7 @@ func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef) (*gce.Inst
 	if err != nil {
 		if err, ok := err.(*googleapi.Error); ok {
 			if err.Code == http.StatusNotFound {
-				return nil, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "", err)
+				return nil, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "%s", err.Error())
 			}
 		}
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -26,7 +26,9 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/api/googleapi"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
 
 	gce "google.golang.org/api/compute/v1"
@@ -149,6 +151,11 @@ func (client *autoscalingGceClientV1) FetchMigTargetSize(migRef GceRef) (int64, 
 	registerRequest("instance_group_managers", "get")
 	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Do()
 	if err != nil {
+		if err, ok := err.(*googleapi.Error); ok {
+			if err.Code == http.StatusNotFound {
+				return 0, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "", err)
+			}
+		}
 		return 0, err
 	}
 	return igm.TargetSize, nil
@@ -338,6 +345,11 @@ func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef) (*gce.Inst
 	registerRequest("instance_group_managers", "get")
 	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Do()
 	if err != nil {
+		if err, ok := err.(*googleapi.Error); ok {
+			if err.Code == http.StatusNotFound {
+				return nil, errors.NewAutoscalerError(errors.NodeGroupDoesNotExistError, "", err)
+			}
+		}
 		return nil, err
 	}
 	templateUrl, err := url.Parse(igm.InstanceTemplate)

--- a/cluster-autoscaler/cloudprovider/gce/mig_target_sizes_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_target_sizes_provider.go
@@ -17,9 +17,9 @@ limitations under the License.
 package gce
 
 import (
-	"fmt"
-	klog "k8s.io/klog/v2"
 	"sync"
+
+	klog "k8s.io/klog/v2"
 )
 
 // MigTargetSizesProvider allows obtaining target sizes of MIGs
@@ -55,20 +55,16 @@ func (c *cachingMigTargetSizesProvider) GetMigTargetSize(migRef GceRef) (int64, 
 	}
 
 	newTargetSizes, err := c.fillInMigTargetSizeCache()
-	if err != nil {
-		// fallback to querying for single mig
+
+	// if we still do not have value here return an error
+	size, found := newTargetSizes[migRef]
+	if err != nil || !found {
 		targetSize, err = c.gceClient.FetchMigTargetSize(migRef)
 		if err != nil {
 			return 0, err
 		}
 		c.cache.SetMigTargetSize(migRef, targetSize)
 		return targetSize, nil
-	}
-
-	// if we still do not have value here return an error
-	size, found := newTargetSizes[migRef]
-	if !found {
-		return 0, fmt.Errorf("Could not get target size for mig %v", migRef.String())
 	}
 
 	// we are good

--- a/cluster-autoscaler/cloudprovider/gce/mig_target_sizes_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_target_sizes_provider.go
@@ -56,9 +56,9 @@ func (c *cachingMigTargetSizesProvider) GetMigTargetSize(migRef GceRef) (int64, 
 
 	newTargetSizes, err := c.fillInMigTargetSizeCache()
 
-	// if we still do not have value here return an error
 	size, found := newTargetSizes[migRef]
 	if err != nil || !found {
+		// fallback to querying for single mig
 		targetSize, err = c.gceClient.FetchMigTargetSize(migRef)
 		if err != nil {
 			return 0, err

--- a/cluster-autoscaler/utils/errors/errors.go
+++ b/cluster-autoscaler/utils/errors/errors.go
@@ -58,6 +58,9 @@ const (
 	// ConfigurationError is an error related to bad configuration provided
 	// by a user.
 	ConfigurationError AutoscalerErrorType = "configurationError"
+	// NodeGroupDoesNotExistError signifies that a NodeGroup
+	// does not exist.
+	NodeGroupDoesNotExistError AutoscalerErrorType = "nodeGroupDoesNotExistError"
 )
 
 // NewAutoscalerError returns new autoscaler error with a message constructed from format string

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -237,3 +237,25 @@ func (l *HttpServerMock) handle(url string) string {
 	args := l.Called(url)
 	return args.String(0)
 }
+
+// NewHttpServerMock creates new HttpServerMock.
+func NewHttpServerMockWithStatusCode() *HttpServerMock {
+	httpServerMock := &HttpServerMock{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/",
+		func(w http.ResponseWriter, req *http.Request) {
+			code, result := httpServerMock.handleWithStatusCode(req.URL.Path)
+			w.WriteHeader(code)
+			w.Write([]byte(result))
+			//w.Write([]byte("status: " + string(code) + "\n" + result))
+		})
+
+	server := httptest.NewServer(mux)
+	httpServerMock.Server = server
+	return httpServerMock
+}
+
+func (l *HttpServerMock) handleWithStatusCode(url string) (int, string) {
+	args := l.Called(url)
+	return args.Int(0), args.String(1)
+}

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -225,7 +225,7 @@ func NewHttpServerMock() *HttpServerMock {
 	mux.HandleFunc("/",
 		func(w http.ResponseWriter, req *http.Request) {
 			result := httpServerMock.handle(req.URL.Path)
-			w.Write([]byte(result))
+			_, _ = w.Write([]byte(result))
 		})
 
 	server := httptest.NewServer(mux)
@@ -246,8 +246,7 @@ func NewHttpServerMockWithStatusCode() *HttpServerMock {
 		func(w http.ResponseWriter, req *http.Request) {
 			code, result := httpServerMock.handleWithStatusCode(req.URL.Path)
 			w.WriteHeader(code)
-			w.Write([]byte(result))
-			//w.Write([]byte("status: " + string(code) + "\n" + result))
+			_, _ = w.Write([]byte(result))
 		})
 
 	server := httptest.NewServer(mux)

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -238,7 +238,7 @@ func (l *HttpServerMock) handle(url string) string {
 	return args.String(0)
 }
 
-// NewHttpServerMock creates new HttpServerMock.
+// NewHttpServerMockWithStatusCode creates new HttpServerMock.
 func NewHttpServerMockWithStatusCode() *HttpServerMock {
 	httpServerMock := &HttpServerMock{}
 	mux := http.NewServeMux()


### PR DESCRIPTION
This is to support no nodepool exists conditions, which crashes Autoscaler