### PR TITLE
add configuration diagrams to clusterapi readme

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -66,30 +66,80 @@ To specify the kubeconfig path for the management cluster to monitor, use the
 `--cloud-config` option is not specified it will fall back to using the kubeconfig
 that was provided with the `--kubeconfig` option.
 
+### Autoscaler running in a joined cluster using service account credentials
+```
++-----------------+
+| mgmt / workload |
+| --------------- |
+|    autoscaler   |
++-----------------+
+```
 Use in-cluster config for both management and workload cluster:
 ```
 cluster-autoscaler --cloud-provider=clusterapi
 ```
 
+### Autoscaler running in workload cluster using service account credentials, with separate management cluster
+```
++--------+              +------------+
+|  mgmt  |              |  workload  |
+|        | cloud-config | ---------- |
+|        |<-------------+ autoscaler |
++--------+              +------------+
+```
+
 Use in-cluster config for workload cluster, specify kubeconfig for management cluster:
 ```
-cluster-autoscaler --cloud-provider=clusterapi --cloud-config=/mnt/kubeconfig
+cluster-autoscaler --cloud-provider=clusterapi \
+                   --cloud-config=/mnt/kubeconfig
+```
+
+### Autoscaler running in management cluster using service account credentials, with separate workload cluster
+```
++------------+             +----------+
+|    mgmt    |             | workload |
+| ---------- | kubeconfig  |          |
+| autoscaler +------------>|          |
++------------+             +----------+
 ```
 
 Use in-cluster config for management cluster, specify kubeconfig for workload cluster:
 ```
-cluster-autoscaler --cloud-provider=clusterapi --kubeconfig=/mnt/kubeconfig --clusterapi-cloud-config-authoritative
+cluster-autoscaler --cloud-provider=clusterapi \
+                   --kubeconfig=/mnt/kubeconfig \
+                   --clusterapi-cloud-config-authoritative
+```
+
+### Autoscaler running anywhere, with separate kubeconfigs for management and workload clusters
+```
++--------+               +------------+             +----------+
+|  mgmt  |               |     ?      |             | workload |
+|        |  cloud-config | ---------- | kubeconfig  |          |
+|        |<--------------+ autoscaler +------------>|          |
++--------+               +------------+             +----------+
 ```
 
 Use separate kubeconfigs for both management and workload cluster:
 ```
-cluster-autoscaler --cloud-provider=clusterapi --kubeconfig=/mnt/workload.kubeconfig --cloud-config=/mnt/management.kubeconfig
+cluster-autoscaler --cloud-provider=clusterapi \
+                   --kubeconfig=/mnt/workload.kubeconfig \
+                   --cloud-config=/mnt/management.kubeconfig
+```
+
+### Autoscaler running anywhere, with a common kubeconfig for management and workload clusters
+```
++---------------+             +------------+
+| mgmt/workload |             |     ?      |
+|               |  kubeconfig | ---------- |
+|               |<------------+ autoscaler |
++---------------+             +------------+
 ```
 
 Use a single provided kubeconfig for both management and workload cluster:
 ```
-cluster-autoscaler --cloud-provider=clusterapi --kubeconfig=/mnt/workload.kubeconfig
-``` 
+cluster-autoscaler --cloud-provider=clusterapi \
+                   --kubeconfig=/mnt/workload.kubeconfig
+```
 
 ## Enabling Autoscaling
 


### PR DESCRIPTION
This change adds ascii diagrams to help illustrate the differences
between the various authentication configurations for the clusterapi
provider. Due to the distributed nature of Cluster API and its ability
to have several Kubernetes clusters managed from a central location, the
kubeconfig authentication options for it are slightly more complex than
other providers.