### PR TITLE
scale up: tests and support for pods with volumes

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/replace"
 )
 
 // GpuLimits define lower and upper bound on GPU instances of given type in cluster
@@ -145,6 +147,11 @@ type AutoscalingOptions struct {
 	MaxBulkSoftTaintTime time.Duration
 	// IgnoredTaints is a list of taints to ignore when considering a node template for scheduling.
 	IgnoredTaints []string
+	// LabelReplacements is a list of regular expressions and their replacement that get applied
+	// to labels of existing nodes when creating node templates. The string that the regular
+	// expression is matched against is "<key>=<value>". If the value part is empty or missing
+	// after the transformation, the tag gets removed.
+	LabelReplacements replace.Replacements
 	// BalancingExtraIgnoredLabels is a list of labels to additionally ignore when comparing if two node groups are similar.
 	// Labels in BasicIgnoredLabels and the cloud provider-specific ignored labels are always ignored.
 	BalancingExtraIgnoredLabels []string

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -198,7 +198,7 @@ func NewScaleTestAutoscalingContext(
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
 	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName)
-	predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(fakeClient, make(chan struct{}))
+	predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(fakeClient, nil)
 	if err != nil {
 		return context.AutoscalingContext{}, err
 	}

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -74,6 +74,30 @@ type podConfig struct {
 	gpu          int64
 	node         string
 	toleratesGpu bool
+	pvcs         []string
+}
+
+type pvcConfig struct {
+	name         string
+	size         string // must parse as a resource.Quantity
+	storageclass string
+}
+
+type scConfig struct {
+	name        string
+	provisioner string
+}
+
+type csiDriverConfig struct {
+	name            string
+	storageCapacity bool
+}
+
+type csiStorageCapacityConfig struct {
+	name         string
+	storageClass string
+	nodeLabels   map[string]string
+	capacity     string
 }
 
 type groupSizeChange struct {
@@ -85,6 +109,10 @@ type scaleTestConfig struct {
 	nodes                   []nodeConfig
 	pods                    []podConfig
 	extraPods               []podConfig
+	pvcs                    []pvcConfig
+	scs                     []scConfig
+	csi                     []csiDriverConfig
+	cap                     []csiStorageCapacityConfig
 	options                 config.AutoscalingOptions
 	nodeDeletionTracker     *NodeDeletionTracker
 	expansionOptionToChoose groupSizeChange // this will be selected by assertingStrategy.BestOption
@@ -170,7 +198,7 @@ func NewScaleTestAutoscalingContext(
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
 	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName)
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(fakeClient, make(chan struct{}))
 	if err != nil {
 		return context.AutoscalingContext{}, err
 	}

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -1180,8 +1180,8 @@ func TestScaleUpEnoughStorage(t *testing.T) {
 	// unbound PVC with late binding can be scheduled only if the
 	// node candidates are known to have capacity available.
 	// This can be configured for node candidates by giving them
-	// special labels (TODO: how?) and then manually creating
-	// CSIStorageCapacity objects for them.
+	// special labels (via regex replace and/or labels on the node pool)
+	// and then manually creating CSIStorageCapacity objects for them.
 	config := &scaleTestConfig{
 		nodes: []nodeConfig{
 			{"n1", 100, 100, 0, true, "ng1"},

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -762,6 +762,12 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
 	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.nodeTransformation.IgnoredTaints, allNodes, readyNodes)
+
+	// Filter out nodes that aren't ready because of a missing CSI driver.
+	if a.processors.CSIProcessor != nil {
+		allNodes, readyNodes = a.processors.CSIProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
+	}
+
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/replace"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
 	kube_client "k8s.io/client-go/kubernetes"
@@ -172,7 +173,13 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up.")
 
-	ignoreTaintsFlag                   = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	ignoreTaintsFlag  = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	labelReplacements = func() *replace.Replacements {
+		repl := &replace.Replacements{}
+		flag.Var(repl, "replace-labels", "Specifies one or more regular expression replacements of the form ;<regexp>;<replacement>; (any other character as separator also allowed) which get applied one after the other to labels of a node to form a template node. Labels are represented as a single string with <key>=<value>. If the key is empty after replacement, the label gets removed.")
+		return repl
+	}()
+
 	balancingIgnoreLabelsFlag          = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	awsUseStaticInstanceList           = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
 	concurrentGceRefreshes             = flag.Int("gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
@@ -252,6 +259,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		Regional:                           *regional,
 		NewPodScaleUpDelay:                 *newPodScaleUpDelay,
 		IgnoredTaints:                      *ignoreTaintsFlag,
+		LabelReplacements:                  *labelReplacements,
 		BalancingExtraIgnoredLabels:        *balancingIgnoreLabelsFlag,
 		KubeConfigPath:                     *kubeConfigFile,
 		NodeDeletionDelayTimeout:           *nodeDeletionDelayTimeout,

--- a/cluster-autoscaler/processors/csi/csi_processor.go
+++ b/cluster-autoscaler/processors/csi/csi_processor.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/client-go/informers"
+	storagev1beta1listers "k8s.io/client-go/listers/storage/v1beta1"
+	"k8s.io/klog/v2"
+)
+
+// CSIProcessor checks whether a node is ready for applications using volumes
+// provided by a CSI driver. This is relevant when the autoscaler has been
+// configured to check storage capacity.
+//
+// Without this processor, the following happens:
+// - autoscaler determines that it needs a new node to get volumes
+//   for a pending pod created
+// - the new node starts and is ready to run pods, but the CSI driver
+//   itself hasn't started running on it yet
+// - autoscaler checks for pending pods, finds that the pod still
+//   cannot run and asks for another node
+// - the CSI driver starts, creates volumes and the pod runs
+// => the extra node is redundant
+//
+// To determine whether a node will have a CSI driver, a heuristic is used: if
+// a template node derived from the node has a CSIStorageCapacity object, then
+// the node itself should also have one, otherwise it is not ready.
+type CSIProcessor interface {
+	// FilterOutNodesWithUnreadyResources removes nodes that should have a CSI
+	// driver, but don't have CSIStorageCapacity information yet.
+	FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node)
+
+	// CleanUp frees resources.
+	CleanUp()
+}
+
+type csiProcessor struct {
+	csiStorageCapacityLister storagev1beta1listers.CSIStorageCapacityLister
+}
+
+// FilterOutNodesWithUnreadyResources removes nodes that should have a CSI
+// driver, but don't have CSIStorageCapacity information yet.
+func (p csiProcessor) FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	newAllNodes := make([]*apiv1.Node, 0, len(allNodes))
+	newReadyNodes := make([]*apiv1.Node, 0, len(readyNodes))
+	nodesWithUnreadyCSI := make(map[string]*apiv1.Node)
+	for _, node := range readyNodes {
+		// TODO: short-circuit this check if the node has been in the
+		// ready state long enough? If all of the tests below hit the
+		// API server to query CSIDriver and CSIStorageCapacity objects
+		// and all nodes in a cluster get checked again during each
+		// scale up run, then this might create a lot of additional
+		// load.
+		klog.V(3).Infof("checking CSIStorageCapacity of node %s", node.Name)
+		if p.isReady(context, node) {
+			newReadyNodes = append(newReadyNodes, node)
+		} else {
+			nodesWithUnreadyCSI[node.Name] = kubernetes.GetUnreadyNodeCopy(node)
+		}
+	}
+	// Override any node with unready CSI with its "unready" copy
+	for _, node := range allNodes {
+		if newNode, found := nodesWithUnreadyCSI[node.Name]; found {
+			newAllNodes = append(newAllNodes, newNode)
+		} else {
+			newAllNodes = append(newAllNodes, node)
+		}
+	}
+	return newAllNodes, newReadyNodes
+}
+
+func (p csiProcessor) isReady(context *context.AutoscalingContext, node *v1.Node) bool {
+	cloudProvider := context.CloudProvider
+	nodeGroup, err := cloudProvider.NodeGroupForNode(node)
+	if err != nil || nodeGroup == nil {
+		// Not a node that is part of a node group? Assume that the normal
+		// ready state applies and continue.
+		klog.V(3).Infof("node %s has no node group, skip CSI check (error: %v)", node.Name, err)
+		return true
+	}
+	nodeInfo, err := nodeGroup.TemplateNodeInfo()
+	if err != nil {
+		// Again, ignore the node.
+		klog.V(3).Infof("node %s has no node info, skip CSI check: %v", node.Name, err)
+		return true
+	}
+	templateNode := nodeInfo.Node()
+	expected := p.numStorageCapacityObjects(templateNode)
+	if expected == 0 {
+		// Node cannot be unready because no CSI storage is expected.
+		klog.V(3).Infof("node %s is not expected to have CSI storage: %v", node.Name)
+		return true
+	}
+	actual := p.numStorageCapacityObjects(node)
+	if expected <= actual {
+		klog.V(3).Infof("node %s has enough CSIStorageCapacity objects (expected %d, have %d)",
+			node.Name, expected, actual)
+		return true
+	}
+
+	// CSI driver should have published capacity information and
+	// hasn't done it yet -> treat the node as not ready yet.
+	klog.V(3).Infof("node %s is expected to have %d CSIStorageCapacity objects, only has %d -> treat it as unready",
+		node.Name, expected, actual)
+	return false
+}
+
+func (p csiProcessor) numStorageCapacityObjects(node *v1.Node) int {
+	count := 0
+	capacities, err := p.csiStorageCapacityLister.List(labels.Everything())
+	if err != nil {
+		klog.Error(err, "list CSIStorageCapacity")
+		return 0
+	}
+	for _, capacity := range capacities {
+		// match labels
+		if capacity.NodeTopology == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(capacity.NodeTopology)
+		if err != nil {
+			// Invalid capacity object? Ignore it.
+			continue
+		}
+		if selector.Matches(labels.Set(node.Labels)) {
+			count++
+		}
+	}
+	return count
+}
+
+func (p csiProcessor) CleanUp() {}
+
+// NewDefaultCSIProcessor returns a default instance of CSIProcessor.
+func NewDefaultCSIProcessor(informerFactory informers.SharedInformerFactory) CSIProcessor {
+	return csiProcessor{
+		csiStorageCapacityLister: informerFactory.Storage().V1beta1().CSIStorageCapacities().Lister(),
+	}
+}

--- a/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
@@ -23,15 +23,15 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // TemplateNodeInfoProvider is provides the initial nodeInfos set.
 type TemplateNodeInfoProvider interface {
 	// Process returns a map of nodeInfos for node groups.
-	Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError)
+	Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, nodeTransformation *utils.NodeTransformation, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError)
 	// CleanUp cleans up processor's internal structures.
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -18,6 +18,7 @@ package processors
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/csi"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/client-go/informers"
 )
 
 // AutoscalingProcessors are a set of customizable processors used for encapsulating
@@ -60,10 +62,12 @@ type AutoscalingProcessors struct {
 	CustomResourcesProcessor customresources.CustomResourcesProcessor
 	// ActionableClusterProcessor is interface defining whether the cluster is in an actionable state
 	ActionableClusterProcessor actionablecluster.ActionableClusterProcessor
+	// CSIProcessor checks for nodes that are not ready because the CSI driver is still starting up.
+	CSIProcessor csi.CSIProcessor
 }
 
 // DefaultProcessors returns default set of processors.
-func DefaultProcessors() *AutoscalingProcessors {
+func DefaultProcessors(informerFactory informers.SharedInformerFactory) *AutoscalingProcessors {
 	return &AutoscalingProcessors{
 		PodListProcessor:           pods.NewDefaultPodListProcessor(),
 		NodeGroupListProcessor:     nodegroups.NewDefaultNodeGroupListProcessor(),
@@ -77,6 +81,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
+		CSIProcessor:               csi.NewDefaultCSIProcessor(informerFactory),
 		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(),
 		ActionableClusterProcessor: actionablecluster.NewDefaultActionableClusterProcessor(),
 	}
@@ -96,6 +101,7 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeInfoProcessor.CleanUp()
 	ap.NodeGroupConfigProcessor.CleanUp()
 	ap.CustomResourcesProcessor.CleanUp()
+	ap.CSIProcessor.CleanUp()
 	ap.TemplateNodeInfoProvider.CleanUp()
 	ap.ActionableClusterProcessor.CleanUp()
 }

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -73,6 +73,17 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-
 	// informerFactory....Lister()/informerFactory....Informer() methods
 	informerFactory.Start(stop)
 
+	// Also wait for all informers to be up-to-date. This is necessary for
+	// objects that were added when creating the fake client. Without
+	// this wait, those objects won't be visible via the informers when
+	// the test runs.
+	synced := informerFactory.WaitForCacheSync(stop)
+	for k, v := range synced {
+		if !v {
+			return nil, fmt.Errorf("failed to sync informer %v", k)
+		}
+	}
+
 	return checker, nil
 }
 

--- a/cluster-autoscaler/simulator/test_predicates_checker.go
+++ b/cluster-autoscaler/simulator/test_predicates_checker.go
@@ -23,5 +23,5 @@ import (
 // NewTestPredicateChecker builds test version of PredicateChecker.
 func NewTestPredicateChecker() (PredicateChecker, error) {
 	// just call out to NewSchedulerBasedPredicateChecker but use fake kubeClient
-	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), make(chan struct{}))
+	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), nil)
 }

