### PR TITLE
Metrics for AWS API calls

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling.go
@@ -106,7 +106,9 @@ func (m autoScalingWrapper) getInstanceTypeByLCNames(launchConfigToQuery []*stri
 			LaunchConfigurationNames: launchConfigToQuery[i:end],
 			MaxRecords:               aws.Int64(50),
 		}
+		start := time.Now()
 		r, err := m.DescribeLaunchConfigurations(params)
+		observeAWSRequest("DescribeLaunchConfigurations", err, start)
 		if err != nil {
 			return nil, err
 		}
@@ -156,12 +158,15 @@ func (m *autoScalingWrapper) getAutoscalingGroupsByNames(names []string) ([]*aut
 			AutoScalingGroupNames: aws.StringSlice(names[i:end]),
 			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
 		}
-		if err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
+		start := time.Now()
+		err := m.DescribeAutoScalingGroupsPages(input, func(output *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 			asgs = append(asgs, output.AutoScalingGroups...)
 			// We return true while we want to be called with the next page of
 			// results, if any.
 			return true
-		}); err != nil {
+		})
+		observeAWSRequest("DescribeAutoScalingGroupsPages", err, start)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -235,12 +240,16 @@ func (m *autoScalingWrapper) getAutoscalingGroupNamesByTags(kvs map[string]strin
 		Filters:    filters,
 		MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
 	}
-	if err := m.DescribeTagsPages(input, func(out *autoscaling.DescribeTagsOutput, _ bool) bool {
+	start := time.Now()
+	err := m.DescribeTagsPages(input, func(out *autoscaling.DescribeTagsOutput, _ bool) bool {
 		tags = append(tags, out.Tags...)
 		// We return true while we want to be called with the next page of
 		// results, if any.
 		return true
-	}); err != nil {
+	})
+	observeAWSRequest("DescribeTagsPages", err, start)
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 
@@ -217,7 +218,9 @@ func (m *asgCache) setAsgSizeNoLock(asg *asg, size int) error {
 		HonorCooldown:        aws.Bool(false),
 	}
 	klog.V(0).Infof("Setting asg %s size to %d", asg.Name, size)
+	start := time.Now()
 	_, err := m.service.SetDesiredCapacity(params)
+	observeAWSRequest("SetDesiredCapacity", err, start)
 	if err != nil {
 		return err
 	}
@@ -270,7 +273,9 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 				InstanceId:                     aws.String(instance.Name),
 				ShouldDecrementDesiredCapacity: aws.Bool(true),
 			}
+			start := time.Now()
 			resp, err := m.service.TerminateInstanceInAutoScalingGroup(params)
+			observeAWSRequest("TerminateInstanceInAutoScalingGroup", err, start)
 			if err != nil {
 				return err
 			}

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -393,5 +393,6 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if err != nil {
 		klog.Fatalf("Failed to create AWS cloud provider: %v", err)
 	}
+	RegisterMetrics()
 	return provider
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_metrics.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_metrics.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	caNamespace = "cluster_autoscaler"
+)
+
+var (
+	/**** Metrics related to AWS API usage ****/
+	requestSummary = k8smetrics.NewHistogramVec(
+		&k8smetrics.HistogramOpts{
+			Namespace: caNamespace,
+			Name:      "aws_request_duration_seconds",
+			Help:      "Time taken by AWS requests, by method and status code, in seconds",
+			Buckets:   []float64{0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0},
+		}, []string{"endpoint", "status"},
+	)
+)
+
+// RegisterMetrics registers all AWS metrics.
+func RegisterMetrics() {
+	legacyregistry.MustRegister(requestSummary)
+}
+
+// observeAWSRequest records AWS API calls counts and durations
+func observeAWSRequest(endpoint string, err error, start time.Time) {
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+		if awsErr, ok := err.(awserr.Error); ok {
+			status = awsErr.Code()
+		}
+	}
+	requestSummary.WithLabelValues(endpoint, status).Observe(duration)
+}

--- a/cluster-autoscaler/cloudprovider/aws/ec2.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -37,7 +38,9 @@ func (m ec2Wrapper) getInstanceTypeByLT(launchTemplate *launchTemplate) (string,
 		Versions:           []*string{aws.String(launchTemplate.version)},
 	}
 
+	start := time.Now()
 	describeData, err := m.DescribeLaunchTemplateVersions(params)
+	observeAWSRequest("DescribeLaunchTemplateVersions", err, start)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Provide metrics for AWS API calls; helps identifying slowness, throttling causes, and errors bursts.
That's similar to what [GCE provider does](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/gce/gce_metrics.go).