### PR TITLE
Support AWS new GPU type - T4

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -42,6 +42,7 @@ var (
 		"nvidia-tesla-k80":  {},
 		"nvidia-tesla-p100": {},
 		"nvidia-tesla-v100": {},
+		"nvidia-tesla-t4":   {},
 	}
 )
 


### PR DESCRIPTION
AWS introduced EC2 G4 instances that run up to
4 NVIDIA T4 GPUs.

See https://docs.aws.amazon.com/dlami/latest/devguide/gpu.html
for more info on the new instance type.

Signed-off-by: Raymond Etornam <retornam@users.noreply.github.com>