### PR TITLE
gce: refresh instances templates in background

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -402,6 +402,15 @@ func (gc *GceCache) InvalidateAllMigInstanceTemplates() {
 	gc.instanceTemplatesCache = map[GceRef]*gce.InstanceTemplate{}
 }
 
+// SetAllMigInstanceTemplates replace all instance template cache entries
+func (gc *GceCache) SetAllMigInstanceTemplates(gceRefsToTemplates map[GceRef]*gce.InstanceTemplate) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	klog.V(5).Infof("Instance template cache replaced")
+	gc.instanceTemplatesCache = gceRefsToTemplates
+}
+
 // GetMachineFromCache retrieves machine type from cache under lock.
 func (gc *GceCache) GetMachineFromCache(machineType string, zone string) (*gce.MachineType, error) {
 	gc.cacheMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -50,6 +50,7 @@ import (
 const (
 	refreshInterval              = 1 * time.Minute
 	machinesRefreshInterval      = 1 * time.Hour
+	templatesRefreshInterval     = 30 * time.Minute
 	httpTimeout                  = 30 * time.Second
 	scaleToZeroSupported         = true
 	autoDiscovererTypeMIG        = "mig"
@@ -198,6 +199,10 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 	if manager.migAutoDiscoverySpecs, err = parseMIGAutoDiscoverySpecs(discoveryOpts); err != nil {
 		return nil, err
 	}
+
+	go wait.Until(func() {
+		manager.migInstanceTemplatesProvider.Refresh(manager.cache.getMigRefs(), concurrentGceRefreshes)
+	}, templatesRefreshInterval, manager.interrupt)
 
 	if err := manager.forceRefresh(); err != nil {
 		return nil, err


### PR DESCRIPTION
This is an alternate (maybe less intrusive) approach to PR #3862 : avoid blocking head of line when instance templates cache expires (all at once).

The GCE instance template's Get API is not fast (on my projects, it takes about 400ms to get a single template), and for each template we also need to get an instance group manager from the API (also a couple hundred milliseconds).

Due to that, even a cluster with just a dozen attached ITs experiences latencies at each cache expiration deadline. That latency grows linearly with the number of instance templates.

Contrary to the other PR, this runs the refreshes entirely in background, but doesn't spread refreshes over cache TTL to be kind with GCE API; I can rework to combine both approaches if that's preferred.