### PR TITLE
Helm Chart RBAC update

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.9.2
+version: 9.9.3

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -104,6 +104,8 @@ rules:
   - apiGroups:
     - storage.k8s.io
     resources:
+    - csistoragecapacities
+    - csidrivers
     - storageclasses
     - csinodes
     verbs:


### PR DESCRIPTION
Currently, RBAC for autoscaler does not allow csidriver and csistoragecapacities resources, which generates errors when applied. This generates logs such as the following:

```sh
Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: csidrivers.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-aws-cluster-autoscaler" cannot list resource "csidrivers" in API group "storage.k8s.io" at the cluster scope
```

```sh
Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: csistoragecapacities.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-aws-cluster-autoscaler" cannot list resource "csistoragecapacities" in API group "storage.k8s.io" at the cluster scope
```

To resolve the issue, these endpoints are added to the cluster role RBAC.