### PR TITLE
implement GetOptions for GCE

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -69,6 +69,7 @@ type GceCache struct {
 	instanceRefToMigRef      map[GceRef]GceRef
 	instancesFromUnknownMigs map[GceRef]struct{}
 	resourceLimiter          *cloudprovider.ResourceLimiter
+	autoscalingOptionsCache  map[GceRef]map[string]string
 	machinesCache            map[MachineTypeKey]machinesCacheValue
 	migTargetSizeCache       map[GceRef]int64
 	migBaseNameCache         map[GceRef]string
@@ -85,6 +86,7 @@ func NewGceCache(gceService AutoscalingGceClient, concurrentGceRefreshes int) *G
 		migs:                     map[GceRef]Mig{},
 		instanceRefToMigRef:      map[GceRef]GceRef{},
 		instancesFromUnknownMigs: map[GceRef]struct{}{},
+		autoscalingOptionsCache:  map[GceRef]map[string]string{},
 		machinesCache:            map[MachineTypeKey]machinesCacheValue{},
 		migTargetSizeCache:       map[GceRef]int64{},
 		migBaseNameCache:         map[GceRef]string{},
@@ -288,6 +290,20 @@ func (gc *GceCache) RegenerateInstancesCache() error {
 	}
 
 	return nil
+}
+
+// SetAutoscalingOptions stores autoscaling options strings obtained from IT.
+func (gc *GceCache) SetAutoscalingOptions(ref GceRef, options map[string]string) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+	gc.autoscalingOptionsCache[ref] = options
+}
+
+// GetAutoscalingOptions return autoscaling options strings obtained from IT.
+func (gc *GceCache) GetAutoscalingOptions(ref GceRef) map[string]string {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+	return gc.autoscalingOptionsCache[ref]
 }
 
 // SetResourceLimiter sets resource limiter.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -330,7 +330,7 @@ func (mig *gceMig) Autoprovisioned() bool {
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 func (mig *gceMig) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	return mig.gceManager.GetMigOptions(mig, defaults), nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -85,6 +86,11 @@ func (m *gceManagerMock) GetResourceLimiter() (*cloudprovider.ResourceLimiter, e
 func (m *gceManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	args := m.Called()
 	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *gceManagerMock) GetMigOptions(mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
+	args := m.Called(mig, defaults)
+	return args.Get(0).(*config.NodeGroupAutoscalingOptions)
 }
 
 func (m *gceManagerMock) GetMigTemplateNode(mig Mig) (*apiv1.Node, error) {

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -336,6 +337,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		GceService:               gceService,
 		instanceRefToMigRef:      make(map[GceRef]GceRef),
 		instancesFromUnknownMigs: make(map[GceRef]struct{}),
+		autoscalingOptionsCache:  map[GceRef]map[string]string{},
 		machinesCache: map[MachineTypeKey]machinesCacheValue{
 			{"us-central1-b", "n1-standard-1"}: {&gce.MachineType{GuestCpus: 1, MemoryMb: 1}, nil},
 			{"us-central1-c", "n1-standard-1"}: {&gce.MachineType{GuestCpus: 1, MemoryMb: 1}, nil},
@@ -1575,4 +1577,70 @@ func TestAppendInstances(t *testing.T) {
 	err := g.CreateInstances(defaultPoolMig, 2)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
+}
+
+func TestGetMigOptions(t *testing.T) {
+	defaultOptions := &config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    0.1,
+		ScaleDownGpuUtilizationThreshold: 0.2,
+		ScaleDownUnneededTime:            time.Second,
+		ScaleDownUnreadyTime:             time.Minute,
+	}
+
+	cases := []struct {
+		desc     string
+		opts     map[string]string
+		expected *config.NodeGroupAutoscalingOptions
+	}{
+		{
+			desc:     "return provided defaults on empty metadata",
+			opts:     map[string]string{},
+			expected: defaultOptions,
+		},
+		{
+			desc: "return specified options",
+			opts: map[string]string{
+				config.DefaultScaleDownGpuUtilizationThresholdKey: "0.6",
+				config.DefaultScaleDownUtilizationThresholdKey:    "0.7",
+				config.DefaultScaleDownUnneededTimeKey:            "1h",
+				config.DefaultScaleDownUnreadyTimeKey:             "30m",
+			},
+			expected: &config.NodeGroupAutoscalingOptions{
+				ScaleDownGpuUtilizationThreshold: 0.6,
+				ScaleDownUtilizationThreshold:    0.7,
+				ScaleDownUnneededTime:            time.Hour,
+				ScaleDownUnreadyTime:             30 * time.Minute,
+			},
+		},
+		{
+			desc: "complete partial options specs with defaults",
+			opts: map[string]string{
+				config.DefaultScaleDownGpuUtilizationThresholdKey: "0.1",
+				config.DefaultScaleDownUnneededTimeKey:            "1m",
+			},
+			expected: &config.NodeGroupAutoscalingOptions{
+				ScaleDownGpuUtilizationThreshold: 0.1,
+				ScaleDownUtilizationThreshold:    defaultOptions.ScaleDownUtilizationThreshold,
+				ScaleDownUnneededTime:            time.Minute,
+				ScaleDownUnreadyTime:             defaultOptions.ScaleDownUnreadyTime,
+			},
+		},
+		{
+			desc: "keep defaults on unparsable options values",
+			opts: map[string]string{
+				config.DefaultScaleDownGpuUtilizationThresholdKey: "foo",
+				config.DefaultScaleDownUnneededTimeKey:            "bar",
+			},
+			expected: defaultOptions,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			mgr := newTestGceManager(t, "", false)
+			mig := setupTestDefaultPool(mgr, true)
+			mgr.cache.SetAutoscalingOptions(mig.GceRef(), c.opts)
+			actual := mgr.GetMigOptions(mig, *defaultOptions)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
 }

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	gpuUtils "k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 
@@ -478,6 +479,64 @@ func TestBuildCapacityMemory(t *testing.T) {
 			expectedCapacity, err := makeResourceList2(tc.physicalCpu, tc.expectedCapacityMemory, 0, 110)
 			assert.NoError(t, err)
 			assertEqualResourceLists(t, "Capacity", expectedCapacity, buildCapacity)
+		})
+	}
+}
+
+func TestExtractAutoscalingOptionsFromKubeEnv(t *testing.T) {
+	cases := []struct {
+		desc          string
+		env           string
+		expectedValue map[string]string
+		expectedErr   bool
+	}{
+		{
+			desc:          "autoscaling_options not specified",
+			env:           "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d;node_taints=a=b:c,d=e:f\n",
+			expectedValue: map[string]string{},
+			expectedErr:   false,
+		},
+		{
+			desc:          "empty KubeEnv",
+			env:           "",
+			expectedValue: map[string]string{},
+			expectedErr:   false,
+		},
+		{
+			desc:          "unparsable KubeEnv",
+			env:           "AUTOSCALER_ENV_VARS",
+			expectedValue: nil,
+			expectedErr:   true,
+		},
+		{
+			desc: "partial option set",
+			env:  "AUTOSCALER_ENV_VARS: node_labels=a=b;autoscaling_options=scaledownunreadytime=1h",
+			expectedValue: map[string]string{
+				config.DefaultScaleDownUnreadyTimeKey: "1h",
+			},
+			expectedErr: false,
+		},
+		{
+			desc: "full option set",
+			env:  "AUTOSCALER_ENV_VARS: node_labels=a,b;autoscaling_options=scaledownutilizationthreshold=0.4,scaledowngpuutilizationthreshold=0.5,scaledownunneededtime=30m,scaledownunreadytime=1h",
+			expectedValue: map[string]string{
+				config.DefaultScaleDownUtilizationThresholdKey:    "0.4",
+				config.DefaultScaleDownGpuUtilizationThresholdKey: "0.5",
+				config.DefaultScaleDownUnneededTimeKey:            "30m",
+				config.DefaultScaleDownUnreadyTimeKey:             "1h",
+			},
+			expectedErr: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			value, err := extractAutoscalingOptionsFromKubeEnv(c.env)
+			assert.Equal(t, c.expectedValue, value)
+			if c.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cluster-autoscaler/config/const.go
+++ b/cluster-autoscaler/config/const.go
@@ -21,4 +21,13 @@ const (
 	DefaultMaxClusterCores = 5000 * 64
 	// DefaultMaxClusterMemory is the default maximum number of gigabytes of memory in cluster.
 	DefaultMaxClusterMemory = 5000 * 64 * 20
+
+	// DefaultScaleDownUtilizationThresholdKey identifies ScaleDownUtilizationThreshold autoscaling option
+	DefaultScaleDownUtilizationThresholdKey = "scaledownutilizationthreshold"
+	// DefaultScaleDownGpuUtilizationThresholdKey identifies ScaleDownGpuUtilizationThreshold autoscaling option
+	DefaultScaleDownGpuUtilizationThresholdKey = "scaledowngpuutilizationthreshold"
+	// DefaultScaleDownUnneededTimeKey identifies ScaleDownUnneededTime autoscaling option
+	DefaultScaleDownUnneededTimeKey = "scaledownunneededtime"
+	// DefaultScaleDownUnreadyTimeKey identifies ScaleDownUnreadyTime autoscaling option
+	DefaultScaleDownUnreadyTimeKey = "scaledownunreadytime"
 )


### PR DESCRIPTION
Support per-MIG (scaledown) settings as permited by the
cloudprovider's interface `GetOptions()` method.