### PR TITLE
Azure: Cleanup test

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_config_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config_test.go
@@ -235,11 +235,3 @@ func TestOverrideDefaultRateLimitConfig(t *testing.T) {
 	newconfig = overrideDefaultRateLimitConfig(&defaultConfigWithRateLimits.RateLimitConfig, &falseCloudProviderRateLimit.RateLimitConfig)
 	assert.Equal(t, &falseCloudProviderRateLimit.RateLimitConfig, newconfig)
 }
-
-func TestGetSubscriptionIdFromInstanceMetadata(t *testing.T) {
-	// metadataURL in azure_manager.go is not available for our tests, expect fail.
-	result, err := getSubscriptionIdFromInstanceMetadata()
-	expected := ""
-	assert.NotNil(t, err.Error())
-	assert.Equal(t, expected, result, "Verify return result failed, expected: %v, actual: %v", expected, result)
-}


### PR DESCRIPTION
The test assumption "metadataURL in azure_manager.go is not available for our tests" is not correct, let's remove this test case.

closes #3861 