### PR TITLE
Separate and refactor custom resources logic

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -273,17 +273,17 @@ const (
 	ResourceNameMemory = "memory"
 )
 
-// IsGpuResource checks if given resource name point denotes a gpu type
-func IsGpuResource(resourceName string) bool {
+// IsCustomResource checks if given resource name point denotes a gpu type
+func IsCustomResource(resourceName string) bool {
 	// hack: we assume anything which is not cpu/memory to be a gpu.
 	// we are not getting anything more that a map string->limits from the user
 	return resourceName != ResourceNameCores && resourceName != ResourceNameMemory
 }
 
-// ContainsGpuResources returns true iff given list contains any resource name denoting a gpu type
-func ContainsGpuResources(resources []string) bool {
+// ContainsCustomResources returns true iff given list contains any custom resource name
+func ContainsCustomResources(resources []string) bool {
 	for _, resource := range resources {
-		if IsGpuResource(resource) {
+		if IsCustomResource(resource) {
 			return true
 		}
 	}

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
 	processor_callbacks "k8s.io/autoscaler/cluster-autoscaler/processors/callbacks"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
@@ -142,6 +143,7 @@ func NewTestProcessors() *processors.AutoscalingProcessors {
 		NodeGroupManager:           nodegroups.NewDefaultNodeGroupManager(),
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
+		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
 	}
 }
 

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -53,17 +53,18 @@ type scaleUpResourcesDelta map[string]int64
 const scaleUpLimitUnknown = math.MaxInt64
 
 func computeScaleUpResourcesLeftLimits(
-	cp cloudprovider.CloudProvider,
+	context *context.AutoscalingContext,
+	processors *ca_processors.AutoscalingProcessors,
 	nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*schedulerframework.NodeInfo,
 	nodesFromNotAutoscaledGroups []*apiv1.Node,
 	resourceLimiter *cloudprovider.ResourceLimiter) (scaleUpResourcesLimits, errors.AutoscalerError) {
 	totalCores, totalMem, errCoresMem := calculateScaleUpCoresMemoryTotal(nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups)
 
-	var totalGpus map[string]int64
-	var totalGpusErr error
-	if cloudprovider.ContainsGpuResources(resourceLimiter.GetResources()) {
-		totalGpus, totalGpusErr = calculateScaleUpGpusTotal(cp.GPULabel(), nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups)
+	var totalResources map[string]int64
+	var totalResourcesErr error
+	if cloudprovider.ContainsCustomResources(resourceLimiter.GetResources()) {
+		totalResources, totalResourcesErr = calculateScaleUpCustomResourcesTotal(context, processors, nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups)
 	}
 
 	resultScaleUpLimits := make(scaleUpResourcesLimits)
@@ -91,11 +92,11 @@ func computeScaleUpResourcesLeftLimits(
 					resultScaleUpLimits[resource] = computeBelowMax(totalMem, max)
 				}
 
-			case cloudprovider.IsGpuResource(resource):
-				if totalGpusErr != nil {
+			case cloudprovider.IsCustomResource(resource):
+				if totalResourcesErr != nil {
 					resultScaleUpLimits[resource] = scaleUpLimitUnknown
 				} else {
-					resultScaleUpLimits[resource] = computeBelowMax(totalGpus[resource], max)
+					resultScaleUpLimits[resource] = computeBelowMax(totalResources[resource], max)
 				}
 
 			default:
@@ -139,8 +140,9 @@ func calculateScaleUpCoresMemoryTotal(
 	return coresTotal, memoryTotal, nil
 }
 
-func calculateScaleUpGpusTotal(
-	GPULabel string,
+func calculateScaleUpCustomResourcesTotal(
+	context *context.AutoscalingContext,
+	processors *ca_processors.AutoscalingProcessors,
 	nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*schedulerframework.NodeInfo,
 	nodesFromNotAutoscaledGroups []*apiv1.Node) (map[string]int64, errors.AutoscalerError) {
@@ -156,23 +158,30 @@ func calculateScaleUpGpusTotal(
 			return nil, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for: %s", nodeGroup.Id())
 		}
 		if currentSize > 0 {
-			gpuType, gpuCount, err := gpu.GetNodeTargetGpus(GPULabel, nodeInfo.Node(), nodeGroup)
+			resourceTargets, err := processors.CustomResourcesProcessor.GetNodeResourceTargets(context, nodeInfo.Node(), nodeGroup)
 			if err != nil {
 				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node group %v:", nodeGroup.Id())
 			}
-			if gpuType == "" {
-				continue
+			for _, resourceTarget := range resourceTargets {
+				if resourceTarget.ResourceType == "" || resourceTarget.ResourceCount == 0 {
+					continue
+				}
+				result[resourceTarget.ResourceType] += resourceTarget.ResourceCount * int64(currentSize)
 			}
-			result[gpuType] += gpuCount * int64(currentSize)
 		}
 	}
 
 	for _, node := range nodesFromNotAutoscaledGroups {
-		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(GPULabel, node, nil)
+		resourceTargets, err := processors.CustomResourcesProcessor.GetNodeResourceTargets(context, node, nil)
 		if err != nil {
 			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node gpus count for node %v:", node.Name)
 		}
-		result[gpuType] += gpuCount
+		for _, resourceTarget := range resourceTargets {
+			if resourceTarget.ResourceType == "" || resourceTarget.ResourceCount == 0 {
+				continue
+			}
+			result[resourceTarget.ResourceType] += resourceTarget.ResourceCount
+		}
 	}
 
 	return result, nil
@@ -185,19 +194,22 @@ func computeBelowMax(total int64, max int64) int64 {
 	return 0
 }
 
-func computeScaleUpResourcesDelta(cp cloudprovider.CloudProvider, nodeInfo *schedulerframework.NodeInfo, nodeGroup cloudprovider.NodeGroup, resourceLimiter *cloudprovider.ResourceLimiter) (scaleUpResourcesDelta, errors.AutoscalerError) {
+func computeScaleUpResourcesDelta(context *context.AutoscalingContext, processors *ca_processors.AutoscalingProcessors,
+	nodeInfo *schedulerframework.NodeInfo, nodeGroup cloudprovider.NodeGroup, resourceLimiter *cloudprovider.ResourceLimiter) (scaleUpResourcesDelta, errors.AutoscalerError) {
 	resultScaleUpDelta := make(scaleUpResourcesDelta)
 
 	nodeCPU, nodeMemory := getNodeInfoCoresAndMemory(nodeInfo)
 	resultScaleUpDelta[cloudprovider.ResourceNameCores] = nodeCPU
 	resultScaleUpDelta[cloudprovider.ResourceNameMemory] = nodeMemory
 
-	if cloudprovider.ContainsGpuResources(resourceLimiter.GetResources()) {
-		gpuType, gpuCount, err := gpu.GetNodeTargetGpus(cp.GPULabel(), nodeInfo.Node(), nodeGroup)
+	if cloudprovider.ContainsCustomResources(resourceLimiter.GetResources()) {
+		resourceTargets, err := processors.CustomResourcesProcessor.GetNodeResourceTargets(context, nodeInfo.Node(), nodeGroup)
 		if err != nil {
-			return scaleUpResourcesDelta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target gpu for node group %v:", nodeGroup.Id())
+			return scaleUpResourcesDelta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("Failed to get target custom resources for node group %v:", nodeGroup.Id())
 		}
-		resultScaleUpDelta[gpuType] = gpuCount
+		for _, resourceTarget := range resourceTargets {
+			resultScaleUpDelta[resourceTarget.ResourceType] = resourceTarget.ResourceCount
+		}
 	}
 
 	return resultScaleUpDelta, nil
@@ -343,7 +355,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			errCP)
 	}
 
-	scaleUpResourcesLeft, errLimits := computeScaleUpResourcesLeftLimits(context.CloudProvider, nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups, resourceLimiter)
+	scaleUpResourcesLeft, errLimits := computeScaleUpResourcesLeftLimits(context, processors, nodeGroups, nodeInfos, nodesFromNotAutoscaledGroups, resourceLimiter)
 	if errLimits != nil {
 		return &status.ScaleUpStatus{Result: status.ScaleUpError}, errLimits.AddPrefix("Could not compute total resources: ")
 	}
@@ -409,7 +421,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			continue
 		}
 
-		scaleUpResourcesDelta, err := computeScaleUpResourcesDelta(context.CloudProvider, nodeInfo, nodeGroup, resourceLimiter)
+		scaleUpResourcesDelta, err := computeScaleUpResourcesDelta(context, processors, nodeInfo, nodeGroup, resourceLimiter)
 		if err != nil {
 			klog.Errorf("Skipping node group %s; error getting node group resources: %v", nodeGroup.Id(), err)
 			skippedNodeGroups[nodeGroup.Id()] = notReadyReason
@@ -533,7 +545,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		}
 
 		// apply upper limits for CPU and memory
-		newNodes, err = applyScaleUpResourcesLimits(context.CloudProvider, newNodes, scaleUpResourcesLeft, nodeInfo, bestOption.NodeGroup, resourceLimiter)
+		newNodes, err = applyScaleUpResourcesLimits(context, processors, newNodes, scaleUpResourcesLeft, nodeInfo, bestOption.NodeGroup, resourceLimiter)
 		if err != nil {
 			return &status.ScaleUpStatus{Result: status.ScaleUpError, CreateNodeGroupResults: createNodeGroupResults}, err
 		}
@@ -685,14 +697,15 @@ func executeScaleUp(context *context.AutoscalingContext, clusterStateRegistry *c
 }
 
 func applyScaleUpResourcesLimits(
-	cp cloudprovider.CloudProvider,
+	context *context.AutoscalingContext,
+	processors *ca_processors.AutoscalingProcessors,
 	newNodes int,
 	scaleUpResourcesLeft scaleUpResourcesLimits,
 	nodeInfo *schedulerframework.NodeInfo,
 	nodeGroup cloudprovider.NodeGroup,
 	resourceLimiter *cloudprovider.ResourceLimiter) (int, errors.AutoscalerError) {
 
-	delta, err := computeScaleUpResourcesDelta(cp, nodeInfo, nodeGroup, resourceLimiter)
+	delta, err := computeScaleUpResourcesDelta(context, processors, nodeInfo, nodeGroup, resourceLimiter)
 	if err != nil {
 		return 0, err
 	}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	scheduler_utils "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
@@ -719,7 +718,7 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// Treat those nodes as unready until GPU actually becomes available and let
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
-	allNodes, readyNodes = gpu.FilterOutNodesWithUnreadyGpus(cp.GPULabel(), allNodes, readyNodes)
+	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
 	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.ignoredTaints, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }

--- a/cluster-autoscaler/processors/customresources/custom_resources_processor.go
+++ b/cluster-autoscaler/processors/customresources/custom_resources_processor.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresources
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+// CustomResourceTarget contains information about targeted custom resources
+type CustomResourceTarget struct {
+	// ResourceType is a type of targeted resources
+	ResourceType string
+	// ResourceCount is a count of targeted resources
+	ResourceCount int64
+}
+
+// CustomResourcesProcessor is interface defining handling custom resources
+type CustomResourcesProcessor interface {
+	// FilterOutNodesWithUnreadyResources removes nodes that should have a custom resource, but don't have
+	// it in allocatable from ready nodes list and updates their status to unready on all nodes list.
+	FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node)
+	// GetNodeResourceTargets returns mapping of resource names to their targets.
+	GetNodeResourceTargets(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError)
+	// CleanUp cleans up processor's internal structures.
+	CleanUp()
+}
+
+// NewDefaultCustomResourcesProcessor returns a default instance of CustomResourcesProcessor.
+func NewDefaultCustomResourcesProcessor() CustomResourcesProcessor {
+	return &GpuCustomResourcesProcessor{}
+}

--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresources
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// GpuCustomResourcesProcessor handles only the GPU custom resource. It assumes,
+// that the GPU may not become allocatable immediately after the node creation.
+// It uses additional hacks to predict the type/count of GPUs in that case.
+type GpuCustomResourcesProcessor struct {
+}
+
+// FilterOutNodesWithUnreadyResources removes nodes that should have GPU, but don't have
+// it in allocatable from ready nodes list and updates their status to unready on all nodes list.
+// This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
+// in GPU missing from their allocatable and capacity.
+func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	newAllNodes := make([]*apiv1.Node, 0)
+	newReadyNodes := make([]*apiv1.Node, 0)
+	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
+	for _, node := range readyNodes {
+		_, hasGpuLabel := node.Labels[context.CloudProvider.GPULabel()]
+		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[gpu.ResourceNvidiaGPU]
+		// We expect node to have GPU based on label, but it doesn't show up
+		// on node object. Assume the node is still not fully started (installing
+		// GPU drivers).
+		if hasGpuLabel && (!hasGpuAllocatable || gpuAllocatable.IsZero()) {
+			klog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
+				node.Name)
+			nodesWithUnreadyGpu[node.Name] = kubernetes.GetUnreadyNodeCopy(node)
+		} else {
+			newReadyNodes = append(newReadyNodes, node)
+		}
+	}
+	// Override any node with unready GPU with its "unready" copy
+	for _, node := range allNodes {
+		if newNode, found := nodesWithUnreadyGpu[node.Name]; found {
+			newAllNodes = append(newAllNodes, newNode)
+		} else {
+			newAllNodes = append(newAllNodes, node)
+		}
+	}
+	return newAllNodes, newReadyNodes
+}
+
+// GetNodeResourceTargets returns mapping of resource names to their targets.
+// This includes resources which are not yet ready to use and visible in kubernetes.
+func (p *GpuCustomResourcesProcessor) GetNodeResourceTargets(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+	gpuTarget, err := p.GetNodeGpuTarget(context.CloudProvider.GPULabel(), node, nodeGroup)
+	return []CustomResourceTarget{gpuTarget}, err
+}
+
+// GetNodeGpuTarget returns the gpu target of a given node. This includes gpus
+// that are not ready to use and visible in kubernetes.
+func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(GPULabel string, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (CustomResourceTarget, errors.AutoscalerError) {
+	gpuLabel, found := node.Labels[GPULabel]
+	if !found {
+		return CustomResourceTarget{}, nil
+	}
+
+	gpuAllocatable, found := node.Status.Allocatable[gpu.ResourceNvidiaGPU]
+	if found && gpuAllocatable.Value() > 0 {
+		return CustomResourceTarget{gpuLabel, gpuAllocatable.Value()}, nil
+	}
+
+	// A node is supposed to have GPUs (based on label), but they're not available yet
+	// (driver haven't installed yet?).
+	// Unfortunately we can't deduce how many GPUs it will actually have from labels (just
+	// that it will have some).
+	// Ready for some evil hacks? Well, you won't be disappointed - let's pretend we haven't
+	// seen the node and just use the template we use for scale from 0. It'll be our little
+	// secret.
+
+	if nodeGroup == nil {
+		// We expect this code path to be triggered by situation when we are looking at a node which is expected to have gpus (has gpu label)
+		// But those are not yet visible in node's resource (e.g. gpu drivers are still being installed).
+		// In case of node coming from autoscaled node group we would look and node group template here.
+		// But for nodes coming from non-autoscaled groups we have no such possibility.
+		// Let's hope it is a transient error. As long as it exists we will not scale nodes groups with gpus.
+		return CustomResourceTarget{}, errors.NewAutoscalerError(errors.InternalError, "node without with gpu label, without capacity not belonging to autoscaled node group")
+	}
+
+	template, err := nodeGroup.TemplateNodeInfo()
+	if err != nil {
+		klog.Errorf("Failed to build template for getting GPU estimation for node %v: %v", node.Name, err)
+		return CustomResourceTarget{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
+	}
+	if gpuCapacity, found := template.Node().Status.Capacity[gpu.ResourceNvidiaGPU]; found {
+		return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
+	}
+
+	// if template does not define gpus we assume node will not have any even if ith has gpu label
+	klog.Warningf("Template does not define gpus even though node from its node group does; node=%v", node.Name)
+	return CustomResourceTarget{}, nil
+}
+
+// CleanUp cleans up processor's internal structures.
+func (p *GpuCustomResourcesProcessor) CleanUp() {
+}

--- a/cluster-autoscaler/processors/customresources/gpu_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresources
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+)
+
+const (
+	GPULabel = "TestGPULabel/accelerator"
+)
+
+func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
+	start := time.Now()
+	later := start.Add(10 * time.Minute)
+	expectedReadiness := make(map[string]bool)
+	gpuLabels := map[string]string{
+		GPULabel: "nvidia-tesla-k80",
+	}
+	readyCondition := apiv1.NodeCondition{
+		Type:               apiv1.NodeReady,
+		Status:             apiv1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(later),
+	}
+	unreadyCondition := apiv1.NodeCondition{
+		Type:               apiv1.NodeReady,
+		Status:             apiv1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(later),
+	}
+
+	nodeGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeGpuReady",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeGpuReady.Status.Allocatable[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeGpuReady.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	expectedReadiness[nodeGpuReady.Name] = true
+
+	nodeGpuUnready := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeGpuUnready",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeGpuUnready.Status.Allocatable[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
+	nodeGpuUnready.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
+	expectedReadiness[nodeGpuUnready.Name] = false
+
+	nodeGpuUnready2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeGpuUnready2",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	expectedReadiness[nodeGpuUnready2.Name] = false
+
+	nodeNoGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeNoGpuReady",
+			Labels:            make(map[string]string),
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	expectedReadiness[nodeNoGpuReady.Name] = true
+
+	nodeNoGpuUnready := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeNoGpuUnready",
+			Labels:            make(map[string]string),
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{unreadyCondition},
+		},
+	}
+	expectedReadiness[nodeNoGpuUnready.Name] = false
+
+	initialReadyNodes := []*apiv1.Node{
+		nodeGpuReady,
+		nodeGpuUnready,
+		nodeGpuUnready2,
+		nodeNoGpuReady,
+	}
+	initialAllNodes := []*apiv1.Node{
+		nodeGpuReady,
+		nodeGpuUnready,
+		nodeGpuUnready2,
+		nodeNoGpuReady,
+		nodeNoGpuUnready,
+	}
+
+	processor := NewDefaultCustomResourcesProcessor()
+	provider := testprovider.NewTestCloudProvider(nil, nil)
+	ctx := &context.AutoscalingContext{CloudProvider: provider}
+	newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(ctx, initialAllNodes, initialReadyNodes)
+
+	foundInReady := make(map[string]bool)
+	for _, node := range newReadyNodes {
+		foundInReady[node.Name] = true
+		assert.True(t, expectedReadiness[node.Name], fmt.Sprintf("Node %s found in ready nodes list (it shouldn't be there)", node.Name))
+	}
+	for nodeName, expected := range expectedReadiness {
+		if expected {
+			assert.True(t, foundInReady[nodeName], fmt.Sprintf("Node %s expected ready, but not found in ready nodes list", nodeName))
+		}
+	}
+	for _, node := range newAllNodes {
+		assert.Equal(t, len(node.Status.Conditions), 1)
+		if expectedReadiness[node.Name] {
+			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionTrue, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
+		} else {
+			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionFalse, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
+		}
+	}
+}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package processors
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
@@ -49,6 +50,8 @@ type AutoscalingProcessors struct {
 	NodeInfoProcessor nodeinfos.NodeInfoProcessor
 	// NodeGroupConfigProcessor provides config option for each NodeGroup.
 	NodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor
+	// CustomResourcesProcessor is interface defining handling custom resources
+	CustomResourcesProcessor customresources.CustomResourcesProcessor
 }
 
 // DefaultProcessors returns default set of processors.
@@ -64,6 +67,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeGroupManager:           nodegroups.NewDefaultNodeGroupManager(),
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
+		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
 	}
 }
 
@@ -79,4 +83,5 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.ScaleDownNodeProcessor.CleanUp()
 	ap.NodeInfoProcessor.CleanUp()
 	ap.NodeGroupConfigProcessor.CleanUp()
+	ap.CustomResourcesProcessor.CleanUp()
 }

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -19,10 +19,7 @@ package gpu
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
-
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -47,39 +44,6 @@ const (
 	// MetricsNoGPU - for when there is no GPU and no label all
 	MetricsNoGPU = ""
 )
