### PR TITLE
CA-Chart Readme Updates & Fix Chart Lint and Test Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,19 +25,24 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch history
         run: git fetch --prune --unshallow
-      - id: lint
-        name: Run chart-testing (lint)
+      - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: lint
+      - name: Run chart-testing (lint)
+        run: ct lint
       # Only build a kind cluster if there are chart changes to test.
-      - if: steps.lint.outputs.changed == 'true'
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+      - if: steps.list-changed.outputs.changed == 'true'
         name: Create kind cluster
         uses: helm/kind-action@v1.1.0
-      - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: install
+      - if: steps.list-changed.outputs.changed == 'true'
+        name: Run chart-testing (install)
+        run: ct install
   helm-docs-validate:
     if: ${{ needs.changes.outputs.charts == 'true' }}
     name: Helm Docs

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,6 +17,8 @@ The binary for `pre-commit` can be installed via Homebrew:
 $ brew install pre-commit
 ```
 
+For those without Homebrew, Pre-commit has [other installation methods available](https://pre-commit.com/#install).
+
 ### Install git hooks
 
 After the `pre-commit` binary is installed, go to this repository's directory, and run the following command to install the git hook:

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.20.0
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler
-icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 maintainers:
   - email: e.bailey@sportradar.com
     name: yurrriq
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.7.0
+version: 9.8.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -35,16 +35,21 @@ This chart bootstraps a cluster-autoscaler deployment on a [Kubernetes](http://k
 The previous `cluster-autoscaler` Helm chart hosted at [helm/charts](https://github.com/helm/charts) has been moved to this repository in accordance with the [Deprecation timeline](https://github.com/helm/charts#deprecation-timeline). Note that a few things have changed between this version and the old version:
 
 - This repository **only** supports Helm chart installations using Helm 3+ since the `apiVersion` on the charts has been marked as `v2`.
-- Previous versions of the Helm chart have not been migrated, and the version was reset to `1.0.0` initially. If you are looking for old versions of the chart, it's best to run `helm pull stable/cluster-autoscaler --version <your-version>` until you are ready to move to this repository's version.
-- The previous versioning scheme has been returned to as of version `9.0.0` for ease of migration from the previous chart location.
+- Previous versions of the Helm chart have not been migrated
 
 ## Migration from 1.X to 9.X+ versions of this Chart
 
-On initial adoption of this chart this chart was renamed from `cluster-autoscaler` to `cluster-autoscaler-chart` due to technical limitations. This affects all `1.X` releases of the chart.
+**TL;DR:**
+You should choose to use versions >=9.0.0 of the `cluster-autoscaler` chart published from this repository; previous versions, and the `cluster-autoscaler-chart` with versioning 1.X.X published from this repository are deprecated.
 
-Releases of the chart from `9.0.0` onwards return the naming of the chart to `cluster-autoscaler` and return to following the versioning established by the chart's previous location.
+<details>
+  <summary>Previous versions of this chart - further details</summary>
+On initial migration of this chart from the `helm/charts` repository this chart was renamed from `cluster-autoscaler` to `cluster-autoscaler-chart` due to technical limitations. This affected all `1.X` releases of the chart, version 2.0.0 of this chart exists only to mark the [`cluster-autoscaler-chart` chart](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler-chart) as deprecated.
+
+Releases of the chart from `9.0.0` onwards return the naming of the chart to `cluster-autoscaler` and return to following the versioning established by the chart's previous location at .
 
 To migrate from a 1.X release of the chart to a `9.0.0` or later release, you should first uninstall your `1.X` install of the `cluster-autoscaler-chart` chart, before performing the installation of the new `cluster-autoscaler` chart.
+</details>
 
 ## Migration from 9.0 to 9.1
 
@@ -361,7 +366,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | fullnameOverride | string | `""` | String to fully override `cluster-autoscaler.fullname` template. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
-| image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"` | Image repository |
+| image.repository | string | `"k8s.gcr.io/autoscaling/cluster-autoscaler"` | Image repository |
 | image.tag | string | `"v1.20.0"` | Image tag |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | magnumCABundlePath | string | `"/etc/kubernetes/ca-bundle.crt"` | Path to the host's CA bundle, from `ca-file` in the cloud-config file. |

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -35,16 +35,21 @@ This chart bootstraps a cluster-autoscaler deployment on a [Kubernetes](http://k
 The previous `cluster-autoscaler` Helm chart hosted at [helm/charts](https://github.com/helm/charts) has been moved to this repository in accordance with the [Deprecation timeline](https://github.com/helm/charts#deprecation-timeline). Note that a few things have changed between this version and the old version:
 
 - This repository **only** supports Helm chart installations using Helm 3+ since the `apiVersion` on the charts has been marked as `v2`.
-- Previous versions of the Helm chart have not been migrated, and the version was reset to `1.0.0` initially. If you are looking for old versions of the chart, it's best to run `helm pull stable/cluster-autoscaler --version <your-version>` until you are ready to move to this repository's version.
-- The previous versioning scheme has been returned to as of version `9.0.0` for ease of migration from the previous chart location.
+- Previous versions of the Helm chart have not been migrated
 
 ## Migration from 1.X to 9.X+ versions of this Chart
 
-On initial adoption of this chart this chart was renamed from `cluster-autoscaler` to `cluster-autoscaler-chart` due to technical limitations. This affects all `1.X` releases of the chart.
+**TL;DR:**
+You should choose to use versions >=9.0.0 of the `cluster-autoscaler` chart published from this repository; previous versions, and the `cluster-autoscaler-chart` with versioning 1.X.X published from this repository are deprecated.
 
-Releases of the chart from `9.0.0` onwards return the naming of the chart to `cluster-autoscaler` and return to following the versioning established by the chart's previous location.
+<details>
+  <summary>Previous versions of this chart - further details</summary>
+On initial migration of this chart from the `helm/charts` repository this chart was renamed from `cluster-autoscaler` to `cluster-autoscaler-chart` due to technical limitations. This affected all `1.X` releases of the chart, version 2.0.0 of this chart exists only to mark the [`cluster-autoscaler-chart` chart](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler-chart) as deprecated.
+
+Releases of the chart from `9.0.0` onwards return the naming of the chart to `cluster-autoscaler` and return to following the versioning established by the chart's previous location at .
 
 To migrate from a 1.X release of the chart to a `9.0.0` or later release, you should first uninstall your `1.X` install of the `cluster-autoscaler-chart` chart, before performing the installation of the new `cluster-autoscaler` chart.
+</details>
 
 ## Migration from 9.0 to 9.1
 

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -192,7 +192,7 @@ fullnameOverride: ""
 
 image:
   # image.repository -- Image repository
-  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
   tag: v1.20.0
   # image.pullPolicy -- Image pull policy


### PR DESCRIPTION
* Fixes #3899 by clarifying Helm chart versioning confusion, hides details under an expandable section and makes strong recommendation to use supported version
* Updates the image for the repo to point at the raw kubernetes logo, for [Artifact hub](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler) purposes, the current URL 404s
* Updates the default Cluster-autoscaler image repository to the full vanity URL rather than the US endpoint, this should provide some speed benefits for non US based users
* Fixes the helm testing and linting actions run on PRs, as per [discussion on a previous PR](https://github.com/kubernetes/autoscaler/pull/3880#issuecomment-778280580) this should have been caught by the action but due to the [major version bump](https://github.com/kubernetes/autoscaler/pull/3793) in the GH actions not also changing the invoking of the actions as per the [Action's docs](https://github.com/helm/chart-testing-action#upgrading-from-v1xx), they hadn't been successfully running, instead failing silently upon installing the actions. Tested as failing PRs which do not [bump the chart version on my fork](https://github.com/gjtempleton/autoscaler/pull/3/checks?check_run_id=2060909941).