### PR TITLE
Automated cherry pick of #3714: Add build support for ARM64

### DIFF
--- a/cluster-autoscaler/Dockerfile.amd64
+++ b/cluster-autoscaler/Dockerfile.amd64
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG BASEIMAGE=gcr.io/distroless/static:latest
+ARG BASEIMAGE=gcr.io/distroless/static:latest-amd64
 FROM $BASEIMAGE
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
-COPY cluster-autoscaler /
+COPY cluster-autoscaler-amd64 /cluster-autoscaler
 CMD ["/cluster-autoscaler"]

--- a/cluster-autoscaler/Dockerfile.arm64
+++ b/cluster-autoscaler/Dockerfile.arm64
@@ -1,0 +1,19 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASEIMAGE=gcr.io/distroless/static:latest-arm64
+FROM $BASEIMAGE
+LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
+
+COPY cluster-autoscaler-arm64 /cluster-autoscaler
+CMD ["/cluster-autoscaler"]

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -1,10 +1,12 @@
-all: build
+ALL_ARCH = amd64 arm64
+all: $(addprefix build-arch-,$(ALL_ARCH))
 
 TAG?=dev
 FLAGS=
 LDFLAGS?=-s
 ENVVAR=CGO_ENABLED=0 GO111MODULE=off
 GOOS?=linux
+GOARCH?=$(shell go env GOARCH)
 REGISTRY?=staging-k8s.gcr.io
 ifdef BUILD_TAGS
   TAGS_FLAG=--tags ${BUILD_TAGS}
@@ -21,56 +23,83 @@ else
   LDFLAGS_FLAG=
 endif
 
-build: clean deps
-	$(ENVVAR) GOOS=$(GOOS) go build ${LDFLAGS_FLAG} ${TAGS_FLAG} ./...
-	$(ENVVAR) GOOS=$(GOOS) go build -o cluster-autoscaler ${LDFLAGS_FLAG} ${TAGS_FLAG}
+build: build-arch-$(GOARCH)
 
-build-binary: clean deps
-	$(ENVVAR) GOOS=$(GOOS) go build -o cluster-autoscaler ${LDFLAGS_FLAG} ${TAGS_FLAG}
+build-arch-%: clean-arch-%
+	$(ENVVAR) GOOS=$(GOOS) GOARCH=$* go build ${LDFLAGS_FLAG} ${TAGS_FLAG} ./...
+	$(ENVVAR) GOOS=$(GOOS) GOARCH=$* go build -o cluster-autoscaler-$* ${LDFLAGS_FLAG} ${TAGS_FLAG}
 
-test-unit: clean deps build
+build-binary: build-binary-arch-$(GOARCH)
+
+build-binary-arch-%: clean-arch-%
+	$(ENVVAR) GOOS=$(GOOS) GOARCH=$* go build -o cluster-autoscaler-$* ${LDFLAGS_FLAG} ${TAGS_FLAG}
+
+test-unit: clean build
 	GO111MODULE=off go test --test.short -race ./... ${TAGS_FLAG}
 
-dev-release: build-binary execute-release
-	@echo "Release ${TAG}${FOR_PROVIDER} completed"
+dev-release: dev-release-arch-$(GOARCH)
 
-make-image:
+dev-release-arch-%: build-binary-arch-% make-image-arch-% push-image-arch-%
+	@echo "Release ${TAG}${FOR_PROVIDER}-$* completed"
+
+make-image: make-image-arch-$(GOARCH)
+
+make-image-arch-%:
 ifdef BASEIMAGE
 	docker build --pull --build-arg BASEIMAGE=${BASEIMAGE} \
-	    -t ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG} .
+		-t ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG}-$* \
+		-f Dockerfile.$* .
 else
-	docker build --pull -t ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG} .
+	docker build --pull \
+		-t ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG}-$* \
+		-f Dockerfile.$* .
 endif
+	@echo "Image ${TAG}${FOR_PROVIDER}-$* completed"
 
-push-image:
-	./push_image.sh ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG}
+push-image: push-image-arch-$(GOARCH)
 
-execute-release: make-image push-image
+push-image-arch-%:
+	./push_image.sh ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG}-$*
 
-clean:
-	rm -f cluster-autoscaler
+push-manifest:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG} \
+		$(addprefix $(REGISTRY)/cluster-autoscaler$(PROVIDER):$(TAG)-, $(ALL_ARCH))
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push --purge ${REGISTRY}/cluster-autoscaler${PROVIDER}:${TAG}
+
+execute-release: $(addprefix make-image-arch-,$(ALL_ARCH)) $(addprefix push-image-arch-,$(ALL_ARCH)) push-manifest
+	@echo "Release ${TAG}${FOR_PROVIDER} completed"
+
+clean: clean-arch-$(GOARCH)
+
+clean-arch-%:
+	rm -f cluster-autoscaler-$*
 
 generate:
 	go generate ./cloudprovider/aws
 
 format:
 	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -d {} + | tee /dev/stderr)" || \
-    test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -w {} + | tee /dev/stderr)"
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -w {} + | tee /dev/stderr)"
 
 docker-builder:
 	docker build -t autoscaling-builder ../builder
 
-build-in-docker: clean docker-builder
-	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && BUILD_TAGS=${BUILD_TAGS} LDFLAGS="${LDFLAGS}" make build-binary'
+build-in-docker: build-in-docker-arch-$(GOARCH)
 
-release: build-in-docker execute-release
+build-in-docker-arch-%: clean-arch-% docker-builder
+	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest \
+		bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && BUILD_TAGS=${BUILD_TAGS} LDFLAGS="${LDFLAGS}" make build-binary-arch-$*'
+
+release: $(addprefix build-in-docker-arch-,$(ALL_ARCH)) execute-release
 	@echo "Full in-docker release ${TAG}${FOR_PROVIDER} completed"
 
-container: build-in-docker make-image
-	@echo "Created in-docker image ${TAG}${FOR_PROVIDER}"
+container: container-arch-$(GOARCH)
+
+container-arch-%: build-in-docker-arch-% make-image-arch-%
+	@echo "Full in-docker image ${TAG}${FOR_PROVIDER}-$* completed"
 
 test-in-docker: clean docker-builder
-	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && GO111MODULE=off go test -race ./... ${TAGS_FLAG}'
+	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest \
+		bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && GO111MODULE=off go test -race ./... ${TAGS_FLAG}'
 
-.PHONY: all deps build test-unit clean format execute-release dev-release docker-builder build-in-docker release generate
-
+.PHONY: all build test-unit clean format execute-release dev-release docker-builder build-in-docker release generate push-image push-manifest


### PR DESCRIPTION
Cherry pick of #3714 on cluster-autoscaler-release-1.19.

#3714: Add build support for ARM64

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.