### PR TITLE
[HELM] Fix missing yaml conversion for expander priorities

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.8
+version: 9.10.9

--- a/charts/cluster-autoscaler/templates/priority-expander-configmap.yaml
+++ b/charts/cluster-autoscaler/templates/priority-expander-configmap.yaml
@@ -12,6 +12,10 @@ metadata:
   {{- end }}
 data:
   priorities: |-
+{{- if kindIs "string" .Values.expanderPriorities }}
 {{ .Values.expanderPriorities | indent 4 }}
+{{- else }}
+{{ toYaml .Values.expanderPriorities | indent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This should fix an error with Helm when passing expanderPriorities:

```
Error: template: cluster-autoscaler/templates/priority-expander-configmap.yaml:11:39: executing "cluster-autoscaler/templates/priority-expander-configmap.yaml" at <4>: wrong type for value; expected string; got map[string]interface {}
```