### PR TITLE
Initial Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,65 @@
+---
+name: Bug report
+about: Create a bug report for one of the autoscaler components
+title: ''
+labels: 'kind/bug'
+assignees: ''
+
+---
+
+<!--
+Please answer these questions before submitting your bug report. Thanks!
+-->
+
+**Which component are you using?**:
+
+<!--
+Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) is the bug in?
+-->
+
+**What version of the component are you using?**:
+
+<!--
+What version of the relevant component are you using? Either the image tag or helm chart version.
+-->
+
+Component version:
+
+**What k8s version are you using (`kubectl version`)?**:
+
+<details><summary><code>kubectl version</code> Output</summary><br><pre>
+$ kubectl version
+
+</pre></details>
+
+**What environment is this in?**:
+
+<!--
+If you're using a cloud provider or hardware configuration as your deployment environment let us know here.
+-->
+
+**What did you expect to happen?**:
+
+<!--
+What behaviour did you expect to see?
+-->
+
+**What happened instead?**:
+
+<!--
+What behaviour did see instead?
+-->
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+<!--
+If possible, provide a recipe for reproducing the error.
+A detailed sequence of steps describing what to do to observe the issue is good.
+A complete runnable bash shell script is best.
+-->
+
+**Anything else we need to know?**:
+
+<!--
+Is there anything else you think we should know? Configuration of the component (be careful what you post here if so)? Relevant logs?
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Suggest an idea for one of the autoscaling components hosted in this repository
+title: ''
+labels: 'kind/feature'
+assignees: ''
+
+---
+
+<!--
+Thanks for taking the time to raise a feature request! Please answer these questions as best you can before submitting.
+-->
+
+**Which component are you using?**:
+
+<!--
+Which component hosted in this repository is this a feature for?
+-->
+
+**Is your feature request designed to solve a problem? If so describe the problem this feature should solve.**:
+<!--
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
+
+**Describe the solution you'd like.**:
+
+<!--
+A clear and concise description of what you want to happen.
+-->
+
+**Describe any alternative solutions you've considered.**:
+
+<!--
+A description of any alternative solutions or features you've considered, especially in comparison to your preferred solution/feature.
+-->
+
+**Additional context.**:
+
+<!--
+Add any other context or screenshots about your feature request here.
+-->


### PR DESCRIPTION
As discussed on weekly meeting, the first cut of suggested issue templates. Based off the main k/k repo's [issue templates](https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE).

I think I've covered all of the details we generally want to gather for either bug reports or feature requests.