### PR TITLE
Fix CAPI example

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -129,7 +129,12 @@ these environment variables to set the namespace to deploy into as well as the i
 
 ```
 export AUTOSCALER_NS=kube-system
-export CAPI_NS=capi-system
 export AUTOSCALER_IMAGE=us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.20.0
 envsubst < examples/deployment.yaml | kubectl apply -f-
 ```
+
+### A note on permissions
+The `cluster-autoscaler-management` role for accessing cluster api scalable resources is scoped to `ClusterRole`.
+This may not be ideal for all environments (eg. Multi tenant environments).
+In such cases, it is recommended to scope it to a `Role` mapped to a specific namespace.
+

--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -150,11 +150,10 @@ rules:
     - get
     - update
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-management
-  namespace: ${CAPI_NS}
 rules:
   - apiGroups:
     - cluster.x-k8s.io


### PR DESCRIPTION
This PR updates capi namespace in autoscaler deployment in cluster api examples. This is needed since #4012 introduced changes to use `Role` rbac instead of `ClusterRole` for watching capi scalable resources