### PR TITLE
refactor CAPI controller unit test to use PollImmediate

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -70,6 +70,7 @@ type testSpec struct {
 }
 
 const customCAPIGroup = "custom.x-k8s.io"
+const fifteenSecondDuration = time.Second * 15
 
 func mustCreateTestController(t *testing.T, testConfigs ...*testConfig) (*machineController, testControllerShutdownFunc) {
 	t.Helper()
@@ -444,7 +445,7 @@ func createResource(client dynamic.Interface, informer informers.GenericInformer
 		return err
 	}
 
-	return wait.PollImmediateInfinite(time.Microsecond, func() (bool, error) {
+	return wait.PollImmediate(time.Microsecond, fifteenSecondDuration, func() (bool, error) {
 		_, err := informer.Lister().ByNamespace(resource.GetNamespace()).Get(resource.GetName())
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -463,7 +464,7 @@ func updateResource(client dynamic.Interface, informer informers.GenericInformer
 		return err
 	}
 
-	return wait.PollImmediateInfinite(time.Microsecond, func() (bool, error) {
+	return wait.PollImmediate(time.Microsecond, fifteenSecondDuration, func() (bool, error) {
 		result, err := informer.Lister().ByNamespace(resource.GetNamespace()).Get(resource.GetName())
 		if err != nil {
 			return false, err
@@ -477,7 +478,7 @@ func deleteResource(client dynamic.Interface, informer informers.GenericInformer
 		return err
 	}
 
-	return wait.PollImmediateInfinite(time.Microsecond, func() (bool, error) {
+	return wait.PollImmediate(time.Microsecond, fifteenSecondDuration, func() (bool, error) {
 		_, err := informer.Lister().ByNamespace(resource.GetNamespace()).Get(resource.GetName())
 		if err != nil && apierrors.IsNotFound(err) {
 			return true, nil


### PR DESCRIPTION
This change removes the `PollImmediateInfinite` calls in the cluster-api
controller unit tests in favor of `PollImmediate`. It is being proposed
to prevent an edge case where the polling calls would become blocked
indefinitely. As we are using fake clients within the unit tests there
should be no delay getting a return value, but just in case there is a
miss on the poll function the new `PollImmediate` will timeout after 15
seconds.