### PR TITLE
Change VPA storage version from v1beta2 to v1

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -109,7 +109,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
   - name: v1beta2
     schema:
       openAPIV3Schema:
@@ -202,7 +202,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
 status:
   acceptedNames:
     kind: ""
@@ -476,7 +476,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
   - name: v1beta2
     schema:
       openAPIV3Schema:
@@ -707,7 +707,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -38,6 +38,7 @@ type VerticalPodAutoscalerList struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vpa
 
 // VerticalPodAutoscaler is the configuration for a vertical pod
@@ -288,6 +289,7 @@ type VerticalPodAutoscalerCondition struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vpacheckpoint
 
 // VerticalPodAutoscalerCheckpoint is the checkpoint of the internal state of VPA that

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -39,7 +39,6 @@ type VerticalPodAutoscalerList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=vpa
-// +kubebuilder:storageversion
 
 // VerticalPodAutoscaler is the configuration for a vertical pod
 // autoscaler, which automatically manages pod resources based on historical and
@@ -267,7 +266,6 @@ type VerticalPodAutoscalerCondition struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vpacheckpoint
 
 // VerticalPodAutoscalerCheckpoint is the checkpoint of the internal state of VPA that


### PR DESCRIPTION
With the recent switch to generated CRD definition, we also stopped saving unknown fields. Since v1beta2 does not contain some fields that v1 does, the fields get dropped silently on object creation. 
Switching to v1  as storage version solves that problem.

fixes #3800 