### PR TITLE
[Helm chart] Update helm-docs version and add PR action to ensure docs are updated

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,5 +38,19 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: install
+  helm-docs-validate:
+    if: ${{ needs.changes.outputs.charts == 'true' }}
+    name: Helm Docs
+    needs:
+      - changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run helm-docs
+        uses: docker://jnorwood/helm-docs:v1.3.0
+      - name: Check for changes
+        run: git diff --quiet charts/*/README.md
+
 name: Lint and Test Charts
 on: pull_request

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,5 +10,6 @@ repos:
     rev: v0.1.9
   - hooks:
       - id: helm-docs
+        files: (README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$
     repo: https://github.com/norwoodj/helm-docs
-    rev: v0.13.0
+    rev: v1.3.0

--- a/charts/README.md
+++ b/charts/README.md
@@ -27,8 +27,6 @@ $ pre-commit install
 
 ### Install hook dependencies
 
-The pre-commit hooks themselves call binaries under the hood; they can be installed via the following command:
+The pre-commit hooks themselves call binaries under the hood; they can be installed via the [instructions found here](https://github.com/norwoodj/helm-docs#installation).
 
-```shell
-$ brew install helm norwoodj/tap/helm-docs
-```
+Note: You should ensure that whichever installation method you are using you either install the same version of helm-docs as used in the PR workflow to ensure your PR passes CI checks or update the version used by the workflow to match.

--- a/charts/cluster-autoscaler-chart/Chart.yaml
+++ b/charts/cluster-autoscaler-chart/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler-chart
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 1.0.4
+version: 1.0.5

--- a/charts/cluster-autoscaler-chart/README.md
+++ b/charts/cluster-autoscaler-chart/README.md
@@ -1,5 +1,4 @@
-cluster-autoscaler-chart
-========================
+# cluster-autoscaler-chart
 
 Scales Kubernetes worker nodes within autoscaling groups.
 
@@ -286,7 +285,7 @@ Containers:
 
 Though enough for the majority of installations, the default PodSecurityPolicy _could_ be too restrictive depending on the specifics of your release. Please make sure to check that the template fits with any customizations made or disable it by setting `rbac.pspEnabled` to `false`.
 
-## Chart Values
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -335,8 +334,8 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | resources | object | `{}` | Pod resource requests and limits. |
 | securityContext | object | `{}` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | service.annotations | object | `{}` | Annotations to add to service |
-| service.labels | object | `{}` | Labels to add to service |
 | service.externalIPs | list | `[]` | List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips. |
+| service.labels | object | `{}` | Labels to add to service |
 | service.loadBalancerIP | string | `""` | IP address to assign to load balancer (if supported). |
 | service.loadBalancerSourceRanges | list | `[]` | List of IP CIDRs allowed access to load balancer (if supported). |
 | service.portName | string | `"http"` | Name for service port. |

--- a/charts/cluster-autoscaler-chart/README.md.gotmpl
+++ b/charts/cluster-autoscaler-chart/README.md.gotmpl
@@ -252,7 +252,7 @@ For Kubernetes clusters that use Amazon EKS, the service account can be configur
 
 In order to accomplish this, you will first need to create a new IAM role with the above mentions policies.  Take care in [configuring the trust relationship](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration) to restrict access just to the service account used by cluster autoscaler.
 
-Once you have the IAM role configured, you would then need to `--set rbac.serviceAccountAnnotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing.
+Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing.
 
 ## Troubleshooting
 


### PR DESCRIPTION
As per discussion in https://github.com/kubernetes/autoscaler/pull/3424#issuecomment-704809247

* Adds a new step to the PR workflow to ensure that the docs have been generated by `helm-docs` and are up to date (enforced via `git diff --quiet`)

  * Validated both successful and failing runs:

    - Success: https://github.com/gjtempleton/autoscaler/runs/1223133897?check_suite_focus=true
    - Failure: https://github.com/gjtempleton/autoscaler/runs/1223139683?check_suite_focus=true

* Updates the version of pre-commit hook of `helm-docs` used to update the files matcher pattern to include the `README.go.tmpl` ([this was added here](https://github.com/norwoodj/helm-docs/pull/50))

* Bumps the chart version by a minor bump