### PR TITLE
[Examples] Update the AWS examples to have 600Mi of memory

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -143,10 +143,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -143,10 +143,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -143,10 +143,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -150,10 +150,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
This change updates the AWS examples to have 600Mi of memory because CAS downloads a pricing file that contains EC2 instance info at startup which grows each time there's new EC2 instance information available. Currently the largest region is hitting the 300Mi limit when downloading that file, so we are increasing the memory limit in our examples for customers.