### PR TITLE
update cluster-autoscaler CAPI provider owners

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/OWNERS
+++ b/cluster-autoscaler/cloudprovider/clusterapi/OWNERS
@@ -1,14 +1,15 @@
 approvers:
-- frobware
 - enxebre
 - elmiko
 - hardikdr
 - detiber
-- ncdc
 reviewers:
-- frobware
 - enxebre
 - elmiko
 - hardikdr
 - detiber
-- ncdc
+- randomvariable
+- jackfrancis
+- mrajashree
+- arunmk
+- shysank


### PR DESCRIPTION
This change is adding github users arunmk, mrajashree, jackfrancis, and shysank
to the reviews for the cluster-api provider. It also removes frobware
from the approvers and reviewers.