### PR TITLE
add DaemonSet eviction option for empty nodes

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -149,4 +149,6 @@ type AutoscalingOptions struct {
 	ClusterAPICloudConfigAuthoritative bool
 	// Enable or disable cordon nodes functionality before terminating the node during downscale process
 	CordonNodeBeforeTerminate bool
+	// DaemonSetEvictionForEmptyNodes is whether CA will gracefully terminate DaemonSet pods from empty nodes.
+	DaemonSetEvictionForEmptyNodes bool
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -176,6 +176,7 @@ var (
 	enableProfiling                    = flag.Bool("profiling", false, "Is debug/pprof endpoint enabled")
 	clusterAPICloudConfigAuthoritative = flag.Bool("clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
 	cordonNodeBeforeTerminate          = flag.Bool("cordon-node-before-terminating", false, "Should CA cordon nodes before terminating during downscale process")
+	daemonSetEvictionForEmptyNodes     = flag.Bool("daemonset-eviction-for-empty-nodes", false, "DaemonSet pods will be gracefully terminated from empty nodes")
 )
 
 func createAutoscalingOptions() config.AutoscalingOptions {
@@ -247,6 +248,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ConcurrentGceRefreshes:             *concurrentGceRefreshes,
 		ClusterAPICloudConfigAuthoritative: *clusterAPICloudConfigAuthoritative,
 		CordonNodeBeforeTerminate:          *cordonNodeBeforeTerminate,
+		DaemonSetEvictionForEmptyNodes:     *daemonSetEvictionForEmptyNodes,
 	}
 }
 


### PR DESCRIPTION
We consider a node to be empty if it doesn’t run any regular pod, i.e. node runs only Mirror and DaemonSet pods.

Cluster Autoscaler checks for empty nodes in the cluster and deletes them if they exist. The process deletes a chunk of empty nodes concurrently without DaemonSet pods eviction (meaning those pods have no chance to cleanly exit)

This PR is aimed to add DaemonSet eviction functionality for empty nodes.

More info in the discussion: #1578