### PR TITLE
Separate limits scaling between CPU & memory

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -256,7 +256,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 			expectedCPU:      resource.MustParse("1Ei"),
 			expectedMem:      resource.MustParse("1Ei"),
 			expectedCPULimit: resource.NewMilliQuantity(math.MaxInt64, resource.DecimalExponent),
-			expectedMemLimit: resource.NewMilliQuantity(math.MaxInt64, resource.DecimalExponent),
+			expectedMemLimit: resource.NewQuantity(math.MaxInt64, resource.DecimalExponent),
 			annotations: vpa_api_util.ContainerToAnnotationsMap{
 				containerName: []string{
 					"cpu: failed to keep limit to request ratio; capping limit to int64",

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -335,8 +335,8 @@ func getBoundaryRecommendation(recommendation apiv1.ResourceList, container apiv
 	if boundaryLimit == nil {
 		return apiv1.ResourceList{}
 	}
-	boundaryCpu := GetBoundaryRequest(container.Resources.Requests.Cpu(), container.Resources.Limits.Cpu(), boundaryLimit.Cpu(), defaultLimit.Cpu())
-	boundaryMem := GetBoundaryRequest(container.Resources.Requests.Memory(), container.Resources.Limits.Memory(), boundaryLimit.Memory(), defaultLimit.Memory())
+	boundaryCpu := GetBoundaryRequest(apiv1.ResourceCPU, container.Resources.Requests.Cpu(), container.Resources.Limits.Cpu(), boundaryLimit.Cpu(), defaultLimit.Cpu())
+	boundaryMem := GetBoundaryRequest(apiv1.ResourceMemory, container.Resources.Requests.Memory(), container.Resources.Limits.Memory(), boundaryLimit.Memory(), defaultLimit.Memory())
 	return apiv1.ResourceList{
 		apiv1.ResourceCPU:    *boundaryCpu,
 		apiv1.ResourceMemory: *boundaryMem,
@@ -373,9 +373,9 @@ func applyPodLimitRange(resources []vpa_types.RecommendedContainerResources,
 			request := (*fieldGetter(resources[i]))[resourceName]
 			var cappedContainerRequest *resource.Quantity
 			if resourceName == apiv1.ResourceMemory {
-				cappedContainerRequest, _ = scaleQuantityProportionally(&request, &sumRecommendation, &minLimit, roundUpToFullUnit)
+				cappedContainerRequest, _ = scaleQuantityProportionallyMem(&request, &sumRecommendation, &minLimit, roundUpToFullUnit)
 			} else {
-				cappedContainerRequest, _ = scaleQuantityProportionally(&request, &sumRecommendation, &minLimit, noRounding)
+				cappedContainerRequest, _ = scaleQuantityProportionallyCPU(&request, &sumRecommendation, &minLimit, noRounding)
 			}
 			(*fieldGetter(resources[i]))[resourceName] = *cappedContainerRequest
 		}
@@ -397,9 +397,9 @@ func applyPodLimitRange(resources []vpa_types.RecommendedContainerResources,
 		limit := (*fieldGetter(resources[i]))[resourceName]
 		var cappedContainerRequest *resource.Quantity
 		if resourceName == apiv1.ResourceMemory {
-			cappedContainerRequest, _ = scaleQuantityProportionally(&limit, &sumLimit, &targetTotalLimit, roundDownToFullUnit)
+			cappedContainerRequest, _ = scaleQuantityProportionallyMem(&limit, &sumLimit, &targetTotalLimit, roundDownToFullUnit)
 		} else {
-			cappedContainerRequest, _ = scaleQuantityProportionally(&limit, &sumLimit, &targetTotalLimit, noRounding)
+			cappedContainerRequest, _ = scaleQuantityProportionallyCPU(&limit, &sumLimit, &targetTotalLimit, noRounding)
 		}
 		(*fieldGetter(resources[i]))[resourceName] = *cappedContainerRequest
 	}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -375,7 +375,7 @@ func TestApplyCapsToLimitRange(t *testing.T) {
 				ContainerName: "container",
 				Target: apiv1.ResourceList{
 					apiv1.ResourceCPU:    resource.MustParse("1000m"),
-					apiv1.ResourceMemory: resource.MustParse("500000000000m"),
+					apiv1.ResourceMemory: resource.MustParse("500000000"),
 				},
 			},
 		},
@@ -895,13 +895,13 @@ func TestCapPodMemoryWithUnderByteSplit(t *testing.T) {
 					{
 						ContainerName: "container-1",
 						Target: apiv1.ResourceList{
-							apiv1.ResourceMemory: *resource.NewQuantity(1431655766, resource.BinarySI),
+							apiv1.ResourceMemory: *resource.NewQuantity(1431655765, resource.BinarySI),
 						},
 					},
 					{
 						ContainerName: "container-2",
 						Target: apiv1.ResourceList{
-							apiv1.ResourceMemory: *resource.NewQuantity(2863311531, resource.BinarySI),
+							apiv1.ResourceMemory: *resource.NewQuantity(2863311530, resource.BinarySI),
 						},
 					},
 				},


### PR DESCRIPTION
See the [comment](https://github.com/kubernetes/autoscaler/issues/3965#issuecomment-851024267) I made for issue #3965

When the ratio between the original memory requests/limits on the Deployment is a floating point number instead of an integer, the calculated limit is expressed in millivalues, (https://play.golang.org/p/dR4SaXRBGmB) which is valid for CPU values, but not necessarily for memory values.

The purpose of this PR is to ensure it is expressed as bytes.