### PR TITLE
Update Cluster Autoscaler version with vendor

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -65,3 +65,5 @@ go get "k8s.io/kubernetes@v${VERSION}"
 go mod vendor
 go mod tidy
 git rm -r --force --ignore-unmatch kubernetes
+
+sed -i "s|\(const ClusterAutoscalerVersion = \)\".*\"|\1\"$VERSION\"|" version/version.go


### PR DESCRIPTION
Since Cluster Autoscaler versioning should be in sync with Kubernetes,
update-vendor.sh can simply set the version after a successful
dependency update.

When CA 1.21 was released, the version was bumped only on the release branch, but not on the master branch. This should help with keeping them in sync.

@bpineau FYI

/assign @MaciekPytel 