### PR TITLE
simplify DeleteNode logic by removing an extra Mutex

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -185,7 +185,6 @@ func getAutoscaleNodePools(manager *huaweicloudCloudManager, opts config.Autosca
 	}
 
 	clusterUpdateLock := sync.Mutex{}
-	deleteMux := sync.Mutex{}
 
 	// Given our current implementation just support single node pool,
 	// please make sure there is only one node pool with Autoscaling flag turned on in CCE cluster
@@ -200,7 +199,6 @@ func getAutoscaleNodePools(manager *huaweicloudCloudManager, opts config.Autosca
 
 		nodePoolsWithAutoscalingEnabled = append(nodePoolsWithAutoscalingEnabled, NodeGroup{
 			huaweiCloudManager: manager,
-			deleteMutex:        &deleteMux,
 			clusterUpdateMutex: &clusterUpdateLock,
 			nodePoolName:       nodePool.Metadata.Name,
 			nodePoolId:         nodePool.Metadata.Uid,

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_node_group_test.go
@@ -43,7 +43,6 @@ func createTestNodeGroup(manager *huaweicloudCloudManager) *NodeGroup {
 	size := nodePoolNodeCount
 	return &NodeGroup{
 		huaweiCloudManager: manager,
-		deleteMutex:        &sync.Mutex{},
 		clusterUpdateMutex: &sync.Mutex{},
 		nodePoolName:       nodePoolName,
 		nodePoolId:         nodePoolUID,


### PR DESCRIPTION
Previously, two mutexes are used in the logic of removing a node from a node pool. Now only one mutex is used to simplify the logic and the time for removing a node can be shortened with this logic since it doesn't always have to wait for a certain time length before being deleted.