### PR TITLE
cloudprovider: ClusterAPIProviderName spelling

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -53,7 +53,7 @@ var AvailableCloudProviders = []string{
 	cloudprovider.HuaweicloudProviderName,
 	cloudprovider.HetznerProviderName,
 	cloudprovider.OVHcloudProviderName,
-	cloudprovider.ClusterAPIProiverName,
+	cloudprovider.ClusterAPIProviderName,
 	cloudprovider.IonoscloudProviderName,
 	cloudprovider.LinodeProviderName,
 }
@@ -89,7 +89,7 @@ func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGro
 		return hetzner.BuildHetzner(opts, do, rl)
 	case packet.ProviderName:
 		return packet.BuildPacket(opts, do, rl)
-	case cloudprovider.ClusterAPIProiverName:
+	case cloudprovider.ClusterAPIProviderName:
 		return clusterapi.BuildClusterAPI(opts, do, rl)
 	case cloudprovider.IonoscloudProviderName:
 		return ionoscloud.BuildIonosCloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
@@ -26,15 +26,15 @@ import (
 
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
-	cloudprovider.ClusterAPIProiverName,
+	cloudprovider.ClusterAPIProviderName,
 }
 
 // DefaultCloudProvider for machineapi-only build.
-const DefaultCloudProvider = cloudprovider.ClusterAPIProiverName
+const DefaultCloudProvider = cloudprovider.ClusterAPIProviderName
 
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
-	case cloudprovider.ClusterAPIProiverName:
+	case cloudprovider.ClusterAPIProviderName:
 		return clusterapi.BuildClusterAPI(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -38,8 +38,8 @@ const (
 	BaiducloudProviderName = "baiducloud"
 	// CloudStackProviderName gets the provider name of cloudstack
 	CloudStackProviderName = "cloudstack"
-	// ClusterAPIProiverName gets the provider name of clusterapi
-	ClusterAPIProiverName = "clusterapi"
+	// ClusterAPIProviderName gets the provider name of clusterapi
+	ClusterAPIProviderName = "clusterapi"
 	// DigitalOceanProviderName gets the provider name of digitalocean
 	DigitalOceanProviderName = "digitalocean"
 	// ExoscaleProviderName gets the provider name of exoscale

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -193,5 +193,5 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 		klog.Fatal(err)
 	}
 
-	return newProvider(cloudprovider.ClusterAPIProiverName, rl, controller)
+	return newProvider(cloudprovider.ClusterAPIProviderName, rl, controller)
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
@@ -32,9 +32,9 @@ func TestProviderConstructorProperties(t *testing.T) {
 	controller, stop := mustCreateTestController(t)
 	defer stop()
 
-	provider := newProvider(cloudprovider.ClusterAPIProiverName, &resourceLimits, controller)
-	if actual := provider.Name(); actual != cloudprovider.ClusterAPIProiverName {
-		t.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProiverName, actual)
+	provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller)
+	if actual := provider.Name(); actual != cloudprovider.ClusterAPIProviderName {
+		t.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProviderName, actual)
 	}
 
 	rl, err := provider.GetResourceLimiter()


### PR DESCRIPTION
This is a housekeeping PR that updates the cluster-api provider const reference to `ClusterAPIProviderName` (from `ClusterAPIProiverName`).

No functional change should be observed as a result of updating this const.