### PR TITLE
Update VPA README with current default version

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -46,7 +46,7 @@ procedure described below.
 
 # Installation
 
-The current default version is Vertical Pod Autoscaler 0.8.0
+The current default version is Vertical Pod Autoscaler 0.9.2
 
 ### Compatibility
 


### PR DESCRIPTION
In c2d24bd716da4428e29b34a3d3bb2623902181cd the default
version of VPA was updated to 0.9.2
This patch reflects the change in the README, as well.