### PR TITLE
CA - AWS - Update StaticListLastUpdateTime on re-generating instance …

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -354,7 +354,7 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	// Generate EC2 list
 	instanceTypes, lastUpdateTime := GetStaticEC2InstanceTypes()
 	if opts.AWSUseStaticInstanceList {
-		klog.Warningf("Use static EC2 Instance Types and list could be outdated. Last update time: %s", lastUpdateTime)
+		klog.Warningf("Using static EC2 Instance Types, this list could be outdated. Last update time: %s", lastUpdateTime)
 	} else {
 		region, err := GetCurrentAwsRegion()
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -39,7 +39,6 @@ var (
 	ec2MetaDataServiceUrl          = "http://169.254.169.254"
 	ec2PricingServiceUrlTemplate   = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/%s/index.json"
 	ec2PricingServiceUrlTemplateCN = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/AmazonEC2/current/%s/index.json"
-	staticListLastUpdateTime       = "2021-10-29"
 	ec2Arm64Processors             = []string{"AWS Graviton Processor", "AWS Graviton2 Processor"}
 )
 
@@ -127,7 +126,7 @@ func GenerateEC2InstanceTypes(region string) (map[string]*InstanceType, error) {
 
 // GetStaticEC2InstanceTypes return pregenerated ec2 instance type list
 func GetStaticEC2InstanceTypes() (map[string]*InstanceType, string) {
-	return InstanceTypes, staticListLastUpdateTime
+	return InstanceTypes, StaticListLastUpdateTime
 }
 
 func unmarshalProductsResponse(r io.Reader) (*response, error) {

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -27,6 +27,9 @@ type InstanceType struct {
 	Architecture string
 }
 
+// StaticListLastUpdateTime is a string declaring the last time the static list was updated.
+var StaticListLastUpdateTime = "2021-11-14"
+
 // InstanceTypes is a map of ec2 resources
 var InstanceTypes = map[string]*InstanceType{
 	"a1": {
@@ -1074,6 +1077,69 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"g4dn.xlarge": {
 		InstanceType: "g4dn.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          1,
+		Architecture: "amd64",
+	},
+	"g5": {
+		InstanceType: "g5",
+		VCPU:         192,
+		MemoryMb:     0,
+		GPU:          8,
+		Architecture: "amd64",
+	},
+	"g5.12xlarge": {
+		InstanceType: "g5.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          4,
+		Architecture: "amd64",
+	},
+	"g5.16xlarge": {
+		InstanceType: "g5.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          1,
+		Architecture: "amd64",
+	},
+	"g5.24xlarge": {
+		InstanceType: "g5.24xlarge",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          4,
+		Architecture: "amd64",
+	},
+	"g5.2xlarge": {
+		InstanceType: "g5.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          1,
+		Architecture: "amd64",
+	},
+	"g5.48xlarge": {
+		InstanceType: "g5.48xlarge",
+		VCPU:         192,
+		MemoryMb:     786432,
+		GPU:          8,
+		Architecture: "amd64",
+	},
+	"g5.4xlarge": {
+		InstanceType: "g5.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          1,
+		Architecture: "amd64",
+	},
+	"g5.8xlarge": {
+		InstanceType: "g5.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          1,
+		Architecture: "amd64",
+	},
+	"g5.xlarge": {
+		InstanceType: "g5.xlarge",
 		VCPU:         4,
 		MemoryMb:     16384,
 		GPU:          1,


### PR DESCRIPTION
…list

Moves the generation of the `lastUpdateTime` string used to warn users of the last time the static instance list was updated to be generated by the same code as that which generates the instance list data. Currently, the fact that this is a separate string in a separate file makes it easy to forget to update this when running `make generate` to update the instance data.