### PR TITLE
Do not set limits when recommendation is 0

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
@@ -70,6 +70,10 @@ func getProportionalResourceLimit(resourceName core.ResourceName, originalLimit,
 	if originalLimit == nil || originalLimit.Value() == 0 {
 		return nil, ""
 	}
+	// recommendedRequest not set, don't set limit.
+	if recommendedRequest == nil || recommendedRequest.Value() == 0 {
+		return nil, ""
+	}
 	// originalLimit set but originalRequest not set - K8s will treat the pod as if they were equal,
 	// recommend limit equal to request
 	if originalRequest == nil || originalRequest.Value() == 0 {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
@@ -68,6 +68,13 @@ func TestGetProportionalResourceLimit(t *testing.T) {
 			expectLimit:        mustParseToPointer("10"),
 		},
 		{
+			name:               "no recommendation",
+			originalRequest:    mustParseToPointer("1"),
+			recommendedRequest: mustParseToPointer("0"),
+			defaultLimit:       mustParseToPointer("2"),
+			expectLimit:        nil,
+		},
+		{
 			name:               "limit equal to request",
 			originalLimit:      mustParseToPointer("1"),
 			originalRequest:    mustParseToPointer("1"),


### PR DESCRIPTION
In this PR changed not to set a limit when a recommendation is empty. This solves #3902 issue of sending patches for the not-controlled resource by VPA when Pod has resource limits.