### PR TITLE
Cluster Autoscaler GCE: change the format of MIG id

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -22,33 +22,34 @@ import (
 )
 
 const (
-	gceUrlSchema        = "https"
-	gceDomainSuffix     = "googleapis.com/compute/v1/projects/"
-	gcePrefix           = gceUrlSchema + "://content." + gceDomainSuffix
+	gceUrlSchema    = "https"
+	gceDomainSuffix = "googleapis.com/compute/v1/projects/"
+	// Cluster Autoscaler previously used "content" instead of "www" here, for reasons unknown.
+	gcePrefix           = gceUrlSchema + "://www." + gceDomainSuffix
 	instanceUrlTemplate = gcePrefix + "%s/zones/%s/instances/%s"
 	migUrlTemplate      = gcePrefix + "%s/zones/%s/instanceGroups/%s"
 )
 
 // ParseMigUrl expects url in format:
-// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instanceGroups/<name>
+// https://www.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instanceGroups/<name>
 func ParseMigUrl(url string) (project string, zone string, name string, err error) {
 	return parseGceUrl(url, "instanceGroups")
 }
 
 // ParseIgmUrl expects url in format:
-// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instanceGroupManagers/<name>
+// https://www.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instanceGroupManagers/<name>
 func ParseIgmUrl(url string) (project string, zone string, name string, err error) {
 	return parseGceUrl(url, "instanceGroupManagers")
 }
 
 // ParseInstanceUrl expects url in format:
-// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
+// https://www.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
 func ParseInstanceUrl(url string) (project string, zone string, name string, err error) {
 	return parseGceUrl(url, "instances")
 }
 
 // ParseInstanceUrlRef expects url in format:
-// https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
+// https://www.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/instances/<name>
 // and returns a GceRef struct for it.
 func ParseInstanceUrlRef(url string) (GceRef, error) {
 	project, zone, name, err := parseGceUrl(url, "instances")
@@ -73,7 +74,7 @@ func GenerateMigUrl(ref GceRef) string {
 }
 
 func parseGceUrl(url, expectedResource string) (project string, zone string, name string, err error) {
-	errMsg := fmt.Errorf("wrong url: expected format https://content.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/%s/<name>, got %s", expectedResource, url)
+	errMsg := fmt.Errorf("wrong url: expected format https://www.googleapis.com/compute/v1/projects/<project-id>/zones/<zone>/%s/<name>, got %s", expectedResource, url)
 	if !strings.Contains(url, gceDomainSuffix) {
 		return "", "", "", errMsg
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
@@ -29,6 +29,8 @@ func TestParseUrl(t *testing.T) {
 	assert.Equal(t, "us-central1-b", zone)
 	assert.Equal(t, "kubernetes-minion-group", name)
 
+	// Cluster Autoscaler previously used this format for MIG id (with "content" instead of "www"). Make sure it's still accepted
+	// just to be safe.
 	proj, zone, name, err = parseGceUrl("https://content.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.Nil(t, err)
 	assert.Equal(t, "mwielgus-proj", proj)
@@ -38,6 +40,6 @@ func TestParseUrl(t *testing.T) {
 	_, _, _, err = parseGceUrl("www.onet.pl", "instanceGroups")
 	assert.NotNil(t, err)
 
-	_, _, _, err = parseGceUrl("https://content.googleapis.com/compute/vabc/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
+	_, _, _, err = parseGceUrl("https://www.googleapis.com/compute/vabc/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
The current implementation assumes MIG ids have the
"https://content.googleapis.com" prefix, while the
canonical id format seems to begin with "https://www.googleapis.com".
Both formats work while talking to the GCE API, but
the API returns the latter and other GCP services seem to
assume it as well.