### PR TITLE
CA-Chart - 9.2.0 Release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,29 @@ entries:
   cluster-autoscaler:
   - apiVersion: v2
     appVersion: 1.18.1
+    created: "2020-12-03T09:55:45.893963Z"
+    description: Scales Kubernetes worker nodes within autoscaling groups.
+    digest: 1186806946d43fae4325725b75a30c148397c2a361709f742ff40829bb7983e6
+    home: https://github.com/kubernetes/autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: e.bailey@sportradar.com
+      name: yurrriq
+    - email: mgoodness@gmail.com
+      name: mgoodness
+    - email: guyjtempleton@googlemail.com
+      name: gjtempleton
+    - email: scott.crooks@gmail.com
+      name: sc250024
+    name: cluster-autoscaler
+    sources:
+    - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
+    urls:
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.2.0/cluster-autoscaler-9.2.0.tgz
+    version: 9.2.0
+  - apiVersion: v2
+    appVersion: 1.18.1
     created: "2020-11-24T08:33:57.63267Z"
     description: Scales Kubernetes worker nodes within autoscaling groups.
     digest: 5f094e6666928dafafa0670cdbfe58e3dd682424781eff118a8e9564e9eb0705
@@ -20,6 +43,7 @@ entries:
     name: cluster-autoscaler
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.1.0/cluster-autoscaler-9.1.0.tgz
     version: 9.1.0
@@ -42,6 +66,7 @@ entries:
     name: cluster-autoscaler
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.0.0/cluster-autoscaler-9.0.0.tgz
     version: 9.0.0
@@ -65,6 +90,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.1.1/cluster-autoscaler-chart-1.1.1.tgz
     version: 1.1.1
@@ -87,6 +113,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.1.0/cluster-autoscaler-chart-1.1.0.tgz
     version: 1.1.0
@@ -109,6 +136,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.5/cluster-autoscaler-chart-1.0.5.tgz
     version: 1.0.5
@@ -131,6 +159,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.4/cluster-autoscaler-chart-1.0.4.tgz
     version: 1.0.4
@@ -153,6 +182,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.3/cluster-autoscaler-chart-1.0.3.tgz
     version: 1.0.3
@@ -175,6 +205,7 @@ entries:
     name: cluster-autoscaler-chart
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.2/cluster-autoscaler-chart-1.0.2.tgz
     version: 1.0.2
@@ -195,9 +226,9 @@ entries:
     - email: scott.crooks@gmail.com
       name: sc250024
     name: cluster-autoscaler-chart
-    type: application
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.1/cluster-autoscaler-chart-1.0.1.tgz
     version: 1.0.1
@@ -218,10 +249,10 @@ entries:
     - email: scott.crooks@gmail.com
       name: sc250024
     name: cluster-autoscaler-chart
-    type: application
     sources:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.0/cluster-autoscaler-chart-1.0.0.tgz
     version: 1.0.0
-generated: "2020-11-24T08:33:57.629044Z"
+generated: "2020-12-03T09:55:45.888602Z"


### PR DESCRIPTION
* Brings in new functionality from #3692 

Addition/re-organisation of `type: application` labels on all previous charts due to update of local helm version being used to generate the `index.yaml`