### PR TITLE
digitalocean: do not Refresh() on startup

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 var _ cloudprovider.CloudProvider = (*digitaloceanCloudProvider)(nil)
@@ -45,15 +45,11 @@ type digitaloceanCloudProvider struct {
 	resourceLimiter *cloudprovider.ResourceLimiter
 }
 
-func newDigitalOceanCloudProvider(manager *Manager, rl *cloudprovider.ResourceLimiter) (*digitaloceanCloudProvider, error) {
-	if err := manager.Refresh(); err != nil {
-		return nil, err
-	}
-
+func newDigitalOceanCloudProvider(manager *Manager, rl *cloudprovider.ResourceLimiter) *digitaloceanCloudProvider {
 	return &digitaloceanCloudProvider{
 		manager:         manager,
 		resourceLimiter: rl,
-	}, nil
+	}
 }
 
 // Name returns name of the cloud provider.
@@ -185,12 +181,7 @@ func BuildDigitalOcean(
 	// the cloud provider automatically uses all node pools in DigitalOcean.
 	// This means we don't use the cloudprovider.NodeGroupDiscoveryOptions
 	// flags (which can be set via '--node-group-auto-discovery' or '-nodes')
-	provider, err := newDigitalOceanCloudProvider(manager, rl)
-	if err != nil {
-		klog.Fatalf("Failed to create DigitalOcean cloud provider: %v", err)
-	}
-
-	return provider
+	return newDigitalOceanCloudProvider(manager, rl)
 }
 
 // toProviderID returns a provider ID from the given node ID.

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
@@ -83,10 +83,7 @@ func testCloudProvider(t *testing.T, client *doClientMock) *digitaloceanCloudPro
 
 	manager.client = client
 
-	provider, err := newDigitalOceanCloudProvider(manager, rl)
-	assert.NoError(t, err)
-	return provider
-
+	return newDigitalOceanCloudProvider(manager, rl)
 }
 
 func TestNewDigitalOceanCloudProvider(t *testing.T) {
@@ -106,6 +103,8 @@ func TestDigitalOceanCloudProvider_Name(t *testing.T) {
 
 func TestDigitalOceanCloudProvider_NodeGroups(t *testing.T) {
 	provider := testCloudProvider(t, nil)
+	err := provider.manager.Refresh()
+	assert.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		nodes := provider.NodeGroups()
@@ -150,6 +149,8 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 		).Once()
 
 		provider := testCloudProvider(t, client)
+		err := provider.manager.Refresh()
+		assert.NoError(t, err)
 
 		// let's get the nodeGroup for the node with ID 4
 		node := &apiv1.Node{
@@ -190,6 +191,8 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 		).Once()
 
 		provider := testCloudProvider(t, client)
+		err := provider.manager.Refresh()
+		assert.NoError(t, err)
 
 		node := &apiv1.Node{
 			Spec: apiv1.NodeSpec{


### PR DESCRIPTION
If the API is temporarily unavailable, cluster-autoscaler will be crash-looping on startup during the initial call to `Refresh()`. This makes for a bad user/operator experience since it aggravates differentiating between API and cluster/workload problems.

Let autoscaler start up and retry fetching node pool information from the API as part of the pre-existing, periodic sync. This should be no different to experiencing transient API problems during runtime.