### PR TITLE
[CA]delete nodes from cluster after scale down

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-svcaccount.yaml
@@ -19,7 +19,7 @@ rules:
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["watch", "list", "get", "update"]
+    verbs: ["watch", "list", "get", "update", "delete"]
   - apiGroups: [""]
     resources:
       - "pods"


### PR DESCRIPTION
This PR :
- make sure all nodes belong to the specific node group before scale down.
- remove nodes from cluster after scale down.
- update example service account, CA requires node delete.

some logs from local testing:
```
I1110 05:03:59.033880       1 delete.go:103] Successfully added ToBeDeletedTaint on node k8s-node-components-1ney296p
I1110 05:03:59.158326       1 huaweicloud_auto_scaling_group.go:123] going to remove node from scaling group. group: e7c3f6ff-d6b3-4b22-b809-47a22c180276, node: eb81661f-ad84-4f8e-8a19-c31b514e3d12
I1110 05:03:59.372705       1 huaweicloud_auto_scaling_group.go:250] deleted one node from cluster. node name: k8s-node-components-1ney296p
```