### PR TITLE
CA-Chart - 9.0.0 & 9.1.0 Release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,28 @@ entries:
   cluster-autoscaler:
   - apiVersion: v2
     appVersion: 1.18.1
+    created: "2020-11-24T08:33:57.63267Z"
+    description: Scales Kubernetes worker nodes within autoscaling groups.
+    digest: 5f094e6666928dafafa0670cdbfe58e3dd682424781eff118a8e9564e9eb0705
+    home: https://github.com/kubernetes/autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: e.bailey@sportradar.com
+      name: yurrriq
+    - email: mgoodness@gmail.com
+      name: mgoodness
+    - email: guyjtempleton@googlemail.com
+      name: gjtempleton
+    - email: scott.crooks@gmail.com
+      name: sc250024
+    name: cluster-autoscaler
+    sources:
+    - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    urls:
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.1.0/cluster-autoscaler-9.1.0.tgz
+    version: 9.1.0
+  - apiVersion: v2
+    appVersion: 1.18.1
     created: "2020-11-23T16:12:58.413807Z"
     description: Scales Kubernetes worker nodes within autoscaling groups.
     digest: d8c997bcc69ca7acdb2905bd89adba314fcb4f84212e81117801153f76b82d9b
@@ -202,4 +224,4 @@ entries:
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.0/cluster-autoscaler-chart-1.0.0.tgz
     version: 1.0.0
-generated: "2020-11-23T16:12:58.412355Z"
+generated: "2020-11-24T08:33:57.629044Z"

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,28 @@
 apiVersion: v1
 entries:
+  cluster-autoscaler:
+  - apiVersion: v2
+    appVersion: 1.18.1
+    created: "2020-11-23T16:12:58.413807Z"
+    description: Scales Kubernetes worker nodes within autoscaling groups.
+    digest: d8c997bcc69ca7acdb2905bd89adba314fcb4f84212e81117801153f76b82d9b
+    home: https://github.com/kubernetes/autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: e.bailey@sportradar.com
+      name: yurrriq
+    - email: mgoodness@gmail.com
+      name: mgoodness
+    - email: guyjtempleton@googlemail.com
+      name: gjtempleton
+    - email: scott.crooks@gmail.com
+      name: sc250024
+    name: cluster-autoscaler
+    sources:
+    - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    urls:
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.0.0/cluster-autoscaler-9.0.0.tgz
+    version: 9.0.0
   cluster-autoscaler-chart:
   - apiVersion: v2
     appVersion: 1.18.1
@@ -179,4 +202,4 @@ entries:
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.0/cluster-autoscaler-chart-1.0.0.tgz
     version: 1.0.0
-generated: "2020-11-09T22:16:07.427031Z"
+generated: "2020-11-23T16:12:58.412355Z"


### PR DESCRIPTION
* Includes changes from:
  * #3679 - Renames chart to `cluster-autoscaler` and associated version bump to `9.0.0`
  * #3691  - Adds extra config map injection functionality and documents existing options - bump to `9.1.0`