### PR TITLE
chart: fix reference to additionalLabels in deployment template

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.3.0
+version: 9.3.1

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       labels:
 {{ include "cluster-autoscaler.instance-name" . | indent 8 }}
       {{- if .Values.additionalLabels }}
-{{ toYaml .values.additionalLabels | indent 8 }}
+{{ toYaml .Values.additionalLabels | indent 8 }}
       {{- end }}
       {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}


### PR DESCRIPTION
Because of incorrect casing (.values instead of .Values), the Deployment template fails when the additionalLabels block is defined.
