### PR TITLE
Processor policy

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -55,6 +55,7 @@ this document:
   * [What events are emitted by CA?](#what-events-are-emitted-by-ca)
   * [What happens in scale-up when I have no more quota in the cloud provider?](#what-happens-in-scale-up-when-i-have-no-more-quota-in-the-cloud-provider)
 * [Developer](#developer)
+  * [How should I implement new features?](#how-should-i-implement-new-features)
   * [How can I run e2e tests?](#how-can-i-run-e2e-tests)
   * [How should I test my code before submitting PR?](#how-should-i-test-my-code-before-submitting-pr)
   * [How can I update CA dependencies (particularly k8s.io/kubernetes)?](#how-can-i-update-ca-dependencies-particularly-k8siokubernetes)
@@ -897,6 +898,15 @@ From version 0.6.2, Cluster Autoscaler backs off from scaling up a node group af
 Depending on how long scale-ups have been failing, it may wait up to 30 minutes before next attempt.
 
 # Developer:
+
+### How should I implement new features?
+
+The preferred way of implementing new features is via [processor
+interfaces](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/processors).
+Before opening a PR with changes (and especially significant changes) to core CA
+logic please check if those changes can instead be encapsulated behind on of the
+existing interfaces. Reviewers may suggest a way to re-implement a feature as a
+processor.
 
 ### How can I run e2e tests?
 

--- a/cluster-autoscaler/processors/README.md
+++ b/cluster-autoscaler/processors/README.md
@@ -1,0 +1,32 @@
+# Processor interfaces
+
+Processors are golang interfaces that allow modifying key Cluster Autoscaler
+data structures at various points in CA logic. This makes them a powerful tool
+for building advanced features and customizing CA behavior.
+
+  * Processors are intended to simplify management of customized CA fork by
+    allowing most (and hopefully all) custom logic to be encapsulated behind a
+    few interfaces.
+  * Processors implementing generic features that may be useful to a large
+    number of CA users may be merged to kubernetes/autoscaler repository.
+
+Processors are the *preferred way* for introducing new features to core CA
+logic. If a feature can be implemented via an existing processor interface, the
+reviewers may ask for a PR to be implemented this way.
+
+## Changes and deprecations
+
+Adding new processors, adding new methods to existing processors or adding
+additional parameters to existing methods may all happen in minor releases of
+Cluster Autoscaler.
+
+A processor interface (or parts of it) may be removed, for example as a result
+of Cluster Autoscaler refactor or if it's superseded by a new processor.
+Removing a processor interface or any of the methods or removing a method from
+an existing processor will follow requirements stated in Rule #5b of
+[Kubernetes deprecation
+policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/),
+meaning that the interface will function for 1 minor release or 6 months after
+the deprecation is announced.
+The announcement will be included in Cluster Autoscaler release notes and
+discussed in sig-autoscaling weekly meeting.

--- a/cluster-autoscaler/processors/nodeinfos/node_info_processor.go
+++ b/cluster-autoscaler/processors/nodeinfos/node_info_processor.go
@@ -22,6 +22,11 @@ import (
 )
 
 // NodeInfoProcessor processes nodeInfos after they're created.
+// Deprecated: This interface has been deprecated and may be removed in version 1.24.
+// This interface has been DEPRECATED in favor of TemplateNodeInfoProvider interface.
+// To migrate existing implementation of NodeInfoProcessor consider moving the logic
+// to TemplateNodeInfoProvider that wraps the default MixedTemplateNodeInfoProvider
+// and postprocesses the result.
 type NodeInfoProcessor interface {
 	// Process processes a map of nodeInfos for node groups.
 	Process(ctx *context.AutoscalingContext, nodeInfosForNodeGroups map[string]*schedulerframework.NodeInfo) (map[string]*schedulerframework.NodeInfo, error)

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -48,6 +48,8 @@ type AutoscalingProcessors struct {
 	// NodeGroupManager is responsible for creating/deleting node groups.
 	NodeGroupManager nodegroups.NodeGroupManager
 	// NodeInfoProcessor is used to process nodeInfos after they're created.
+	// Deprecated: This field has been DEPRECATED and may be removed in 1.24.
+	// Consider using TemplateNodeInfoProvider instead.
 	NodeInfoProcessor nodeinfos.NodeInfoProcessor
 	// TemplateNodeInfoProvider is used to create the initial nodeInfos set.
 	TemplateNodeInfoProvider nodeinfosprovider.TemplateNodeInfoProvider


### PR DESCRIPTION
Start a README file for processor documenting the deprecation policy,
as well as existing code review practices.
The deprecation policy has been discussed in
#4191 (comment) and
sig-meeting, where it gained an approval from both top-level OWNERS and
the sig in general.
Add deprecation warnings for NodeInfoProcessor.

