### PR TITLE
Document that CA is not responsible for registering new nodes

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -474,6 +474,12 @@ still unregistered, it stops considering them in simulations and may attempt to 
 different group if the pods are still pending. It will also attempt to remove
 any nodes left unregistered after this time.
 
+> Note: Cluster Autoscaler is **not** responsible for behaviour and registration
+> to the cluster of the new nodes it creates. The responsibility of registering the new nodes
+> into your cluster lies with the cluster provisioning tooling you use.
+> Example: If you use kubeadm to provision your cluster, it is up to you to automatically
+> execute `kubeadm join` at boot time via some script.
+
 ### How does scale-down work?
 
 Every 10 seconds (configurable by `--scan-interval` flag), if no scale-up is


### PR DESCRIPTION
Resolves #4065. **Sincere** thanks for trying to resolve it with #4067, but I do not think it helped, so instead of explaining it again, I created a PR.

I took the wording from https://github.com/kubernetes/autoscaler/issues/3953#issuecomment-804426721

I hope this will help with issues like #3953 as I was expecting the CA to magically register nodes as well. 