### PR TITLE
fix(leader-elect-resource-lock-role): Add permissions to role if leader election is based off configmaps

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.5
+version: 9.10.6

--- a/charts/cluster-autoscaler/templates/role.yaml
+++ b/charts/cluster-autoscaler/templates/role.yaml
@@ -32,4 +32,15 @@ rules:
 {{- if eq (default "" .Values.extraArgs.expander) "priority" }}
       - watch
 {{- end }}
+{{- if  eq (default "" (index .Values.extraArgs "leader-elect-resource-lock")) "configmaps" }}
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - cluster-autoscaler
+    verbs:
+      - get
+      - update
+{{- end }}
 {{- end -}}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -141,6 +141,7 @@ extraArgs:
   # write-status-configmap: true
   # status-config-map-name: cluster-autoscaler-status
   # leader-elect: true
+  # leader-elect-resource-lock: endpoints
   # skip-nodes-with-local-storage: true
   # expander: random
   # scale-down-enabled: true


### PR DESCRIPTION
cluster-autoscaler has an argument:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca

| Parameter | Description | Default |
| --- | --- | --- |
| `leader-elect-resource-lock` | The type of resource object that is used for locking during leader election.<br>Supported options are `endpoints` (default) and `configmaps` | "endpoints"

This adds the chart support to have the appropriate permissions to get/update the configmap that's being used for leader tracking (by default `configmap/cluster-autoscaler`)

Fixes bug #4275