### PR TITLE
Enable custom k8s fork in update-vendor.sh

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -921,14 +921,15 @@ unexpected problems coming from version incompatibilities.
 
 To sync the repositories' vendored k8s libraries, we have a script that takes a
 released version of k8s and updates the `replace` directives of each k8s
-sub-library.
+sub-library. It can be used with custom kubernetes fork, by default it uses
+`git@github.com:kubernetes/kubernetes.git`.
 
 Example execution looks like this:
 ```
-./hack/update-vendor.sh 1.20.0-alpha.1
+./hack/update-vendor.sh 1.20.0-alpha.1 git@github.com:kubernetes/kubernetes.git
 ```
 
 If you need to update vendor to an unreleased commit of Kubernetes, you can use the breakglass script:
 ```
-./hack/submodule-k8s.sh <k8s commit sha>
+./hack/submodule-k8s.sh <k8s commit sha> git@github.com:kubernetes/kubernetes.git
 ```


### PR DESCRIPTION
`update-vendor.sh` was using hardcoded open-source Kubernetes repository, which made it impossible to update vendor dependencies based on a Kubernetes fork, which was the case prior to the refactor of `update-vendor.sh`. This PR implements that by moving from `curl` command to `git` based solution which works also in closed source repositories. 