### PR TITLE
Skipping metrics tests added in #4022

### DIFF
--- a/cluster-autoscaler/metrics/metrics_test.go
+++ b/cluster-autoscaler/metrics/metrics_test.go
@@ -24,12 +24,14 @@ import (
 )
 
 func TestDisabledPerNodeGroupMetrics(t *testing.T) {
+	t.Skip("Registering metrics multiple times causes panic. Skipping until the test is fixed to not impact other tests.")
 	RegisterAll(false)
 	assert.False(t, nodesGroupMinNodes.IsCreated())
 	assert.False(t, nodesGroupMaxNodes.IsCreated())
 }
 
 func TestEnabledPerNodeGroupMetrics(t *testing.T) {
+	t.Skip("Registering metrics multiple times causes panic. Skipping until the test is fixed to not impact other tests.")
 	RegisterAll(true)
 	assert.True(t, nodesGroupMinNodes.IsCreated())
 	assert.True(t, nodesGroupMaxNodes.IsCreated())


### PR DESCRIPTION
Each test works in isolation, but they cause panic when the entire
suite is run (ex. make test-in-docker), because the underlying
metrics library panics when the same metric is registered twice.