### PR TITLE
Backport of #3805: Fix cluster-autoscaler clusterapi sample manifest

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -158,6 +158,7 @@ rules:
     - cluster.x-k8s.io
     resources:
     - machinedeployments
+    - machinedeployments/scale
     - machines
     - machinesets
     verbs:


### PR DESCRIPTION
This PR fixes sample manifest of cluster-autoscaler clusterapi provider.

(cherry picked from commit a5fee21a6889c39ab3bab384f74e72b18b891659)