### PR TITLE
CA - Update gofmt of CAPI_nodegroup.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	debugFormat                    = "%s (min: %d, max: %d, replicas: %d)"
+	debugFormat = "%s (min: %d, max: %d, replicas: %d)"
 )
 
 type nodegroup struct {


### PR DESCRIPTION
Resolves a gofmt error introduced by merging of #4463 currently blocking other PRs (see e.g. #4411 )

(Side note, I've now loosened the restrictions on auto running the GH actions to hopefully prevent this from happening in the future.)