### PR TITLE
Correct link for CA 9.10.3 release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -22,7 +22,7 @@ entries:
     - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
     type: application
     urls:
-    - cluster-autoscaler-9.10.3.tgz
+    - https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.10.3/cluster-autoscaler-9.10.3.tgz
     version: 9.10.3
   - apiVersion: v2
     appVersion: 1.21.0


### PR DESCRIPTION
Follow-up to #4180 - correct the link for the 9.10.3 release.