-
-// FilterOutNodesWithUnreadyGpus removes nodes that should have GPU, but don't have it in allocatable
-// from ready nodes list and updates their status to unready on all nodes list.
-// This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
-// in GPU missing from their allocatable and capacity.
-func FilterOutNodesWithUnreadyGpus(GPULabel string, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
-	newAllNodes := make([]*apiv1.Node, 0)
-	newReadyNodes := make([]*apiv1.Node, 0)
-	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
-	for _, node := range readyNodes {
-		_, hasGpuLabel := node.Labels[GPULabel]
-		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[ResourceNvidiaGPU]
-		// We expect node to have GPU based on label, but it doesn't show up
-		// on node object. Assume the node is still not fully started (installing
-		// GPU drivers).
-		if hasGpuLabel && (!hasGpuAllocatable || gpuAllocatable.IsZero()) {
-			klog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
-				node.Name)
-			nodesWithUnreadyGpu[node.Name] = kubernetes.GetUnreadyNodeCopy(node)
-		} else {
-			newReadyNodes = append(newReadyNodes, node)
-		}
-	}
-	// Override any node with unready GPU with its "unready" copy
-	for _, node := range allNodes {
-		if newNode, found := nodesWithUnreadyGpu[node.Name]; found {
-			newAllNodes = append(newAllNodes, newNode)
-		} else {
-			newAllNodes = append(newAllNodes, node)
-		}
-	}
-	return newAllNodes, newReadyNodes
-}
 
 // GetGpuTypeForMetrics returns name of the GPU used on the node or empty string if there's no GPU
 // if the GPU type is unknown, "generic" is returned
