### PR TITLE
Enable magnum provider scale to zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/magnum_util.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_util.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	scaleToZeroSupported = false
+	scaleToZeroSupported = true
 )
 
 // NodeRef stores the name, systemUUID and providerID of a node.


### PR DESCRIPTION
Fixes #3928

Now supported by magnum.
https://review.opendev.org/c/openstack/magnum/+/737580/

If using node group autodiscovery, older versions
of magnum will still forbid scaling to zero or
setting the minimum node count to zero.