### PR TITLE
Include taints by condition when determining if a node is unready/still starting

### DIFF
--- a/cluster-autoscaler/utils/kubernetes/ready.go
+++ b/cluster-autoscaler/utils/kubernetes/ready.go
@@ -67,6 +67,21 @@ func GetReadinessState(node *apiv1.Node) (isNodeReady bool, lastTransitionTime t
 			}
 		}
 	}
+
+	notReadyTaints := map[string]bool{
+		apiv1.TaintNodeNotReady:           true,
+		apiv1.TaintNodeDiskPressure:       true,
+		apiv1.TaintNodeNetworkUnavailable: true,
+	}
+	for _, taint := range node.Spec.Taints {
+		if notReadyTaints[taint.Key] {
+			canNodeBeReady = false
+			if taint.TimeAdded != nil && lastTransitionTime.Before(taint.TimeAdded.Time) {
+				lastTransitionTime = taint.TimeAdded.Time
+			}
+		}
+	}
+
 	if !readyFound {
 		return false, time.Time{}, fmt.Errorf("readiness information not found")
 	}


### PR DESCRIPTION
Conditions and their corresponding taints can sometimes skew, which
can cause unnecessary scale-up. CA thinks nodes are ready because it
looks only at the conditions, but scheduler predicates fail because they
consider the taints as well. CA adds nodes, even though the existing
nodes are still starting. This commit brings CA behavior in line
with scheduler predicates behavior, eliminating the unnecessary
scale-up.

NOTE: NoSchedule taints don't have TimeAdded set, which is why I
implemented `isNodeStillStarting` this way.