### PR TITLE
Update values.yaml defaults to match real default values

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.3.1
+version: 9.3.2

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -351,7 +351,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | envFromConfigMap | string | `""` | ConfigMap name to use as envFrom. |
 | envFromSecret | string | `""` | Secret name to use as envFrom. |
 | expanderPriorities | object | `{}` | The expanderPriorities is used if `extraArgs.expander` is set to `priority` and expanderPriorities is also set with the priorities. If `extraArgs.expander` is set to `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities. See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md |
-| extraArgs | object | `{"logtostderr":true,"stderrthreshold":"info","v":4}` | Additional container arguments. |
+| extraArgs | object | `{"logtostderr":true,"stderrthreshold":"info","v":4}` | Additional container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. |
 | extraEnv | object | `{}` | Additional container environment variables. |
 | extraEnvConfigMaps | object | `{}` | Additional container environment variables from ConfigMaps. |
 | extraEnvSecrets | object | `{}` | Additional container environment variables from Secrets. |

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -126,19 +126,21 @@ dnsPolicy: ClusterFirst
 expanderPriorities: {}
 
 # extraArgs -- Additional container arguments.
+# Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler
+# parameters and their default values.
 extraArgs:
   logtostderr: true
   stderrthreshold: info
   v: 4
   # write-status-configmap: true
   # leader-elect: true
-  # skip-nodes-with-local-storage: false
-  # expander: least-waste
+  # skip-nodes-with-local-storage: true
+  # expander: random
   # scale-down-enabled: true
   # balance-similar-node-groups: true
-  # min-replica-count: 2
+  # min-replica-count: 0
   # scale-down-utilization-threshold: 0.5
-  # scale-down-non-empty-candidates-count: 5
+  # scale-down-non-empty-candidates-count: 30
   # max-node-provision-time: 15m0s
   # scan-interval: 10s
   # scale-down-delay-after-add: 10m


### PR DESCRIPTION
Conventionally, commented out values in the values.yaml file should match the default values for the commented out parameters. Some of the parameters here didn't match, so I've corrected them, as per the documented defaults in [the FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).

It's likely worth discussing whether this section should either be supplemented to include all of the defaults, or whether it should just link to the documentation of the flags in the FAQ. However for now, the defaults listed match their real default values.