### PR TITLE
update storage API version

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-go/blob/master/CHANGELOG.md#v4700 seems to have switched that API to preview for whatever reason.

![image](https://user-images.githubusercontent.com/7871596/118903719-34e28900-b8cd-11eb-8a88-e18b7cb01725.png)
