### PR TITLE
Cherry pick #4261 (magnum microversion) to cluster-autoscaler-release-1.22

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/README.md
+++ b/cluster-autoscaler/cloudprovider/magnum/README.md
@@ -16,6 +16,8 @@ using the cluster autoscaler v1.18 or lower.
 
 ## Updates
 
+* CA 1.22
+  * Allow scaling node groups to 0 nodes, if supported (requires Magnum Wallaby).
 * CA 1.19
   * Update to support Magnum node groups (introduced in Magnum Train).
     * Add node group autodiscovery based on the group's role property.

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
@@ -29,6 +29,10 @@ import (
 const (
 	// Magnum microversion that must be requested to use the node groups API.
 	microversionNodeGroups = "1.9"
+	// Magnum microversion that must be requested to support scaling node groups to 0 nodes.
+	microversionScaleToZero = "1.10"
+	// Magnum interprets "latest" to mean the highest available microversion.
+	microversionLatest = "latest"
 )
 
 // magnumManager is an interface for the basic interactions with the cluster.
@@ -61,7 +65,7 @@ func createMagnumManager(configReader io.Reader, discoverOpts cloudprovider.Node
 		return nil, err
 	}
 
-	clusterClient.Microversion = microversionNodeGroups
+	clusterClient.Microversion = microversionLatest
 
 	// This replaces the cluster name with a UUID if the name was given in the parameters.
 	err = checkClusterUUID(provider, clusterClient, opts)


### PR DESCRIPTION
Issue #4254
PR #4261

Fix the magnum API microversion used, to enable scaling node groups to size 0.