### PR TITLE
cleanup: refactor Azure cache and remove redundant API calls

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -153,7 +153,7 @@ In addition, cluster-autoscaler exposes a `AZURE_VMSS_CACHE_TTL` environment var
 
 | Config Name | Default | Environment Variable | Cloud Config File |
 | ----------- | ------- | -------------------- | ----------------- |
-| VmssCacheTTL | 15 | AZURE_VMSS_CACHE_TTL | vmssCacheTTL |
+| VmssCacheTTL | 60 | AZURE_VMSS_CACHE_TTL | vmssCacheTTL |
 
 The `AZURE_VMSS_VMS_CACHE_TTL` environment variable affects the `GetScaleSetVms` (VMSS VM List) calls rate. The default value is 300 seconds.
 A configurable jitter (`AZURE_VMSS_VMS_CACHE_JITTER` environment variable, default 0) expresses the maximum number of second that will be subtracted from that initial VMSS cache TTL after a new VMSS is discovered by the cluster-autoscaler: this can prevent a dogpile effect on clusters having many VMSS.

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -35,20 +35,12 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	klog "k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/legacy-cloud-providers/azure/retry"
 )
 
 const (
-	vmInstancesRefreshPeriod          = 5 * time.Minute
 	clusterAutoscalerDeploymentPrefix = `cluster-autoscaler-`
 	defaultMaxDeploymentsCount        = 10
 )
