### PR TITLE
Add unremovable_nodes_count metric

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -659,6 +659,16 @@ func (sd *ScaleDown) addUnremovableNode(unremovableNode *simulator.UnremovableNo
 	sd.unremovableNodeReasons[unremovableNode.Node.Name] = unremovableNode
 }
 
+func (sd *ScaleDown) getUnremovableNodesCount() map[simulator.UnremovableReason]int {
+	reasons := make(map[simulator.UnremovableReason]int)
+
+	for _, node := range sd.unremovableNodeReasons {
+		reasons[node.Reason]++
+	}
+
+	return reasons
+}
+
 // markSimulationError indicates a simulation error by clearing  relevant scale
 // down state and returning an appropriate error.
 func (sd *ScaleDown) markSimulationError(simulatorErr errors.AutoscalerError,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -526,6 +526,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
 			scaleDownStatus, typedErr := scaleDown.TryToScaleDown(currentTime, pdbs)
 			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
+			metrics.UpdateUnremovableNodesCount(scaleDown.getUnremovableNodesCount())
 
 			scaleDownStatus.RemovedNodeGroups = removedNodeGroups
 


### PR DESCRIPTION
I want to set up alerting for cases where nodes are unremovable due to user errors, like lack of "safe to deschedule" annotation, and so this Pull Requests adds a Gauge sliced by `fmt.Sprintf("%s", simulator.UnremovableReason)`.

I wasn't sure if there is any concurrent access involved, so added a mutex for the counter map, please let me know if it is unnecessary.

I also wasn't sure how to test this, any suggestions are welcome.