### PR TITLE
remove nodes stuck creating even if this takes us below nodeGroup minSize

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	scaleToZeroSupported          = true
-	placeholderInstanceNamePrefix = "i-placeholder"
+	scaleToZeroSupported = true
 )
 
 type asgCache struct {
@@ -264,7 +263,7 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 	for _, instance := range instances {
 		// check if the instance is a placeholder - a requested instance that was never created by the node group
 		// if it is, just decrease the size of the node group, as there's no specific instance we can remove
-		if m.isPlaceholderInstance(instance) {
+		if instance.isPlaceholder() {
 			klog.V(4).Infof("instance %s is detected as a placeholder, decreasing ASG requested size instead "+
 				"of deleting instance", instance.Name)
 			m.decreaseAsgSizeByOneNoLock(commonAsg)
@@ -286,11 +285,6 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 		}
 	}
 	return nil
-}
-
-// isPlaceholderInstance checks if the given instance is only a placeholder
-func (m *asgCache) isPlaceholderInstance(instance *AwsInstanceRef) bool {
-	return strings.HasPrefix(instance.Name, placeholderInstanceNamePrefix)
 }
 
 // Fetch automatically discovered ASGs. These ASGs should be unregistered if

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -240,7 +240,12 @@ func TestNodeGroupForNode(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, []cloudprovider.Instance{{Id: "aws:///us-east-1a/test-instance-id"}}, nodes)
+	assert.Equal(t, []cloudprovider.Instance{
+		{
+			Id:     "aws:///us-east-1a/test-instance-id",
+			Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning},
+		},
+	}, nodes)
 	service.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
 
 	// test node in cluster that is not in a group managed by cluster autoscaler


### PR DESCRIPTION
This PR is an attempt to resolve #4351.  The AWS cloudprovider doesn't currently set the `InstanceStatus` field on `cloudprovider.Instance`, so in this change we start populating this field.  We set it to `InstanceRunning` except when the node is a placeholder node, in which case we set it to `InstanceCreating`.  Then, in the `removeOldUnregisteredNodes` function, if removing the node would take us below the node group's `minSize`, but the status is "creating", we go ahead and remove the node anyways.  The logic here is that if the node is stuck in creating for 15 minutes (or whatever the max node provision time is), we're _already_ below the node group's minimum size, but CA just doesn't think it is.

I've added a case to the `TestStaticAutoscalerRunOnceWithLongUnregisteredNodes` test case to confirm that this works as expected.

I _think_ this is a relatively simple/safe change.  My only slight concern is that I'm not sure how other cloud providers that use the `InstanceStatus` field will respond to this change.  It [looks like](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/kubernetes/autoscaler%24+file:%5Ecluster-autoscaler/cloudprovider/.*/.*+InstanceCreating&patternType=literal) the other cloud providers that use the `InstanceCreating` value are:

* Azure
* Bizfly
* DigitalOcean
* Exoscale
* GCE
* Hetzner
* Huawei
* Ionos
* Magnum
* OVH

I don't know a good way to test the behaviour of these other cloud providers.  :\

The other thing I was unsure about was what to do in the `ClusterStateRegistry` when an instance changes state.  My intuition was that if a node transitions from (say) "creating" to "running", that it would make sense to reset the node's "unregistered-since" timer, but since we currently don't track the state transitions at all, this would be a change from the existing behaviour that might be unexpected.