-
-var virtualMachinesStatusCache struct {
-	lastRefresh     map[string]time.Time
-	mutex           sync.Mutex
-	virtualMachines map[string][]compute.VirtualMachine
-}
 
 // AgentPool implements NodeGroup interface for agent pools deployed by aks-engine.
 type AgentPool struct {
@@ -132,54 +124,24 @@ func (as *AgentPool) MaxSize() int {
 	return as.maxSize
 }
 
-func (as *AgentPool) getVirtualMachinesFromCache() ([]compute.VirtualMachine, error) {
-	virtualMachinesStatusCache.mutex.Lock()
-	defer virtualMachinesStatusCache.mutex.Unlock()
-	klog.V(4).Infof("getVirtualMachinesFromCache: starts for %+v", as)
-
-	if virtualMachinesStatusCache.virtualMachines == nil {
-		klog.V(4).Infof("getVirtualMachinesFromCache: initialize vm cache")
-		virtualMachinesStatusCache.virtualMachines = make(map[string][]compute.VirtualMachine)
-	}
-	if virtualMachinesStatusCache.lastRefresh == nil {
-		klog.V(4).Infof("getVirtualMachinesFromCache: initialize last refresh time cache")
-		virtualMachinesStatusCache.lastRefresh = make(map[string]time.Time)
-	}
-
-	if virtualMachinesStatusCache.lastRefresh[as.Id()].Add(vmInstancesRefreshPeriod).After(time.Now()) {
-		klog.V(4).Infof("getVirtualMachinesFromCache: get vms from cache")
-		return virtualMachinesStatusCache.virtualMachines[as.Id()], nil
-	}
-	klog.V(4).Infof("getVirtualMachinesFromCache: get vms from API")
-	vms, rerr := as.GetVirtualMachines()
-	klog.V(4).Infof("getVirtualMachinesFromCache: got vms from API, len = %d", len(vms))
-
-	if rerr != nil {
-		if isAzureRequestsThrottled(rerr) {
-			klog.Warningf("getAllVirtualMachines: throttling with message %v, would return the cached vms", rerr)
-			return virtualMachinesStatusCache.virtualMachines[as.Id()], nil
-		}
-
-		return []compute.VirtualMachine{}, rerr.Error()
-	}
-
-	virtualMachinesStatusCache.virtualMachines[as.Id()] = vms
-	virtualMachinesStatusCache.lastRefresh[as.Id()] = time.Now()
-
-	return vms, nil
+// Id returns AgentPool id.
+func (as *AgentPool) Id() string {
+	return as.Name
 }
 
-func invalidateVMCache(agentpoolName string) {
-	virtualMachinesStatusCache.mutex.Lock()
-	virtualMachinesStatusCache.lastRefresh[agentpoolName] = time.Now().Add(-1 * vmInstancesRefreshPeriod)
-	virtualMachinesStatusCache.mutex.Unlock()
+func (as *AgentPool) getVMsFromCache() ([]compute.VirtualMachine, error) {
+	allVMs := as.manager.azureCache.getVirtualMachines()
+	if _, exists := allVMs[as.Name]; !exists {
+		return []compute.VirtualMachine{}, fmt.Errorf("could not find VMs with poolName: %s", as.Name)
+	}
+	return allVMs[as.Name], nil
 }
 
 // GetVMIndexes gets indexes of all virtual machines belonging to the agent pool.
 func (as *AgentPool) GetVMIndexes() ([]int, map[int]string, error) {
 	klog.V(6).Infof("GetVMIndexes: starts for as %v", as)
 
-	instances, err := as.getVirtualMachinesFromCache()
+	instances, err := as.getVMsFromCache()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -222,8 +184,8 @@ func (as *AgentPool) getCurSize() (int64, error) {
 	klog.V(5).Infof("Returning agent pool (%q) size: %d\n", as.Name, len(indexes))
 
 	if as.curSize != int64(len(indexes)) {
-		klog.V(6).Infof("getCurSize:as.curSize(%d) != real size (%d), invalidating vm cache", as.curSize, len(indexes))
-		invalidateVMCache(as.Id())
+		klog.V(6).Infof("getCurSize:as.curSize(%d) != real size (%d), invalidating cache", as.curSize, len(indexes))
+		as.manager.invalidateCache()
 	}
 
 	as.curSize = int64(len(indexes))
@@ -316,8 +278,8 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 		klog.Warningf("IncreaseSize: failed to cleanup outdated deployments with err: %v.", err)
 	}
 
-	klog.V(6).Infof("IncreaseSize: invalidating vm cache")
-	invalidateVMCache(as.Id())
+	klog.V(6).Infof("IncreaseSize: invalidating cache")
+	as.manager.invalidateCache()
 
 	indexes, _, err := as.GetVMIndexes()
 	if err != nil {
@@ -357,41 +319,13 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 		// Update cache after scale success.
 		as.curSize = int64(expectedSize)
 		as.lastRefresh = time.Now()
-		klog.V(6).Info("IncreaseSize: invalidating vm cache")
-		invalidateVMCache(as.Id())
+		klog.V(6).Info("IncreaseSize: invalidating cache")
+		as.manager.invalidateCache()
 		return nil
 	}
 
 	klog.Errorf("deploymentsClient.CreateOrUpdate for deployment %q failed: %v", newDeploymentName, realError)
 	return realError
-}
-
-// GetVirtualMachines returns list of nodes for the given agent pool.
-func (as *AgentPool) GetVirtualMachines() ([]compute.VirtualMachine, *retry.Error) {
-	ctx, cancel := getContextWithCancel()
-	defer cancel()
-
-	result, rerr := as.manager.azClient.virtualMachinesClient.List(ctx, as.manager.config.ResourceGroup)
-	if rerr != nil {
-		return nil, rerr
-	}
-
-	instances := make([]compute.VirtualMachine, 0)
-	for _, instance := range result {
-		if instance.Tags == nil {
-			continue
-		}
-
-		tags := instance.Tags
-		vmPoolName := tags["poolName"]
-		if vmPoolName == nil || !strings.EqualFold(*vmPoolName, as.Id()) {
-			continue
-		}
-
-		instances = append(instances, instance)
-	}
-
-	return instances, nil
 }
 
 // DecreaseTargetSize decreases the target size of the node group. This function
@@ -403,7 +337,7 @@ func (as *AgentPool) DecreaseTargetSize(delta int) error {
 	as.mutex.Lock()
 	defer as.mutex.Unlock()
 
-	nodes, err := as.getVirtualMachinesFromCache()
+	nodes, err := as.getVMsFromCache()
 	if err != nil {
 		return err
 	}
@@ -427,14 +361,14 @@ func (as *AgentPool) Belongs(node *apiv1.Node) (bool, error) {
 		Name: node.Spec.ProviderID,
 	}
 
-	targetAsg, err := as.manager.GetAsgForInstance(ref)
+	targetAsg, err := as.manager.GetNodeGroupForInstance(ref)
 	if err != nil {
 		return false, err
 	}
 	if targetAsg == nil {
 		return false, fmt.Errorf("%s doesn't belong to a known agent pool", node.Name)
 	}
-	if !strings.EqualFold(targetAsg.Id(), as.Id()) {
+	if !strings.EqualFold(targetAsg.Id(), as.Name) {
 		return false, nil
 	}
 	return true, nil
@@ -446,13 +380,13 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 		return nil
 	}
 
-	commonAsg, err := as.manager.GetAsgForInstance(instances[0])
+	commonAsg, err := as.manager.GetNodeGroupForInstance(instances[0])
 	if err != nil {
 		return err
 	}
 
 	for _, instance := range instances {
-		asg, err := as.manager.GetAsgForInstance(instance)
+		asg, err := as.manager.GetNodeGroupForInstance(instance)
 		if err != nil {
 			return err
 		}
@@ -476,8 +410,8 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 		}
 	}
 
-	klog.V(6).Infof("DeleteInstances: invalidating vm cache")
-	invalidateVMCache(as.Id())
+	klog.V(6).Infof("DeleteInstances: invalidating cache")
+	as.manager.invalidateCache()
 	return nil
 }
 
@@ -501,7 +435,7 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 		}
 
 		if belongs != true {
-			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, as.Id())
+			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, as.Name)
 		}
 
 		ref := &azureRef{
@@ -518,14 +452,9 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 	return as.DeleteInstances(refs)
 }
 
