### PR TITLE
Addon Resizer - Handling decoding error

### DIFF
--- a/addon-resizer/nanny/kubernetes_client.go
+++ b/addon-resizer/nanny/kubernetes_client.go
@@ -96,7 +96,7 @@ func (k *kubernetesClient) countNodesThroughMetrics() (uint64, error) {
 			if err == io.EOF {
 				break
 			}
-			continue
+			return 0, fmt.Errorf("decoding error: %v", err)
 		}
 
 		if !hasEqualValues(objectCountMetricName, mf.Name) {


### PR DESCRIPTION
Node calculation should fail when there is a problem with decoding metrics. Addon Resizer will retry querying metrics after a few second (main loop).