### PR TITLE
add arch specific cluster-autoscaler targets to gitignore

### DIFF
--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -1,4 +1,6 @@
 cluster-autoscaler
+cluster-autoscaler-amd64
+cluster-autoscaler-arm64
 cluster_autoscaler
 .cover
 


### PR DESCRIPTION
adding entries for the amd64 and arm64 targets.