### PR TITLE
Comment to add policy to nodegroup

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -1,3 +1,22 @@
+#     For Autodiscovery to work, add the follwoing policy to nodegroup. 
+# 
+#        {
+#         Effect : "Allow",
+#         Principal : {
+#           Federated : format("arn:aws:iam::${local.aws_account_id}:%s", replace(module.eks.cluster_oidc_issuer_url, "https://", "oidc-provider/"))
+#         },
+#         Action : "sts:AssumeRoleWithWebIdentity",
+#         Condition : {
+#           StringEquals : {
+#             format(
+#               "%s:sub",
+#               trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+#             ) : "system:serviceaccount:kube-system:cluster-autoscaler"
+#           }
+#         }
+#       }
+
+
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The Auto discovery will not work without required policy to be added to Node group, added a comment to remind the same.