### PR TITLE
implemented TemplateNodeInfo function

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -158,7 +158,17 @@ func (asg *AutoScalingGroup) Nodes() ([]cloudprovider.Instance, error) {
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
 func (asg *AutoScalingGroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	template, err := asg.cloudServiceManager.getAsgTemplate(asg.groupID)
+	if err != nil {
+		return nil, err
+	}
+	node, err := asg.cloudServiceManager.buildNodeFromTemplate(asg.groupName, template)
+	if err != nil {
+		return nil, err
+	}
+	nodeInfo := schedulerframework.NewNodeInfo(cloudprovider.BuildKubeProxy(asg.groupName))
+	nodeInfo.SetNode(node)
+	return nodeInfo, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
@@ -442,7 +442,7 @@ func (csm *cloudServiceManager) getScalingGroupConfigByID(groupID, configID stri
 		return nil, err
 	}
 	if response == nil || response.ScalingConfiguration == nil {
-		return nil, fmt.Errorf("no instance in scaling group: %s", groupID)
+		return nil, fmt.Errorf("no scaling configuration found, groupID: %s, configID: %s", groupID, configID)
 	}
 	return response.ScalingConfiguration, nil
 }
@@ -507,7 +507,7 @@ func (csm *cloudServiceManager) buildNodeFromTemplate(asgName string, template *
 	node.Status = apiv1.NodeStatus{
 		Capacity: apiv1.ResourceList{},
 	}
-	// TODO: get a real value.
+
 	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
 	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(template.vcpu, resource.DecimalSI)
 	node.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(template.gpu, resource.DecimalSI)

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
@@ -442,7 +442,7 @@ func (csm *cloudServiceManager) getScalingGroupConfigByID(groupID, configID stri
 		return nil, err
 	}
 	if response == nil || response.ScalingConfiguration == nil {
-		return nil, fmt.Errorf("no scaling configuration not found, groupID: %s, configID: %s", groupID, configID)
+		return nil, fmt.Errorf("no scaling configuration found, groupID: %s, configID: %s", groupID, configID)
 	}
 	return response.ScalingConfiguration, nil
 }

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
@@ -442,7 +442,7 @@ func (csm *cloudServiceManager) getScalingGroupConfigByID(groupID, configID stri
 		return nil, err
 	}
 	if response == nil || response.ScalingConfiguration == nil {
-		return nil, fmt.Errorf("no scaling configuration found, groupID: %s, configID: %s", groupID, configID)
+		return nil, fmt.Errorf("no scaling configuration not found, groupID: %s, configID: %s", groupID, configID)
 	}
 	return response.ScalingConfiguration, nil
 }


### PR DESCRIPTION
Implemented TemplateNodeInfo function. TemplateNodeInfo returns a schedulerframework.NodeInfo structure of an empty
(as if just started) node. This will be used in scale-up simulations to predict what would a new node look like if a node group was expanded. The returned NodeInfo is expected to have a fully populated Node object, with all of the labels, capacity and allocatable information as well as all pods that are started on the node by default, using manifest (most likely only kube-proxy).