### PR TITLE
Remove obsolete comments

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -60,8 +60,6 @@ func patchVpa(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, 
 }
 
 // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
-// It prevents race conditions by verifying that the lastUpdateTime of the
-// API object and its model representation are equal.
 func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, newStatus,
 	oldStatus *vpa_types.VerticalPodAutoscalerStatus) (result *vpa_types.VerticalPodAutoscaler, err error) {
 	patches := []patchRecord{{


### PR DESCRIPTION
LastUpdateTime no longer exists and it is not used by this function.
The field was removed in API v1beta2 for scaling issue.

ref: https://github.com/kubernetes/autoscaler/pull/968