### PR TITLE
improve addon-resizer deployment example

### DIFF
--- a/addon-resizer/deploy/example.yaml
+++ b/addon-resizer/deploy/example.yaml
@@ -1,6 +1,7 @@
 # Config map for resource configuration.
-# Specify 'cpu', 'extra-cpu', 'memory' and 'extra-memory'
-# to overwrite resource requirements.
+# Specify 'baseCPU', 'cpuPerNode', 'baseMemory', and 'memoryPerNode' to
+# overwrite the CLI resource options 'cpu', 'extra-cpu', 'memory' and 'extra-memory'
+# respectively.
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
This fixes the comment at the beginning of the addon-resizer deployment example
so that it describes the correct key names to use for configuring the cpu
and memory parameters.