### PR TITLE
CA - AWS CloudProvider - Fallback to Static EC2 list rather than fatal error

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -366,7 +366,7 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 
 		generatedInstanceTypes, err := GenerateEC2InstanceTypes(region)
 		if err != nil {
-			klog.Fatalf("Failed to generate AWS EC2 Instance Types: %v", err)
+			klog.Warningf("Failed to generate AWS EC2 Instance Types: %v, falling back to using static Instance Types. Last update time: %s", err, lastUpdateTime)
 		}
 		// fallback on the static list if we miss any instance types in the generated output
 		// credits to: https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/80
@@ -385,7 +385,7 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 			keys = append(keys, key)
 		}
 
-		klog.Infof("Successfully load %d EC2 Instance Types %s", len(keys), keys)
+		klog.Infof("Successfully loaded %d EC2 Instance Types %s", len(keys), keys)
 	}
 
 	manager, err := CreateAwsManager(config, do, instanceTypes)


### PR DESCRIPTION
Related to #4464 

Currently, if the CA is unable to dynamically load instances the CA immediately crashes fatally. Instead, we should gracefully fall back to using the bundled static list of EC2 instance types, warning the user this is what we're doing.

I'm not 100% sure this is the right move to make, as it will potentially mask more errors in people's configs by running with degraded functionality, though #4468 should help alleviate this, by returning more meaningful AWS errors from `GenerateEC2InstanceTypes`. 

In this case, if someone was running this way (e.g. due to insufficient IAM permissions) and tried to use a newer instance type not included in the fallback static list, they would then receive an error. It may not be clear from the distance between where this fallback message is, and the error being generated why this would be happening: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/aws_manager.go#L328