### PR TITLE
Watch only pods in state Running and Unknown

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -172,7 +172,14 @@ func watchEvictionEvents(evictedEventChan <-chan watch.Event, observer oom.Obser
 
 // Creates clients watching pods: PodLister (listing only not terminated pods).
 func newPodClients(kubeClient kube_client.Interface, resourceEventHandler cache.ResourceEventHandler, namespace string) v1lister.PodLister {
-	selector := fields.ParseSelectorOrDie("status.phase!=" + string(apiv1.PodPending))
+	// We are interested in pods which are Running or Unknown (in case the pod is
+	// running but there are some transient errors we don't want to delete it from
+	// our model).
+	// We don't want to watch Pending, Succeeded, or Failed failed pods because we
+	// know they're not generating any usage.
+	// Filter
+	statusFilter := fmt.Sprintf("status.phase!=%s,status.phase!=%s,status.phase!=%s", apiv1.PodPending, apiv1.PodSucceeded, apiv1.PodFailed)
+	selector := fields.ParseSelectorOrDie(statusFilter)
 	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespace, selector)
 	indexer, controller := cache.NewIndexerInformer(
 		podListWatch,


### PR DESCRIPTION
Stop watching pods in `Succeeded` and `Failed` states. I ran `full-vpa` e2e tests on this and they passed (including the OOM test).

I grabbed VPA logs about OOMs and one was discarded.  But it was because the OOM was too old, not because we removed the container (which was my worry about the change):

```
$ kubectl logs -n kube-system vpa-recommender-f7c794c46-swx8l|grep -i oom
I1204 14:57:45.110882       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 14:57:35 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-7787 PodName:hamster-69d67ccbd4-lghrd} ContainerName:hamster}}
I1204 14:57:45.110956       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 14:57:37 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-7787 PodName:hamster-69d67ccbd4-j6gsz} ContainerName:hamster}}
I1204 14:57:45.110981       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 14:57:37 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-7787 PodName:hamster-69d67ccbd4-967k8} ContainerName:hamster}}
I1204 14:59:45.111255       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 14:58:50 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-7787 PodName:hamster-69d67ccbd4-lghrd} ContainerName:hamster}}
I1204 14:59:45.111350       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 14:59:35 +0000 UTC Memory:1555165137 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-7787 PodName:hamster-69d67ccbd4-lm6km} ContainerName:hamster}}
I1204 15:01:45.113617       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:01:04 +0000 UTC Memory:262144000 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-h2z5s} ContainerName:hamster}}
W1204 15:01:45.113662       1 cluster_feeder.go:421] Failed to record OOM {Timestamp:2020-12-04 15:01:04 +0000 UTC Memory:262144000 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-h2z5s} ContainerName:hamster}}. Reason: error while recording OOM for {{vertical-pod-autoscaling-202 hamster-69d67ccbd4-h2z5s} hamster}, Reason: OOM event will be discarded - it is too old (2020-12-04 15:01:04 +0000 UTC)
I1204 15:01:45.113725       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:01:23 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-nn89m} ContainerName:hamster}}
I1204 15:01:45.113826       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:01:24 +0000 UTC Memory:1073741824 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-k2ggq} ContainerName:hamster}}
I1204 15:01:45.113936       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:01:23 +0000 UTC Memory:262144000 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-h2z5s} ContainerName:hamster}}
I1204 15:02:45.111330       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:01:53 +0000 UTC Memory:262144000 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-h2z5s} ContainerName:hamster}}
I1204 15:03:45.113214       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:02:35 +0000 UTC Memory:262144000 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-h2z5s} ContainerName:hamster}}
I1204 15:03:45.113262       1 cluster_feeder.go:419] OOM detected {Timestamp:2020-12-04 15:03:34 +0000 UTC Memory:1555165137 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-202 PodName:hamster-69d67ccbd4-jzc6d} ContainerName:hamster}}
``` 