### PR TITLE
Fix cluster feeder test

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -399,7 +399,7 @@ func TestClusterStateFeeder_InitFromHistoryProvider(t *testing.T) {
 			pod1: &pod1History,
 		},
 	}
-	clusterState := model.NewClusterState()
+	clusterState := model.NewClusterState(testGcPeriod)
 	feeder := clusterStateFeeder{
 		clusterState: clusterState,
 	}


### PR DESCRIPTION
I didn't update one call to `model.NewClusterState` in #4308. Fix it.

I wonder why presubmit didn't complain on the PR which introduced the problem