### PR TITLE
vpa: Replace component-base restclient metrics with built-in copy

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
+	metrics_restclient "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/restclient"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 	"k8s.io/client-go/informers"
@@ -76,6 +77,7 @@ func main() {
 
 	healthCheck := metrics.NewHealthCheck(time.Minute, false)
 	metrics.Initialize(*address, healthCheck)
+	metrics_restclient.Register()
 	metrics_admission.Register()
 
 	certs := initCerts(*certsConfiguration)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
+	metrics_restclient "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/restclient"
 	"k8s.io/client-go/rest"
 	kube_flag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog"
@@ -76,6 +77,7 @@ func main() {
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)
+	metrics_restclient.Register()
 	metrics_recommender.Register()
 	metrics_quality.Register()
 

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+
 	"os"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
+	metrics_restclient "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/restclient"
 	metrics_updater "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/updater"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
@@ -74,6 +76,7 @@ func main() {
 
 	healthCheck := metrics.NewHealthCheck(*updaterInterval*5, true)
 	metrics.Initialize(*address, healthCheck)
+	metrics_restclient.Register()
 	metrics_updater.Register()
 
 	config, err := kube_restclient.InClusterConfig()

--- a/vertical-pod-autoscaler/pkg/utils/metrics/metrics.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/metrics.go
@@ -25,7 +25,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	_ "k8s.io/component-base/metrics/prometheus/restclient" // for client-go metrics registration
 	"k8s.io/klog"
 )
 

--- a/vertical-pod-autoscaler/pkg/utils/metrics/restclient/restclient.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/restclient/restclient.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package restclient replaces k8s.io/component-base/metrics/prometheus/restclient
+package restclient
+
+import (
+	"math"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/client-go/tools/metrics"
+)
+
+const (
+	metricsNamespace = "rest_client"
+)
+
+var (
+	// requestLatency is a Prometheus Summary metric type partitioned by
+	// "verb" and "url" labels. It is used for the rest client latency metrics.
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "request_duration_seconds",
+			Help:      "Request latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+		},
+		[]string{"verb", "url"},
+	)
+
+	rateLimiterLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "rate_limiter_duration_seconds",
+			Help:      "Client side rate limiter latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+		},
+		[]string{"verb", "url"},
+	)
+
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "requests_total",
+			Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
+		},
+		[]string{"code", "method", "host"},
+	)
+
+	execPluginCertTTLAdapter = &expiryToTTLAdapter{}
+
+	execPluginCertTTL = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "exec_plugin_ttl_seconds",
+			Help: "Gauge of the shortest TTL (time-to-live) of the client " +
+				"certificate(s) managed by the auth exec plugin. The value " +
+				"is in seconds until certificate expiry (negative if " +
+				"already expired). If auth exec plugins are unused or manage no " +
+				"TLS certificates, the value will be +INF.",
+			//StabilityLevel: prometheus.ALPHA,
+		},
+		func() float64 {
+			if execPluginCertTTLAdapter.e == nil {
+				return math.Inf(1)
+			}
+			return execPluginCertTTLAdapter.e.Sub(time.Now()).Seconds()
+		},
+	)
+
+	execPluginCertRotation = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "exec_plugin_certificate_rotation_age",
+			Help: "Histogram of the number of seconds the last auth exec " +
+				"plugin client certificate lived before being rotated. " +
+				"If auth exec plugin client certificates are unused, " +
+				"histogram will contain no data.",
+			// There are three sets of ranges these buckets intend to capture:
+			//   - 10-60 minutes: captures a rotation cadence which is
+			//     happening too quickly.
+			//   - 4 hours - 1 month: captures an ideal rotation cadence.
+			//   - 3 months - 4 years: captures a rotation cadence which is
+			//     is probably too slow or much too slow.
+			Buckets: []float64{
+				600,       // 10 minutes
+				1800,      // 30 minutes
+				3600,      // 1  hour
+				14400,     // 4  hours
+				86400,     // 1  day
+				604800,    // 1  week
+				2592000,   // 1  month
+				7776000,   // 3  months
+				15552000,  // 6  months
+				31104000,  // 1  year
+				124416000, // 4  years
+			},
+		},
+	)
+)
+
+// Register initializes all metrics for client-go (restclient) observability
+func Register() {
+	prometheus.MustRegister(requestLatency)
+	prometheus.MustRegister(requestResult)
+	prometheus.MustRegister(execPluginCertTTL)
+	prometheus.MustRegister(execPluginCertRotation)
+	metrics.Register(metrics.RegisterOpts{
+		ClientCertExpiry:      execPluginCertTTLAdapter,
+		ClientCertRotationAge: &rotationAdapter{m: execPluginCertRotation},
+		RequestLatency:        &latencyAdapter{m: requestLatency},
+		RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
+		RequestResult:         &resultAdapter{requestResult},
+	})
+}
+
+type latencyAdapter struct {
+	m *prometheus.HistogramVec
+}
+
+func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
+	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+}
+
+type resultAdapter struct {
+	m *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(code, method, host string) {
+	r.m.WithLabelValues(code, method, host).Inc()
+}
+
+type expiryToTTLAdapter struct {
+	e *time.Time
+}
+
+func (e *expiryToTTLAdapter) Set(expiry *time.Time) {
+	e.e = expiry
+}
+
+type rotationAdapter struct {
+	m prometheus.Histogram
+}
+
+func (r *rotationAdapter) Observe(d time.Duration) {
+	r.m.Observe(d.Seconds())
+}


### PR DESCRIPTION
restclient metrics from controller-base were not showing up as vertical-pod-autoscaler uses prometheus metrics directly instead of via k8smetrics wrappers. therefore, the restclient hooks get attached to the legacyregistry but never used. 

this PR creates a copy of the restclient hooks which are compatible with the prometheus interface used throughout vpa to enable capturing rest_client_* metrics alongside the vpa_* metrics.