### PR TITLE
Increase the server creation timeout to give the initialization process some leeway

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -40,7 +40,7 @@ const (
 	nodeGroupLabel         = hcloudLabelNamespace + "/node-group"
 	hcloudLabelNamespace   = "hcloud"
 	drainingNodePoolId     = "draining-node-pool"
-	serverCreateTimeout    = 1 * time.Minute
+	serverCreateTimeout    = 5 * time.Minute
 	serverRegisterTimeout  = 10 * time.Minute
 	defaultPodAmountsLimit = 110
 )


### PR DESCRIPTION
Currently, if the Hetzner Cloud initialization process takes longer than a minute, perhaps due to spinning up images from large snapshots (or other reasons), the server is deleted via the API and the autoscaler tries again. This results in a constant deletion/creation loop which could potentially get expensive.

I have a working docker image built off this fix and I've not run into issues thus far. The image below is linked from my autoscaler fork.

```
docker pull ghcr.io/marvinpinto/autoscaler:628f187a
```

cc: @LKaemmerling @fhofherr
