### PR TITLE
Fix: CA does not work properly while using AWS EC2 IMDSv2

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -355,3 +355,6 @@ To refresh static list, please run `go run ec2_instance_types/gen.go` under
   `aws:///us-east-1a/i-01234abcdef`.
 * If you want to use regional STS endpoints (e.g. when using VPC endpoint for
   STS) the env `AWS_STS_REGIONAL_ENDPOINTS=regional` should be set.
+* If you want to run it on instances with IMDSv1 disabled make sure your
+  EC2 launch configuration has the setting `Metadata response hop limit` set to `2`.
+  Otherwise, the `/latest/api/token` call will timeout and result in an error.

--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -20,7 +20,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"io/ioutil"
 	klog "k8s.io/klog/v2"
 	"net/http"
@@ -31,7 +34,7 @@ import (
 )
 
 var (
-	ec2MetaDataServiceUrl          = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+	ec2MetaDataServiceUrl          = "http://169.254.169.254"
 	ec2PricingServiceUrlTemplate   = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/%s/index.json"
 	ec2PricingServiceUrlTemplateCN = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/AmazonEC2/current/%s/index.json"
 	staticListLastUpdateTime       = "2020-12-07"
@@ -169,26 +172,13 @@ func GetCurrentAwsRegion() (string, error) {
 	region, present := os.LookupEnv("AWS_REGION")
 
 	if !present {
-		klog.V(1).Infof("fetching %s\n", ec2MetaDataServiceUrl)
-		res, err := http.Get(ec2MetaDataServiceUrl)
+		c := aws.NewConfig().
+			WithEndpoint(ec2MetaDataServiceUrl)
+		sess, err := session.NewSession()
 		if err != nil {
-			return "", fmt.Errorf("Error fetching %s", ec2MetaDataServiceUrl)
+			return "", fmt.Errorf("failed to create session")
 		}
-
-		defer res.Body.Close()
-
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return "", fmt.Errorf("Error parsing %s", ec2MetaDataServiceUrl)
-		}
-
-		var unmarshalled = map[string]string{}
-		err = json.Unmarshal(body, &unmarshalled)
-		if err != nil {
-			klog.Warningf("Error unmarshalling %s, skip...\n", ec2MetaDataServiceUrl)
-		}
-
-		region = unmarshalled["region"]
+		return ec2metadata.New(sess, c).Region()
 	}
 
 	return region, nil


### PR DESCRIPTION
This fixes #3592.
We use the aws sdk to fetch the metadata. The endpoint explicitly set to `"http://169.254.169.254"` so that tests don't fail.

We tested it by applying these [changes](https://github.com/kubernetes/autoscaler/compare/cluster-autoscaler-1.18.3...shreyas-srinivas:imdsv2-1.18.3?expand=1) in 1.18.3 and it worked fine. tested both scale up and scale down.

This was tested in instances with IMDsV1 enabled and disabled.