### PR TITLE
use docker buildx to buld multi-arch image

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -27,6 +27,8 @@ IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 TAG = 2.3
+# The output type could either be docker (local), or registry.
+OUTPUT_TYPE ?= docker
 
 BASEIMAGE?=gcr.io/distroless/static:latest
 
@@ -43,8 +45,12 @@ sub-push-%:
 all-container: test $(addprefix sub-container-,$(ALL_ARCH))
 
 all-push: $(addprefix sub-push-,$(ALL_ARCH))
+
+buildx-setup:
+	docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
+
 container: .container-$(ARCH)
-.container-$(ARCH):
+.container-$(ARCH): buildx-setup
 	cp -r * $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
@@ -55,7 +61,11 @@ container: .container-$(ARCH)
             cd /go/src/k8s.io/autoscaler/addon-resizer/ && \
             CGO_ENABLED=0 GOARM=$(GOARM) GOARCH=$(ARCH) godep go build -a -installsuffix cgo --ldflags '-w -X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=$(TAG)' -o $(TEMP_DIR)/pod_nanny main.go"
 
-	docker build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
+	docker buildx build \
+		--pull \
+		--platform linux/$(ARCH) \
+		--output=type=$(OUTPUT_TYPE) \
+		-t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
 
 ifeq ($(ARCH), amd64)
 	# This is for to maintain the backward compatibility


### PR DESCRIPTION
currently, we can build image with the same arch as the host node, for cross-arch building, we need `docker buildx`
The following image is build by `ARCH=arm64 make container` on a amd64-based host and pushed into ACR, manifest inspect shows it still uses amd64 even though we build the image specifying `ARCH=arm64`

```
➜  addon-resizer git:(master) docker manifest inspect qingchuanhao.azurecr.io/addon-resizer-arm64:2.3 --verbose
{
        "Ref": "qingchuanhao.azurecr.io/addon-resizer-arm64:2.3",
        "Descriptor": {
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "digest": "sha256:52bd42707a470ad5fc8e3b07e35e82654d3005966c3bf97a1f39fea654be23dc",
                "size": 738,
                "platform": {
                        "architecture": "amd64",
                        "os": "linux"
                }
        },
        "SchemaV2Manifest": {
                "schemaVersion": 2,
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "config": {
                        "mediaType": "application/vnd.docker.container.image.v1+json",
                        "size": 1797,
                        "digest": "sha256:20e5d2ef4950a2e21c13f815db89b115e6610a52d3538f96bb5111abb97be0c0"
                },
                "layers": [
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 803696,
                                "digest": "sha256:ec52731e927332d44613a9b1d70e396792d20a50bccfa06332a371e1c68d7785"
                        },
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 7505424,
                                "digest": "sha256:0f84d65db469a2894d201e22f583e82a56c6f61752654a38271da558ce113093"
                        }
                ]
        }
}
```

after I switched to `docker buildx`, the result is as follows:
```
➜  addon-resizer git:(docker-buildx-for-mult-arch) docker manifest inspect qingchuanhao.azurecr.io/addon-resizer-arm64:2.3 --verbose
{
        "Ref": "qingchuanhao.azurecr.io/addon-resizer-arm64:2.3",
        "Descriptor": {
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "digest": "sha256:f0a7762abb7a1205f2e25492c8161e7c78c42205d19e6b10cd00c95c2c4d3411",
                "size": 737,
                "platform": {
                        "architecture": "arm64",
                        "os": "linux"
                }
        },
        "SchemaV2Manifest": {
                "schemaVersion": 2,
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "config": {
                        "mediaType": "application/vnd.docker.container.image.v1+json",
                        "size": 890,
                        "digest": "sha256:b25060321e0d895aa31a1f4ceb65cdb1df7c825bc9d3d3c65a6226f485ac667c"
                },
                "layers": [
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 803696,
                                "digest": "sha256:d3784b5411957f878f8dd6c981e562f265a4b9500cf7402753241d746390cbda"
                        },
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 7505448,
                                "digest": "sha256:ac4c60dbd5eb0eb340c485991b5e0b7ad201ac0ccc7db6f2bc203f1e7ad3fdfb"
                        }
                ]
        }
}
```