### PR TITLE
Remove redundant log lines and reduce severity around parsing kubeEnv

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -244,8 +244,10 @@ func extractLabelsFromKubeEnv(kubeEnv string) (map[string]string, error) {
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
 	labels, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "node_labels")
-	if !found || err != nil {
-		klog.Errorf("node_labels not found via AUTOSCALER_ENV_VARS, will try NODE_LABELS; found=%v,  err=%v", found, err)
+	if err != nil {
+		klog.Errorf("error while trying to extract node_labels from AUTOSCALER_ENV_VARS: %v", err)
+	}
+	if !found {
 		labels, err = extractFromKubeEnv(kubeEnv, "NODE_LABELS")
 		if err != nil {
 			return nil, err
@@ -259,8 +261,10 @@ func extractTaintsFromKubeEnv(kubeEnv string) ([]apiv1.Taint, error) {
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
 	taints, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "node_taints")
-	if !found || err != nil {
-		klog.Errorf("node_taints not found via AUTOSCALER_ENV_VARS, will try NODE_TAINTS; found=%v, err=%v", found, err)
+	if err != nil {
+		klog.Errorf("error while trying to extract node_taints from AUTOSCALER_ENV_VARS: %v", err)
+	}
+	if !found {
 		taints, err = extractFromKubeEnv(kubeEnv, "NODE_TAINTS")
 		if err != nil {
 			return nil, err
@@ -278,8 +282,10 @@ func extractKubeReservedFromKubeEnv(kubeEnv string) (string, error) {
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
 	kubeReserved, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "kube_reserved")
-	if !found || err != nil {
-		klog.Errorf("kube_reserved not found via AUTOSCALER_ENV_VARS, will try kube-reserved in KUBELET_TEST_ARGS; found=%v, err=%v", found, err)
+	if err != nil {
+		klog.Errorf("error while trying to extract kube_reserved from AUTOSCALER_ENV_VARS: %v", err)
+	}
+	if !found {
 		kubeletArgs, err := extractFromKubeEnv(kubeEnv, "KUBELET_TEST_ARGS")
 		if err != nil {
 			return "", err
@@ -355,7 +361,7 @@ func extractAutoscalerVarFromKubeEnv(kubeEnv, name string) (value string, found 
 			return strings.Trim(items[1], " \"'"), true, nil
 		}
 	}
-	klog.Warningf("var %s not found in %s: %v", name, autoscalerVars, autoscalerVals)
+	klog.Infof("var %s not found in %s: %v", name, autoscalerVars, autoscalerVals)
 	return "", false, nil
 }
 


### PR DESCRIPTION
The removed log lines had a very misleading ERROR severity, which
caused confusion. Furthermore, they were completely redundant when
no error happens - the same information can be deduced from the log
line at the end of extractAutoscalerVarFromKubeEnv.

Not finding a value in kubeEnv having a WARNING severity also seems
like too much.