### PR TITLE
fix: add missing RBAC permissions to example spec

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -105,6 +105,8 @@ rules:
     resources:
     - csinodes
     - storageclasses
+    - csidrivers
+    - csistoragecapacities
     verbs:
     - get
     - list


### PR DESCRIPTION
Similar change was done in https://github.com/kubernetes/autoscaler/pull/4154

Without these RBAC permissions seeing below in the pod logs:
```
I0817 17:35:12.084244       1 reflector.go:255] Listing and watching *v1.CSIDriver from k8s.io/client-go/informers/factory.go:134
E0817 17:35:12.086678       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: csidrivers.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "csidrivers" in API group "storage.k8s.io" at the cluster scope
I0817 17:35:12.684613       1 reflector.go:255] Listing and watching *v1beta1.CSIStorageCapacity from k8s.io/client-go/informers/factory.go:134
E0817 17:35:12.687383       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: csistoragecapacities.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "csistoragecapacities" in API group "storage.k8s.io" at the cluster scope
```