### PR TITLE
implement GetOptions for AWS

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -162,6 +162,20 @@ Example tags:
 
 - `k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage`: `100G`
 
+ASG labels can specify autoscaling options, overriding the global cluster-autoscaler
+settings for the labeled ASGs. Those labels takes the same values format as the
+cluster-autoscaler command line flags they override (a float or a duration, encoded
+as string). Currently supported autoscaling options (and example values) are:
+
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownutilizationthreshold`: `0.5`
+  (overrides `--scale-down-utilization-threshold` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledowngpuutilizationthreshold`: `0.5`
+  (overrides `--scale-down-gpu-utilization-threshold` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownunneededtime`: `10m0s`
+  (overrides `--scale-down-unneeded-time` value for that specific ASG)
+* `k8s.io/cluster-autoscaler/node-template/autoscaling-options/scaledownunreadytime`: `20m0s`
+  (overrides `--scale-down-unready-time` value for that specific ASG)
+
 **NOTE:** It is your responsibility to ensure such labels and/or taints are
 applied via the node's kubelet configuration at startup. Cluster Autoscaler will not set the node taints for you.
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -220,7 +220,10 @@ func (ng *AwsNodeGroup) Delete() error {
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 func (ng *AwsNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	if ng.asg == nil || ng.asg.Tags == nil || len(ng.asg.Tags) == 0 {
+		return &defaults, nil
+	}
+	return ng.awsManager.GetAsgOptions(*ng.asg, defaults), nil
 }
 
 // IncreaseSize increases Asg size

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -51,6 +51,7 @@ func newTestAwsManagerWithMockServices(mockAutoScaling autoScalingI, mockEC2 ec2
 			interrupt:             make(chan struct{}),
 			asgAutoDiscoverySpecs: autoDiscoverySpecs,
 			awsService:            &awsService,
+			autoscalingOptions:    make(map[AwsRef]map[string]string),
 		},
 	}
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
 	provider_aws "k8s.io/legacy-cloud-providers/aws"
@@ -52,6 +54,7 @@ const (
 	refreshInterval         = 1 * time.Minute
 	autoDiscovererTypeASG   = "asg"
 	asgAutoDiscovererKeyTag = "tag"
+	optionsTagsPrefix       = "k8s.io/cluster-autoscaler/node-template/autoscaling-options/"
 )
 
 // AwsManager is handles aws communication and data caching.
@@ -273,6 +276,10 @@ func (m *AwsManager) getAsgs() []*asg {
 	return m.asgCache.Get()
 }
 
+func (m *AwsManager) getAutoscalingOptions(ref AwsRef) map[string]string {
+	return m.asgCache.GetAutoscalingOptions(ref)
+}
+
 // SetAsgSize sets ASG size.
 func (m *AwsManager) SetAsgSize(asg *asg, size int) error {
 	return m.asgCache.SetAsgSize(asg, size)
@@ -319,6 +326,52 @@ func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 		}, nil
 	}
 	return nil, fmt.Errorf("ASG %q uses the unknown EC2 instance type %q", asg.Name, instanceTypeName)
+}
+
+// GetAsgOptions parse options extracted from ASG tags and merges them with provided defaults
+func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
+	options := m.getAutoscalingOptions(asg.AwsRef)
+	if options == nil || len(options) == 0 {
+		return &defaults
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUtilizationThresholdKey]; found {
+		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to float: %v",
+				asg.Name, config.DefaultScaleDownUtilizationThresholdKey, err)
+		} else {
+			defaults.ScaleDownUtilizationThreshold = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownGpuUtilizationThresholdKey]; found {
+		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to float: %v",
+				asg.Name, config.DefaultScaleDownGpuUtilizationThresholdKey, err)
+		} else {
+			defaults.ScaleDownGpuUtilizationThreshold = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUnneededTimeKey]; found {
+		if opt, err := time.ParseDuration(stringOpt); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+				asg.Name, config.DefaultScaleDownUnneededTimeKey, err)
+		} else {
+			defaults.ScaleDownUnneededTime = opt
+		}
+	}
+
+	if stringOpt, found := options[config.DefaultScaleDownUnreadyTimeKey]; found {
+		if opt, err := time.ParseDuration(stringOpt); err != nil {
+			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+				asg.Name, config.DefaultScaleDownUnreadyTimeKey, err)
+		} else {
+			defaults.ScaleDownUnreadyTime = opt
+		}
+	}
+
+	return &defaults
 }
 
 func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*apiv1.Node, error) {
@@ -399,6 +452,21 @@ func extractLabelsFromAsg(tags []*autoscaling.TagDescription) map[string]string 
 	}
 
 	return result
+}
+
+func extractAutoscalingOptionsFromTags(tags []*autoscaling.TagDescription) map[string]string {
+	options := make(map[string]string)
+	for _, tag := range tags {
+		if !strings.HasPrefix(aws.StringValue(tag.Key), optionsTagsPrefix) {
+			continue
+		}
+		splits := strings.Split(aws.StringValue(tag.Key), optionsTagsPrefix)
+		if len(splits) != 2 || splits[1] == "" {
+			continue
+		}
+		options[splits[1]] = aws.StringValue(tag.Value)
+	}
+	return options
 }
 
 func extractAllocatableResourcesFromAsg(tags []*autoscaling.TagDescription) map[string]*resource.Quantity {


### PR DESCRIPTION
Support per-ASG (scaledown) settings as specified by the cloudprovider's interface GetOptions() method.

For ref, merged PRs providing similar GetOptions support for other providers:
* [GCE version](https://github.com/kubernetes/autoscaler/pull/4236)
* [Azure version](https://github.com/kubernetes/autoscaler/pull/4237)