### PR TITLE
Helm Chart image update to 1.19.1

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.18.1
+appVersion: 1.19.1
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.4.0
+version: 9.5.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -362,7 +362,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"` | Image repository |
-| image.tag | string | `"v1.18.1"` | Image tag |
+| image.tag | string | `"v1.19.1"` | Image tag |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | magnumCABundlePath | string | `"/etc/kubernetes/ca-bundle.crt"` | Path to the host's CA bundle, from `ca-file` in the cloud-config file. |
 | magnumClusterName | string | `""` | Cluster name or ID in Magnum. Required if `cloudProvider=magnum` and not setting `autoDiscovery.clusterName`. |

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -194,7 +194,7 @@ image:
   # image.repository -- Image repository
   repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.18.1
+  tag: v1.19.1
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
This is in line with https://github.com/kubernetes/autoscaler/pull/3880, I think there should be also a release of 1.19 for anyone who wants to run on Kubernetes 1.19.