### PR TITLE
add init container when vpa recommender init from history provider

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -239,6 +239,9 @@ func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider histor
 				PodID:         podID,
 				ContainerName: containerName,
 			}
+			if err = feeder.clusterState.AddOrUpdateContainer(containerID, nil); err != nil {
+				klog.Warningf("Failed to add container %+v. Reason: %+v", containerID, err)
+			}
 			klog.V(4).Infof("Adding %d samples for container %v", len(sampleList), containerID)
 			for _, sample := range sampleList {
 				if err := feeder.clusterState.AddSample(


### PR DESCRIPTION
We are using vertical-pod-autoscaler for autoscaler. We use **prometheus** as history data provider. 
Got  Error adding metric sample for container

There are two related issues found:
https://github.com/kubernetes/autoscaler/issues/2010
https://github.com/kubernetes/autoscaler/issues/2512

After checking, we found the ContainerState is not initialized before LoadPods of RunOnce method. 
Due to InitFromHistoryProvider is before RunOnce in main loop, the feeder.clusterState.AddSample will always got fail.  The history data will not be added to the ClusterState.

The solution is init container in InitFromHistoryProvider after init pod in ClusterState. Since the request of container is unknown, give a nil as param. The resource request will be updated to right value in the LoadPods in RunOnce of main loop.