### PR TITLE
[CA] [AWS examples] Add priorityClassName & securityContext & upgrade image

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -142,7 +142,7 @@ spec:
         runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -136,9 +136,13 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -142,7 +142,7 @@ spec:
         runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -136,9 +136,13 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -142,7 +142,7 @@ spec:
         runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -136,9 +136,13 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -149,7 +149,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -136,6 +136,10 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: cluster-autoscaler
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
Hello, some improvements on AWS examples.

To ensure the pod is scheduled
```
priorityClassName: system-cluster-critical
```

To run pod as non-root (security best practice)
```
securityContext:
  runAsNonRoot: true
  runAsUser: 65534
```

And use the last image (1.22.0).