### PR TITLE
Increase upper bound for expected VPA CPU recommendations

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -102,7 +102,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
+			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -180,7 +180,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
+			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })

--- a/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/full_vpa.go
@@ -102,7 +102,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
+			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 


### PR DESCRIPTION
Tests are flaky with VPA sometimes generating recommendations higher
than 1000 mCPU.

I think this is a reasonable behavior - we're asking resoirce consumer
to use 1800 mCPU between 3 pods, if it gets unevenly distributed we can
end up with some pods using 1000 mCPU.