### PR TITLE
Reduce logging in scale calculation

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -418,12 +418,13 @@ func (sd *ScaleDown) checkNodeUtilization(timestamp time.Time, node *apiv1.Node,
 	if err != nil {
 		klog.Warningf("Failed to calculate utilization for %s: %v", node.Name, err)
 	}
-	klog.V(4).Infof("Node %s - %s utilization %f", node.Name, utilInfo.ResourceName, utilInfo.Utilization)
 
 	if !sd.isNodeBelowUtilizationThreshold(node, utilInfo) {
 		klog.V(4).Infof("Node %s is not suitable for removal - %s utilization too big (%f)", node.Name, utilInfo.ResourceName, utilInfo.Utilization)
 		return simulator.NotUnderutilized, &utilInfo
 	}
+
+	klog.V(4).Infof("Node %s - %s utilization %f", node.Name, utilInfo.ResourceName, utilInfo.Utilization)
 
 	return simulator.NoReason, &utilInfo
 }


### PR DESCRIPTION
I noticed this log message on a cluster with a large amount of nodes and many scale events. Especially in cases where a node isNodeBelowUtilizationThreshold() this reduces the number of lines logged. This log message is redundant since the same information is found in the isNodeBelowUtilizationThreshold check, so moving this log after it reduces the total number of messages 

Since this function is called for each node, reducing the number of logs in total is desired 