### PR TITLE
Revert base price changes from PR #3603

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -32,9 +32,9 @@ type GcePriceModel struct {
 
 const (
 	//TODO: Move it to a config file.
-	cpuPricePerHour         = 0.022890
-	memoryPricePerHourPerGb = 0.003067
-	preemptibleDiscount     = 0.006867 / 0.022890
+	cpuPricePerHour         = 0.033174
+	memoryPricePerHourPerGb = 0.004446
+	preemptibleDiscount     = 0.00698 / 0.033174
 	gpuPricePerHour         = 0.700
 
 	preemptibleLabel = "cloud.google.com/gke-preemptible"


### PR DESCRIPTION
It turns out changing those values has unexpected impact on
the results of pricing expander. I think that a different base
value implicitly changes the weight of pricing to the
other parts of expander formula which is some cases changes CA
scaling decisions.
While not necessarilly wrong we shouldn't make changes like this
without analyzing implications and testing, hence the revert
of this part.