### PR TITLE
fix 4256 autoscaler permit

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.4
+version: 9.10.5

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -47,6 +47,7 @@ rules:
   - apiGroups:
     - ""
     resources:
+      - namespaces
       - pods
       - services
       - replicationcontrollers


### PR DESCRIPTION
Fixes problem when using v1.22.0 of autoscaler with the chart  as shown in https://github.com/kubernetes/autoscaler/issues/4256.

From logs we can see that it is requiring permission to list namespaces:
```
I0811 23:49:55.792818       1 request.go:597] Waited for 361.356292ms due to client-side throttling, not priority and fairness, request: GET:https://172.20.0.1:443/api/v1/namespaces?limit=500&resourceVersion=0
E0811 23:49:55.794467       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-aws-cluster-autoscaler" cannot list resource "namespaces" in API group "" at the cluster scope

...
E0812 00:02:42.414760       1 plugin.go:138] "getting namespace, assuming empty set of namespace labels" err="namespace \"kube-system\" not found" namespace="kube-system"
E0812 00:02:42.414843       1 plugin.go:138] "getting namespace, assuming empty set of namespace labels" err="namespace \"kube-system\" not found" namespace="kube-system"
E0812 00:02:42.414919       1 plugin.go:138] "getting namespace, assuming empty set of namespace labels" err="namespace \"kube-system\" not found" namespace="kube-system"
```