### PR TITLE
Add comment for exported type InstanceType in gen template

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types/gen.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types/gen.go
@@ -46,6 +46,7 @@ limitations under the License.
 
 package aws
 
+// InstanceType is spec of EC2 instance
 type InstanceType struct {
 	InstanceType string
 	VCPU         int64


### PR DESCRIPTION
The "gen" tool used to generate ec2_instance_types.go creates the file without a comment for the exported type InstanceType so golint complains in the CI, this patch adds the same comment that currently is in ec2_instance_types.go in the template too.  