### PR TITLE
Fix typo in values.yaml example for extraVolumeMounts

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.9.1
+version: 9.9.2

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -186,7 +186,7 @@ extraVolumes: []
 extraVolumeMounts: []
   # - name: ssl-certs
   #   mountPath: /etc/ssl/certs/ca-certificates.crt
-  #   readonly: true
+  #   readOnly: true
 
 # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
 fullnameOverride: ""


### PR DESCRIPTION
Incredibly minor, but there's a typo in the Charts default values; the field for volume mounts when mounted read only is `readOnly`, not `readonly`, so if you directly uncomment it, `helm install` will fail. This fixes that.