### PR TITLE
CAPI Management cluster informer to watch single namespce

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -129,6 +129,7 @@ these environment variables to set the namespace to deploy into as well as the i
 
 ```
 export AUTOSCALER_NS=kube-system
+export CAPI_NS=capi-system
 export AUTOSCALER_IMAGE=us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.20.0
 envsubst < examples/deployment.yaml | kubectl apply -f-
 ```

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -96,4 +97,13 @@ func allowedByAutoDiscoverySpec(spec *clusterAPIAutoDiscoveryConfig, r *unstruct
 	default:
 		return true
 	}
+}
+
+func namespaceToWatch(specs []*clusterAPIAutoDiscoveryConfig) string {
+	for _, spec := range specs {
+		if spec.namespace != "" {
+			return spec.namespace
+		}
+	}
+	return metav1.NamespaceAll
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery_test.go
@@ -322,3 +322,42 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		})
 	}
 }
+
+func Test_namespaceToWatch(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		autoDiscoveryConfigs []*clusterAPIAutoDiscoveryConfig
+		matchingNamespace    string
+	}{{
+		name: "returns the namespace configured in auto discovery specs",
+		autoDiscoveryConfigs: []*clusterAPIAutoDiscoveryConfig{
+			{
+				clusterName: "my-cluster",
+			},
+			{
+				namespace: "ns1",
+			},
+		},
+		matchingNamespace: "ns1",
+	},
+		{
+			name: "returns empty namespace if not configure in autodiscovery spec",
+			autoDiscoveryConfigs: []*clusterAPIAutoDiscoveryConfig{
+				{
+					clusterName: "my-cluster",
+				},
+				{
+					labelSelector: labels.SelectorFromSet(labels.Set{"color": "green"}),
+				},
+			},
+			matchingNamespace: "",
+		}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := namespaceToWatch(tc.autoDiscoveryConfigs)
+
+			if got != tc.matchingNamespace {
+				t.Errorf("namespaceToWatch got = %v, want %v", got, tc.matchingNamespace)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -319,12 +319,13 @@ func newMachineController(
 	discoveryOpts cloudprovider.NodeGroupDiscoveryOptions,
 ) (*machineController, error) {
 	workloadInformerFactory := kubeinformers.NewSharedInformerFactory(workloadClient, 0)
-	managementInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(managementClient, 0, metav1.NamespaceAll, nil)
 
 	autoDiscoverySpecs, err := parseAutoDiscovery(discoveryOpts.NodeGroupAutoDiscoverySpecs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse auto discovery configuration: %v", err)
 	}
+
+	managementInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(managementClient, 0, namespaceToWatch(autoDiscoverySpecs), nil)
 
 	CAPIGroup := getCAPIGroup()
 	CAPIVersion, err := getAPIGroupPreferredVersion(managementDiscoveryClient, CAPIGroup)

--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -150,10 +150,11 @@ rules:
     - get
     - update
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-management
+  namespace: ${CAPI_NS}
 rules:
   - apiGroups:
     - cluster.x-k8s.io


### PR DESCRIPTION
This PR updates managementInformerFactory to watch only the namespace specified in auto discovery specs. This is useful to limit rbac permissions for management cluster role. Right now we use `ClusterRole` for accessing scalable resources in management cluster. With this change, we can limit it to a single namespace where the scalable resources are to be watched.
Fixes #3870 
