### PR TITLE
clusterapi: fmt clusterapi_nodegroup.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	debugFormat                    = "%s (min: %d, max: %d, replicas: %d)"
+	debugFormat = "%s (min: %d, max: %d, replicas: %d)"
 )
 
 type nodegroup struct {


### PR DESCRIPTION
Otherwise we fail lint tests on new or rebased PRs.