### PR TITLE
CA-Chart - Update index with final ca-chart chart release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -165,6 +165,30 @@ entries:
   cluster-autoscaler-chart:
   - apiVersion: v2
     appVersion: 1.18.1
+    created: "2021-02-12T19:44:40.231182Z"
+    deprecated: true
+    description: Scales Kubernetes worker nodes within autoscaling groups.
+    digest: 19c1a6bdb2a55a881f79e01ad5d7ba23d9b4d430eb93dfe831b4094c482fc520
+    home: https://github.com/kubernetes/autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: e.bailey@sportradar.com
+      name: yurrriq
+    - email: mgoodness@gmail.com
+      name: mgoodness
+    - email: guyjtempleton@googlemail.com
+      name: gjtempleton
+    - email: scott.crooks@gmail.com
+      name: sc250024
+    name: cluster-autoscaler-chart
+    sources:
+    - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
+    urls:
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-2.0.0/cluster-autoscaler-chart-2.0.0.tgz
+    version: 2.0.0
+  - apiVersion: v2
+    appVersion: 1.18.1
     created: "2020-11-09T22:16:07.439126Z"
     description: Scales Kubernetes worker nodes within autoscaling groups.
     digest: dbbd204e977b60a04d5fe94aeb07ad1d1bf9bf4f054d37fb21b2bc114a69dbaf
@@ -347,4 +371,4 @@ entries:
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.0/cluster-autoscaler-chart-1.0.0.tgz
     version: 1.0.0
-generated: "2021-01-24T22:29:00.777507Z"
+generated: "2021-02-12T19:44:40.228373Z"


### PR DESCRIPTION
* Pushes the release caused by #3719 to the index.yaml for indexing by artifact hub to complete marking of prior chart release name as deprecated