### PR TITLE
gcp: faster startup and refreshes with many MIGs

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache_test.go
@@ -82,7 +82,7 @@ func TestMachineCache(t *testing.T) {
 			},
 		},
 	}
-	c := NewGceCache(nil)
+	c := NewGceCache(nil, 1)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, m := range tc.machines {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -350,7 +350,7 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		defer config.Close()
 	}
 
-	manager, err := CreateGceManager(config, do, opts.Regional)
+	manager, err := CreateGceManager(config, do, opts.Regional, opts.ConcurrentGceRefreshes)
 	if err != nil {
 		klog.Fatalf("Failed to create GCE Manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -24,14 +25,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+	"k8s.io/client-go/util/workqueue"
 
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	provider_gce "k8s.io/legacy-cloud-providers/gce"
 
 	"cloud.google.com/go/compute/metadata"
@@ -98,6 +101,7 @@ type gceManagerImpl struct {
 	cache                    *GceCache
 	lastRefresh              time.Time
 	machinesCacheLastRefresh time.Time
+	concurrentGceRefreshes   int
 
 	GceService                   AutoscalingGceClient
 	migTargetSizesProvider       MigTargetSizesProvider
@@ -113,7 +117,7 @@ type gceManagerImpl struct {
 }
 
 // CreateGceManager constructs GceManager object.
-func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, regional bool) (GceManager, error) {
+func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, regional bool, concurrentGceRefreshes int) (GceManager, error) {
 	// Create Google Compute Engine token.
 	var err error
 	tokenSource := google.ComputeTokenSource("")
@@ -167,7 +171,7 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 	if err != nil {
 		return nil, err
 	}
-	cache := NewGceCache(gceService)
+	cache := NewGceCache(gceService, concurrentGceRefreshes)
 	manager := &gceManagerImpl{
 		cache:                        cache,
 		GceService:                   gceService,
@@ -179,6 +183,7 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 		templates:                    &GceTemplateBuilder{},
 		interrupt:                    make(chan struct{}),
 		explicitlyConfigured:         make(map[GceRef]bool),
+		concurrentGceRefreshes:       concurrentGceRefreshes,
 	}
 
 	if err := manager.fetchExplicitMigs(discoveryOpts.NodeGroupSpecs); err != nil {
@@ -359,12 +364,15 @@ func (m *gceManagerImpl) buildMigFromSpec(s *dynamic.NodeGroupSpec) (Mig, error)
 // they no longer exist in GCE.
 func (m *gceManagerImpl) fetchAutoMigs() error {
 	exists := make(map[GceRef]bool)
-	changed := false
+	var changed int32 = 0
+
+	toRegister := make([]Mig, 0)
 	for _, cfg := range m.migAutoDiscoverySpecs {
 		links, err := m.findMigsNamed(cfg.Re)
 		if err != nil {
 			return fmt.Errorf("cannot autodiscover managed instance groups: %v", err)
 		}
+
 		for _, link := range links {
 			mig, err := m.buildMigFromAutoCfg(link, cfg)
 			if err != nil {
@@ -378,21 +386,26 @@ func (m *gceManagerImpl) fetchAutoMigs() error {
 				klog.V(3).Infof("Ignoring explicitly configured MIG %s in autodiscovery.", mig.GceRef().String())
 				continue
 			}
-			if m.registerMig(mig) {
-				klog.V(3).Infof("Autodiscovered MIG %s using regexp %s", mig.GceRef().String(), cfg.Re.String())
-				changed = true
-			}
+			toRegister = append(toRegister, mig)
 		}
 	}
+
+	workqueue.ParallelizeUntil(context.Background(), m.concurrentGceRefreshes, len(toRegister), func(piece int) {
+		mig := toRegister[piece]
+		if m.registerMig(mig) {
+			klog.V(3).Infof("Autodiscovered MIG %s", mig.GceRef().String())
+			atomic.StoreInt32(&changed, int32(1))
+		}
+	}, workqueue.WithChunkSize(m.concurrentGceRefreshes))
 
 	for _, mig := range m.GetMigs() {
 		if !exists[mig.GceRef()] && !m.explicitlyConfigured[mig.GceRef()] {
 			m.cache.UnregisterMig(mig)
-			changed = true
+			atomic.StoreInt32(&changed, int32(1))
 		}
 	}
 
-	if changed {
+	if atomic.LoadInt32(&changed) > 0 {
 		return m.cache.RegenerateInstancesCache()
 	}
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -344,6 +344,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		migTargetSizeCache:     map[GceRef]int64{},
 		instanceTemplatesCache: map[GceRef]*gce.InstanceTemplate{},
 		migBaseNameCache:       map[GceRef]string{},
+		concurrentGceRefreshes: 1,
 	}
 	manager := &gceManagerImpl{
 		cache:                        cache,
@@ -354,6 +355,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		regional:                     regional,
 		templates:                    &GceTemplateBuilder{},
 		explicitlyConfigured:         make(map[GceRef]bool),
+		concurrentGceRefreshes:       1,
 	}
 	if regional {
 		manager.location = region

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -140,6 +140,8 @@ type AutoscalingOptions struct {
 	BalancingExtraIgnoredLabels []string
 	// AWSUseStaticInstanceList tells if AWS cloud provider use static instance type list or dynamically fetch from remote APIs.
 	AWSUseStaticInstanceList bool
+	// ConcurrentGceRefreshes is the maximum number of concurrently refreshed instance groups or instance templates.
+	ConcurrentGceRefreshes int
 	// Path to kube configuration if available
 	KubeConfigPath string
 	// ClusterAPICloudConfigAuthoritative tells the Cluster API provider to treat the CloudConfig option as authoritative and

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -172,6 +172,7 @@ var (
 	ignoreTaintsFlag                   = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
 	balancingIgnoreLabelsFlag          = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	awsUseStaticInstanceList           = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
+	concurrentGceRefreshes             = flag.Int("gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
 	enableProfiling                    = flag.Bool("profiling", false, "Is debug/pprof endpoint enabled")
 	clusterAPICloudConfigAuthoritative = flag.Bool("clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
 )
@@ -242,6 +243,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		KubeConfigPath:                     *kubeConfigFile,
 		NodeDeletionDelayTimeout:           *nodeDeletionDelayTimeout,
 		AWSUseStaticInstanceList:           *awsUseStaticInstanceList,
+		ConcurrentGceRefreshes:             *concurrentGceRefreshes,
 		ClusterAPICloudConfigAuthoritative: *clusterAPICloudConfigAuthoritative,
 	}
 }


### PR DESCRIPTION
With 1.5k MIGs attached to a cluster, cluster-autoscaler needs about
40mn to start. Refreshing MIGs+ITs concurrently brings that down to
about 5mn.

While bulk GCE API calls (triggered at startup and on Refresh() calls)
and a few stateless functions (called by GetMigInstanceTemplate) become
concurrent, cache accesses remains lock protected. To that effect:
* Set RegenerateInstancesCache to run parallels RegenerateInstanceCacheForMig
  (slightly adapted so the slow GceService.FetchMigInstances call isn't locked)
* Set fetchAutoMigs to run parallels registerMig: rework GetMigInstanceTemplate
  so the slow InstanceGroupManagers.Get+InstanceTemplates.Get calls aren't locked

Tested on a large k8s cluster (> 1k MIGs) with intense scaling activity,
and tested on live clusters with "go build -race" cluster-autoscaler builds.