### PR TITLE
bump clusterapi sample suggested version from 1.18.1 to 1.20.0

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -129,6 +129,6 @@ these environment variables to set the namespace to deploy into as well as the i
 
 ```
 export AUTOSCALER_NS=kube-system
-export AUTOSCALER_IMAGE=us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1
+export AUTOSCALER_IMAGE=us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.20.0
 envsubst < examples/deployment.yaml | kubectl apply -f-
 ```


### PR DESCRIPTION
not only for currency, but also for not able to scale up issue

exactly same env using 18.1 see 
```
 Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-deployment-779b9ccfcb-ghhpv", UID:"4b3c8da3-0d61-41cb-8f72-b26565be42e4", APIVersion:"v1", ResourceVersion:"720250", FieldPath:""}): type: 'Normal' reason: 'NotTriggerScaleUp' pod didn't trigger scale-up (it wouldn't fit if a new node is added)
```

but 1.20.0 can successfully scale up node