### PR TITLE
Move GetNodeInfosForGroups to it's own processor

### DIFF
--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfos"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -142,6 +143,7 @@ func NewTestProcessors() *processors.AutoscalingProcessors {
 		AutoscalingStatusProcessor: &status.NoOpAutoscalingStatusProcessor{},
 		NodeGroupManager:           nodegroups.NewDefaultNodeGroupManager(),
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
+		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
 	}

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -528,7 +529,7 @@ func runSimpleScaleUpTest(t *testing.T, config *scaleTestConfig) *scaleTestResul
 	}
 	context.ExpanderStrategy = expander
 
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, listers, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 
@@ -687,7 +688,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodes := []*apiv1.Node{n1, n2}
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, listers, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 	p3 := BuildTestPod("p-new", 550, 0)
@@ -727,7 +728,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodes := []*apiv1.Node{n1}
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, listers, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 	p3 := BuildTestPod("p-new", 500, 0)
@@ -792,7 +793,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil)
 	assert.NoError(t, err)
 
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, listers, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 
@@ -860,7 +861,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	processors.NodeGroupManager = &mockAutoprovisioningNodeGroupManager{t, 0}
 
 	nodes := []*apiv1.Node{}
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, context.ListerRegistry, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 
 	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p1}, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 	assert.NoError(t, err)
@@ -913,7 +914,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	processors.NodeGroupManager = &mockAutoprovisioningNodeGroupManager{t, 2}
 
 	nodes := []*apiv1.Node{}
-	nodeInfos, _ := utils.GetNodeInfosForGroups(nodes, nil, provider, context.ListerRegistry, []*appsv1.DaemonSet{}, context.PredicateChecker, nil)
+	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider().Process(nodes, &context, []*appsv1.DaemonSet{}, nil)
 
 	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, []*apiv1.Pod{p1, p2, p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 	assert.NoError(t, err)

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -31,139 +31,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
-	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-
-	klog "k8s.io/klog/v2"
 )
