### PR TITLE
Early abort if AWS node group has no capacity

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/CA_with_AWS_IAM_OIDC.md
+++ b/cluster-autoscaler/cloudprovider/aws/CA_with_AWS_IAM_OIDC.md
@@ -67,6 +67,7 @@ __NOTE:__ Please see [the README](README.md#IAM-Policy) for more information on 
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:DescribeScalingActivities",
                 "autoscaling:DescribeTags",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeLaunchTemplateVersions"

--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -93,6 +93,7 @@ binary, replacing min and max node counts and the ASG:
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeScalingActivities",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup"
       ],

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -33,7 +33,7 @@ import (
 const (
 	scaleToZeroSupported           = true
 	placeholderInstanceNamePrefix  = "i-placeholder"
-	placeholderUnfulfillableStatus = "placeholder-cannot-be-fullfilled"
+	placeholderUnfulfillableStatus = "placeholder-cannot-be-fulfilled"
 )
 
 type asgCache struct {

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -479,7 +479,6 @@ func (m *asgCache) createPlaceholdersForDesiredNonStartedInstances(groups []*aut
 func (m *asgCache) isNodeGroupAvailable(group *autoscaling.Group) (bool, error) {
 	input := &autoscaling.DescribeScalingActivitiesInput{
 		AutoScalingGroupName: group.AutoScalingGroupName,
-		MaxRecords:           aws.Int64(1), // We only care about the most recent event
 	}
 
 	start := time.Now()
@@ -496,6 +495,7 @@ func (m *asgCache) isNodeGroupAvailable(group *autoscaling.Group) (bool, error) 
 			if activity.StartTime.Before(lut) {
 				break
 			} else if *activity.StatusCode == "Failed" {
+				klog.Warningf("ASG %s scaling failed with %s", asgRef.Name, *activity)
 				return false, nil
 			}
 		} else {

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -67,7 +67,7 @@ type asg struct {
 	minSize        int
 	maxSize        int
 	curSize        int
-	lastUpdateTime *time.Time
+	lastUpdateTime time.Time
 
 	AvailabilityZones       []string
 	LaunchConfigurationName string
@@ -254,7 +254,7 @@ func (m *asgCache) setAsgSizeNoLock(asg *asg, size int) error {
 	}
 
 	// Proactively set the ASG size so autoscaler makes better decisions
-	asg.lastUpdateTime = &start
+	asg.lastUpdateTime = start
 	asg.curSize = size
 
 	return nil
@@ -489,12 +489,13 @@ func (m *asgCache) isNodeGroupAvailable(group *autoscaling.Group) (bool, error) 
 		return true, err // If we can't describe the scaling activities we assume the node group is available
 	}
 
-	if len(response.Activities) > 0 {
-		activity := response.Activities[0]
+	for _, activity := range response.Activities {
 		asgRef := AwsRef{Name: *group.AutoScalingGroupName}
 		if a, ok := m.registeredAsgs[asgRef]; ok {
 			lut := a.lastUpdateTime
-			if lut != nil && activity.StartTime.After(*lut) && *activity.StatusCode == "Failed" {
+			if activity.StartTime.Before(lut) {
+				break
+			} else if *activity.StatusCode == "Failed" {
 				return false, nil
 			}
 		} else {

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -128,7 +128,6 @@ func TestCreatePlaceholders(t *testing.T) {
 			if shouldCallDescribeScalingActivities {
 				a.On("DescribeScalingActivities", &autoscaling.DescribeScalingActivitiesInput{
 					AutoScalingGroupName: asgName,
-					MaxRecords:           aws.Int64(1),
 				}).Return(
 					&autoscaling.DescribeScalingActivitiesOutput{Activities: tc.activities},
 					tc.describeErr,

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -59,7 +59,7 @@ func TestCreatePlaceholders(t *testing.T) {
 		name                string
 		desiredCapacity     *int64
 		activities          []*autoscaling.Activity
-		groupLastUpdateTime *time.Time
+		groupLastUpdateTime time.Time
 		describeErr         error
 		asgToCheck          *string
 	}{
@@ -85,7 +85,7 @@ func TestCreatePlaceholders(t *testing.T) {
 					StartTime:  aws.Time(time.Unix(10, 0)),
 				},
 			},
-			groupLastUpdateTime: aws.Time(time.Unix(9, 0)),
+			groupLastUpdateTime: time.Unix(9, 0),
 		},
 		{
 			name:            "AWS scaling failed event before CA scale_up",
@@ -96,7 +96,7 @@ func TestCreatePlaceholders(t *testing.T) {
 					StartTime:  aws.Time(time.Unix(9, 0)),
 				},
 			},
-			groupLastUpdateTime: aws.Time(time.Unix(10, 0)),
+			groupLastUpdateTime: time.Unix(10, 0),
 		},
 		{
 			name:            "asg not registered",
@@ -107,7 +107,7 @@ func TestCreatePlaceholders(t *testing.T) {
 					StartTime:  aws.Time(time.Unix(10, 0)),
 				},
 			},
-			groupLastUpdateTime: aws.Time(time.Unix(9, 0)),
+			groupLastUpdateTime: time.Unix(9, 0),
 			asgToCheck:          aws.String("unregisteredAsgName"),
 		},
 	}
@@ -158,7 +158,7 @@ func TestCreatePlaceholders(t *testing.T) {
 			}
 			asgCache.createPlaceholdersForDesiredNonStartedInstances(groups)
 			assert.Equal(t, int64(len(groups[0].Instances)), *tc.desiredCapacity)
-			if tc.activities != nil && *tc.activities[0].StatusCode == "Failed" && tc.activities[0].StartTime.After(*tc.groupLastUpdateTime) && asgName == registeredAsgName {
+			if tc.activities != nil && *tc.activities[0].StatusCode == "Failed" && tc.activities[0].StartTime.After(tc.groupLastUpdateTime) && asgName == registeredAsgName {
 				assert.Equal(t, *groups[0].Instances[0].HealthStatus, placeholderUnfulfillableStatus)
 			} else if len(groups[0].Instances) > 0 {
 				assert.Equal(t, *groups[0].Instances[0].HealthStatus, "")

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package aws
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,4 +49,121 @@ func validateAsg(t *testing.T, asg *asg, name string, minSize int, maxSize int) 
 	assert.Equal(t, name, asg.Name)
 	assert.Equal(t, minSize, asg.minSize)
 	assert.Equal(t, maxSize, asg.maxSize)
+}
+
+func TestCreatePlaceholders(t *testing.T) {
+	registeredAsgName := aws.String("test-asg")
+	registeredAsgRef := AwsRef{Name: *registeredAsgName}
+
+	cases := []struct {
+		name                string
+		desiredCapacity     *int64
+		activities          []*autoscaling.Activity
+		groupLastUpdateTime *time.Time
+		describeErr         error
+		asgToCheck          *string
+	}{
+		{
+			name:            "add placeholders successful",
+			desiredCapacity: aws.Int64(10),
+		},
+		{
+			name:            "no placeholders needed",
+			desiredCapacity: aws.Int64(0),
+		},
+		{
+			name:            "DescribeScalingActivities failed",
+			desiredCapacity: aws.Int64(1),
+			describeErr:     errors.New("timeout"),
+		},
+		{
+			name:            "early abort if AWS scaling up fails",
+			desiredCapacity: aws.Int64(1),
+			activities: []*autoscaling.Activity{
+				{
+					StatusCode: aws.String("Failed"),
+					StartTime:  aws.Time(time.Unix(10, 0)),
+				},
+			},
+			groupLastUpdateTime: aws.Time(time.Unix(9, 0)),
+		},
+		{
+			name:            "AWS scaling failed event before CA scale_up",
+			desiredCapacity: aws.Int64(1),
+			activities: []*autoscaling.Activity{
+				{
+					StatusCode: aws.String("Failed"),
+					StartTime:  aws.Time(time.Unix(9, 0)),
+				},
+			},
+			groupLastUpdateTime: aws.Time(time.Unix(10, 0)),
+		},
+		{
+			name:            "asg not registered",
+			desiredCapacity: aws.Int64(10),
+			activities: []*autoscaling.Activity{
+				{
+					StatusCode: aws.String("Failed"),
+					StartTime:  aws.Time(time.Unix(10, 0)),
+				},
+			},
+			groupLastUpdateTime: aws.Time(time.Unix(9, 0)),
+			asgToCheck:          aws.String("unregisteredAsgName"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shouldCallDescribeScalingActivities := true
+			if *tc.desiredCapacity == int64(0) {
+				shouldCallDescribeScalingActivities = false
+			}
+
+			asgName := registeredAsgName
+			if tc.asgToCheck != nil {
+				asgName = tc.asgToCheck
+			}
+
+			a := &autoScalingMock{}
+			if shouldCallDescribeScalingActivities {
+				a.On("DescribeScalingActivities", &autoscaling.DescribeScalingActivitiesInput{
+					AutoScalingGroupName: asgName,
+					MaxRecords:           aws.Int64(1),
+				}).Return(
+					&autoscaling.DescribeScalingActivitiesOutput{Activities: tc.activities},
+					tc.describeErr,
+				).Once()
+			}
+
+			asgCache := &asgCache{
+				awsService: &awsWrapper{
+					autoScalingI: a,
+					ec2I:         nil,
+				},
+				registeredAsgs: map[AwsRef]*asg{
+					registeredAsgRef: &asg{
+						AwsRef:         registeredAsgRef,
+						lastUpdateTime: tc.groupLastUpdateTime,
+					},
+				},
+			}
+
+			groups := []*autoscaling.Group{
+				{
+					AutoScalingGroupName: asgName,
+					AvailabilityZones:    []*string{aws.String("westeros-1a")},
+					DesiredCapacity:      tc.desiredCapacity,
+					Instances:            []*autoscaling.Instance{},
+				},
+			}
+			asgCache.createPlaceholdersForDesiredNonStartedInstances(groups)
+			assert.Equal(t, int64(len(groups[0].Instances)), *tc.desiredCapacity)
+			if tc.activities != nil && *tc.activities[0].StatusCode == "Failed" && tc.activities[0].StartTime.After(*tc.groupLastUpdateTime) && asgName == registeredAsgName {
+				assert.Equal(t, *groups[0].Instances[0].HealthStatus, placeholderUnfulfillableStatus)
+			} else if len(groups[0].Instances) > 0 {
+				assert.Equal(t, *groups[0].Instances[0].HealthStatus, "")
+			}
+			a.AssertExpectations(t)
+		})
+	}
 }

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -141,7 +141,7 @@ func TestCreatePlaceholders(t *testing.T) {
 					ec2I:         nil,
 				},
 				registeredAsgs: map[AwsRef]*asg{
-					registeredAsgRef: &asg{
+					registeredAsgRef: {
 						AwsRef:         registeredAsgRef,
 						lastUpdateTime: tc.groupLastUpdateTime,
 					},

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -86,12 +86,12 @@ func (aws *awsCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 // NodeGroups returns all node groups configured for this cloud provider.
 func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	asgs := aws.awsManager.getAsgs()
-	ngs := make([]cloudprovider.NodeGroup, len(asgs))
-	for i, asg := range asgs {
-		ngs[i] = &AwsNodeGroup{
+	ngs := make([]cloudprovider.NodeGroup, 0, len(asgs))
+	for _, asg := range asgs {
+		ngs = append(ngs, &AwsNodeGroup{
 			asg:        asg,
 			awsManager: aws.awsManager,
-		}
+		})
 	}
 
 	return ngs
@@ -320,7 +320,10 @@ func (ng *AwsNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	instances := make([]cloudprovider.Instance, len(asgNodes))
 
 	for i, asgNode := range asgNodes {
-		instances[i] = cloudprovider.Instance{Id: asgNode.ProviderID}
+		instances[i] = cloudprovider.Instance{
+			Id:     asgNode.ProviderID,
+			Status: nil,
+		}
 	}
 	return instances, nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -29,7 +29,7 @@ import (
 
 var testAwsManager = &AwsManager{
 	asgCache: &asgCache{
-		registeredAsgs: make([]*asg, 0),
+		registeredAsgs: make(map[AwsRef]*asg, 0),
 		asgToInstances: make(map[AwsRef][]AwsInstanceRef),
 		instanceToAsg:  make(map[AwsInstanceRef]*asg),
 		interrupt:      make(chan struct{}),
@@ -43,7 +43,7 @@ func newTestAwsManagerWithMockServices(mockAutoScaling autoScalingI, mockEC2 ec2
 	return &AwsManager{
 		awsService: awsService,
 		asgCache: &asgCache{
-			registeredAsgs:        make([]*asg, 0),
+			registeredAsgs:        make(map[AwsRef]*asg, 0),
 			asgToInstances:        make(map[AwsRef][]AwsInstanceRef),
 			instanceToAsg:         make(map[AwsInstanceRef]*asg),
 			asgInstanceTypeCache:  newAsgInstanceTypeCache(&awsService),

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -466,7 +466,6 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 	a.On("DescribeScalingActivities",
 		&autoscaling.DescribeScalingActivitiesInput{
 			AutoScalingGroupName: aws.String("test-asg"),
-			MaxRecords:           aws.Int64(1),
 		},
 	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -468,7 +468,7 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 			AutoScalingGroupName: aws.String("test-asg"),
 			MaxRecords:           aws.Int64(1),
 		},
-	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 
 	provider.Refresh()
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -463,6 +463,13 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 		expectedInstancesCount = 1
 	}).Return(nil)
 
+	a.On("DescribeScalingActivities",
+		&autoscaling.DescribeScalingActivitiesInput{
+			AutoScalingGroupName: aws.String("test-asg"),
+			MaxRecords:           aws.Int64(1),
+		},
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
+
 	provider.Refresh()
 
 	initialSize, err := asgs[0].TargetSize()

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -301,6 +301,10 @@ func (m *AwsManager) GetAsgNodes(ref AwsRef) ([]AwsInstanceRef, error) {
 	return m.asgCache.InstancesByAsg(ref)
 }
 
+func (m *AwsManager) GetInstanceStatus(ref AwsInstanceRef) (*string, error) {
+	return m.asgCache.InstanceStatus(ref)
+}
+
 func (m *AwsManager) getAsgTemplate(asg *asg) (*asgTemplate, error) {
 	if len(asg.AvailabilityZones) < 1 {
 		return nil, fmt.Errorf("unable to get first AvailabilityZone for ASG %q", asg.Name)

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -301,6 +301,7 @@ func (m *AwsManager) GetAsgNodes(ref AwsRef) ([]AwsInstanceRef, error) {
 	return m.asgCache.InstancesByAsg(ref)
 }
 
+// GetInstanceStatus returns the status of ASG nodes
 func (m *AwsManager) GetInstanceStatus(ref AwsInstanceRef) (*string, error) {
 	return m.asgCache.InstanceStatus(ref)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -273,7 +273,7 @@ func (m *AwsManager) Cleanup() {
 	m.asgCache.Cleanup()
 }
 
-func (m *AwsManager) getAsgs() []*asg {
+func (m *AwsManager) getAsgs() map[AwsRef]*asg {
 	return m.asgCache.Get()
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -358,6 +358,7 @@ func makeTaintSet(taints []apiv1.Taint) map[apiv1.Taint]bool {
 
 func TestFetchExplicitAsgs(t *testing.T) {
 	min, max, groupname := 1, 10, "coolasg"
+	asgRef := AwsRef{Name: groupname}
 
 	a := &autoScalingMock{}
 	a.On("DescribeAutoScalingGroups", &autoscaling.DescribeAutoScalingGroupsInput{
@@ -408,7 +409,7 @@ func TestFetchExplicitAsgs(t *testing.T) {
 
 	asgs := m.asgCache.Get()
 	assert.Equal(t, 1, len(asgs))
-	validateAsg(t, asgs[0], groupname, min, max)
+	validateAsg(t, asgs[asgRef], groupname, min, max)
 }
 
 func TestGetASGTemplate(t *testing.T) {
@@ -504,6 +505,7 @@ func TestGetASGTemplate(t *testing.T) {
 func TestFetchAutoAsgs(t *testing.T) {
 	min, max := 1, 10
 	groupname, tags := "coolasg", []string{"tag", "anothertag"}
+	asgRef := AwsRef{Name: groupname}
 
 	a := &autoScalingMock{}
 	// Lookup groups associated with tags
@@ -561,7 +563,7 @@ func TestFetchAutoAsgs(t *testing.T) {
 
 	asgs := m.asgCache.Get()
 	assert.Equal(t, 1, len(asgs))
-	validateAsg(t, asgs[0], groupname, min, max)
+	validateAsg(t, asgs[asgRef], groupname, min, max)
 
 	// Simulate the previously discovered ASG disappearing
 	a.On("DescribeTagsPages", mock.MatchedBy(tagsMatcher(expectedTagsInput)),

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -394,7 +394,6 @@ func TestFetchExplicitAsgs(t *testing.T) {
 	a.On("DescribeScalingActivities",
 		&autoscaling.DescribeScalingActivitiesInput{
 			AutoScalingGroupName: aws.String("coolasg"),
-			MaxRecords:           aws.Int64(1),
 		},
 	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 
@@ -559,7 +558,6 @@ func TestFetchAutoAsgs(t *testing.T) {
 	a.On("DescribeScalingActivities",
 		&autoscaling.DescribeScalingActivitiesInput{
 			AutoScalingGroupName: aws.String("coolasg"),
-			MaxRecords:           aws.Int64(1),
 		},
 	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -391,6 +391,13 @@ func TestFetchExplicitAsgs(t *testing.T) {
 			}}, false)
 	}).Return(nil)
 
+	a.On("DescribeScalingActivities",
+		&autoscaling.DescribeScalingActivitiesInput{
+			AutoScalingGroupName: aws.String("coolasg"),
+			MaxRecords:           aws.Int64(1),
+		},
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
+
 	do := cloudprovider.NodeGroupDiscoveryOptions{
 		// Register the same node group twice with different max nodes.
 		// The intention is to test that the asgs.Register method will update
@@ -548,6 +555,13 @@ func TestFetchAutoAsgs(t *testing.T) {
 				DesiredCapacity:      aws.Int64(int64(min)),
 			}}}, false)
 	}).Return(nil).Twice()
+
+	a.On("DescribeScalingActivities",
+		&autoscaling.DescribeScalingActivitiesInput{
+			AutoScalingGroupName: aws.String("coolasg"),
+			MaxRecords:           aws.Int64(1),
+		},
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{
 		NodeGroupAutoDiscoverySpecs: []string{fmt.Sprintf("asg:tag=%s", strings.Join(tags, ","))},

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -396,7 +396,7 @@ func TestFetchExplicitAsgs(t *testing.T) {
 			AutoScalingGroupName: aws.String("coolasg"),
 			MaxRecords:           aws.Int64(1),
 		},
-	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{
 		// Register the same node group twice with different max nodes.
@@ -561,7 +561,7 @@ func TestFetchAutoAsgs(t *testing.T) {
 			AutoScalingGroupName: aws.String("coolasg"),
 			MaxRecords:           aws.Int64(1),
 		},
-	).Return(&autoscaling.DescribeScalingActivitiesOutput{})
+	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{
 		NodeGroupAutoDiscoverySpecs: []string{fmt.Sprintf("asg:tag=%s", strings.Join(tags, ","))},

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -33,6 +33,7 @@ import (
 type autoScalingI interface {
 	DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoScalingGroupsInput, fn func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error
 	DescribeLaunchConfigurations(*autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error)
+	DescribeScalingActivities(*autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error)
 	DescribeTagsPages(input *autoscaling.DescribeTagsInput, fn func(*autoscaling.DescribeTagsOutput, bool) bool) error
 	SetDesiredCapacity(input *autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error)
 	TerminateInstanceInAutoScalingGroup(input *autoscaling.TerminateInstanceInAutoScalingGroupInput) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -45,6 +45,11 @@ func (a *autoScalingMock) DescribeLaunchConfigurations(i *autoscaling.DescribeLa
 	return args.Get(0).(*autoscaling.DescribeLaunchConfigurationsOutput), nil
 }
 
+func (a *autoScalingMock) DescribeScalingActivities(i *autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+	args := a.Called(i)
+	return args.Get(0).(*autoscaling.DescribeScalingActivitiesOutput), nil
+}
+
 func (a *autoScalingMock) DescribeTagsPages(i *autoscaling.DescribeTagsInput, fn func(*autoscaling.DescribeTagsOutput, bool) bool) error {
 	args := a.Called(i, fn)
 	return args.Error(0)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -47,7 +47,7 @@ func (a *autoScalingMock) DescribeLaunchConfigurations(i *autoscaling.DescribeLa
 
 func (a *autoScalingMock) DescribeScalingActivities(i *autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
 	args := a.Called(i)
-	return args.Get(0).(*autoscaling.DescribeScalingActivitiesOutput), nil
+	return args.Get(0).(*autoscaling.DescribeScalingActivitiesOutput), args.Error(1)
 }
 
 func (a *autoScalingMock) DescribeTagsPages(i *autoscaling.DescribeTagsInput, fn func(*autoscaling.DescribeTagsOutput, bool) bool) error {

--- a/cluster-autoscaler/cloudprovider/aws/instance_type_cache.go
+++ b/cluster-autoscaler/cloudprovider/aws/instance_type_cache.go
@@ -84,7 +84,7 @@ func (c *jitterClock) Since(ts time.Time) time.Duration {
 	return since
 }
 
-func (es instanceTypeExpirationStore) populate(autoscalingGroups []*asg) error {
+func (es instanceTypeExpirationStore) populate(autoscalingGroups map[AwsRef]*asg) error {
 	asgsToQuery := []*asg{}
 
 	if c, ok := es.jitterClock.(*jitterClock); ok {

--- a/cluster-autoscaler/cloudprovider/aws/instance_type_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/instance_type_cache_test.go
@@ -79,9 +79,10 @@ func TestLTVersionChange(t *testing.T) {
 	m := newAsgInstanceTypeCacheWithClock(&awsWrapper{a, e, nil}, fakeClock, fakeStore)
 
 	for i := 0; i < 2; i++ {
-		err := m.populate([]*asg{
-			{
-				AwsRef: AwsRef{Name: asgName},
+		asgRef := AwsRef{Name: asgName}
+		err := m.populate(map[AwsRef]*asg{
+			asgRef: {
+				AwsRef: asgRef,
 				LaunchTemplate: &launchTemplate{
 					name:    ltName,
 					version: aws.StringValue(ltVersions[i]),


### PR DESCRIPTION
## Summary

This change makes it so that Cluster Autoscaler will early-abort if AWS does not have any capacity available (e.g., it is a spot node group, and there are no spot instances available).  It works by polling the `DescribeScalingActivities` AWS EC2 endpoint, and setting the node group status to an error if the `DescribeScalingActivities` call returns "Failed".  This short-circuits the 15-minute waiting period for nodes to join the cluster before the node group is added to the backoff list, which allows Cluster Autoscaler to more rapidly try a different node group that is more likely to succeed.

## Notes for reviewer:

* Recommend reviewing the commits separately
* All existing tests pass
* New unit tests for the new behaviour
* Tested in a test cluster at Airbnb (see below for details)

## Testing details

I created 3 `c5ad.16xlarge` ASGs in `test-mc-a`, and tried to scale up a test deployment in the cluster that had a "required during scheduling" node affinity for `c5ad.16xlarge`.  The node group quickly ran out of capacity, and then deleted all of the "upcoming" nodes from the node group, as you can see in the follow series of graphs:

<img width="594" alt="Screen Shot 2021-11-22 at 3 08 31 PM" src="https://user-images.githubusercontent.com/3268445/142948401-fb055ca7-cf52-4dc1-94a5-f79c5a9a04a6.png">

Specifically, note that at multiple points in the time period, it tries to scale up, creates a bunch of un-registered nodes (yellow bars in the bottom graph), and then deletes them shortly thereafter.  We can see from the following graphs that the reason for the failed scale-up is `placeholder-cannot-be-fulfilled`:

<img width="593" alt="Screen Shot 2021-11-22 at 3 09 51 PM" src="https://user-images.githubusercontent.com/3268445/142948513-6e3d9eef-5739-4689-aa8b-65b6a24bb934.png">

We can also look at the logs for this time period:

```
F I1122 17:02:51.876677       1 auto_scaling_groups.go:432] Instance group kubernetes-minion-test-mc-a-amd-asg-us-east-1a has only 0 instances created while requested count is 14. Creating placeholder instances.
...
F W1122 17:02:51.935464       1 auto_scaling_groups.go:440] Instance group kubernetes-minion-test-mc-a-amd-asg-us-east-1a cannot provision any more nodes!
...
F W1122 17:02:52.094981       1 clusterstate.go:281] Disabling scale-up for node group kubernetes-minion-test-mc-a-amd-asg-us-east-1b until 2021-11-22 17:07:50.399430339 +0000 UTC m=+48821.870874859; errorClass=OutOfResource; errorCode=placeholder-cannot-be-fullfilled
...
F I1122 17:02:52.095011       1 clusterstate.go:1043] Failed adding 14 nodes (14 unseen previously) to group kubernetes-minion-test-mc-a-amd-asg-us-east-1a due to OutOfResource.placeholder-cannot-be-fullfilled; errorMessages=[]string{"AWS cannot provision any more instances for this node group"}
...
F I1122 17:02:52.095226       1 auto_scaling_groups.go:287] instance i-placeholder-kubernetes-minion-test-mc-a-amd-asg-us-east-1b-0 is detected as a placeholder, decreasing ASG requested size instead of deleting instance
...
F W1122 17:03:09.808770       1 scale_up.go:383] Node group kubernetes-minion-test-mc-a-amd-asg-us-east-1b is not ready for scaleup - backoff
```

Here we can see the node group errors out and is added to the backoff list, and the placeholder nodes are deleted, as desired.