### PR TITLE
expand CAPI_GROUP usage to cover other capi group variables

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -121,6 +121,15 @@ some situations, such as testing or prototyping, you may wish to change this
 group variable. For these situations you may use the environment variable
 `CAPI_GROUP` to change the group that the provider will use.
 
+Please note that setting the `CAPI_GROUP` environment variable will also cause the
+annotations for minimum and maximum size to change.
+This behavior will also affect the machine annotation on nodes, the machine deletion annotation,
+and the cluster name label. For example, if `CAPI_GROUP=test.k8s.io`
+then the minimum size annotation key will be `test.k8s.io/cluster-api-autoscaler-node-group-min-size`,
+the machine annotation on nodes will be `test.8s.io/machine`, the machine deletion
+annotation will be `test.k8s.io/delete-machine`, and the cluster name label will be
+`test.k8s.io/cluster-name`.
+
 ## Sample manifest
 
 A sample manifest that will create a deployment running the autoscaler is

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -32,8 +32,6 @@ const (
 	deprecatedMachineDeleteAnnotationKey = "cluster.k8s.io/delete-machine"
 	// TODO: determine what currently relies on deprecatedMachineAnnotationKey to determine when it can be removed
 	deprecatedMachineAnnotationKey = "cluster.k8s.io/machine"
-	machineDeleteAnnotationKey     = "cluster.x-k8s.io/delete-machine"
-	machineAnnotationKey           = "cluster.x-k8s.io/machine"
 	debugFormat                    = "%s (min: %d, max: %d, replicas: %d)"
 )
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clusterapi
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -686,6 +688,92 @@ func Test_clusterNameFromResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := clusterNameFromResource(tc.resource); got != tc.want {
 				t.Errorf("clusterNameFromResource() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+}
+
+func Test_getKeyHelpers(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		expected string
+		testfunc func() string
+	}{
+		{
+			name:     "default group, min size annotation key",
+			expected: fmt.Sprintf("%s/cluster-api-autoscaler-node-group-min-size", defaultCAPIGroup),
+			testfunc: getNodeGroupMinSizeAnnotationKey,
+		},
+		{
+			name:     "default group, max size annotation key",
+			expected: fmt.Sprintf("%s/cluster-api-autoscaler-node-group-max-size", defaultCAPIGroup),
+			testfunc: getNodeGroupMaxSizeAnnotationKey,
+		},
+		{
+			name:     "default group, machine delete annotation key",
+			expected: fmt.Sprintf("%s/delete-machine", defaultCAPIGroup),
+			testfunc: getMachineDeleteAnnotationKey,
+		},
+		{
+			name:     "default group, machine annotation key",
+			expected: fmt.Sprintf("%s/machine", defaultCAPIGroup),
+			testfunc: getMachineAnnotationKey,
+		},
+		{
+			name:     "default group, cluster name label",
+			expected: fmt.Sprintf("%s/cluster-name", defaultCAPIGroup),
+			testfunc: getClusterNameLabel,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := tc.testfunc()
+			if observed != tc.expected {
+				t.Errorf("%s, mismatch, expected=%s, observed=%s", tc.name, observed, tc.expected)
+			}
+		})
+	}
+
+	testgroup := "test.k8s.io"
+	if err := os.Setenv(CAPIGroupEnvVar, testgroup); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		expected string
+		testfunc func() string
+	}{
+		{
+			name:     "test group, min size annotation key",
+			expected: fmt.Sprintf("%s/cluster-api-autoscaler-node-group-min-size", testgroup),
+			testfunc: getNodeGroupMinSizeAnnotationKey,
+		},
+		{
+			name:     "test group, max size annotation key",
+			expected: fmt.Sprintf("%s/cluster-api-autoscaler-node-group-max-size", testgroup),
+			testfunc: getNodeGroupMaxSizeAnnotationKey,
+		},
+		{
+			name:     "test group, machine delete annotation key",
+			expected: fmt.Sprintf("%s/delete-machine", testgroup),
+			testfunc: getMachineDeleteAnnotationKey,
+		},
+		{
+			name:     "test group, machine annotation key",
+			expected: fmt.Sprintf("%s/machine", testgroup),
+			testfunc: getMachineAnnotationKey,
+		},
+		{
+			name:     "test group, cluster name label",
+			expected: fmt.Sprintf("%s/cluster-name", testgroup),
+			testfunc: getClusterNameLabel,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := tc.testfunc()
+			if observed != tc.expected {
+				t.Errorf("%s, mismatch, expected=%s, observed=%s", tc.name, observed, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This change updates the logic for the clusterapi autoscaler provider so
that the `CAPI_GROUP` environment variable will also affect the
annotations keys for minimum and maximum node group size, the machine
annotation, machine deletion, and the cluster name label. It also addes
unit tests and an update to the readme.