### PR TITLE
Add Fetch Error Output to Warning Log

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -76,7 +76,7 @@ func GenerateEC2InstanceTypes(region string) (map[string]*InstanceType, error) {
 			klog.V(1).Infof("fetching %s\n", url)
 			res, err := http.Get(url)
 			if err != nil {
-				klog.Warningf("Error fetching %s skipping...\n", url)
+				klog.Warningf("Error fetching %s skipping...\n%s\n", url, err)
 				continue
 			}
 


### PR DESCRIPTION
Add the output of the error to the log so users can identify why the autoscaler was unable to fetch the url.

See https://github.com/kubernetes/autoscaler/issues/3891