-// Id returns AgentPool id.
-func (as *AgentPool) Id() string {
-	return as.Name
-}
-
 // Debug returns a debug string for the agent pool.
 func (as *AgentPool) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", as.Id(), as.MinSize(), as.MaxSize())
+	return fmt.Sprintf("%s (%d:%d)", as.Name, as.MinSize(), as.MaxSize())
 }
 
 // TemplateNodeInfo returns a node template for this agent pool.
@@ -535,7 +464,7 @@ func (as *AgentPool) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
 
 // Nodes returns a list of all nodes that belong to this node group.
 func (as *AgentPool) Nodes() ([]cloudprovider.Instance, error) {
-	instances, err := as.getVirtualMachinesFromCache()
+	instances, err := as.getVMsFromCache()
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_autodiscovery.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_autodiscovery.go
@@ -26,14 +26,14 @@ const (
 	autoDiscovererTypeLabel = "label"
 )
 
-// A labelAutoDiscoveryConfig specifies how to auto-discover Azure scale sets.
+// A labelAutoDiscoveryConfig specifies how to auto-discover Azure node groups.
 type labelAutoDiscoveryConfig struct {
 	// Key-values to match on.
 	Selector map[string]string
 }
 
 // ParseLabelAutoDiscoverySpecs returns any provided NodeGroupAutoDiscoverySpecs
-// parsed into configuration appropriate for ASG autodiscovery.
+// parsed into configuration appropriate for node group autodiscovery.
 func ParseLabelAutoDiscoverySpecs(o cloudprovider.NodeGroupDiscoveryOptions) ([]labelAutoDiscoveryConfig, error) {
 	cfgs := make([]labelAutoDiscoveryConfig, len(o.NodeGroupAutoDiscoverySpecs))
 	var err error

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -80,7 +80,7 @@ func (azure *AzureCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 
 // NodeGroups returns all node groups configured for this cloud provider.
 func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
-	asgs := azure.azureManager.getAsgs()
+	asgs := azure.azureManager.getNodeGroups()
 
 	ngs := make([]cloudprovider.NodeGroup, len(asgs))
 	for i, asg := range asgs {
@@ -102,7 +102,7 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 	}
 
 	klog.V(6).Infof("NodeGroupForNode: ref.Name %s", ref.Name)
-	return azure.azureManager.GetAsgForInstance(ref)
+	return azure.azureManager.GetNodeGroupForInstance(ref)
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -38,10 +38,9 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager:           manager,
-		minSize:           1,
-		maxSize:           5,
-		sizeRefreshPeriod: defaultVmssSizeRefreshPeriod,
+		manager: manager,
+		minSize: 1,
+		maxSize: 5,
 	}
 }
 
@@ -76,7 +75,7 @@ func newTestVMSSVMList(count int) []compute.VirtualMachineScaleSetVM {
 
 func TestMaxSize(t *testing.T) {
 	provider := newTestProvider(t)
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
@@ -85,7 +84,7 @@ func TestMaxSize(t *testing.T) {
 
 func TestMinSize(t *testing.T) {
 	provider := newTestProvider(t)
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
@@ -101,13 +100,15 @@ func TestTargetSize(t *testing.T) {
 
 	provider := newTestProvider(t)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
 
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
@@ -133,15 +134,18 @@ func TestIncreaseSize(t *testing.T) {
 	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
 
 	ss := newTestScaleSet(provider.azureManager, "test-asg")
 	ss.lastSizeRefresh = time.Now()
+	ss.sizeRefreshPeriod = 1 * time.Minute
 	ss.curSize = -1
-	err := ss.IncreaseSize(100)
+	err = ss.IncreaseSize(100)
 	expectedErr := fmt.Errorf("the scale set test-asg is under initialization, skipping IncreaseSize")
 	assert.Equal(t, expectedErr, err)
 
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
@@ -190,9 +194,9 @@ func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
 	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-updating", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	registered := manager.RegisterAsg(newTestScaleSet(manager, vmssName))
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
 	assert.True(t, registered)
-	manager.regenerateCache()
+	manager.Refresh()
 
 	provider, err := BuildAzureCloudProvider(manager, nil)
 	assert.NoError(t, err)
@@ -219,15 +223,13 @@ func TestBelongs(t *testing.T) {
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
-	// TODO: this should call manager.Refresh() once the fetchAutoASG
-	// logic is refactored out
-	provider.azureManager.regenerateCache()
+	provider.azureManager.Refresh()
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -266,17 +268,15 @@ func TestDeleteNodes(t *testing.T) {
 	expectedVMSSVMs := newTestVMSSVMList(3)
 
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
 	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockVMSSClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), gomock.Any()).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-
-	// TODO: this should call manager.Refresh() once the fetchAutoASG
-	// logic is refactored out
-	manager.regenerateCache()
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
 
 	resourceLimiter := cloudprovider.NewResourceLimiter(
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
@@ -284,12 +284,11 @@ func TestDeleteNodes(t *testing.T) {
 	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
 	assert.NoError(t, err)
 
-	registered := manager.RegisterAsg(
+	registered := manager.RegisterNodeGroup(
 		newTestScaleSet(manager, "test-asg"))
 	assert.True(t, registered)
-	// TODO: this should call manager.Refresh() once the fetchAutoASG
-	// logic is refactored out
-	manager.regenerateCache()
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
 
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
@@ -313,6 +312,21 @@ func TestDeleteNodes(t *testing.T) {
 	}
 	err = scaleSet.DeleteNodes(nodesToDelete)
 	assert.NoError(t, err)
+	vmssCapacity = 1
+	expectedScaleSets = []compute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			Sku: &compute.Sku{
+				Capacity: &vmssCapacity,
+			},
+		},
+	}
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	expectedVMSSVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
 
 	// Ensure the the cached size has been proactively decremented by 2
 	targetSize, err = scaleSet.TargetSize()
@@ -327,7 +341,6 @@ func TestDeleteNodes(t *testing.T) {
 	instance2, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2))
 	assert.True(t, found, true)
 	assert.Equal(t, instance2.Status.State, cloudprovider.InstanceDeleting)
-
 }
 
 func TestDeleteNoConflictRequest(t *testing.T) {
@@ -371,9 +384,9 @@ func TestDeleteNoConflictRequest(t *testing.T) {
 	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
 	assert.NoError(t, err)
 
-	registered := manager.RegisterAsg(newTestScaleSet(manager, "test-asg"))
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
 	assert.True(t, registered)
-	manager.regenerateCache()
+	manager.Refresh()
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -389,7 +402,7 @@ func TestDeleteNoConflictRequest(t *testing.T) {
 
 func TestId(t *testing.T) {
 	provider := newTestProvider(t)
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
@@ -421,11 +434,9 @@ func TestScaleSetNodes(t *testing.T) {
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
-	// TODO: this should call manager.Refresh() once the fetchAutoASG
-	// logic is refactored out
-	provider.azureManager.regenerateCache()
+	provider.azureManager.Refresh()
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
 
@@ -462,8 +473,10 @@ func TestTemplateNodeInfo(t *testing.T) {
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
 
-	registered := provider.azureManager.RegisterAsg(
+	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
 	assert.Equal(t, len(provider.NodeGroups()), 1)


### PR DESCRIPTION
This PR cleans up the Azure cloud provider cache to optimize API calls and facilitate further improvements.

Currently, multiple Azure VMSS List calls are made throughout the code, such as [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_manager.go#L267) and [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go#L188). In addition, [agent_pools](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go#L374) and [aks](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go#L173) providers both have their own code to list VMs.

This centralizes all VM and VMSS List() API calls in one central cache which refreshes every minute, which means we should see 60 VM list and 60 VMSS list API calls per hour, regardless of # of agent pools/scale sets. The other calls for VMSS are 1) capacity increase/decrease for scale ups and scale downs, and 2) VMSS VM list (which lists all the instances in a scale set). Number 2) is still quite costly and increases linearly with the number of scale sets. I'd like to try and tackle it next once this PR merges. For agent pools, the only other calls are Deletes and Creates to add/remove VMs.

Here is some initial data I gathered. Both of these clusters have 10 scale sets. The first one is running the latest cluster-autoscaler release, and the second is running with an image built from this PR's code. Chart shows number of API calls per 5 minutes:

<img width="905" alt="Screen Shot 2020-11-23 at 5 14 39 PM" src="https://user-images.githubusercontent.com/8650424/100029874-74616a00-2daf-11eb-8c4e-6a298acb62a0.png">

<img width="907" alt="Screen Shot 2020-11-23 at 5 14 51 PM" src="https://user-images.githubusercontent.com/8650424/100029867-6f9cb600-2daf-11eb-8e7a-5123b9945e8a.png">

With 20 scale sets when autoscaler is idle (no workloads running):
Before (54-56 calls per 5 minutes):
<img width="909" alt="Screen Shot 2020-11-24 at 6 24 11 PM" src="https://user-images.githubusercontent.com/8650424/100170222-6597b780-2e82-11eb-952e-7a97a8040de5.png">

After (50 calls per 5 minutes):
<img width="916" alt="Screen Shot 2020-11-24 at 6 23 52 PM" src="https://user-images.githubusercontent.com/8650424/100170231-6af50200-2e82-11eb-9c12-fe8ae7054563.png">
