### PR TITLE
Switch from v1beta1 to v1 for rbac

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         key: node-role.kubernetes.io/master
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-workload
 roleRef:
@@ -43,7 +43,7 @@ subjects:
   namespace: ${AUTOSCALER_NS}
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-management
 roleRef:
@@ -62,7 +62,7 @@ metadata:
   namespace: ${AUTOSCALER_NS}
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-workload
 rules:
@@ -150,7 +150,7 @@ rules:
     - update
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-management
 rules:


### PR DESCRIPTION
when apply those rbac file, it mentioned 

```
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding

```