### PR TITLE
Allow multiStringFlag arguments using a slice

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.8
+version: 9.11.0

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -75,7 +75,13 @@ spec:
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if not (kindIs "invalid" $value) }}
+            {{- if (kindIs "slice" $value)}}
+            {{- range $value}}
+            - --{{ $key | mustRegexFind "^[^_]+" }}={{ . }}
+            {{- end }}
+            {{- else }}
             - --{{ $key | mustRegexFind "^[^_]+" }}={{ $value }}
+            {{- end }}
             {{- else }}
             - --{{ $key | mustRegexFind "^[^_]+" }}
             {{- end }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -158,6 +158,9 @@ extraArgs:
   # skip-nodes-with-system-pods: true
   # balancing-ignore-label_1: first-label-to-ignore
   # balancing-ignore-label_2: second-label-to-ignore
+  # balancing-igonre-label:
+  #   - first-label-to-ignore
+  #   - second-label-to-ignore
 
 # extraEnv -- Additional container environment variables.
 extraEnv: {}


### PR DESCRIPTION
This allows you to do things like

```
extraArgs:
  balancing-ignore-label:
    - label1
    - label2
```

And it will template into

```
--balance-ignore-label=label1
--balance-ignore-label=label2
```