### PR TITLE
Only release one arch for tests

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -70,7 +70,7 @@ for i in ${COMPONENTS}; do
   if [ $i == admission-controller ] ; then
     (cd ${SCRIPT_ROOT}/pkg/${i} && bash ./gencerts.sh || true)
   fi
-  make --directory ${SCRIPT_ROOT}/pkg/${i} release
+  ALL_ARCHITECTURES=amd64 make --directory ${SCRIPT_ROOT}/pkg/${i} release
 done
 
 kubectl create -f ${SCRIPT_ROOT}/deploy/vpa-v1-crd.yaml

--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -8,9 +8,8 @@ ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=admission-controller
 FULL_COMPONENT=vpa-${COMPONENT}
-ARCH?=amd64
 
-ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
+ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 build: clean

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -8,9 +8,8 @@ ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=recommender
 FULL_COMPONENT=vpa-${COMPONENT}
-ARCH?=amd64
 
-ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
+ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 build: clean

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -8,9 +8,8 @@ ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
 GOOS?=linux
 COMPONENT=updater
 FULL_COMPONENT=vpa-${COMPONENT}
-ARCH?=amd64
 
-ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
+ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 build: clean


### PR DESCRIPTION
Currently, images for 5 architectures are released for e2e, but only the ones for amd64 are actually used.
Building 5 versions of images takes quite a lot of time.