### PR TITLE
Remove unreachable code

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -78,18 +78,10 @@ func computeScaleUpResourcesLeftLimits(
 			}
 			switch {
 			case resource == cloudprovider.ResourceNameCores:
-				if errCoresMem != nil {
-					resultScaleUpLimits[resource] = scaleUpLimitUnknown
-				} else {
-					resultScaleUpLimits[resource] = computeBelowMax(totalCores, max)
-				}
+				resultScaleUpLimits[resource] = computeBelowMax(totalCores, max)
 
 			case resource == cloudprovider.ResourceNameMemory:
-				if errCoresMem != nil {
-					resultScaleUpLimits[resource] = scaleUpLimitUnknown
-				} else {
-					resultScaleUpLimits[resource] = computeBelowMax(totalMem, max)
-				}
+				resultScaleUpLimits[resource] = computeBelowMax(totalMem, max)
 
 			case cloudprovider.IsGpuResource(resource):
 				if totalGpusErr != nil {


### PR DESCRIPTION
Looks like there is [unreachable code](https://github.com/kubernetes/autoscaler/blob/0fb897b83992787fd75f262499c71b8ff3bfd14c/cluster-autoscaler/core/scale_up.go#L82) in `if errCoresMem != nil` condition under the `switch`.

Because this case was handled above:
```
if (resource == cloudprovider.ResourceNameCores || resource == cloudprovider.ResourceNameMemory) && errCoresMem != nil
```