### PR TITLE
Cherry pick 535a212 onto 1.20 - Fix logging level

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -312,7 +312,7 @@ func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 	region := az[0 : len(az)-1]
 
 	if len(asg.AvailabilityZones) > 1 {
-		klog.Warningf("Found multiple availability zones for ASG %q; using %s\n", asg.Name, az)
+		klog.V(4).Infof("Found multiple availability zones for ASG %q; using %s for %s label\n", asg.Name, az, apiv1.LabelFailureDomainBetaZone)
 	}
 
 	instanceTypeName, err := m.buildInstanceType(asg)


### PR DESCRIPTION
Cherry picks https://github.com/kubernetes/autoscaler/commit/535a21263e77d92778043cd39d1c4f2845748424 so that we have an appropriate log level

Used commands:
```
git clone nitrag/autoscaler
git checkout -b backport-535a212-1.20 upstream/cluster-autoscaler-release-1.20
git cherry-pick 535a21263e77d92778043cd39d1c4f2845748424 
git push --set-upstream origin backport-535a212-1.20
```