### PR TITLE
add recent AKS agentpool label to ignore for similarity checks

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
@@ -20,12 +20,21 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// AzureNodepoolLabel is a label specifying which Azure node pool a particular node belongs to.
-const AzureNodepoolLabel = "agentpool"
+// AzureNodepoolLegacyLabel is a label specifying which Azure node pool a particular node belongs to.
+const AzureNodepoolLegacyLabel = "agentpool"
+
+// AzureNodepoolLabel is an AKS label specifying which nodepool a particular node belongs to
+const AzureNodepoolLabel = "kubernetes.azure.com/agentpool"
 
 func nodesFromSameAzureNodePool(n1, n2 *schedulerframework.NodeInfo) bool {
 	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLabel]
 	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLabel]
+	return (n1AzureNodePool != "" && n1AzureNodePool == n2AzureNodePool) || nodesFromSameAzureNodePoolLegacy(n1, n2)
+}
+
+func nodesFromSameAzureNodePoolLegacy(n1, n2 *schedulerframework.NodeInfo) bool {
+	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLegacyLabel]
+	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLegacyLabel]
 	return n1AzureNodePool != "" && n1AzureNodePool == n2AzureNodePool
 }
 
@@ -37,6 +46,7 @@ func CreateAzureNodeInfoComparator(extraIgnoredLabels []string) NodeInfoComparat
 	for k, v := range BasicIgnoredLabels {
 		azureIgnoredLabels[k] = v
 	}
+	azureIgnoredLabels[AzureNodepoolLegacyLabel] = true
 	azureIgnoredLabels[AzureNodepoolLabel] = true
 	for _, k := range extraIgnoredLabels {
 		azureIgnoredLabels[k] = true

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
@@ -41,6 +41,10 @@ func TestIsAzureNodeInfoSimilar(t *testing.T) {
 	n1.ObjectMeta.Labels["agentpool"] = ""
 	n2.ObjectMeta.Labels["agentpool"] = ""
 	checkNodesSimilar(t, n1, n2, comparator, false)
+	// AKS agentpool labels
+	n1.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foo"
+	n2.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "bar"
+	checkNodesSimilar(t, n1, n2, comparator, false)
 	// Only one non empty
 	n1.ObjectMeta.Labels["agentpool"] = ""
 	n2.ObjectMeta.Labels["agentpool"] = "foo"
@@ -109,6 +113,8 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	// Unless we give them nodepool label.
 	n1.ObjectMeta.Labels["agentpool"] = "foobar"
 	n2.ObjectMeta.Labels["agentpool"] = "foobar"
+	n1.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar"
+	n2.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar"
 	similar, err = processor.FindSimilarNodeGroups(context, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, similar, []cloudprovider.NodeGroup{ng2})
@@ -125,6 +131,9 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	n1.ObjectMeta.Labels["agentpool"] = "foobar1"
 	n2.ObjectMeta.Labels["agentpool"] = "foobar2"
 	n3.ObjectMeta.Labels["agentpool"] = "foobar3"
+	n1.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar1"
+	n2.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar2"
+	n3.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar3"
 
 	similar, err = processor.FindSimilarNodeGroups(context, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)


### PR DESCRIPTION
AKS added a new agentpool label "kubernetes.azure.com/agentpool". We need to ignore that for similarity purposes.