### PR TITLE
Print out error when unable to download module

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -50,8 +50,14 @@ rm -rf ${WORKDIR}
 
 for MOD in "${MODS[@]}"; do
     V=$(
-        go mod download -json "${MOD}@kubernetes-${VERSION}" |
-        sed -n 's|.*"Version": "\(.*\)".*|\1|p'
+        GOMOD="${MOD}@kubernetes-${VERSION}"
+        JSON=$(go mod download -json "${GOMOD}")
+        retval=$?
+        if [ $retval -ne 0 ]; then
+            echo "Error downloading module ${GOMOD}."
+            exit 1
+        fi
+        echo "${JSON}" | sed -n 's|.*"Version": "\(.*\)".*|\1|p'
     )
     go mod edit "-replace=${MOD}=${MOD}@${V}"
 done


### PR DESCRIPTION
Use shell syntax instead of pipe so error messages are printed out. Before
this change, if it could not download a module, it would just exit without
printing an error message due to the pipe. With this change it now prints
out the error message(unable to download) from the underlying process.