### PR TITLE
[Helm Chart] Add support to configure custom service labels

### DIFF
--- a/charts/cluster-autoscaler-chart/Chart.yaml
+++ b/charts/cluster-autoscaler-chart/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler-chart
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/charts/cluster-autoscaler-chart/README.md
+++ b/charts/cluster-autoscaler-chart/README.md
@@ -335,6 +335,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | resources | object | `{}` | Pod resource requests and limits. |
 | securityContext | object | `{}` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | service.annotations | object | `{}` | Annotations to add to service |
+| service.labels | object | `{}` | Labels to add to service |
 | service.externalIPs | list | `[]` | List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips. |
 | service.loadBalancerIP | string | `""` | IP address to assign to load balancer (if supported). |
 | service.loadBalancerSourceRanges | list | `[]` | List of IP CIDRs allowed access to load balancer (if supported). |

--- a/charts/cluster-autoscaler-chart/templates/service.yaml
+++ b/charts/cluster-autoscaler-chart/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
 {{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 spec:
 {{- if .Values.service.clusterIP }}

--- a/charts/cluster-autoscaler-chart/values.yaml
+++ b/charts/cluster-autoscaler-chart/values.yaml
@@ -210,6 +210,8 @@ securityContext: {}
 service:
   # service.annotations -- Annotations to add to service
   annotations: {}
+  # service.labels -- Labels to add to service
+  labels: {}
   # service.externalIPs -- List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips.
   externalIPs: []
 


### PR DESCRIPTION
This PR adds support to configure additional service labels on the Helm chart.