### PR TITLE
fix(docs): corrects various typos in project documentation

### DIFF
--- a/cluster-autoscaler/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
+++ b/cluster-autoscaler/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
@@ -4,7 +4,7 @@ Version 3 adds several new, frequently requested features.  To do so, it introdu
 
 ### `Token.Claims` is now an interface type
 
-The most requested feature from the 2.0 verison of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
+The most requested feature from the 2.0 version of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
 
 `MapClaims` is an alias for `map[string]interface{}` with built in validation behavior.  It is the default claims type when using `Parse`.  The usage is unchanged except you must type cast the claims property.
 

--- a/cluster-autoscaler/vendor/github.com/form3tech-oss/jwt-go/MIGRATION_GUIDE.md
+++ b/cluster-autoscaler/vendor/github.com/form3tech-oss/jwt-go/MIGRATION_GUIDE.md
@@ -4,7 +4,7 @@ Version 3 adds several new, frequently requested features.  To do so, it introdu
 
 ### `Token.Claims` is now an interface type
 
-The most requested feature from the 2.0 verison of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
+The most requested feature from the 2.0 version of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
 
 `MapClaims` is an alias for `map[string]interface{}` with built in validation behavior.  It is the default claims type when using `Parse`.  The usage is unchanged except you must type cast the claims property.
 

--- a/cluster-autoscaler/vendor/github.com/jmespath/go-jmespath/README.md
+++ b/cluster-autoscaler/vendor/github.com/jmespath/go-jmespath/README.md
@@ -56,7 +56,7 @@ result [ 'a', 'c' ]
 result = [ { age: 35 }, { age: 40 } ]
 ```
 
-You can also pre-compile your query. This is usefull if 
+You can also pre-compile your query. This is useful if 
 you are going to run multiple searches with it:
 
 ```go

--- a/cluster-autoscaler/vendor/github.com/karrick/godirwalk/README.md
+++ b/cluster-autoscaler/vendor/github.com/karrick/godirwalk/README.md
@@ -148,7 +148,7 @@ until it is fixed in the standard library, it presents a compatibility
 problem.
 
 This library fixes the above problem such that it will never follow
-logical file sytem loops on either unix or Windows. Furthermore, it
+logical file system loops on either unix or Windows. Furthermore, it
 will only follow symbolic links when `FollowSymbolicLinks` is set to
 true. Behavior on Windows and other operating systems is identical.
 
@@ -196,7 +196,7 @@ Windows.
 
 This library invokes the callback function with `some\path\to\foo.txt`
 for the same file when running on Windows, eliminating the need to
-normalize the pathname by the client, and lessen the likelyhood that a
+normalize the pathname by the client, and lessen the likelihood that a
 client will work on unix but not on Windows.
 
 This enhancement eliminates necessity for some more boilerplate code

--- a/vertical-pod-autoscaler/e2e/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
+++ b/vertical-pod-autoscaler/e2e/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
@@ -4,7 +4,7 @@ Version 3 adds several new, frequently requested features.  To do so, it introdu
 
 ### `Token.Claims` is now an interface type
 
-The most requested feature from the 2.0 verison of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
+The most requested feature from the 2.0 version of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
 
 `MapClaims` is an alias for `map[string]interface{}` with built in validation behavior.  It is the default claims type when using `Parse`.  The usage is unchanged except you must type cast the claims property.
 


### PR DESCRIPTION
Scope of changes is restricted to docs only. Changes made in accordance with Standard English. CLA previously signed.