### PR TITLE
Fix addon resizer node metric

### DIFF
--- a/addon-resizer/nanny/kubernetes_client.go
+++ b/addon-resizer/nanny/kubernetes_client.go
@@ -33,9 +33,11 @@ import (
 )
 
 const (
-	// objectCountMetricName is the metric to be used to get number of nodes
-	objectCountMetricName = "etcd_object_counts"
-	// nodeResourceName is the label value for Nodes in objectCountMetricName metric.
+	// objectCountMetricName is the preferred metric to be used to get number of nodes (present in Kubernetes 1.21 and higher)
+	objectCountMetricName = "apiserver_storage_objects"
+	// objectCountFallbackMetricName is the metric to be used to get number of nodes if objectCountMetricName metric is missing
+	objectCountFallbackMetricName = "etcd_object_counts"
+	// nodeResourceName is the label value for Nodes in objectCountFallbackMetricName and objectCountMetricName metrics.
 	nodeResourceName = "nodes"
 	// resourceLabel is the label name for resource.
 	resourceLabel = "resource"
@@ -83,17 +85,36 @@ func hasEqualValues(a string, b *string) bool {
 	return b != nil && a == *b
 }
 
-func (k *kubernetesClient) countNodesThroughMetrics() (uint64, error) {
-	// Similarly as for listing nodes, permissions for /metrics endpoint are needed.
-	// Other than that, endpoint is visible from everywhere.
-	reader, err := k.clientset.CoreV1().RESTClient().Get().RequestURI("/metrics").Stream(context.Background())
-	if err != nil {
-		return 0, err
+func extractMetricValueForNodeCount(mf dto.MetricFamily) (uint64, error) {
+	for _, metric := range mf.Metric {
+		hasLabel := false
+		for _, label := range metric.Label {
+			if hasEqualValues(resourceLabel, label.Name) && hasEqualValues(nodeResourceName, label.Value) {
+				hasLabel = true
+				break
+			}
+		}
+		if !hasLabel {
+			continue
+		}
+		if metric.Gauge == nil || metric.Gauge.Value == nil {
+			continue
+		}
+		if *metric.Gauge.Value < 0 {
+			return 0, fmt.Errorf("metric unknown")
+		}
+		value := uint64(*metric.Gauge.Value)
+		return value, nil
 	}
+	return 0, fmt.Errorf("no valid metric values")
+}
 
-	decoder := expfmt.NewDecoder(reader, expfmt.FmtText)
-
+func getNodeCountFromDecoder(decoder expfmt.Decoder) (uint64, error) {
 	var mf dto.MetricFamily
+	var fallbackNodeCountMetricValue uint64
+	var fallbackMetricError error
+	useNodeCountFromFallbackMetric := false
+
 	for {
 		if err := decoder.Decode(&mf); err != nil {
 			if err == io.EOF {
@@ -101,34 +122,31 @@ func (k *kubernetesClient) countNodesThroughMetrics() (uint64, error) {
 			}
 			return 0, fmt.Errorf("decoding error: %v", err)
 		}
-
-		if !hasEqualValues(objectCountMetricName, mf.Name) {
-			continue
+		if hasEqualValues(objectCountMetricName, mf.Name) {
+			// Preferred metric is present - return immediately
+			return extractMetricValueForNodeCount(mf)
 		}
-		for _, metric := range mf.Metric {
-			hasLabel := false
-			for _, label := range metric.Label {
-				if hasEqualValues(resourceLabel, label.Name) && hasEqualValues(nodeResourceName, label.Value) {
-					hasLabel = true
-					break
-				}
-			}
-			if !hasLabel {
-				continue
-			}
-			if metric.Gauge == nil || metric.Gauge.Value == nil {
-				continue
-			}
-			if *metric.Gauge.Value < 0 {
-				return 0, fmt.Errorf("metric unknown")
-			}
-			value := uint64(*metric.Gauge.Value)
-			return value, nil
-
+		if hasEqualValues(objectCountFallbackMetricName, mf.Name) {
+			// Fallback metric is present - store values to return later (in case the preferred metric is missing)
+			fallbackNodeCountMetricValue, fallbackMetricError = extractMetricValueForNodeCount(mf)
+			useNodeCountFromFallbackMetric = true
 		}
 	}
 
+	if useNodeCountFromFallbackMetric {
+		return fallbackNodeCountMetricValue, fallbackMetricError
+	}
 	return 0, fmt.Errorf("metric unset")
+}
+
+func (k *kubernetesClient) countNodesThroughMetrics() (uint64, error) {
+	// Similarly as for listing nodes, permissions for /metrics endpoint are needed.
+	// Other than that, endpoint is visible from everywhere.
+	reader, err := k.clientset.CoreV1().RESTClient().Get().RequestURI("/metrics").Stream(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	return getNodeCountFromDecoder(expfmt.NewDecoder(reader, expfmt.FmtText))
 }
 
 func (k *kubernetesClient) ContainerResources() (*corev1.ResourceRequirements, error) {

--- a/addon-resizer/nanny/kubernetes_client.go
+++ b/addon-resizer/nanny/kubernetes_client.go
@@ -119,10 +119,10 @@ func (k *kubernetesClient) countNodesThroughMetrics() (uint64, error) {
 			if metric.Gauge == nil || metric.Gauge.Value == nil {
 				continue
 			}
-			value := uint64(*metric.Gauge.Value)
-			if value < 0 {
+			if *metric.Gauge.Value < 0 {
 				return 0, fmt.Errorf("metric unknown")
 			}
+			value := uint64(*metric.Gauge.Value)
 			return value, nil
 
 		}

--- a/addon-resizer/nanny/kubernetes_client_test.go
+++ b/addon-resizer/nanny/kubernetes_client_test.go
@@ -274,7 +274,7 @@ func TestGetNodeCountFromDecoder(t *testing.T) {
 			expectErr:   fmt.Errorf("decoding error: oops"),
 		},
 		{
-			name:        "fallbacks on error preferred on preferred metric",
+			name:        "falls back on error in preferred metric",
 			finalResult: io.EOF,
 			metricValues: []dto.MetricFamily{
 				{


### PR DESCRIPTION
Addon Resizer will use available metric for node count
    
Kubernetes 1.21 and newer have `apiserver_storage_objects` (1.20 and older don't have the metric).
Kubernetes 1.21 and older have `etcd_object_counts` (1.22 and newer won't have the metric).
    
To let addon resizer work with all K8s versions use whichever metric is available, if both are available then prefer the newer metric.
    
See also https://github.com/kubernetes/autoscaler/issues/3979

Fix a small bug where we were checking if unsigned int is less than 0.