### PR TITLE
Add NAMESPACE as an environment variable to the updater deployment config

### DIFF
--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -28,6 +28,11 @@ spec:
         - name: updater
           image: k8s.gcr.io/autoscaling/vpa-updater:0.9.2
           imagePullPolicy: Always
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
Hello! I noticed that although we set the default value of `namespace` using the environment variable `NAMESPACE` [here](https://github.com/kubernetes/autoscaler/blob/vpa-release-0.9/vertical-pod-autoscaler/pkg/updater/main.go#L64), the current updater deployment configuration does not set the environment variable. This change will allow us to deploy the VPA components outside of the `kube-system` namespace without any issues. 

The changes I have made are taken from the admission controller deployment configuration [here](https://github.com/kubernetes/autoscaler/blob/vpa-release-0.9/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml#L25-L29). It is important that these two components are deployed in the same namespace.

This PR should also resolve #3736.