### PR TITLE
add Packet provider links to the root README.md

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -17,6 +17,7 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [AWS](./cloudprovider/aws/README.md)
 * [BaiduCloud](./cloudprovider/baiducloud/README.md)
 * [HuaweiCloud](./cloudprovider/huaweicloud/README.md)
+* [Packet](./cloudprovider/packet/README.md#notes) 
 
 # Releases
 
@@ -144,3 +145,4 @@ Supported cloud providers:
 * OpenStack Magnum https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/magnum/README.md
 * DigitalOcean https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/digitalocean/README.md
 * Exoscale https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/exoscale/README.md
+* Packet https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/packet/README.md


### PR DESCRIPTION
This PR adds links to the Packet provider README.md to the root README.md.  It is otherwise not obvious that Packet support is included.

The Packet provider will need to be renamed to Equinix Metal in the future. I'm using the existing naming in this PR.