-
-// GetNodeInfosForGroups finds NodeInfos for all node groups used to manage the given nodes. It also returns a node group to sample node mapping.
-func GetNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedulerframework.NodeInfo, cloudProvider cloudprovider.CloudProvider, listers kube_util.ListerRegistry,
-	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.
-	// TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
-	daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
-	result := make(map[string]*schedulerframework.NodeInfo)
-	seenGroups := make(map[string]bool)
-
-	podsForNodes, err := getPodsForNodes(listers)
-	if err != nil {
-		return map[string]*schedulerframework.NodeInfo{}, err
-	}
-
-	// processNode returns information whether the nodeTemplate was generated and if there was an error.
-	processNode := func(node *apiv1.Node) (bool, string, errors.AutoscalerError) {
-		nodeGroup, err := cloudProvider.NodeGroupForNode(node)
-		if err != nil {
-			return false, "", errors.ToAutoscalerError(errors.CloudProviderError, err)
-		}
-		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
-			return false, "", nil
-		}
-		id := nodeGroup.Id()
-		if _, found := result[id]; !found {
-			// Build nodeInfo.
-			nodeInfo, err := simulator.BuildNodeInfoForNode(node, podsForNodes)
-			if err != nil {
-				return false, "", err
-			}
-			sanitizedNodeInfo, err := sanitizeNodeInfo(nodeInfo, id, ignoredTaints)
-			if err != nil {
-				return false, "", err
-			}
-			result[id] = sanitizedNodeInfo
-			return true, id, nil
-		}
-		return false, "", nil
-	}
-
-	for _, node := range nodes {
-		// Broken nodes might have some stuff missing. Skipping.
-		if !kube_util.IsNodeReadyAndSchedulable(node) {
-			continue
-		}
-		added, id, typedErr := processNode(node)
-		if typedErr != nil {
-			return map[string]*schedulerframework.NodeInfo{}, typedErr
-		}
-		if added && nodeInfoCache != nil {
-			if nodeInfoCopy, err := deepCopyNodeInfo(result[id]); err == nil {
-				nodeInfoCache[id] = nodeInfoCopy
-			}
-		}
-	}
-	for _, nodeGroup := range cloudProvider.NodeGroups() {
-		id := nodeGroup.Id()
-		seenGroups[id] = true
-		if _, found := result[id]; found {
-			continue
-		}
-
-		// No good template, check cache of previously running nodes.
-		if nodeInfoCache != nil {
-			if nodeInfo, found := nodeInfoCache[id]; found {
-				if nodeInfoCopy, err := deepCopyNodeInfo(nodeInfo); err == nil {
-					result[id] = nodeInfoCopy
-					continue
-				}
-			}
-		}
-
-		// No good template, trying to generate one. This is called only if there are no
-		// working nodes in the node groups. By default CA tries to use a real-world example.
-		nodeInfo, err := GetNodeInfoFromTemplate(nodeGroup, daemonsets, predicateChecker, ignoredTaints)
-		if err != nil {
-			if err == cloudprovider.ErrNotImplemented {
-				continue
-			} else {
-				klog.Errorf("Unable to build proper template node for %s: %v", id, err)
-				return map[string]*schedulerframework.NodeInfo{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
-			}
-		}
-		result[id] = nodeInfo
-	}
-
-	// Remove invalid node groups from cache
-	for id := range nodeInfoCache {
-		if _, ok := seenGroups[id]; !ok {
-			delete(nodeInfoCache, id)
-		}
-	}
-
-	// Last resort - unready/unschedulable nodes.
-	for _, node := range nodes {
-		// Allowing broken nodes
-		if !kube_util.IsNodeReadyAndSchedulable(node) {
-			added, _, typedErr := processNode(node)
-			if typedErr != nil {
-				return map[string]*schedulerframework.NodeInfo{}, typedErr
-			}
-			nodeGroup, err := cloudProvider.NodeGroupForNode(node)
-			if err != nil {
-				return map[string]*schedulerframework.NodeInfo{}, errors.ToAutoscalerError(
-					errors.CloudProviderError, err)
-			}
-			if added {
-				klog.Warningf("Built template for %s based on unready/unschedulable node %s", nodeGroup.Id(), node.Name)
-			}
-		}
-	}
-
-	return result, nil
-}
-
-func getPodsForNodes(listers kube_util.ListerRegistry) (map[string][]*apiv1.Pod, errors.AutoscalerError) {
-	pods, err := listers.ScheduledPodLister().List()
-	if err != nil {
-		return nil, errors.ToAutoscalerError(errors.ApiCallError, err)
-	}
-	podsForNodes := map[string][]*apiv1.Pod{}
-	for _, p := range pods {
-		podsForNodes[p.Spec.NodeName] = append(podsForNodes[p.Spec.NodeName], p)
-	}
-	return podsForNodes, nil
-}
 
 // GetNodeInfoFromTemplate returns NodeInfo object built base on TemplateNodeInfo returned by NodeGroup.TemplateNodeInfo().
 func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
@@ -184,7 +55,7 @@ func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*ap
 	}
 	fullNodeInfo := schedulerframework.NewNodeInfo(pods...)
 	fullNodeInfo.SetNode(baseNodeInfo.Node())
-	sanitizedNodeInfo, typedErr := sanitizeNodeInfo(fullNodeInfo, id, ignoredTaints)
+	sanitizedNodeInfo, typedErr := SanitizeNodeInfo(fullNodeInfo, id, ignoredTaints)
 	if typedErr != nil {
 		return nil, typedErr
 	}
@@ -217,7 +88,8 @@ func FilterOutNodesFromNotAutoscaledGroups(nodes []*apiv1.Node, cloudProvider cl
 	return result, nil
 }
 
