### PR TITLE
[cluster-autoscaler] Backporting #3545 to release 1.18

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -414,7 +414,7 @@ func (sd *ScaleDown) checkNodeUtilization(timestamp time.Time, node *apiv1.Node,
 		return simulator.ScaleDownDisabledAnnotation, nil
 	}
 
-	utilInfo, err := simulator.CalculateUtilization(node, nodeInfo, sd.context.IgnoreDaemonSetsUtilization, sd.context.IgnoreMirrorPodsUtilization, sd.context.CloudProvider.GPULabel())
+	utilInfo, err := simulator.CalculateUtilization(node, nodeInfo, sd.context.IgnoreDaemonSetsUtilization, sd.context.IgnoreMirrorPodsUtilization, sd.context.CloudProvider.GPULabel(), timestamp)
 	if err != nil {
 		klog.Warningf("Failed to calculate utilization for %s: %v", node.Name, err)
 	}
@@ -487,7 +487,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 		klog.V(1).Infof("Scale-down calculation: ignoring %v nodes unremovable in the last %v", skipped, sd.context.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	}
 
-	emptyNodesList := sd.getEmptyNodesNoResourceLimits(currentlyUnneededNodeNames, len(currentlyUnneededNodeNames))
+	emptyNodesList := sd.getEmptyNodesNoResourceLimits(currentlyUnneededNodeNames, len(currentlyUnneededNodeNames), timestamp)
 
 	emptyNodes := make(map[string]bool)
 	for _, node := range emptyNodesList {
@@ -872,7 +872,7 @@ func (sd *ScaleDown) TryToScaleDown(
 	// Trying to delete empty nodes in bulk. If there are no empty nodes then CA will
 	// try to delete not-so-empty nodes, possibly killing some pods and allowing them
 	// to recreate on other nodes.
-	emptyNodes := sd.getEmptyNodes(candidateNames, sd.context.MaxEmptyBulkDelete, scaleDownResourcesLeft)
+	emptyNodes := sd.getEmptyNodes(candidateNames, sd.context.MaxEmptyBulkDelete, scaleDownResourcesLeft, currentTime)
 	if len(emptyNodes) > 0 {
 		nodeDeletionStart := time.Now()
 		deletedNodes, err := sd.scheduleDeleteEmptyNodes(emptyNodes, sd.context.ClientSet, sd.context.Recorder, readinessMap, candidateNodeGroups)
@@ -978,16 +978,16 @@ func updateScaleDownMetrics(scaleDownStart time.Time, findNodesToRemoveDuration 
 	metrics.UpdateDuration(metrics.ScaleDownMiscOperations, miscDuration)
 }
 
-func (sd *ScaleDown) getEmptyNodesNoResourceLimits(candidates []string, maxEmptyBulkDelete int) []*apiv1.Node {
-	return sd.getEmptyNodes(candidates, maxEmptyBulkDelete, noScaleDownLimitsOnResources())
+func (sd *ScaleDown) getEmptyNodesNoResourceLimits(candidates []string, maxEmptyBulkDelete int, timestamp time.Time) []*apiv1.Node {
+	return sd.getEmptyNodes(candidates, maxEmptyBulkDelete, noScaleDownLimitsOnResources(), timestamp)
 }
 
 // This functions finds empty nodes among passed candidates and returns a list of empty nodes
 // that can be deleted at the same time.
 func (sd *ScaleDown) getEmptyNodes(candidates []string, maxEmptyBulkDelete int,
-	resourcesLimits scaleDownResourcesLimits) []*apiv1.Node {
+	resourcesLimits scaleDownResourcesLimits, timestamp time.Time) []*apiv1.Node {
 
-	emptyNodes := simulator.FindEmptyNodesToRemove(sd.context.ClusterSnapshot, candidates)
+	emptyNodes := simulator.FindEmptyNodesToRemove(sd.context.ClusterSnapshot, candidates, timestamp)
 	availabilityMap := make(map[string]int)
 	result := make([]*apiv1.Node, 0)
 	resourcesLimitsCopy := copyScaleDownResourcesLimits(resourcesLimits) // we do not want to modify input parameter

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -158,10 +158,10 @@ candidateloop:
 
 		if fastCheck {
 			podsToRemove, blockingPod, err = FastGetPodsToMove(nodeInfo, *skipNodesWithSystemPods, *skipNodesWithLocalStorage,
-				podDisruptionBudgets)
+				podDisruptionBudgets, timestamp)
 		} else {
 			podsToRemove, blockingPod, err = DetailedGetPodsForMove(nodeInfo, *skipNodesWithSystemPods, *skipNodesWithLocalStorage, listers, int32(*minReplicaCount),
-				podDisruptionBudgets)
+				podDisruptionBudgets, timestamp)
 		}
 
 		if err != nil {
@@ -195,7 +195,7 @@ candidateloop:
 }
 
 // FindEmptyNodesToRemove finds empty nodes that can be removed.
-func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string) []string {
+func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string, timestamp time.Time) []string {
 	result := make([]string, 0)
 	for _, node := range candidates {
 		nodeInfo, err := snapshot.NodeInfos().Get(node)
@@ -204,7 +204,7 @@ func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string) []str
 			continue
 		}
 		// Should block on all pods.
-		podsToRemove, _, err := FastGetPodsToMove(nodeInfo, true, true, nil)
+		podsToRemove, _, err := FastGetPodsToMove(nodeInfo, true, true, nil, timestamp)
 		if err == nil && len(podsToRemove) == 0 {
 			result = append(result, node)
 		}
@@ -215,9 +215,9 @@ func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string) []str
 // CalculateUtilization calculates utilization of a node, defined as maximum of (cpu, memory) or gpu utilization
 // based on if the node has GPU or not. Per resource utilization is the sum of requests for it divided by allocatable.
 // It also returns the individual cpu, memory and gpu utilization.
-func CalculateUtilization(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo, skipDaemonSetPods, skipMirrorPods bool, gpuLabel string) (utilInfo UtilizationInfo, err error) {
+func CalculateUtilization(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo, skipDaemonSetPods, skipMirrorPods bool, gpuLabel string, currentTime time.Time) (utilInfo UtilizationInfo, err error) {
 	if gpu.NodeHasGpu(gpuLabel, node) {
-		gpuUtil, err := calculateUtilizationOfResource(node, nodeInfo, gpu.ResourceNvidiaGPU, skipDaemonSetPods, skipMirrorPods)
+		gpuUtil, err := calculateUtilizationOfResource(node, nodeInfo, gpu.ResourceNvidiaGPU, skipDaemonSetPods, skipMirrorPods, currentTime)
 		if err != nil {
 			klog.V(3).Infof("node %s has unready GPU", node.Name)
 			// Return 0 if GPU is unready. This will guarantee we can still scale down a node with unready GPU.
@@ -228,11 +228,11 @@ func CalculateUtilization(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo
 		return UtilizationInfo{GpuUtil: gpuUtil, ResourceName: gpu.ResourceNvidiaGPU, Utilization: gpuUtil}, nil
 	}
 
-	cpu, err := calculateUtilizationOfResource(node, nodeInfo, apiv1.ResourceCPU, skipDaemonSetPods, skipMirrorPods)
+	cpu, err := calculateUtilizationOfResource(node, nodeInfo, apiv1.ResourceCPU, skipDaemonSetPods, skipMirrorPods, currentTime)
 	if err != nil {
 		return UtilizationInfo{}, err
 	}
-	mem, err := calculateUtilizationOfResource(node, nodeInfo, apiv1.ResourceMemory, skipDaemonSetPods, skipMirrorPods)
+	mem, err := calculateUtilizationOfResource(node, nodeInfo, apiv1.ResourceMemory, skipDaemonSetPods, skipMirrorPods, currentTime)
 	if err != nil {
 		return UtilizationInfo{}, err
 	}
@@ -250,7 +250,7 @@ func CalculateUtilization(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo
 	return utilization, nil
 }
 
-func calculateUtilizationOfResource(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo, resourceName apiv1.ResourceName, skipDaemonSetPods, skipMirrorPods bool) (float64, error) {
+func calculateUtilizationOfResource(node *apiv1.Node, nodeInfo *schedulernodeinfo.NodeInfo, resourceName apiv1.ResourceName, skipDaemonSetPods, skipMirrorPods bool, currentTime time.Time) (float64, error) {
 	nodeAllocatable, found := node.Status.Allocatable[resourceName]
 	if !found {
 		return 0, fmt.Errorf("failed to get %v from %s", resourceName, node.Name)
@@ -266,6 +266,10 @@ func calculateUtilizationOfResource(node *apiv1.Node, nodeInfo *schedulernodeinf
 		}
 		// factor mirror pods out of the utilization calculations
 		if skipMirrorPods && pod_util.IsMirrorPod(pod) {
+			continue
+		}
+		// ignore Pods that should be terminated
+		if drain.IsPodLongTerminating(pod, currentTime) {
 			continue
 		}
 		for _, container := range pod.Spec.Containers {

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -32,6 +33,7 @@ import (
 )
 
 func TestUtilization(t *testing.T) {
+	testTime := time.Date(2020, time.December, 18, 17, 0, 0, 0, time.UTC)
 	gpuLabel := GetGPULabel()
 	pod := BuildTestPod("p1", 100, 200000)
 	pod2 := BuildTestPod("p2", -1, -1)
@@ -40,13 +42,13 @@ func TestUtilization(t *testing.T) {
 	node := BuildTestNode("node1", 2000, 2000000)
 	SetNodeReadyState(node, true, time.Time{})
 
-	utilInfo, err := CalculateUtilization(node, nodeInfo, false, false, gpuLabel)
+	utilInfo, err := CalculateUtilization(node, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
 	node2 := BuildTestNode("node1", 2000, -1)
 
-	_, err = CalculateUtilization(node2, nodeInfo, false, false, gpuLabel)
+	_, err = CalculateUtilization(node2, nodeInfo, false, false, gpuLabel, testTime)
 	assert.Error(t, err)
 
 	daemonSetPod3 := BuildTestPod("p3", 100, 200000)
@@ -57,12 +59,19 @@ func TestUtilization(t *testing.T) {
 	daemonSetPod4.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/daemonset-pod": "true"}
 
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod, pod2, daemonSetPod3, daemonSetPod4)
-	utilInfo, err = CalculateUtilization(node, nodeInfo, true, false, gpuLabel)
+	utilInfo, err = CalculateUtilization(node, nodeInfo, true, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod2, daemonSetPod3)
-	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel)
+	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel, testTime)
+	assert.NoError(t, err)
+	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
+
+	terminatedPod := BuildTestPod("podTerminated", 100, 200000)
+	terminatedPod.DeletionTimestamp = &metav1.Time{testTime.Add(-10 * time.Minute)}
+	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod, pod2, terminatedPod)
+	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
@@ -72,12 +81,12 @@ func TestUtilization(t *testing.T) {
 	}
 
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod, pod2, mirrorPod4)
-	utilInfo, err = CalculateUtilization(node, nodeInfo, false, true, gpuLabel)
+	utilInfo, err = CalculateUtilization(node, nodeInfo, false, true, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod2, mirrorPod4)
-	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel)
+	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
@@ -87,7 +96,7 @@ func TestUtilization(t *testing.T) {
 	RequestGpuForPod(gpuPod, 1)
 	TolerateGpuForPod(gpuPod)
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod, gpuPod)
-	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel)
+	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 1/1, utilInfo.Utilization, 0.01)
 
@@ -95,7 +104,7 @@ func TestUtilization(t *testing.T) {
 	gpuNode = BuildTestNode("gpu_node", 2000, 2000000)
 	AddGpuLabelToNode(gpuNode)
 	nodeInfo = schedulernodeinfo.NewNodeInfo(pod, pod)
-	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel)
+	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.Zero(t, utilInfo.Utilization)
 }
@@ -247,7 +256,8 @@ func TestFindEmptyNodes(t *testing.T) {
 	clusterSnapshot := NewBasicClusterSnapshot()
 	InitializeClusterSnapshotOrDie(t, clusterSnapshot, []*apiv1.Node{nodes[0], nodes[1], nodes[2], nodes[3]}, []*apiv1.Pod{pod1, pod2})
 
-	emptyNodes := FindEmptyNodesToRemove(clusterSnapshot, nodeNames)
+	testTime := time.Date(2020, time.December, 18, 17, 0, 0, 0, time.UTC)
+	emptyNodes := FindEmptyNodesToRemove(clusterSnapshot, nodeNames, testTime)
 	assert.Equal(t, []string{nodeNames[0], nodeNames[2], nodeNames[3]}, emptyNodes)
 }
 

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -35,7 +35,7 @@ import (
 // along with their pods (no abandoned pods with dangling created-by annotation). Useful for fast
 // checks.
 func FastGetPodsToMove(nodeInfo *schedulernodeinfo.NodeInfo, skipNodesWithSystemPods bool, skipNodesWithLocalStorage bool,
-	pdbs []*policyv1.PodDisruptionBudget) ([]*apiv1.Pod, *drain.BlockingPod, error) {
+	pdbs []*policyv1.PodDisruptionBudget, timestamp time.Time) ([]*apiv1.Pod, *drain.BlockingPod, error) {
 	pods, blockingPod, err := drain.GetPodsForDeletionOnNodeDrain(
 		nodeInfo.Pods(),
 		pdbs,
@@ -44,7 +44,7 @@ func FastGetPodsToMove(nodeInfo *schedulernodeinfo.NodeInfo, skipNodesWithSystem
 		false,
 		nil,
 		0,
-		time.Now())
+		timestamp)
 
 	if err != nil {
 		return pods, blockingPod, err
@@ -62,7 +62,7 @@ func FastGetPodsToMove(nodeInfo *schedulernodeinfo.NodeInfo, skipNodesWithSystem
 // still exist.
 func DetailedGetPodsForMove(nodeInfo *schedulernodeinfo.NodeInfo, skipNodesWithSystemPods bool,
 	skipNodesWithLocalStorage bool, listers kube_util.ListerRegistry, minReplicaCount int32,
-	pdbs []*policyv1.PodDisruptionBudget) ([]*apiv1.Pod, *drain.BlockingPod, error) {
+	pdbs []*policyv1.PodDisruptionBudget, timestamp time.Time) ([]*apiv1.Pod, *drain.BlockingPod, error) {
 	pods, blockingPod, err := drain.GetPodsForDeletionOnNodeDrain(
 		nodeInfo.Pods(),
 		pdbs,
@@ -71,7 +71,7 @@ func DetailedGetPodsForMove(nodeInfo *schedulernodeinfo.NodeInfo, skipNodesWithS
 		true,
 		listers,
 		minReplicaCount,
-		time.Now())
+		timestamp)
 	if err != nil {
 		return pods, blockingPod, err
 	}

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	// PodDeletionTimeout - time after which a pod to be deleted is not included in the list of pods for drain.
-	PodDeletionTimeout = 12 * time.Minute
+	// PodLongTerminatingExtraThreshold - time after which a pod, that is terminating and that has run over its terminationGracePeriod, should be ignored and considered as deleted
+	PodLongTerminatingExtraThreshold = 30 * time.Second
 )
 
 const (
@@ -100,7 +100,7 @@ func GetPodsForDeletionOnNodeDrain(
 		// Possibly skip a pod under deletion but only if it was being deleted for long enough
 		// to avoid a situation when we delete the empty node immediately after the pod was marked for
 		// deletion without respecting any graceful termination.
-		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Time.Before(currentTime.Add(-1*PodDeletionTimeout)) {
+		if IsPodLongTerminating(pod, currentTime) {
 			// pod is being deleted for long enough - no need to care about it.
 			continue
 		}
@@ -286,4 +286,19 @@ func hasSafeToEvictAnnotation(pod *apiv1.Pod) bool {
 // This checks if pod has PodSafeToEvictKey annotation set to false
 func hasNotSafeToEvictAnnotation(pod *apiv1.Pod) bool {
 	return pod.GetAnnotations()[PodSafeToEvictKey] == "false"
+}
+
+// IsPodLongTerminating checks if a pod has been terminating for a long time (pod's terminationGracePeriod + an additional const buffer)
+func IsPodLongTerminating(pod *apiv1.Pod, currentTime time.Time) bool {
+	// pod has not even been deleted
+	if pod.DeletionTimestamp == nil {
+		return false
+	}
+
+	gracePeriod := pod.Spec.TerminationGracePeriodSeconds
+	if gracePeriod == nil {
+		defaultGracePeriod := int64(apiv1.DefaultTerminationGracePeriodSeconds)
+		gracePeriod = &defaultGracePeriod
+	}
+	return pod.DeletionTimestamp.Time.Add(time.Duration(*gracePeriod) * time.Second).Add(PodLongTerminatingExtraThreshold).Before(currentTime)
 }

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestDrain(t *testing.T) {
+	testTime := time.Date(2020, time.December, 18, 17, 0, 0, 0, time.UTC)
 	replicas := int32(5)
 
 	rc := apiv1.ReplicationController{
@@ -175,7 +176,7 @@ func TestDrain(t *testing.T) {
 			Name:              "bar",
 			Namespace:         "default",
 			OwnerReferences:   GenerateOwnerReferences(rs.Name, "ReplicaSet", "apps/v1", ""),
-			DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)},
+			DeletionTimestamp: &metav1.Time{Time: testTime.Add(-time.Hour)},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName: "node",
@@ -220,6 +221,41 @@ func TestDrain(t *testing.T) {
 		},
 		Status: apiv1.PodStatus{
 			Phase: apiv1.PodSucceeded,
+		},
+	}
+
+	zeroGracePeriod := int64(0)
+	longTerminatingPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			DeletionTimestamp: &metav1.Time{Time: testTime.Add(-2 * PodLongTerminatingExtraThreshold)},
+			OwnerReferences:   GenerateOwnerReferences(rc.Name, "ReplicationController", "core/v1", ""),
+		},
+		Spec: apiv1.PodSpec{
+			NodeName:                      "node",
+			RestartPolicy:                 apiv1.RestartPolicyOnFailure,
+			TerminationGracePeriodSeconds: &zeroGracePeriod,
+		},
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodUnknown,
+		},
+	}
+	extendedGracePeriod := int64(6 * 60) // 6 minutes
+	longTerminatingPodWithExtendedGracePeriod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			DeletionTimestamp: &metav1.Time{Time: testTime.Add(-time.Duration(extendedGracePeriod/2) * time.Second)},
+			OwnerReferences:   GenerateOwnerReferences(rc.Name, "ReplicationController", "core/v1", ""),
+		},
+		Spec: apiv1.PodSpec{
+			NodeName:                      "node",
+			RestartPolicy:                 apiv1.RestartPolicyOnFailure,
+			TerminationGracePeriodSeconds: &extendedGracePeriod,
+		},
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodUnknown,
 		},
 	}
 
@@ -451,6 +487,22 @@ func TestDrain(t *testing.T) {
 			expectPods:  []*apiv1.Pod{failedPod},
 		},
 		{
+			description: "long terminating pod with 0 grace period",
+			pods:        []*apiv1.Pod{longTerminatingPod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			rcs:         []*apiv1.ReplicationController{&rc},
+			expectFatal: false,
+			expectPods:  []*apiv1.Pod{},
+		},
+		{
+			description: "long terminating pod with extended grace period",
+			pods:        []*apiv1.Pod{longTerminatingPodWithExtendedGracePeriod},
+			pdbs:        []*policyv1.PodDisruptionBudget{},
+			rcs:         []*apiv1.ReplicationController{&rc},
+			expectFatal: false,
+			expectPods:  []*apiv1.Pod{longTerminatingPodWithExtendedGracePeriod},
+		},
+		{
 			description: "evicted pod",
 			pods:        []*apiv1.Pod{evictedPod},
 			pdbs:        []*policyv1.PodDisruptionBudget{},
@@ -569,7 +621,7 @@ func TestDrain(t *testing.T) {
 
 		registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, dsLister, rcLister, jobLister, rsLister, ssLister)
 
-		pods, blockingPod, err := GetPodsForDeletionOnNodeDrain(test.pods, test.pdbs, true, true, true, registry, 0, time.Now())
+		pods, blockingPod, err := GetPodsForDeletionOnNodeDrain(test.pods, test.pdbs, true, true, true, registry, 0, testTime)
 
 		if test.expectFatal {
 			assert.Equal(t, test.expectBlockingPod, blockingPod)
@@ -588,5 +640,109 @@ func TestDrain(t *testing.T) {
 		if len(pods) != len(test.expectPods) {
 			t.Fatalf("Wrong pod list content: %v", test.description)
 		}
+	}
+}
+
+func TestIsPodLongTerminating(t *testing.T) {
+	testTime := time.Date(2020, time.December, 18, 17, 0, 0, 0, time.UTC)
+	twoMinGracePeriod := int64(2 * 60)
+	zeroGracePeriod := int64(0)
+
+	tests := []struct {
+		name string
+		pod  apiv1.Pod
+		want bool
+	}{
+		{
+			name: "No deletion timestamp",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: nil,
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &zeroGracePeriod,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Just deleted no grace period defined",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime}, // default Grace Period is 30s so this pod can still be terminating
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Deleted for longer than PodLongTerminatingExtraThreshold with no grace period",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime.Add(-3 * PodLongTerminatingExtraThreshold)},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: nil,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Just deleted with grace period defined to 0",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &zeroGracePeriod,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Deleted for longer than PodLongTerminatingExtraThreshold with grace period defined to 0",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime.Add(-2 * PodLongTerminatingExtraThreshold)},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &zeroGracePeriod,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Deleted for longer than PodLongTerminatingExtraThreshold but not longer than grace period (2 min)",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime.Add(-2 * PodLongTerminatingExtraThreshold)},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &twoMinGracePeriod,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Deleted for longer than grace period (2 min) and PodLongTerminatingExtraThreshold",
+			pod: apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: testTime.Add(-2*PodLongTerminatingExtraThreshold - time.Duration(twoMinGracePeriod)*time.Second)},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &twoMinGracePeriod,
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPodLongTerminating(&tc.pod, testTime); got != tc.want {
+				t.Errorf("IsPodLongTerminating() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This is a backport of the changes in #3545 to release 1.18 to ignore terminated pods from scaledown calculation.
This is not a direct cherry-pick, mainly addressing the change in https://github.com/kubernetes/autoscaler/pull/3083