### PR TITLE
add field keys to cluster autoscaler unit test structs

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -972,30 +972,20 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	nodeGroupA.On("DeleteNodes", mock.Anything).Return(nil)
 	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
 		{
-			"A1",
-			&cloudprovider.InstanceStatus{
+			Id: "A1",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceRunning,
 			},
 		},
 		{
-			"A2",
-			&cloudprovider.InstanceStatus{
+			Id: "A2",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 			},
 		},
 		{
-			"A3",
-			&cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
-				},
-			},
-		},
-		{
-			"A4",
-			&cloudprovider.InstanceStatus{
+			Id: "A3",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
@@ -1004,8 +994,18 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 			},
 		},
 		{
-			"A5",
-			&cloudprovider.InstanceStatus{
+			Id: "A4",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
+				},
+			},
+		},
+		{
+			Id: "A5",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
@@ -1014,8 +1014,8 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 			},
 		},
 		{
-			"A6",
-			&cloudprovider.InstanceStatus{
+			Id: "A6",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass: cloudprovider.OtherErrorClass,
@@ -1032,8 +1032,8 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	nodeGroupB.On("DeleteNodes", mock.Anything).Return(nil)
 	nodeGroupB.On("Nodes").Return([]cloudprovider.Instance{
 		{
-			"B1",
-			&cloudprovider.InstanceStatus{
+			Id: "B1",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceRunning,
 			},
 		},
@@ -1102,38 +1102,38 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	// restub node group A so nodes are no longer reporting errors
 	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
 		{
-			"A1",
-			&cloudprovider.InstanceStatus{
+			Id: "A1",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceRunning,
 			},
 		},
 		{
-			"A2",
-			&cloudprovider.InstanceStatus{
+			Id: "A2",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 			},
 		},
 		{
-			"A3",
-			&cloudprovider.InstanceStatus{
+			Id: "A3",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceDeleting,
 			},
 		},
 		{
-			"A4",
-			&cloudprovider.InstanceStatus{
+			Id: "A4",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceDeleting,
 			},
 		},
 		{
-			"A5",
-			&cloudprovider.InstanceStatus{
+			Id: "A5",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceDeleting,
 			},
 		},
 		{
-			"A6",
-			&cloudprovider.InstanceStatus{
+			Id: "A6",
+			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceDeleting,
 			},
 		},

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -69,7 +69,7 @@ func TestUtilization(t *testing.T) {
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
 	terminatedPod := BuildTestPod("podTerminated", 100, 200000)
-	terminatedPod.DeletionTimestamp = &metav1.Time{testTime.Add(-10 * time.Minute)}
+	terminatedPod.DeletionTimestamp = &metav1.Time{Time: testTime.Add(-10 * time.Minute)}
 	nodeInfo = schedulerframework.NewNodeInfo(pod, pod, pod2, terminatedPod)
 	utilInfo, err = CalculateUtilization(node, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)


### PR DESCRIPTION
A few of the unit test structures did not have field name keys when
using literal structs. This change adds the fields to make this code a
little more future-proof.