### PR TITLE
digitalocean: remove tag references from README

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/README.md
+++ b/cluster-autoscaler/cloudprovider/digitalocean/README.md
@@ -6,31 +6,10 @@ offering which can be enabled/disable dynamically for an existing cluster.
 
 # Configuration
 
-The `cluster-autoscaler` dynamically runs based on tags associated with node
-pools. These are the current valid tags:
-
-```
-k8s-cluster-autoscaler-enabled:true
-k8s-cluster-autoscaler-min:3
-k8s-cluster-autoscaler-max:10
-```
-
-The syntax is in form of `key:value`.
-
-* If `k8s-cluster-autoscaler-enabled:true` is absent or
-  `k8s-cluster-autoscaler-enabled` is **not** set to `true`, the
-  `cluster-autoscaler` will not process the node pool by default.
-* To set the minimum number of nodes to use `k8s-cluster-autoscaler-min`
-* To set the maximum number of nodes to use `k8s-cluster-autoscaler-max`
-
-
-If you don't set the minimum and maximum tags, node pools will have the
-following default limits:
-
-```
-minimum number of nodes: 1
-maximum number of nodes: 200
-```
+Parameters of the autoscaler (such as whether it is on or off, and the
+minimum/maximum values) are configured through the public DOKS API and
+subsequently reflected by the node pool objects. The cloud provider periodically
+picks up the configuration from the API and adjusts the behavior accordingly.
 
 # Development
 


### PR DESCRIPTION
An initial version of the DigitalOcean cloud provider implementation relied on tags to define the behavior but has since been transitioned to using the public DOKS API. Update the README accordingly.