### PR TITLE
Ignore deleted nodes in upcoming calculation

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -917,7 +917,7 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() map[string]int {
 		readiness := csr.perNodeGroupReadiness[id]
 		ar := csr.acceptableRanges[id]
 		// newNodes is the number of nodes that
-		newNodes := ar.CurrentTarget - (readiness.Ready + readiness.Unready + readiness.LongUnregistered)
+		newNodes := ar.CurrentTarget - (readiness.Ready + readiness.Unready + readiness.Deleted + readiness.LongUnregistered)
 		if newNodes <= 0 {
 			// Negative value is unlikely but theoretically possible.
 			continue


### PR DESCRIPTION
Nodes with the `ToBeDeletedByClusterAutoscaler` taint are currently counted as "upcoming" nodes even though they are not schedulable and are expected to be removed from the cluster. This can cause cluster-autsocaler to deadlock when there are pending pods: the autoscaler will not scale up because it thinks there is already a node starting that the pod will fit on, and the autoscaler will not terminate the tainted node because pending pods disable scaledown.