### PR TITLE
fix expanders unit tests

### DIFF
--- a/cluster-autoscaler/expander/mostpods/mostpods_test.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods_test.go
@@ -26,18 +26,18 @@ import (
 )
 
 func TestMostPods(t *testing.T) {
-	e := NewStrategy()
+	e := NewFilter()
 
 	eo0 := expander.Option{Debug: "EO0"}
-	ret := e.BestOption([]expander.Option{eo0}, nil)
-	assert.Equal(t, *ret, eo0)
+	ret := e.BestOptions([]expander.Option{eo0}, nil)
+	assert.Equal(t, ret, []expander.Option{eo0})
 
 	eo1 := expander.Option{Debug: "EO1", Pods: []*apiv1.Pod{nil}}
-	ret = e.BestOption([]expander.Option{eo0, eo1}, nil)
-	assert.Equal(t, *ret, eo1)
+	ret = e.BestOptions([]expander.Option{eo0, eo1}, nil)
+	assert.Equal(t, ret, []expander.Option{eo1})
 
 	eo1b := expander.Option{Debug: "EO1b", Pods: []*apiv1.Pod{nil}}
-	ret = e.BestOption([]expander.Option{eo0, eo1, eo1b}, nil)
-	assert.NotEqual(t, *ret, eo0)
-	assert.True(t, assert.ObjectsAreEqual(*ret, eo1) || assert.ObjectsAreEqual(*ret, eo1b))
+	ret = e.BestOptions([]expander.Option{eo0, eo1, eo1b}, nil)
+	assert.NotEqual(t, ret, []expander.Option{eo0})
+	assert.ObjectsAreEqual(ret, []expander.Option{eo1, eo1b})
 }

--- a/cluster-autoscaler/expander/price/price_test.go
+++ b/cluster-autoscaler/expander/price/price_test.go
@@ -130,7 +130,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),
@@ -151,7 +151,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(4000, units.GiB),
@@ -188,7 +188,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 
 		&testPreferredNodeProvider{
@@ -210,7 +210,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),
@@ -247,7 +247,7 @@ func TestPriceExpander(t *testing.T) {
 	provider.SetPricingModel(pricingModel)
 	// Both node groups are equally expensive. However 2
 	// accept two pods.
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),
@@ -261,7 +261,7 @@ func TestPriceExpander(t *testing.T) {
 		nodePrice: map[string]float64{},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Empty(t, NewStrategy(
+	assert.Empty(t, NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),
@@ -306,7 +306,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),
@@ -328,7 +328,7 @@ func TestPriceExpander(t *testing.T) {
 		},
 	}
 	provider.SetPricingModel(pricingModel)
-	assert.Equal(t, optionsToDebug(NewStrategy(
+	assert.Equal(t, optionsToDebug(NewFilter(
 		provider,
 		&testPreferredNodeProvider{
 			preferred: buildNode(2000, units.GiB),

--- a/cluster-autoscaler/expander/priority/priority_test.go
+++ b/cluster-autoscaler/expander/priority/priority_test.go
@@ -100,7 +100,7 @@ func getFilterInstance(t *testing.T, config string) (expander.Filter, *record.Fa
 	lister, err := kubernetes.NewTestConfigMapLister([]*apiv1.ConfigMap{cm})
 	assert.Nil(t, err)
 	r := record.NewFakeRecorder(100)
-	s, err := NewStrategy(lister.ConfigMaps(testNamespace), r)
+	s := NewFilter(lister.ConfigMaps(testNamespace), r)
 	return s, r, cm, err
 }
 

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -81,7 +81,7 @@ func makeNodeInfo(cpu int64, memory int64, pods int64) *schedulerframework.NodeI
 func TestLeastWaste(t *testing.T) {
 	cpuPerPod := int64(500)
 	memoryPerPod := int64(1000 * 1024 * 1024)
-	e := NewStrategy()
+	e := NewFilter()
 	balancedNodeInfo := makeNodeInfo(16*cpuPerPod, 16*memoryPerPod, 100)
 	nodeMap := map[string]*schedulerframework.NodeInfo{"balanced": balancedNodeInfo}
 	balancedOption := expander.Option{NodeGroup: &FakeNodeGroup{"balanced"}, NodeCount: 1}


### PR DESCRIPTION
The github action hooks didn't run the unit tests on the expanders
update in #4233 (likely the known "tests don't run automatically for
new contributor" limitation).

NewStrategy became NewFilter, with a BestOptions (plural) method,
and returns an Option slice instead of a single Option.