-func deepCopyNodeInfo(nodeInfo *schedulerframework.NodeInfo) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+// DeepCopyNodeInfo clones the provided nodeInfo
+func DeepCopyNodeInfo(nodeInfo *schedulerframework.NodeInfo) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
 	newPods := make([]*apiv1.Pod, 0)
 	for _, podInfo := range nodeInfo.Pods {
 		newPods = append(newPods, podInfo.Pod.DeepCopy())
@@ -229,7 +101,8 @@ func deepCopyNodeInfo(nodeInfo *schedulerframework.NodeInfo) (*schedulerframewor
 	return newNodeInfo, nil
 }
 
-func sanitizeNodeInfo(nodeInfo *schedulerframework.NodeInfo, nodeGroupName string, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+// SanitizeNodeInfo modify nodeInfos generated from templates to avoid using duplicated host names
+func SanitizeNodeInfo(nodeInfo *schedulerframework.NodeInfo, nodeGroupName string, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
 	// Sanitize node name.
 	sanitizedNode, err := sanitizeTemplateNode(nodeInfo.Node(), nodeGroupName, ignoredTaints)
 	if err != nil {

--- a/cluster-autoscaler/core/utils/utils_test.go
+++ b/cluster-autoscaler/core/utils/utils_test.go
@@ -20,203 +20,13 @@ import (
 	"testing"
 	"time"
 
-	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
-	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
-
-func TestGetNodeInfosForGroups(t *testing.T) {
-	ready1 := BuildTestNode("n1", 1000, 1000)
-	SetNodeReadyState(ready1, true, time.Now())
-	ready2 := BuildTestNode("n2", 2000, 2000)
-	SetNodeReadyState(ready2, true, time.Now())
-	unready3 := BuildTestNode("n3", 3000, 3000)
-	SetNodeReadyState(unready3, false, time.Now())
-	unready4 := BuildTestNode("n4", 4000, 4000)
-	SetNodeReadyState(unready4, false, time.Now())
-
-	tn := BuildTestNode("tn", 5000, 5000)
-	tni := schedulerframework.NewNodeInfo()
-	tni.SetNode(tn)
-
-	// Cloud provider with TemplateNodeInfo implemented.
-	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
-		nil, nil, nil, nil, nil,
-		map[string]*schedulerframework.NodeInfo{"ng3": tni, "ng4": tni})
-	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
-	provider1.AddNode("ng1", ready1)
-	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
-	provider1.AddNode("ng2", ready2)
-	provider1.AddNode("ng2", unready3)
-	provider1.AddNodeGroup("ng3", 1, 10, 1) // Nodegroup with unready node.
-	provider1.AddNode("ng3", unready4)
-	provider1.AddNodeGroup("ng4", 0, 1000, 0) // Nodegroup without nodes.
-
-	// Cloud provider with TemplateNodeInfo not implemented.
-	provider2 := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil, nil, nil, nil, nil)
-	provider2.AddNodeGroup("ng5", 1, 10, 1) // Nodegroup without nodes.
-
-	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
-	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
-
-	predicateChecker, err := simulator.NewTestPredicateChecker()
-	assert.NoError(t, err)
-
-	res, err := GetNodeInfosForGroups([]*apiv1.Node{unready4, unready3, ready2, ready1}, nil,
-		provider1, registry, []*appsv1.DaemonSet{}, predicateChecker, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, len(res))
-	info, found := res["ng1"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready1, info.Node())
-	info, found = res["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, info.Node())
-	info, found = res["ng3"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, tn, info.Node())
-	info, found = res["ng4"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, tn, info.Node())
-
-	// Test for a nodegroup without nodes and TemplateNodeInfo not implemented by cloud proivder
-	res, err = GetNodeInfosForGroups([]*apiv1.Node{}, nil, provider2, registry,
-		[]*appsv1.DaemonSet{}, predicateChecker, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(res))
-}
-
-func TestGetNodeInfosForGroupsCache(t *testing.T) {
-	ready1 := BuildTestNode("n1", 1000, 1000)
-	SetNodeReadyState(ready1, true, time.Now())
-	ready2 := BuildTestNode("n2", 2000, 2000)
-	SetNodeReadyState(ready2, true, time.Now())
-	unready3 := BuildTestNode("n3", 3000, 3000)
-	SetNodeReadyState(unready3, false, time.Now())
-	unready4 := BuildTestNode("n4", 4000, 4000)
-	SetNodeReadyState(unready4, false, time.Now())
-	ready5 := BuildTestNode("n5", 5000, 5000)
-	SetNodeReadyState(ready5, true, time.Now())
-	ready6 := BuildTestNode("n6", 6000, 6000)
-	SetNodeReadyState(ready6, true, time.Now())
-
-	tn := BuildTestNode("tn", 10000, 10000)
-	tni := schedulerframework.NewNodeInfo()
-	tni.SetNode(tn)
-
-	lastDeletedGroup := ""
-	onDeleteGroup := func(id string) error {
-		lastDeletedGroup = id
-		return nil
-	}
-
-	// Cloud provider with TemplateNodeInfo implemented.
-	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
-		nil, nil, nil, onDeleteGroup, nil,
-		map[string]*schedulerframework.NodeInfo{"ng3": tni, "ng4": tni})
-	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
-	provider1.AddNode("ng1", ready1)
-	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
-	provider1.AddNode("ng2", ready2)
-	provider1.AddNode("ng2", unready3)
-	provider1.AddNodeGroup("ng3", 1, 10, 1) // Nodegroup with unready node (and 1 previously ready node).
-	provider1.AddNode("ng3", unready4)
-	provider1.AddNode("ng3", ready5)
-	provider1.AddNodeGroup("ng4", 0, 1000, 0) // Nodegroup without nodes (and 1 previously ready node).
-	provider1.AddNode("ng4", ready6)
-
-	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
-	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
-
-	predicateChecker, err := simulator.NewTestPredicateChecker()
-	assert.NoError(t, err)
-
-	nodeInfoCache := make(map[string]*schedulerframework.NodeInfo)
-
-	// Fill cache
-	res, err := GetNodeInfosForGroups([]*apiv1.Node{unready4, unready3, ready2, ready1}, nodeInfoCache,
-		provider1, registry, []*appsv1.DaemonSet{}, predicateChecker, nil)
-	assert.NoError(t, err)
-	// Check results
-	assert.Equal(t, 4, len(res))
-	info, found := res["ng1"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready1, info.Node())
-	info, found = res["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, info.Node())
-	info, found = res["ng3"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, tn, info.Node())
-	info, found = res["ng4"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, tn, info.Node())
-	// Check cache
-	cachedInfo, found := nodeInfoCache["ng1"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready1, cachedInfo.Node())
-	cachedInfo, found = nodeInfoCache["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
-	cachedInfo, found = nodeInfoCache["ng3"]
-	assert.False(t, found)
-	cachedInfo, found = nodeInfoCache["ng4"]
-	assert.False(t, found)
-
-	// Invalidate part of cache in two different ways
-	provider1.DeleteNodeGroup("ng1")
-	provider1.GetNodeGroup("ng3").Delete()
-	assert.Equal(t, "ng3", lastDeletedGroup)
-
-	// Check cache with all nodes removed
-	res, err = GetNodeInfosForGroups([]*apiv1.Node{}, nodeInfoCache,
-		provider1, registry, []*appsv1.DaemonSet{}, predicateChecker, nil)
-	assert.NoError(t, err)
-	// Check results
-	assert.Equal(t, 2, len(res))
-	info, found = res["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, info.Node())
-	// Check ng4 result and cache
-	info, found = res["ng4"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, tn, info.Node())
-	// Check cache
-	cachedInfo, found = nodeInfoCache["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
-	cachedInfo, found = nodeInfoCache["ng4"]
-	assert.False(t, found)
-
-	// Fill cache manually
-	infoNg4Node6 := schedulerframework.NewNodeInfo()
-	infoNg4Node6.SetNode(ready6.DeepCopy())
-	nodeInfoCache = map[string]*schedulerframework.NodeInfo{"ng4": infoNg4Node6}
-	// Check if cache was used
-	res, err = GetNodeInfosForGroups([]*apiv1.Node{ready1, ready2}, nodeInfoCache,
-		provider1, registry, []*appsv1.DaemonSet{}, predicateChecker, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(res))
-	info, found = res["ng2"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready2, info.Node())
-	info, found = res["ng4"]
-	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready6, info.Node())
-}
-
-func assertEqualNodeCapacities(t *testing.T, expected, actual *apiv1.Node) {
-	t.Helper()
-	assert.Equal(t, getNodeResource(expected, apiv1.ResourceCPU), getNodeResource(actual, apiv1.ResourceCPU), "CPU should be the same")
-	assert.Equal(t, getNodeResource(expected, apiv1.ResourceMemory), getNodeResource(actual, apiv1.ResourceMemory), "Memory should be the same")
-}
 
 func TestSanitizeNodeInfo(t *testing.T) {
 	pod := BuildTestPod("p1", 80, 0)
@@ -227,7 +37,7 @@ func TestSanitizeNodeInfo(t *testing.T) {
 	nodeInfo := schedulerframework.NewNodeInfo(pod)
 	nodeInfo.SetNode(node)
 
-	res, err := sanitizeNodeInfo(nodeInfo, "test-group", nil)
+	res, err := SanitizeNodeInfo(nodeInfo, "test-group", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(res.Pods))
 }

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfosprovider
+
+import (
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	klog "k8s.io/klog/v2"
+)
+
+// MixedTemplateNodeInfoProvider build nodeInfos from the cluster's nodes and node groups.
+type MixedTemplateNodeInfoProvider struct {
+	nodeInfoCache map[string]*schedulerframework.NodeInfo
+}
+
+// NewMixedTemplateNodeInfoProvider returns a NodeInfoProvider processor building
+// NodeInfos from real-world nodes when available, otherwise from node groups templates.
+func NewMixedTemplateNodeInfoProvider() *MixedTemplateNodeInfoProvider {
+	return &MixedTemplateNodeInfoProvider{
+		nodeInfoCache: make(map[string]*schedulerframework.NodeInfo),
+	}
+}
+
+// CleanUp cleans up processor's internal structures.
+func (p *MixedTemplateNodeInfoProvider) CleanUp() {
+}
+
+// Process returns the nodeInfos set for this cluster
+func (p *MixedTemplateNodeInfoProvider) Process(nodes []*apiv1.Node, ctx *context.AutoscalingContext, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.
+	// TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
+	result := make(map[string]*schedulerframework.NodeInfo)
+	seenGroups := make(map[string]bool)
+
+	podsForNodes, err := getPodsForNodes(ctx.ListerRegistry)
+	if err != nil {
+		return map[string]*schedulerframework.NodeInfo{}, err
+	}
+
+	// processNode returns information whether the nodeTemplate was generated and if there was an error.
+	processNode := func(node *apiv1.Node) (bool, string, errors.AutoscalerError) {
+		nodeGroup, err := ctx.CloudProvider.NodeGroupForNode(node)
+		if err != nil {
+			return false, "", errors.ToAutoscalerError(errors.CloudProviderError, err)
+		}
+		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
+			return false, "", nil
+		}
+		id := nodeGroup.Id()
+		if _, found := result[id]; !found {
+			// Build nodeInfo.
+			nodeInfo, err := simulator.BuildNodeInfoForNode(node, podsForNodes)
+			if err != nil {
+				return false, "", err
+			}
+			sanitizedNodeInfo, err := utils.SanitizeNodeInfo(nodeInfo, id, ignoredTaints)
+			if err != nil {
+				return false, "", err
+			}
+			result[id] = sanitizedNodeInfo
+			return true, id, nil
+		}
+		return false, "", nil
+	}
+
+	for _, node := range nodes {
+		// Broken nodes might have some stuff missing. Skipping.
+		if !kube_util.IsNodeReadyAndSchedulable(node) {
+			continue
+		}
+		added, id, typedErr := processNode(node)
+		if typedErr != nil {
+			return map[string]*schedulerframework.NodeInfo{}, typedErr
+		}
+		if added && p.nodeInfoCache != nil {
+			if nodeInfoCopy, err := utils.DeepCopyNodeInfo(result[id]); err == nil {
+				p.nodeInfoCache[id] = nodeInfoCopy
+			}
+		}
+	}
+	for _, nodeGroup := range ctx.CloudProvider.NodeGroups() {
+		id := nodeGroup.Id()
+		seenGroups[id] = true
+		if _, found := result[id]; found {
+			continue
+		}
+
+		// No good template, check cache of previously running nodes.
+		if p.nodeInfoCache != nil {
+			if nodeInfo, found := p.nodeInfoCache[id]; found {
+				if nodeInfoCopy, err := utils.DeepCopyNodeInfo(nodeInfo); err == nil {
+					result[id] = nodeInfoCopy
+					continue
+				}
+			}
+		}
+
+		// No good template, trying to generate one. This is called only if there are no
+		// working nodes in the node groups. By default CA tries to use a real-world example.
+		nodeInfo, err := utils.GetNodeInfoFromTemplate(nodeGroup, daemonsets, ctx.PredicateChecker, ignoredTaints)
+		if err != nil {
+			if err == cloudprovider.ErrNotImplemented {
+				continue
+			} else {
+				klog.Errorf("Unable to build proper template node for %s: %v", id, err)
+				return map[string]*schedulerframework.NodeInfo{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
+			}
+		}
+		result[id] = nodeInfo
+	}
+
+	// Remove invalid node groups from cache
+	for id := range p.nodeInfoCache {
+		if _, ok := seenGroups[id]; !ok {
+			delete(p.nodeInfoCache, id)
+		}
+	}
+
+	// Last resort - unready/unschedulable nodes.
+	for _, node := range nodes {
+		// Allowing broken nodes
+		if !kube_util.IsNodeReadyAndSchedulable(node) {
+			added, _, typedErr := processNode(node)
+			if typedErr != nil {
+				return map[string]*schedulerframework.NodeInfo{}, typedErr
+			}
+			nodeGroup, err := ctx.CloudProvider.NodeGroupForNode(node)
+			if err != nil {
+				return map[string]*schedulerframework.NodeInfo{}, errors.ToAutoscalerError(
+					errors.CloudProviderError, err)
+			}
+			if added {
+				klog.Warningf("Built template for %s based on unready/unschedulable node %s", nodeGroup.Id(), node.Name)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func getPodsForNodes(listers kube_util.ListerRegistry) (map[string][]*apiv1.Pod, errors.AutoscalerError) {
+	pods, err := listers.ScheduledPodLister().List()
+	if err != nil {
+		return nil, errors.ToAutoscalerError(errors.ApiCallError, err)
+	}
+	podsForNodes := map[string][]*apiv1.Pod{}
+	for _, p := range pods {
+		podsForNodes[p.Spec.NodeName] = append(podsForNodes[p.Spec.NodeName], p)
+	}
+	return podsForNodes, nil
+}

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfosprovider
+
+import (
+	"testing"
+	"time"
+
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestGetNodeInfosForGroups(t *testing.T) {
+	ready1 := BuildTestNode("n1", 1000, 1000)
+	SetNodeReadyState(ready1, true, time.Now())
+	ready2 := BuildTestNode("n2", 2000, 2000)
+	SetNodeReadyState(ready2, true, time.Now())
+	unready3 := BuildTestNode("n3", 3000, 3000)
+	SetNodeReadyState(unready3, false, time.Now())
+	unready4 := BuildTestNode("n4", 4000, 4000)
+	SetNodeReadyState(unready4, false, time.Now())
+
+	tn := BuildTestNode("tn", 5000, 5000)
+	tni := schedulerframework.NewNodeInfo()
+	tni.SetNode(tn)
+
+	// Cloud provider with TemplateNodeInfo implemented.
+	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
+		nil, nil, nil, nil, nil,
+		map[string]*schedulerframework.NodeInfo{"ng3": tni, "ng4": tni})
+	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
+	provider1.AddNode("ng1", ready1)
+	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
+	provider1.AddNode("ng2", ready2)
+	provider1.AddNode("ng2", unready3)
+	provider1.AddNodeGroup("ng3", 1, 10, 1) // Nodegroup with unready node.
+	provider1.AddNode("ng3", unready4)
+	provider1.AddNodeGroup("ng4", 0, 1000, 0) // Nodegroup without nodes.
+
+	// Cloud provider with TemplateNodeInfo not implemented.
+	provider2 := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil, nil, nil, nil, nil)
+	provider2.AddNodeGroup("ng5", 1, 10, 1) // Nodegroup without nodes.
+
+	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
+	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
+
+	predicateChecker, err := simulator.NewTestPredicateChecker()
+	assert.NoError(t, err)
+
+	ctx := context.AutoscalingContext{
+		CloudProvider:    provider1,
+		PredicateChecker: predicateChecker,
+		AutoscalingKubeClients: context.AutoscalingKubeClients{
+			ListerRegistry: registry,
+		},
+	}
+	res, err := NewMixedTemplateNodeInfoProvider().Process([]*apiv1.Node{unready4, unready3, ready2, ready1}, &ctx, []*appsv1.DaemonSet{}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(res))
+	info, found := res["ng1"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready1, info.Node())
+	info, found = res["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, info.Node())
+	info, found = res["ng3"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, tn, info.Node())
+	info, found = res["ng4"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, tn, info.Node())
+
+	// Test for a nodegroup without nodes and TemplateNodeInfo not implemented by cloud proivder
+	ctx = context.AutoscalingContext{
+		CloudProvider:    provider2,
+		PredicateChecker: predicateChecker,
+		AutoscalingKubeClients: context.AutoscalingKubeClients{
+			ListerRegistry: registry,
+		},
+	}
+	res, err = NewMixedTemplateNodeInfoProvider().Process([]*apiv1.Node{}, &ctx, []*appsv1.DaemonSet{}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(res))
+}
+
+func TestGetNodeInfosForGroupsCache(t *testing.T) {
+	ready1 := BuildTestNode("n1", 1000, 1000)
+	SetNodeReadyState(ready1, true, time.Now())
+	ready2 := BuildTestNode("n2", 2000, 2000)
+	SetNodeReadyState(ready2, true, time.Now())
+	unready3 := BuildTestNode("n3", 3000, 3000)
+	SetNodeReadyState(unready3, false, time.Now())
+	unready4 := BuildTestNode("n4", 4000, 4000)
+	SetNodeReadyState(unready4, false, time.Now())
+	ready5 := BuildTestNode("n5", 5000, 5000)
+	SetNodeReadyState(ready5, true, time.Now())
+	ready6 := BuildTestNode("n6", 6000, 6000)
+	SetNodeReadyState(ready6, true, time.Now())
+
+	tn := BuildTestNode("tn", 10000, 10000)
+	tni := schedulerframework.NewNodeInfo()
+	tni.SetNode(tn)
+
+	lastDeletedGroup := ""
+	onDeleteGroup := func(id string) error {
+		lastDeletedGroup = id
+		return nil
+	}
+
+	// Cloud provider with TemplateNodeInfo implemented.
+	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
+		nil, nil, nil, onDeleteGroup, nil,
+		map[string]*schedulerframework.NodeInfo{"ng3": tni, "ng4": tni})
+	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
+	provider1.AddNode("ng1", ready1)
+	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
+	provider1.AddNode("ng2", ready2)
+	provider1.AddNode("ng2", unready3)
+	provider1.AddNodeGroup("ng3", 1, 10, 1) // Nodegroup with unready node (and 1 previously ready node).
+	provider1.AddNode("ng3", unready4)
+	provider1.AddNode("ng3", ready5)
+	provider1.AddNodeGroup("ng4", 0, 1000, 0) // Nodegroup without nodes (and 1 previously ready node).
+	provider1.AddNode("ng4", ready6)
+
+	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
+	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
+
+	predicateChecker, err := simulator.NewTestPredicateChecker()
+	assert.NoError(t, err)
+
+	// Fill cache
+	ctx := context.AutoscalingContext{
+		CloudProvider:    provider1,
+		PredicateChecker: predicateChecker,
+		AutoscalingKubeClients: context.AutoscalingKubeClients{
+			ListerRegistry: registry,
+		},
+	}
+	niProcessor := NewMixedTemplateNodeInfoProvider()
+	res, err := niProcessor.Process([]*apiv1.Node{unready4, unready3, ready2, ready1}, &ctx, []*appsv1.DaemonSet{}, nil)
+	assert.NoError(t, err)
+	// Check results
+	assert.Equal(t, 4, len(res))
+	info, found := res["ng1"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready1, info.Node())
+	info, found = res["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, info.Node())
+	info, found = res["ng3"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, tn, info.Node())
+	info, found = res["ng4"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, tn, info.Node())
+	// Check cache
+	cachedInfo, found := niProcessor.nodeInfoCache["ng1"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready1, cachedInfo.Node())
+	cachedInfo, found = niProcessor.nodeInfoCache["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
+	cachedInfo, found = niProcessor.nodeInfoCache["ng3"]
+	assert.False(t, found)
+	cachedInfo, found = niProcessor.nodeInfoCache["ng4"]
+	assert.False(t, found)
+
+	// Invalidate part of cache in two different ways
+	provider1.DeleteNodeGroup("ng1")
+	provider1.GetNodeGroup("ng3").Delete()
+	assert.Equal(t, "ng3", lastDeletedGroup)
+
+	// Check cache with all nodes removed
+	res, err = niProcessor.Process([]*apiv1.Node{unready4, unready3, ready2, ready1}, &ctx, []*appsv1.DaemonSet{}, nil)
+	assert.NoError(t, err)
+	// Check results
+	assert.Equal(t, 2, len(res))
+	info, found = res["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, info.Node())
+	// Check ng4 result and cache
+	info, found = res["ng4"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, tn, info.Node())
+	// Check cache
+	cachedInfo, found = niProcessor.nodeInfoCache["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
+	cachedInfo, found = niProcessor.nodeInfoCache["ng4"]
+	assert.False(t, found)
+
+	// Fill cache manually
+	infoNg4Node6 := schedulerframework.NewNodeInfo()
+	infoNg4Node6.SetNode(ready6.DeepCopy())
+	niProcessor.nodeInfoCache = map[string]*schedulerframework.NodeInfo{"ng4": infoNg4Node6}
+	res, err = niProcessor.Process([]*apiv1.Node{unready4, unready3, ready2, ready1}, &ctx, []*appsv1.DaemonSet{}, nil)
+	// Check if cache was used
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(res))
+	info, found = res["ng2"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready2, info.Node())
+	info, found = res["ng4"]
+	assert.True(t, found)
+	assertEqualNodeCapacities(t, ready6, info.Node())
+}
+
+func assertEqualNodeCapacities(t *testing.T, expected, actual *apiv1.Node) {
+	t.Helper()
+	assert.Equal(t, getNodeResource(expected, apiv1.ResourceCPU), getNodeResource(actual, apiv1.ResourceCPU), "CPU should be the same")
+	assert.Equal(t, getNodeResource(expected, apiv1.ResourceMemory), getNodeResource(actual, apiv1.ResourceMemory), "Memory should be the same")
+}
+
+func getNodeResource(node *apiv1.Node, resource apiv1.ResourceName) int64 {
+	nodeCapacity, found := node.Status.Capacity[resource]
+	if !found {
+		return 0
+	}
+
+	nodeCapacityValue := nodeCapacity.Value()
+	if nodeCapacityValue < 0 {
+		nodeCapacityValue = 0
+	}
+
+	return nodeCapacityValue
+}

--- a/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfosprovider
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// TemplateNodeInfoProvider is provides the initial nodeInfos set.
+type TemplateNodeInfoProvider interface {
+	// Process returns a map of nodeInfos for node groups.
+	Process(nodes []*apiv1.Node, ctx *context.AutoscalingContext, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError)
+	// CleanUp cleans up processor's internal structures.
+	CleanUp()
+}
+
+// NewDefaultTemplateNodeInfoProvider returns a default TemplateNodeInfoProvider.
+func NewDefaultTemplateNodeInfoProvider() TemplateNodeInfoProvider {
+	return NewMixedTemplateNodeInfoProvider()
+}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfos"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
@@ -48,6 +49,8 @@ type AutoscalingProcessors struct {
 	NodeGroupManager nodegroups.NodeGroupManager
 	// NodeInfoProcessor is used to process nodeInfos after they're created.
 	NodeInfoProcessor nodeinfos.NodeInfoProcessor
+	// TemplateNodeInfoProvider is used to create the initial nodeInfos set.
+	TemplateNodeInfoProvider nodeinfosprovider.TemplateNodeInfoProvider
 	// NodeGroupConfigProcessor provides config option for each NodeGroup.
 	NodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor
 	// CustomResourcesProcessor is interface defining handling custom resources
@@ -68,6 +71,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
+		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(),
 	}
 }
 
@@ -84,4 +88,5 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeInfoProcessor.CleanUp()
 	ap.NodeGroupConfigProcessor.CleanUp()
 	ap.CustomResourcesProcessor.CleanUp()
+	ap.TemplateNodeInfoProvider.CleanUp()
 }


### PR DESCRIPTION
Supports providing different NodeInfos sources (either upstream or in
local forks, eg. to properly implement variants like in #4000).

The already existing NodeInfosProcessor doesn't cover that use case: it's
actually a "post processor", and processes the provided nodeInfos set.

This also moves a large and specialized code chunk out of core, and removes
the need to maintain and pass the GetNodeInfosForGroups() cache from the side,
as processors can hold their states themselves.

No functional changes to GetNodeInfosForGroups(), outside mechanical changes
due to the move: remotely call a few utils functions in core/utils package,
pick context attributes (the processor takes the context as arg rather than
ListerRegistry + PredicateChecker + CloudProvider), and use the builtin cache
rather than receiving it from arguments.