### PR TITLE
cluster-autoscaler: fix unit tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager_test.go
@@ -36,7 +36,7 @@ func TestBuildGenericLabels(t *testing.T) {
 	}
 	nodeName := "virtual-node"
 	labels := buildGenericLabels(template, nodeName)
-	assert.Equal(t, labels[apiv1.LabelInstanceType], template.InstanceType.instanceTypeID)
+	assert.Equal(t, labels[apiv1.LabelInstanceTypeStable], template.InstanceType.instanceTypeID)
 }
 
 func TestExtractLabelsFromAsg(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -80,9 +80,9 @@ func TestBuildGenericLabels(t *testing.T) {
 		},
 		Region: "us-east-1",
 	}, "sillyname")
-	assert.Equal(t, "us-east-1", labels[apiv1.LabelZoneRegion])
+	assert.Equal(t, "us-east-1", labels[apiv1.LabelZoneRegionStable])
 	assert.Equal(t, "sillyname", labels[apiv1.LabelHostname])
-	assert.Equal(t, "c4.large", labels[apiv1.LabelInstanceType])
+	assert.Equal(t, "c4.large", labels[apiv1.LabelInstanceTypeStable])
 	assert.Equal(t, cloudprovider.DefaultArch, labels[apiv1.LabelArchStable])
 	assert.Equal(t, cloudprovider.DefaultOS, labels[apiv1.LabelOSStable])
 }

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -226,13 +226,13 @@ func TestBuildGenericLabels(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedLabels := map[string]string{
-				apiv1.LabelTopologyRegion:          "us-central1",
-				apiv1.LabelTopologyZone:       	    "us-central1-b",
-				gceCSITopologyKeyZone:              "us-central1-b",
-				apiv1.LabelHostname:                "sillyname",
-				apiv1.LabelInstanceTypeStable:      "n1-standard-8",
-				apiv1.LabelArchStable:              cloudprovider.DefaultArch,
-				apiv1.LabelOSStable:                tc.expectedOsLabel,
+				apiv1.LabelTopologyRegion:     "us-central1",
+				apiv1.LabelTopologyZone:       "us-central1-b",
+				gceCSITopologyKeyZone:         "us-central1-b",
+				apiv1.LabelHostname:           "sillyname",
+				apiv1.LabelInstanceTypeStable: "n1-standard-8",
+				apiv1.LabelArchStable:         cloudprovider.DefaultArch,
+				apiv1.LabelOSStable:           tc.expectedOsLabel,
 			}
 			labels, err := BuildGenericLabels(GceRef{
 				Name:    "kubernetes-minion-group",


### PR DESCRIPTION
Recent changes configured providers to set stable nodes labels names
exclusively (ie. LabelTopologyZone and not LabelZoneFailureDomain, etc),
with older labels names backfilled at nodeInfos templates generation time
(from GetNodeInfoFromTemplate), which isn't invoked from most tests cases.
GCE NodePirce() might have been dereferencing potentially missing labels.
And run hack/update-gofmt.sh where hack/verify-all.sh fails, to pass CI.