### PR TITLE
update readme and examples to keep it consistent with the community v…

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-deployment.yaml
@@ -25,12 +25,12 @@ spec:
           command:
             - ./cluster-autoscaler
             - --alsologtostderr
-            - --cluster-name=25b884ab-623f-11ea-9981-0255ac101546
             - --cloud-config=/config/cloud-config
             - --cloud-provider=huaweicloud
             - --nodes=1:50:crc-nodepool
             - --scale-down-delay-after-add=1m0s
             - --scale-down-unneeded-time=1m0s
+            - --expander=random
           volumeMounts:
             - name: cloud-config
               mountPath: /config

--- a/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-svcaccount.yaml
@@ -29,9 +29,9 @@ rules:
       - "persistentvolumeclaims"
       - "persistentvolumes"
     verbs: ["watch", "list", "get"]
-  - apiGroups: ["batch"]
+  - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]
-    verbs: ["watch", "list", "get"]
+    verbs: ["watch", "list", "get", "patch"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["watch", "list"]
@@ -39,7 +39,7 @@ rules:
     resources: ["daemonsets", "replicasets", "statefulsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["watch", "list", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -51,6 +51,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["watch", "list", "get", "create", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR made the following modifactions:

- As #4233 changed the config expander to mandatory, I updated our huaweicloud provider examples in order to to eliminate the user's confusion while using.
- Added  resources `"csidrivers", "csistoragecapacities"` to apiGroup `"storage.k8s.io"` and gave them `watch, list, get` permission.
- Updated Readme file and added more detailed steps for deploying CA to Huaweicloud ECS.