### PR TITLE
Make CA version on HEAD match k8s version in go.mod

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.20.0"
+const ClusterAutoscalerVersion = "1.23.0-alpha.0"


### PR DESCRIPTION
Note: This should automatically get synced in the future.