### PR TITLE
Fix VerticalPodAutoscaler version of hamster-vpa sample

### DIFF
--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -5,7 +5,7 @@
 # requests.
 # Note that the update mode is left unset, so it defaults to "Auto" mode.
 ---
-apiVersion: "autoscaling.k8s.io/v1beta2"
+apiVersion: "autoscaling.k8s.io/v1"
 kind: VerticalPodAutoscaler
 metadata:
   name: hamster-vpa


### PR DESCRIPTION
hamster-vpa.yaml has a `.spec.resourcePolicy.containerPolicies` field, 
but that field has been supported from v1.