### PR TITLE
annotate fakeNodes so that cloudprovider implementations can identify them

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -256,6 +256,16 @@ func (c InstanceErrorClass) String() string {
 	}
 }
 
+const (
+	// FakeNodeReasonAnnotation is an annotation added to the fake placeholder nodes CA has created
+	// Note that this don't map to real nodes in k8s and are merely used for error handling
+	FakeNodeReasonAnnotation = "k8s.io/cluster-autoscaler/fake-node-reason"
+	// FakeNodeUnregistered represents a node that is identified by CA as unregistered
+	FakeNodeUnregistered = "unregistered"
+	// FakeNodeCreateError represents a node that is identified by CA as a created node with errors
+	FakeNodeCreateError = "create-error"
+)
+
 // PricingModel contains information about the node price and how it changes in time.
 type PricingModel interface {
 	// NodePrice returns a price of running the given node for a given period of time.

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -51,14 +51,6 @@ const (
 
 	// NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.
 	NodeGroupBackoffResetTimeout = 3 * time.Hour
-
-	// FakeNodeReasonAnnotation is an annotation added to the fake placeholder nodes CA has created
-	// Note that this don't map to real nodes in k8s and are merely used for error handling
-	FakeNodeReasonAnnotation = "k8s.io/cluster-autoscaler/fake-node-reason"
-	// FakeNodeUnregistered represents a node that is identified by CA as unregistered
-	FakeNodeUnregistered = "unregistered"
-	// FakeNodeCreateError represents a node that is identified by CA as a created node with errors
-	FakeNodeCreateError = "create-error"
 )
 
 // ScaleUpRequest contains information about the requested node group scale up.
@@ -957,7 +949,7 @@ func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances ma
 		for _, instance := range instances {
 			if !registered.Has(instance.Id) {
 				notRegistered = append(notRegistered, UnregisteredNode{
-					Node:              fakeNode(instance, FakeNodeUnregistered),
+					Node:              fakeNode(instance, cloudprovider.FakeNodeUnregistered),
 					UnregisteredSince: time,
 				})
 			}
@@ -1104,7 +1096,7 @@ func (csr *ClusterStateRegistry) GetCreatedNodesWithErrors() []*apiv1.Node {
 		_, _, instancesByErrorCode := csr.buildInstanceToErrorCodeMappings(nodeGroupInstances)
 		for _, instances := range instancesByErrorCode {
 			for _, instance := range instances {
-				nodesWithCreateErrors = append(nodesWithCreateErrors, fakeNode(instance, FakeNodeCreateError))
+				nodesWithCreateErrors = append(nodesWithCreateErrors, fakeNode(instance, cloudprovider.FakeNodeCreateError))
 			}
 		}
 	}
@@ -1126,7 +1118,7 @@ func fakeNode(instance cloudprovider.Instance, reason string) *apiv1.Node {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: instance.Id,
 			Annotations: map[string]string{
-				FakeNodeReasonAnnotation: reason,
+				cloudprovider.FakeNodeReasonAnnotation: reason,
 			},
 		},
 		Spec: apiv1.NodeSpec{


### PR DESCRIPTION
This adds an annotation to the "fakeNode" used by CA for unregistered node. This can be useful for cloudproviders in the `DeleteNode()` method to have some custom error handling logic and also identify the reason for the `fakeNode`. (For now, it seems only GCE would make use of the nodes created with error path)

An example of how we want to leverage that: we don't want to decrement the cached NodeGroup capacity in Azure because the capacity reported by APIs won't include Failed instances so the cache will end up drifting unnecessarily from the real capacity and can inadvertently lead to a scale down if some conditions align. 

I've noticed the packet provider tries to identify some via providerId but I don't think this is a reliable way. Similar with the magnum provider via the object UID. I think a namespaced annotation would be a convenient way for identification.