### PR TITLE
Fix BalanceSimilarNodeGroups when scaling from zero

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -76,6 +76,8 @@ type StaticAutoscaler struct {
 	processors              *ca_processors.AutoscalingProcessors
 	processorCallbacks      *staticAutoscalerProcessorCallbacks
 	initialized             bool
+	// Caches generated nodeInfo computed from node groups templates
+	templateInfoCache map[string]*schedulerframework.NodeInfo
 	// Caches nodeInfo computed for previously seen nodes
 	nodeInfoCache map[string]*schedulerframework.NodeInfo
 	ignoredTaints taints.TaintKeySet
@@ -159,6 +161,7 @@ func NewStaticAutoscaler(
 		processors:              processors,
 		processorCallbacks:      processorCallbacks,
 		clusterStateRegistry:    clusterStateRegistry,
+		templateInfoCache:       make(map[string]*schedulerframework.NodeInfo),
 		nodeInfoCache:           make(map[string]*schedulerframework.NodeInfo),
 		ignoredTaints:           ignoredTaints,
 	}
@@ -266,7 +269,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	}
 
 	nodeInfosForGroups, autoscalerError := core_utils.GetNodeInfosForGroups(
-		readyNodes, a.nodeInfoCache, autoscalingContext.CloudProvider, autoscalingContext.ListerRegistry, daemonsets, autoscalingContext.PredicateChecker, a.ignoredTaints)
+		readyNodes, a.nodeInfoCache, a.templateInfoCache, autoscalingContext.CloudProvider, autoscalingContext.ListerRegistry, daemonsets, autoscalingContext.PredicateChecker, a.ignoredTaints, a.processors, autoscalingContext)
 	if autoscalerError != nil {
 		klog.Errorf("Failed to get node infos for groups: %v", autoscalerError)
 		return autoscalerError.AddPrefix("failed to build node infos for node groups: ")

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -396,6 +396,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 		processors:            processors,
 		processorCallbacks:    processorCallbacks,
 		initialized:           true,
+		templateInfoCache:     make(map[string]*schedulerframework.NodeInfo),
 	}
 
 	// Scale up.


### PR DESCRIPTION
Use real-world nodeInfo from similar groups when BalanceSimilarNodeGroups.

Where available, the CA evaluates node groups capacities and labels using real-world nodes, for optimal accuracy (accounting for kubelet and system reserved resources, for instance).

It fallbacks to synthetic nodeInfos inferred from ASG/MIG/VMSs templates when no real nodes are available yet (ie. upscaling from zero/empty node group).

That asymmetric evaluation can prevent `BalanceSimilarNodeGroups` from working reliably when upscaling from zero:
* The first upscaled nodeGroup will get a node (capacity initially evaluated from ASG/MIG/VMSS template, then from the first real node, runtime labels)
* Other empty nodeGroups will likely be considered dissimilar to the first one: we're comparing ASG templates with real-world nodeInfo
* In the case of `least-waste` expander for instance, CA might prefer the nodegroup from real-world node, accounting for reserved resources (best usage) over the others

This change set implements [Maciek Pytel suggestion](https://github.com/kubernetes/autoscaler/issues/2892#issuecomment-595769765) (from a previous attempt at fixing this issue): we try to use real-world nodes examples from ~similar node groups, before a last resort fallback to synthetic nodeInfos built from ASG templates.

We compare nodeInfos using the `FindSimilarNodeGroups` processor primitives in order to leverage per cloud provider comparators (eg. label exclusions).

We look for similar nodegroups using synthetic nodeInfo from ASG/MIG (where available): comparing their nodeInfo from real-world nodes to a synthetic nodeInfo from the empty nodegroup wouldn't work (that's the root cause of this issue). When ~similar nodegroups are found that way, we use their nodeInfos built from real-world nodes as models for empty nodegroups (but keeping original location related labels).

Tested with AWS ASGs, GCP MIGs and Azure VMSS.