### PR TITLE
Mention Packet for supporting price expander

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -657,7 +657,7 @@ after scale-up. This is useful when you have different classes of nodes, for exa
 
 * `price` - select the node group that will cost the least and, at the same time, whose machines
 would match the cluster size. This expander is described in more details
-[HERE](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/pricing.md). Currently it works only for GCE and GKE (patches welcome.)
+[HERE](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/pricing.md). Currently it works only for GCE, GKE and Packet (patches welcome.)
 
 * `priority` - selects the node group that has the highest priority assigned by the user. It's configuration is described in more details [here](expander/priority/readme.md)
 


### PR DESCRIPTION
Packet also supports price expander

See https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/packet#autoscaler-deployment  and https://github.com/kubernetes/autoscaler/blob/1c8efe4640040d1ee0fbc6460d56f13562a44f67/cluster-autoscaler/cloudprovider/packet/packet_price_model.go#L58