### PR TITLE
CA-Chart - 9.6.0 Release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,29 @@ entries:
   cluster-autoscaler:
   - apiVersion: v2
     appVersion: 1.20.0
+    created: "2021-02-26T08:43:23.355313Z"
+    description: Scales Kubernetes worker nodes within autoscaling groups.
+    digest: 515b2fcbc50e8cb0c1995974b65d8cd3cc23c3aac5e76df5d7de130f8dce8e5a
+    home: https://github.com/kubernetes/autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: e.bailey@sportradar.com
+      name: yurrriq
+    - email: mgoodness@gmail.com
+      name: mgoodness
+    - email: guyjtempleton@googlemail.com
+      name: gjtempleton
+    - email: scott.crooks@gmail.com
+      name: sc250024
+    name: cluster-autoscaler
+    sources:
+    - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+    type: application
+    urls:
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.6.0/cluster-autoscaler-9.6.0.tgz
+    version: 9.6.0
+  - apiVersion: v2
+    appVersion: 1.20.0
     created: "2021-02-23T08:33:55.864603Z"
     description: Scales Kubernetes worker nodes within autoscaling groups.
     digest: c9e8c3ae45799142070760aa8e0afa17f4c0849c664d685be029d792e0c7e03f
@@ -394,4 +417,4 @@ entries:
     urls:
     - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-1.0.0/cluster-autoscaler-chart-1.0.0.tgz
     version: 1.0.0
-generated: "2021-02-23T08:33:55.863175Z"
+generated: "2021-02-26T08:43:23.353111Z"


### PR DESCRIPTION
* Publish 9.6.0 of the Cluster Autoscaler chart, includes changes from #3900 