### PR TITLE
gce: spread instance template refreshes deadlines

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -344,7 +344,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 			{"us-central1-f", "n1-standard-1"}: {&gce.MachineType{GuestCpus: 1, MemoryMb: 1}, nil},
 		},
 		migTargetSizeCache:     map[GceRef]int64{},
-		instanceTemplatesCache: map[GceRef]*gce.InstanceTemplate{},
+		instanceTemplatesCache: map[GceRef]*instanceTemplateCacheEntry{},
 		migBaseNameCache:       map[GceRef]string{},
 		concurrentGceRefreshes: 1,
 	}


### PR DESCRIPTION
`FetchMigTemplate()` is costly, causing two cloud API calls (InstanceGroupManagersService.Get and InstanceTemplatesService.Get, at about ~400ms/call).

Due to that, expiring all instance templates at once results in significant latencies spikes, and exposes to throttling, in particular for clusters having many MIGs attached.

On this example medium sized cluster, RunOnce peaked at 1m40s every 30mn, now stable below 30s per iteration:
![avg main   getnodeinfosforgroups functions durations](https://user-images.githubusercontent.com/628273/106449158-f511a600-6483-11eb-824f-c59383279654.png)
![Main loop - p99 duration](https://user-images.githubusercontent.com/628273/106449179-fe027780-6483-11eb-82e6-3f9cb811e3a2.png)
