### PR TITLE
Update go version to 1.16 in Dockerfile and Github Tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - uses: actions/checkout@v2
         with:
@@ -26,11 +26,17 @@ jobs:
       - name: Prepare
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler
         run: hack/install-verify-tools.sh
+        env:
+          GO111MODULE: auto
 
       - name: Verify
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler
         run: hack/verify-all.sh -v
+        env:
+          GO111MODULE: auto
 
       - name: Test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler
         run: hack/for-go-proj.sh test
+        env:
+          GO111MODULE: auto

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14
+FROM golang:1.16
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH
+ENV GO111MODULE auto
 
 RUN apt-get update && apt-get --yes install libseccomp-dev
 RUN go version


### PR DESCRIPTION
Updating the builder in Dockerfile to use go version 1.16, since vendoring to k8s v1.23.0-alpha.0 uses go1.16 packages which will fail otherwise.

GO111MODULE has to turned to `auto` due to the default being changed to `on` in go1.16:
https://golang.org/doc/go1.16#go-command
https://blog.golang.org/go116-module-changes