### PR TITLE
[Autoscaler Helm Chart] Fix wrong URL for the chart release 1.0.4

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -21,7 +21,7 @@ entries:
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
     urls:
-    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.3/cluster-autoscaler-chart-1.0.4.tgz
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.4/cluster-autoscaler-chart-1.0.4.tgz
     version: 1.0.4
   - apiVersion: v2
     appVersion: 1.18.1


### PR DESCRIPTION
I believe the URL was wrong on the previously merged PR here https://github.com/kubernetes/autoscaler/pull/3576.

This is a fix for the 1.0.4 release.