### PR TITLE
[AWS EKS - Scale-to-0] Update conditional to check cluster-name as well

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -381,8 +381,8 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 	// NodeLabels
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, extractLabelsFromAsg(template.Tags))
 
-	if nodegroupName, ok := node.Labels["nodegroup-name"]; ok {
-		klog.V(5).Infof("Nodegroup %s is an EKS managed nodegroup.", nodegroupName)
+	if nodegroupName, clusterName := node.Labels["nodegroup-name"], node.Labels["cluster-name"]; nodegroupName != "" && clusterName != "" {
+		klog.V(5).Infof("Nodegroup %s in cluster %s is an EKS managed nodegroup.", nodegroupName, clusterName)
 		// TODO: Call AWS EKS DescribeNodegroup API, check if keys already exist in Labels and do NOT overwrite
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -207,6 +207,10 @@ func TestExtractLabelsFromAsg(t *testing.T) {
 			Value: aws.String("bar2"),
 		},
 		{
+			Key:   aws.String("eks:cluster-name"),
+			Value: aws.String("bar4"),
+		},
+		{
 			Key:   aws.String("bar"),
 			Value: aws.String("baz"),
 		},
@@ -214,9 +218,10 @@ func TestExtractLabelsFromAsg(t *testing.T) {
 
 	labels := extractLabelsFromAsg(tags)
 
-	assert.Equal(t, 2, len(labels))
+	assert.Equal(t, 3, len(labels))
 	assert.Equal(t, "bar", labels["foo"])
 	assert.Equal(t, "bar2", labels["nodegroup-name"])
+	assert.Equal(t, "bar4", labels["cluster-name"])
 }
 
 func TestExtractTaintsFromAsg(t *testing.T) {


### PR DESCRIPTION
This change updates the conditional to check for the cluster-name label as well since we need both for the DescribeNodegroup API call and a customer can accidentally delete either.