### PR TITLE
Vertical Pod Autoscaler release 0.9.2

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "0.9.1"
+const VerticalPodAutoscalerVersion = "0.9.2"


### PR DESCRIPTION
`full-vpa` tests passed, I'm running other test suits now 