### PR TITLE
Use highest available magnum microversion

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/README.md
+++ b/cluster-autoscaler/cloudprovider/magnum/README.md
@@ -16,6 +16,8 @@ using the cluster autoscaler v1.18 or lower.
 
 ## Updates
 
+* CA 1.22
+  * Allow scaling node groups to 0 nodes, if supported (requires Magnum Wallaby).
 * CA 1.19
   * Update to support Magnum node groups (introduced in Magnum Train).
     * Add node group autodiscovery based on the group's role property.

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
@@ -29,6 +29,10 @@ import (
 const (
 	// Magnum microversion that must be requested to use the node groups API.
 	microversionNodeGroups = "1.9"
+	// Magnum microversion that must be requested to support scaling node groups to 0 nodes.
+	microversionScaleToZero = "1.10"
+	// Magnum interprets "latest" to mean the highest available microversion.
+	microversionLatest = "latest"
 )
 
 // magnumManager is an interface for the basic interactions with the cluster.
@@ -61,7 +65,7 @@ func createMagnumManager(configReader io.Reader, discoverOpts cloudprovider.Node
 		return nil, err
 	}
 
-	clusterClient.Microversion = microversionNodeGroups
+	clusterClient.Microversion = microversionLatest
 
 	// This replaces the cluster name with a UUID if the name was given in the parameters.
 	err = checkClusterUUID(provider, clusterClient, opts)


### PR DESCRIPTION
Fixes #4254 

When I enabled scale to 0 for the magnum provider, I was looking at this patch which allows node groups of size 0 with a new microversion, but did not require the microversion for making resize requests.
https://opendev.org/openstack/magnum/commit/f46923cc5ea74da663640bb0c470a4b1039c777e

The microversion requirement for resizing to 0 was added separately, later on.
https://opendev.org/openstack/magnum/commit/0e6d178939647e61fee1485e7b3611f093adb7c6

This patch makes the magnum client send "latest" as its microversion request, and on the server side magnum will replace it with the highest microversion that it supports.

When microversion 1.10 (or higher) is available, it will be used which allows the autoscaler to scale node groups to 0.

On magnum versions older than Wallaby, microversion 1.9 will still be used.
Attempting to scale to 0 would be an error, but magnum will also not allow the minimum node count of a group to be set to 0, so as long as node group autodiscovery is used then that error will never occur.