### PR TITLE
addon-resizer: Fix --poll-period is not working in 1.8.13

### DIFF
--- a/addon-resizer/nanny/main/pod_nanny.go
+++ b/addon-resizer/nanny/main/pod_nanny.go
@@ -57,7 +57,7 @@ var (
 	podName       = flag.String("pod", os.Getenv("MY_POD_NAME"), "The name of the pod to watch. This defaults to the nanny's own pod.")
 	containerName = flag.String("container", "pod-nanny", "The name of the container to watch. This defaults to the nanny itself.")
 	// Flags to control runtime behavior.
-	pollPeriod     = time.Millisecond * time.Duration(*flag.Int("poll-period", 10000, "The time, in milliseconds, to poll the dependent container."))
+	pollPeriod     = flag.Int("poll-period", 10000, "The time, in milliseconds, to poll the dependent container.")
 	estimator      = flag.String("estimator", "linear", "The estimator to use. Currently supported: linear, exponential")
 	minClusterSize = flag.Uint64("minClusterSize", 16, "The smallest number of nodes resources will be scaled to. Must be > 1. This flag is used only when an exponential estimator is used.")
 	useMetrics     = flag.Bool("use-metrics", false, "Whether to use apiserver metrics to detect cluster size instead of the default method of listing node objects from the Kubernetes API.")
@@ -160,7 +160,7 @@ func main() {
 	}
 
 	// Begin nannying.
-	nanny.PollAPIServer(k8s, est, pollPeriod, *scaleDownDelay, *scaleUpDelay, uint64(*threshold))
+	nanny.PollAPIServer(k8s, est, time.Duration(*pollPeriod)*time.Millisecond, *scaleDownDelay, *scaleUpDelay, uint64(*threshold))
 }
 
 func userAgent() string {


### PR DESCRIPTION
In Addon-resizer 1.8.13 or earlier, pod_nanny has a problem that `--poll-period` flag does not change the poll period.

This is caused by a bug while parsing the flag: pollPeriod value from `flag.Int` is dereferenced too early (before `flag.Parse()`)
and it always be assigned the default value.

This commit resolves this issue by getting the pollPeriod value after `flag.Parse()`.

### Example

```
$ ./pod_nanny --poll-period 300000 --cpu ...
```

pod_nanny should crawl Pod state every 300 seconds but it now does every 10 seconds.