### PR TITLE
fix: add missing RBAC permissions to autoscaler chart

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.9.2
+version: 9.9.3

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -106,6 +106,8 @@ rules:
     resources:
     - storageclasses
     - csinodes
+    - csidrivers
+    - csistoragecapacities
     verbs:
     - watch
     - list


### PR DESCRIPTION
Fixes #4114 

Added RBAC permissions to watch, list and get `csidrivers` and `csistoragecapacities`