### PR TITLE
[chart] Add multi string arg support

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.2
+version: 9.10.3

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -362,7 +362,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | envFromConfigMap | string | `""` | ConfigMap name to use as envFrom. |
 | envFromSecret | string | `""` | Secret name to use as envFrom. |
 | expanderPriorities | object | `{}` | The expanderPriorities is used if `extraArgs.expander` is set to `priority` and expanderPriorities is also set with the priorities. If `extraArgs.expander` is set to `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities. See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md |
-| extraArgs | object | `{"logtostderr":true,"stderrthreshold":"info","v":4}` | Additional container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. |
+| extraArgs | object | `{"logtostderr":true,"stderrthreshold":"info","v":4}` | Additional container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. Everything after the first _ will be ignored allowing the use of multi-string arguments. |
 | extraEnv | object | `{}` | Additional container environment variables. |
 | extraEnvConfigMaps | object | `{}` | Additional container environment variables from ConfigMaps. |
 | extraEnvSecrets | object | `{}` | Additional container environment variables from Secrets. |

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -81,10 +81,16 @@ Auto-discovery finds ASGs tags as below and automatically manages them based on 
 - Verify the [IAM Permissions](#aws---iam)
 - Set `autoDiscovery.clusterName=<YOUR CLUSTER NAME>`
 - Set `awsRegion=<YOUR AWS REGION>`
-- Set `awsAccessKeyID=<YOUR AWS KEY ID>` and `awsSecretAccessKey=<YOUR AWS SECRET KEY>` if you want to [use AWS credentials directly instead of an instance role](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials)
+- Set (option) `awsAccessKeyID=<YOUR AWS KEY ID>` and `awsSecretAccessKey=<YOUR AWS SECRET KEY>` if you want to [use AWS credentials directly instead of an instance role](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials)
 
 ```console
-$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME>
+$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION>
+```
+
+Alternatively with your own AWS credentials
+
+```console
+$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION> --set awsAccessKeyID=<YOUR AWS KEY ID> --set awsSecretAccessKey=<YOUR AWS SECRET KEY>
 ```
 
 #### Specifying groups manually

--- a/charts/cluster-autoscaler/templates/NOTES.txt
+++ b/charts/cluster-autoscaler/templates/NOTES.txt
@@ -13,6 +13,6 @@ To verify that cluster-autoscaler has started, run:
 
 The deployment and pod will not be created and the installation is not functional
 See README:
-  open https://github.com/kubernetes/charts/tree/master/stable/cluster-autoscaler
+  open https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
 
 {{- end -}}

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - --cloud-config={{ .Values.cloudConfigPath }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}={{ $value }}
+            - --{{ $key | mustRegexFind "^[^_]+" }}={{ $value }}
           {{- end }}
           env:
           {{- if and (eq .Values.cloudProvider "aws") (ne .Values.awsRegion "") }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -128,6 +128,7 @@ expanderPriorities: {}
 # extraArgs -- Additional container arguments.
 # Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler
 # parameters and their default values.
+# Everything after the first _ will be ignored allowing the use of multi-string arguments.
 extraArgs:
   logtostderr: true
   stderrthreshold: info
@@ -149,6 +150,8 @@ extraArgs:
   # scale-down-delay-after-failure: 3m
   # scale-down-unneeded-time: 10m
   # skip-nodes-with-system-pods: true
+  # balancing-ignore-label_1: first-label-to-ignore
+  # balancing-ignore-label_2: second-label-to-ignore
 
 # extraEnv -- Additional container environment variables.
 extraEnv: {}


### PR DESCRIPTION
Enable `extraArgs` to contain multi-string arguments via an ignored `_x` suffix.

Fixes #3673.