--- a/cluster-autoscaler/utils/replace/replace.go
+++ b/cluster-autoscaler/utils/replace/replace.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replace
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Replacement contains a regular expresssion and a replacement string.
+type Replacement struct {
+	Re          regexp.Regexp
+	Replacement string
+}
+
+func (r Replacement) String() string {
+	// This is intentionally simplistic: we don't bother checking
+	// whether ";" occurs inside the regular expression or the
+	// replacement string.
+	return ";" + r.Re.String() + ";" + r.Replacement + ";"
+}
+
+// Replacements contains multiple regular expressions and their replacements.
+type Replacements []Replacement
+
+var _ flag.Value = &Replacements{}
+
+// ApplyToPair turns a key/value pair into a single <key>=<value> string,
+// applies all regular expressions, then splits again. Key and value
+// may become empty.
+func (r *Replacements) ApplyToPair(k, v string) (string, string) {
+	if r == nil {
+		return k, v
+	}
+	str := k + "=" + v
+	for _, repl := range *r {
+		str = repl.Re.ReplaceAllString(str, repl.Replacement)
+	}
+	parts := strings.SplitN(str, "=", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+func (r *Replacements) String() string {
+	var parts []string
+	for _, repl := range *r {
+		parts = append(parts, repl.String())
+	}
+	return strings.Join(parts, " ")
+}
+
+const format = "must be of the form <sep><regexp><sep><replacement><sep>"
+
+// Set adds one replacement of the form <sep><regexp><sep><replacement><sep>.
+func (r *Replacements) Set(str string) error {
+	if len(str) < 3 {
+		return errors.New(format + ": too short")
+	}
+	sep := str[0]
+	if str[len(str)-1] != sep {
+		return errors.New(format + ": separator at start and end does not match")
+	}
+	str = str[1 : len(str)-1]
+	parts := strings.Split(str, string(sep))
+	if len(parts) != 2 {
+		return errors.New(format + ": need exactly one separator between regular expression and replacement")
+	}
+	re, err := regexp.Compile(parts[0])
+	if err != nil {
+		return fmt.Errorf("%s: regular expression invalid: %v", format, err)
+	}
+	*r = append(*r, Replacement{Re: *re, Replacement: parts[1]})
+	return nil
+}


### PR DESCRIPTION
Whether a pod has unbound volumes influences scheduling decisions and
thus the scale up decisions in cluster autoscaler.

This PR:
- documents the problem in the FAQ
- adds support for autoscaling in combination with storage capacity tracking and a suitable cluster configuration
- adds tests

These three new test cases cover:
- a pod with an unbound pvc using late binding -> can scale up
- the same with storage capacity feature enabled -> cannot scale up
  without CSIStorageCapacity
- the same with manually configured CSIStorageCapacity -> can scale up

Using this in practice depends on having different CSI topology labels for template nodes and additional configuration for each CSI driver and its storage clases. This is something that cluster administrators must take care of.
