### PR TITLE
Introduce Empty Cluster Processor

### DIFF
--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	processor_callbacks "k8s.io/autoscaler/cluster-autoscaler/processors/callbacks"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
@@ -146,6 +147,7 @@ func NewTestProcessors() *processors.AutoscalingProcessors {
 		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
+		ActionableClusterProcessor: actionablecluster.NewDefaultActionableClusterProcessor(),
 	}
 }
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -54,8 +54,6 @@ const (
 	// The idea is that nodes with GPU are very expensive and we're ready to sacrifice
 	// a bit more latency to wait for more pods and make a more informed scale-up decision.
 	unschedulablePodWithGpuTimeBuffer = 30 * time.Second
-	// How long should Cluster Autoscaler wait for nodes to become ready after start.
-	nodesNotReadyAfterStartTimeout = 10 * time.Minute
 
 	// NodeUpcomingAnnotation is an annotation CA adds to nodes which are upcoming.
 	NodeUpcomingAnnotation = "cluster-autoscaler.k8s.io/upcoming-node"
@@ -67,7 +65,6 @@ type StaticAutoscaler struct {
 	*context.AutoscalingContext
 	// ClusterState for maintaining the state of cluster nodes.
 	clusterStateRegistry    *clusterstate.ClusterStateRegistry
-	startTime               time.Time
 	lastScaleUpTime         time.Time
 	lastScaleDownDeleteTime time.Time
 	lastScaleDownFailTime   time.Time
@@ -81,6 +78,11 @@ type StaticAutoscaler struct {
 type staticAutoscalerProcessorCallbacks struct {
 	disableScaleDownForLoop bool
 	extraValues             map[string]interface{}
+	scaleDown               *ScaleDown
+}
+
+func (callbacks *staticAutoscalerProcessorCallbacks) ResetUnneededNodes() {
+	callbacks.scaleDown.CleanUpUnneededNodes()
 }
 
 func newStaticAutoscalerProcessorCallbacks() *staticAutoscalerProcessorCallbacks {
@@ -145,13 +147,13 @@ func NewStaticAutoscaler(
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(autoscalingContext.CloudProvider, clusterStateConfig, autoscalingContext.LogRecorder, backoff)
 
 	scaleDown := NewScaleDown(autoscalingContext, processors, clusterStateRegistry)
+	processorCallbacks.scaleDown = scaleDown
 
 	// Set the initial scale times to be less than the start time so as to
 	// not start in cooldown mode.
 	initialScaleTime := time.Now().Add(-time.Hour)
 	return &StaticAutoscaler{
 		AutoscalingContext:      autoscalingContext,
-		startTime:               time.Now(),
 		lastScaleUpTime:         initialScaleTime,
 		lastScaleDownDeleteTime: initialScaleTime,
 		lastScaleDownFailTime:   initialScaleTime,
@@ -241,8 +243,9 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		return errors.ToAutoscalerError(errors.ApiCallError, err)
 	}
 
-	if a.actOnEmptyCluster(allNodes, readyNodes, currentTime) {
-		return nil
+	if abortLoop, err := a.processors.ActionableClusterProcessor.ShouldAbort(
+		a.AutoscalingContext, allNodes, readyNodes, currentTime); abortLoop {
+		return err
 	}
 
 	// Update cluster resource usage metrics
@@ -743,25 +746,6 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	return allNodes, readyNodes, nil
 }
 
-// actOnEmptyCluster returns true if the cluster was empty and thus acted upon
-func (a *StaticAutoscaler) actOnEmptyCluster(allNodes, readyNodes []*apiv1.Node, currentTime time.Time) bool {
-	if a.AutoscalingContext.AutoscalingOptions.ScaleUpFromZero {
-		return false
-	}
-	if len(allNodes) == 0 {
-		a.onEmptyCluster("Cluster has no nodes.", true)
-		return true
-	}
-	if len(readyNodes) == 0 {
-		// Cluster Autoscaler may start running before nodes are ready.
-		// Timeout ensures no ClusterUnhealthy events are published immediately in this case.
-		a.onEmptyCluster("Cluster has no ready nodes.", currentTime.After(a.startTime.Add(nodesNotReadyAfterStartTimeout)))
-		return true
-	}
-	// the cluster is not empty
-	return false
-}
-
 func (a *StaticAutoscaler) updateClusterState(allNodes []*apiv1.Node, nodeInfosForGroups map[string]*schedulerframework.NodeInfo, currentTime time.Time) errors.AutoscalerError {
 	err := a.clusterStateRegistry.UpdateNodes(allNodes, nodeInfosForGroups, currentTime)
 	if err != nil {
@@ -772,20 +756,6 @@ func (a *StaticAutoscaler) updateClusterState(allNodes []*apiv1.Node, nodeInfosF
 	core_utils.UpdateClusterStateMetrics(a.clusterStateRegistry)
 
 	return nil
-}
-
-func (a *StaticAutoscaler) onEmptyCluster(status string, emitEvent bool) {
-	klog.Warningf(status)
-	a.scaleDown.CleanUpUnneededNodes()
-	// updates metrics related to empty cluster's state.
-	metrics.UpdateClusterSafeToAutoscale(false)
-	metrics.UpdateNodesCount(0, 0, 0, 0, 0)
-	if a.AutoscalingContext.WriteStatusConfigMap {
-		utils.WriteStatusConfigMap(a.AutoscalingContext.ClientSet, a.AutoscalingContext.ConfigNamespace, status, a.AutoscalingContext.LogRecorder, a.AutoscalingContext.StatusConfigMapName)
-	}
-	if emitEvent {
-		a.AutoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", status)
-	}
 }
 
 func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time) bool {

--- a/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
+++ b/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actionablecluster
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/klog/v2"
+)
+
+// NodesNotReadyAfterStartTimeout How long should Cluster Autoscaler wait for nodes to become ready after start.
+const NodesNotReadyAfterStartTimeout = 10 * time.Minute
+
+// ActionableClusterProcessor defines interface for whether action can be taken on the cluster or not
+type ActionableClusterProcessor interface {
+	// ShouldAbort is the func that will return where the cluster is in an actionable state or not
+	ShouldAbort(context *context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (abortLoop bool, err errors.AutoscalerError)
+	CleanUp()
+}
+
+// EmptyClusterProcessor implements ActionableClusterProcessor by using ScaleUpFromZero flag
+// and other node readiness conditions to check whether the cluster is actionable or not
+type EmptyClusterProcessor struct {
+	nodesNotReadyAfterStartTimeout time.Duration
+	startTime                      time.Time
+}
+
+// ShouldAbort give the decision on whether CA can act on the cluster
+func (e *EmptyClusterProcessor) ShouldAbort(context *context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (bool, errors.AutoscalerError) {
+	if context.AutoscalingOptions.ScaleUpFromZero {
+		return false, nil
+	}
+	if len(allNodes) == 0 {
+		OnEmptyCluster(context, "Cluster has no nodes.", true)
+		return true, nil
+	}
+	if len(readyNodes) == 0 {
+		// Cluster Autoscaler may start running before nodes are ready.
+		// Timeout ensures no ClusterUnhealthy events are published immediately in this case.
+		OnEmptyCluster(context, "Cluster has no ready nodes.", currentTime.After(e.startTime.Add(e.nodesNotReadyAfterStartTimeout)))
+		return true, nil
+	}
+	// the cluster is not empty
+	return false, nil
+}
+
+// OnEmptyCluster runs actions if the cluster is empty
+func OnEmptyCluster(context *context.AutoscalingContext, status string, emitEvent bool) {
+	klog.Warningf(status)
+	context.ProcessorCallbacks.ResetUnneededNodes()
+	// updates metrics related to empty cluster's state.
+	metrics.UpdateClusterSafeToAutoscale(false)
+	metrics.UpdateNodesCount(0, 0, 0, 0, 0)
+	if context.WriteStatusConfigMap {
+		utils.WriteStatusConfigMap(context.ClientSet, context.ConfigNamespace, status, context.LogRecorder, context.StatusConfigMapName)
+	}
+	if emitEvent {
+		context.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", status)
+	}
+}
+
+// CleanUp cleans up the Processor
+func (e *EmptyClusterProcessor) CleanUp() {
+}
+
+// NewDefaultActionableClusterProcessor returns a new Processor instance
+func NewDefaultActionableClusterProcessor() ActionableClusterProcessor {
+	return NewCustomActionableClusterProcessor(time.Now(), NodesNotReadyAfterStartTimeout)
+}
+
+// NewCustomActionableClusterProcessor returns a new instance with custom values
+func NewCustomActionableClusterProcessor(startTime time.Time, nodeNotReadyTimeout time.Duration) ActionableClusterProcessor {
+	return &EmptyClusterProcessor{
+		nodesNotReadyAfterStartTimeout: nodeNotReadyTimeout,
+		startTime:                      startTime,
+	}
+}

--- a/cluster-autoscaler/processors/callbacks/processor_callbacks.go
+++ b/cluster-autoscaler/processors/callbacks/processor_callbacks.go
@@ -21,6 +21,11 @@ type ProcessorCallbacks interface {
 	// DisableScaleDownForLoop disables scale down for current loop iteration
 	DisableScaleDownForLoop()
 
+	// ResetUnneededNodes resets information about any nodes that were previously considered unneeded by scale-down logic.
+	// CA will only delete a node if it's unneeded (meets criteria for scale-down) for time specified
+	// via --scale-down-unneeded-time. This call resets the timer for all the nodes in the cluster.
+	ResetUnneededNodes()
+
 	// SetExtraValue sets arbitrary value for given key. Value storage will be reset at the beginning of each loop iteration.
 	// Arbitrary value storage is used to pass information between processors used in extension points.
 	SetExtraValue(key string, value interface{})

--- a/cluster-autoscaler/processors/callbacks/test_utils.go
+++ b/cluster-autoscaler/processors/callbacks/test_utils.go
@@ -24,6 +24,11 @@ type TestProcessorCallbacks struct {
 	ExtraValues map[string]interface{}
 }
 
+// ResetUnneededNodes is test implementation, which takes no action
+func (callbacks *TestProcessorCallbacks) ResetUnneededNodes() {
+	return
+}
+
 // NewTestProcessorCallbacks creates new instance of TestProcessorCallbacks
 func NewTestProcessorCallbacks() *TestProcessorCallbacks {
 	callbacks := &TestProcessorCallbacks{}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package processors
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
@@ -55,6 +56,8 @@ type AutoscalingProcessors struct {
 	NodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor
 	// CustomResourcesProcessor is interface defining handling custom resources
 	CustomResourcesProcessor customresources.CustomResourcesProcessor
+	// ActionableClusterProcessor is interface defining whether the cluster is in an actionable state
+	ActionableClusterProcessor actionablecluster.ActionableClusterProcessor
 }
 
 // DefaultProcessors returns default set of processors.
@@ -72,6 +75,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
 		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(),
+		ActionableClusterProcessor: actionablecluster.NewDefaultActionableClusterProcessor(),
 	}
 }
 
@@ -89,4 +93,5 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeGroupConfigProcessor.CleanUp()
 	ap.CustomResourcesProcessor.CleanUp()
 	ap.TemplateNodeInfoProvider.CleanUp()
+	ap.ActionableClusterProcessor.CleanUp()
 }


### PR DESCRIPTION
This refactors the handling of cases when the cluster is empty/not ready by CA into a processors in empty_cluster_processor.go