### PR TITLE
Fix GCE where no cloud-config-path is required

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.8.0
+version: 9.9.0

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - --cluster-name={{ .Values.magnumClusterName }}
             {{- end }}
           {{- end }}
-          {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") }}
+          {{- if eq .Values.cloudProvider "magnum" }}
             - --cloud-config={{ .Values.cloudConfigPath }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
@@ -182,9 +182,9 @@ spec:
           securityContext:
             {{ toYaml .Values.containerSecurityContext | nindent 12 | trim }}
           {{- end }}
-          {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumeMounts }}
+          {{- if or (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumeMounts }}
           volumeMounts:
-          {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") }}
+          {{- if eq .Values.cloudProvider "magnum" }}
             - name: cloudconfig
               mountPath: {{ .Values.cloudConfigPath }}
               readOnly: true
@@ -218,9 +218,9 @@ spec:
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 | trim }}
       {{- end }}
-      {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumes }}
+      {{- if or (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumes }}
       volumes:
-      {{- if or (eq .Values.cloudProvider "gce") (eq .Values.cloudProvider "magnum") }}
+      {{- if eq .Values.cloudProvider "magnum" }}
         - name: cloudconfig
           hostPath:
             path: {{ .Values.cloudConfigPath }}


### PR DESCRIPTION
GCE doesn't require loading /etc/gce.conf from a hostpath. In-fact this file isn't available at all on GCE nodes nor on GKE nodes. This was a left-over from the way GKE bundled autoscaler seems to work. There have been multiple reports of GCE deployment being broken due to this. For example see: helm/charts#10292 and helm/charts#15509

Another example of people not being able to deploy GCE because the README points to no longer existing docs: https://github.com/kubernetes/autoscaler/issues/3798

After the PR is merged this blog post will work: https://samos-it.com/posts/gke-custom-oss-cluster-autoscaler.html however if you try to run the blogpost steps today it would fail because it tries to mount /etc/gce.conf with no way of disabling that behaviour.
