### PR TITLE
Fix cluster-autoscaler chart to match with the examples

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.3.2
+version: 9.4.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -355,7 +355,9 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | extraEnv | object | `{}` | Additional container environment variables. |
 | extraEnvConfigMaps | object | `{}` | Additional container environment variables from ConfigMaps. |
 | extraEnvSecrets | object | `{}` | Additional container environment variables from Secrets. |
+| extraVolumeMounts | list | `[]` | Additional volumes to mount. |
 | extraVolumeSecrets | object | `{}` | Additional volumes to mount from Secrets. |
+| extraVolumes | list | `[]` | Additional volumes. |
 | fullnameOverride | string | `""` | String to fully override `cluster-autoscaler.fullname` template. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -182,7 +182,7 @@ spec:
           securityContext:
             {{ toYaml .Values.containerSecurityContext | nindent 12 | trim }}
           {{- end }}
-          {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets }}
+          {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumeMounts }}
           volumeMounts:
           {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") }}
             - name: cloudconfig
@@ -198,6 +198,9 @@ spec:
             - name: {{ $key }}
               mountPath: {{ required "Must specify mountPath!" $value.mountPath }}
               readOnly: true
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
           {{- end }}
     {{- if .Values.affinity }}
@@ -215,7 +218,7 @@ spec:
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 | trim }}
       {{- end }}
-      {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets }}
+      {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumes }}
       volumes:
       {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") }}
         - name: cloudconfig
@@ -235,6 +238,9 @@ spec:
             items:
             {{- toYaml $value.items | nindent 14 }}
             {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 10 }}
       {{- end }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/cluster-autoscaler/templates/role.yaml
+++ b/charts/cluster-autoscaler/templates/role.yaml
@@ -12,14 +12,24 @@ rules:
       - configmaps
     verbs:
       - create
+{{- if eq (default "" .Values.extraArgs.expander) "priority" }}
+      - list
+      - watch
+{{- end }}
   - apiGroups:
       - ""
     resources:
       - configmaps
     resourceNames:
       - cluster-autoscaler-status
+{{- if eq (default "" .Values.extraArgs.expander) "priority" }}
+      - cluster-autoscaler-priority-expander
+{{- end }}
     verbs:
       - delete
       - get
       - update
+{{- if eq (default "" .Values.extraArgs.expander) "priority" }}
+      - watch
+{{- end }}
 {{- end -}}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -175,6 +175,18 @@ extraVolumeSecrets: {}
   #     - key: subkey
   #       path: mypath
 
+# extraVolumes -- Additional volumes.
+extraVolumes: []
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
+
+# extraVolumeMounts -- Additional volumes to mount.
+extraVolumeMounts: []
+  # - name: ssl-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+  #   readonly: true
+
 # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
 fullnameOverride: ""
 


### PR DESCRIPTION
Partially resolves: https://github.com/kubernetes/autoscaler/issues/3724

Following lint error is well known issue:
```
templates/: template: cluster-autoscaler/templates/role.yaml:15:7: executing "cluster-autoscaler/templates/role.yaml" at <eq (default .Values.extraArgs.expander "") "priority">: error calling eq: invalid type for comparison
```
https://github.com/helm/helm/issues/6376
The workaround doesn't seem to work.