### PR TITLE
Update vertical-pod-autoscaler containerPorts to reflect default ports

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -40,6 +40,8 @@ spec:
               memory: 200Mi
           ports:
             - containerPort: 8000
+            - name: prometheus
+              containerPort: 8944
       volumes:
         - name: tls-certs
           secret:

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -36,4 +36,5 @@ spec:
             cpu: 50m
             memory: 500Mi
         ports:
-        - containerPort: 8080
+        - name: prometheus
+          containerPort: 8942

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -36,4 +36,5 @@ spec:
               cpu: 50m
               memory: 500Mi
           ports:
-            - containerPort: 8080
+            - name: prometheus
+              containerPort: 8943


### PR DESCRIPTION
Noticed the container port wasn't actually being listened to, and found out that metrics were running on a different port. Updates the deployment manifests to match the defaults.