### PR TITLE
Add support for nvidia-tesla-a100 gpu for aws cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -43,6 +43,7 @@ var (
 		"nvidia-tesla-p100": {},
 		"nvidia-tesla-v100": {},
 		"nvidia-tesla-t4":   {},
+		"nvidia-tesla-a100": {},
 	}
 )
 


### PR DESCRIPTION
Cluster autoscaler has ec2 instance information for [p4d.24xlarge](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go#L2125-L2131)

```
	"p4d.24xlarge": {
		InstanceType: "p4d.24xlarge",
		VCPU:         96,
		MemoryMb:     1179648,
		GPU:          8,
		Architecture: "amd64",
	},
```

The p4d uses NVIDIA A100 Tensor Core GPUs.
