### PR TITLE
add DaemonSet eviction option for empty nodes

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -145,4 +145,6 @@ type AutoscalingOptions struct {
 	// ClusterAPICloudConfigAuthoritative tells the Cluster API provider to treat the CloudConfig option as authoritative and
 	// not use KubeConfigPath as a fallback when it is not provided.
 	ClusterAPICloudConfigAuthoritative bool
+	// DaemonSetEvictionForEmptyNodes is whether CA will gracefully terminate DaemonSet pods from empty nodes.
+	DaemonSetEvictionForEmptyNodes bool
 }

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -1080,6 +1080,119 @@ var defaultScaleDownOptions = config.AutoscalingOptions{
 	MaxMemoryTotal:                   config.DefaultMaxClusterMemory * units.GiB,
 }
 
+func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
+	testScenarios := []struct {
+		name                  string
+		dsPods                []string
+		nodeInfoSuccess       bool
+		evictionTimeoutExceed bool
+		evictionSuccess       bool
+		err                   error
+	}{
+		{
+			name:                  "Successful attempt to evict DaemonSet pods",
+			dsPods:                []string{"d1", "d2"},
+			nodeInfoSuccess:       true,
+			evictionTimeoutExceed: false,
+			evictionSuccess:       true,
+			err:                   nil,
+		},
+		{
+			name:                  "Failed to get node info",
+			dsPods:                []string{"d1", "d2"},
+			nodeInfoSuccess:       false,
+			evictionTimeoutExceed: false,
+			evictionSuccess:       true,
+			err:                   fmt.Errorf("Failed to get node info"),
+		},
+		{
+			name:                  "Failed to create DaemonSet eviction",
+			dsPods:                []string{"d1", "d2"},
+			nodeInfoSuccess:       true,
+			evictionTimeoutExceed: false,
+			evictionSuccess:       false,
+			err:                   fmt.Errorf("failed to created eviction on the"),
+		},
+		// This test case takes 6 seconds to execute
+		// {
+		// 	name:                  "Eviction timeout exceed",
+		// 	dsPods:                []string{"d1", "d2", "d3"},
+		// 	nodeInfoSuccess:       true,
+		// 	evictionTimeoutExceed: true,
+		// 	evictionSuccess:       true,
+		// 	err:                   fmt.Errorf("Failed to create DaemonSet eviction"),
+		// },
+	}
+
+	for _, scenario := range testScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			options := config.AutoscalingOptions{
+				ScaleDownUtilizationThreshold:  0.5,
+				ScaleDownUnneededTime:          time.Minute,
+				MaxGracefulTerminationSec:      60,
+				DaemonSetEvictionForEmptyNodes: true,
+			}
+			deletedPods := make(chan string, len(scenario.dsPods)+2)
+			dsWaitingTime := 2 * time.Second
+
+			fakeClient := &fake.Clientset{}
+			n1 := BuildTestNode("n1", 1000, 1000)
+			SetNodeReadyState(n1, true, time.Time{})
+			dsPods := make([]*apiv1.Pod, len(scenario.dsPods))
+			for i, dsName := range scenario.dsPods {
+				ds := BuildTestPod(dsName, 100, 0)
+				ds.Spec.NodeName = "n1"
+				ds.OwnerReferences = GenerateOwnerReferences("", "DaemonSet", "", "")
+				dsPods[i] = ds
+			}
+
+			fakeClient.Fake.AddReactor("create", "pods", func(action core.Action) (bool, runtime.Object, error) {
+				createAction := action.(core.CreateAction)
+				if createAction == nil {
+					return false, nil, nil
+				}
+				eviction := createAction.GetObject().(*policyv1.Eviction)
+				if eviction == nil {
+					return false, nil, nil
+				}
+				if scenario.evictionTimeoutExceed {
+					time.Sleep(dsWaitingTime + 6*time.Second)
+					return true, nil, nil
+				}
+				if !scenario.evictionSuccess {
+					return true, nil, fmt.Errorf("failed to created eviction")
+				}
+				deletedPods <- eviction.Name
+				return true, nil, nil
+			})
+			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider.AddNodeGroup("ng1", 1, 10, 1)
+			provider.AddNode("ng1", n1)
+			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+			context, err := NewScaleTestAutoscalingContext(options, fakeClient, registry, provider, nil)
+			assert.NoError(t, err)
+
+			if scenario.nodeInfoSuccess {
+				simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, []*apiv1.Node{n1}, dsPods)
+			} else {
+				simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, []*apiv1.Node{}, []*apiv1.Pod{})
+			}
+
+			err = evictDaemonSetPods(context.ClusterSnapshot, n1, fakeClient, dsWaitingTime, kube_util.CreateEventRecorder(fakeClient), 3)
+			if err != nil {
+				assert.Contains(t, err.Error(), scenario.err.Error())
+				return
+			}
+			deleted := make([]string, len(scenario.dsPods))
+			for i := 0; i < len(scenario.dsPods); i++ {
+				deleted[i] = utils.GetStringFromChan(deletedPods)
+			}
+			assert.ElementsMatch(t, deleted, scenario.dsPods)
+		})
+	}
+}
+
 func TestScaleDownEmptyMultipleNodeGroups(t *testing.T) {
 	config := &scaleTestConfig{
 		nodes: []nodeConfig{

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -174,6 +174,7 @@ var (
 	awsUseStaticInstanceList           = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
 	enableProfiling                    = flag.Bool("profiling", false, "Is debug/pprof endpoint enabled")
 	clusterAPICloudConfigAuthoritative = flag.Bool("clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
+	daemonSetEvictionForEmptyNodes     = flag.Bool("daemonset-eviction-for-empty-nodes", false, "DaemonSet pods will be gracefully terminated from empty nodes")
 )
 
 func createAutoscalingOptions() config.AutoscalingOptions {
@@ -243,6 +244,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		NodeDeletionDelayTimeout:           *nodeDeletionDelayTimeout,
 		AWSUseStaticInstanceList:           *awsUseStaticInstanceList,
 		ClusterAPICloudConfigAuthoritative: *clusterAPICloudConfigAuthoritative,
+		DaemonSetEvictionForEmptyNodes:     *daemonSetEvictionForEmptyNodes,
 	}
 }
 


### PR DESCRIPTION
We consider a node to be empty if it doesn’t run any regular pod, i.e. node runs only Mirror and DaemonSet pods.

Cluster Autoscaler checks for empty nodes in the cluster and deletes them if they exist. The process deletes a chunk of empty nodes concurrently without DaemonSet pods eviction (meaning those pods have no chance to cleanly exit)

This PR is aimed to add DaemonSet eviction functionality for empty nodes.

More info in the discussion: https://github.com/kubernetes/autoscaler/issues/1578 