@@ -151,48 +115,4 @@ func PodRequestsGpu(pod *apiv1.Pod) bool {
 		}
 	}
 	return false
-}
-
-// GetNodeTargetGpus returns the number of gpus on a given node. This includes gpus which are not yet
-// ready to use and visible in kubernetes.
-func GetNodeTargetGpus(GPULabel string, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuType string, gpuCount int64, error errors.AutoscalerError) {
-	gpuLabel, found := node.Labels[GPULabel]
-	if !found {
-		return "", 0, nil
-	}
-
-	gpuAllocatable, found := node.Status.Allocatable[ResourceNvidiaGPU]
-	if found && gpuAllocatable.Value() > 0 {
-		return gpuLabel, gpuAllocatable.Value(), nil
-	}
-
-	// A node is supposed to have GPUs (based on label), but they're not available yet
-	// (driver haven't installed yet?).
-	// Unfortunately we can't deduce how many GPUs it will actually have from labels (just
-	// that it will have some).
-	// Ready for some evil hacks? Well, you won't be disappointed - let's pretend we haven't
-	// seen the node and just use the template we use for scale from 0. It'll be our little
-	// secret.
-
-	if nodeGroup == nil {
-		// We expect this code path to be triggered by situation when we are looking at a node which is expected to have gpus (has gpu label)
-		// But those are not yet visible in node's resource (e.g. gpu drivers are still being installed).
-		// In case of node coming from autoscaled node group we would look and node group template here.
-		// But for nodes coming from non-autoscaled groups we have no such possibility.
-		// Let's hope it is a transient error. As long as it exists we will not scale nodes groups with gpus.
-		return "", 0, errors.NewAutoscalerError(errors.InternalError, "node without with gpu label, without capacity not belonging to autoscaled node group")
-	}
-
-	template, err := nodeGroup.TemplateNodeInfo()
-	if err != nil {
-		klog.Errorf("Failed to build template for getting GPU estimation for node %v: %v", node.Name, err)
-		return "", 0, errors.ToAutoscalerError(errors.CloudProviderError, err)
-	}
-	if gpuCapacity, found := template.Node().Status.Capacity[ResourceNvidiaGPU]; found {
-		return gpuLabel, gpuCapacity.Value(), nil
-	}
-
-	// if template does not define gpus we assume node will not have any even if ith has gpu label
-	klog.Warningf("Template does not define gpus even though node from its node group does; node=%v", node.Name)
-	return "", 0, nil
 }

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package gpu
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,128 +30,6 @@ import (
 const (
 	GPULabel = "TestGPULabel/accelerator"
 )
-
-func TestFilterOutNodesWithUnreadyGpus(t *testing.T) {
-	start := time.Now()
-	later := start.Add(10 * time.Minute)
-	expectedReadiness := make(map[string]bool)
-	gpuLabels := map[string]string{
-		GPULabel: "nvidia-tesla-k80",
-	}
-	readyCondition := apiv1.NodeCondition{
-		Type:               apiv1.NodeReady,
-		Status:             apiv1.ConditionTrue,
-		LastTransitionTime: metav1.NewTime(later),
-	}
-	unreadyCondition := apiv1.NodeCondition{
-		Type:               apiv1.NodeReady,
-		Status:             apiv1.ConditionFalse,
-		LastTransitionTime: metav1.NewTime(later),
-	}
-
-	nodeGpuReady := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nodeGpuReady",
-			Labels:            gpuLabels,
-			CreationTimestamp: metav1.NewTime(start),
-		},
-		Status: apiv1.NodeStatus{
-			Capacity:    apiv1.ResourceList{},
-			Allocatable: apiv1.ResourceList{},
-			Conditions:  []apiv1.NodeCondition{readyCondition},
-		},
-	}
-	nodeGpuReady.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
-	nodeGpuReady.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
-	expectedReadiness[nodeGpuReady.Name] = true
-
-	nodeGpuUnready := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nodeGpuUnready",
-			Labels:            gpuLabels,
-			CreationTimestamp: metav1.NewTime(start),
-		},
-		Status: apiv1.NodeStatus{
-			Capacity:    apiv1.ResourceList{},
-			Allocatable: apiv1.ResourceList{},
-			Conditions:  []apiv1.NodeCondition{readyCondition},
-		},
-	}
-	nodeGpuUnready.Status.Allocatable[ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
-	nodeGpuUnready.Status.Capacity[ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
-	expectedReadiness[nodeGpuUnready.Name] = false
-
-	nodeGpuUnready2 := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nodeGpuUnready2",
-			Labels:            gpuLabels,
-			CreationTimestamp: metav1.NewTime(start),
-		},
-		Status: apiv1.NodeStatus{
-			Conditions: []apiv1.NodeCondition{readyCondition},
-		},
-	}
-	expectedReadiness[nodeGpuUnready2.Name] = false
-
-	nodeNoGpuReady := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nodeNoGpuReady",
-			Labels:            make(map[string]string),
-			CreationTimestamp: metav1.NewTime(start),
-		},
-		Status: apiv1.NodeStatus{
-			Conditions: []apiv1.NodeCondition{readyCondition},
-		},
-	}
-	expectedReadiness[nodeNoGpuReady.Name] = true
-
-	nodeNoGpuUnready := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nodeNoGpuUnready",
-			Labels:            make(map[string]string),
-			CreationTimestamp: metav1.NewTime(start),
-		},
-		Status: apiv1.NodeStatus{
-			Conditions: []apiv1.NodeCondition{unreadyCondition},
-		},
-	}
-	expectedReadiness[nodeNoGpuUnready.Name] = false
-
-	initialReadyNodes := []*apiv1.Node{
-		nodeGpuReady,
-		nodeGpuUnready,
-		nodeGpuUnready2,
-		nodeNoGpuReady,
-	}
-	initialAllNodes := []*apiv1.Node{
-		nodeGpuReady,
-		nodeGpuUnready,
-		nodeGpuUnready2,
-		nodeNoGpuReady,
-		nodeNoGpuUnready,
-	}
-
-	newAllNodes, newReadyNodes := FilterOutNodesWithUnreadyGpus(GPULabel, initialAllNodes, initialReadyNodes)
-
-	foundInReady := make(map[string]bool)
-	for _, node := range newReadyNodes {
-		foundInReady[node.Name] = true
-		assert.True(t, expectedReadiness[node.Name], fmt.Sprintf("Node %s found in ready nodes list (it shouldn't be there)", node.Name))
-	}
-	for nodeName, expected := range expectedReadiness {
-		if expected {
-			assert.True(t, foundInReady[nodeName], fmt.Sprintf("Node %s expected ready, but not found in ready nodes list", nodeName))
-		}
-	}
-	for _, node := range newAllNodes {
-		assert.Equal(t, len(node.Status.Conditions), 1)
-		if expectedReadiness[node.Name] {
-			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionTrue, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
-		} else {
-			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionFalse, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
-		}
-	}
-}
 
 func TestNodeHasGpu(t *testing.T) {
 	gpuLabels := map[string]string{


### PR DESCRIPTION
Currently the logic regarding custom resources (other than cpu and memory) in Cluster Autoscaler is limited to GPU resources. Because nodes need to install GPU drivers, the GPU resources may not become allocatable immediately after the node creation. This required implementing  additional functionality (GPU hack) to better handle this case, predicting the type/count of GPUs in case the drivers were not yet installed.

The refactor was suggested because:
1. This logic is dependent on the underlying implementation of driver installation in the cluster, so it would be useful to have it fine-tunable for specific cases. This was done by creating a separate processor and moving the current implementation there.
2. In the future it may be applied for other custom resources, thus we would greatly benefit from generalisation of the underlying code. This was done by removing the dependency on GPU constants outside of the implementation.