### PR TITLE
[AWS EKS - Scale-to-0] Add Managed Nodegroup Cache

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -60,10 +60,11 @@ const (
 
 // AwsManager is handles aws communication and data caching.
 type AwsManager struct {
-	awsService    awsWrapper
-	asgCache      *asgCache
-	lastRefresh   time.Time
-	instanceTypes map[string]*InstanceType
+	awsService            awsWrapper
+	asgCache              *asgCache
+	lastRefresh           time.Time
+	instanceTypes         map[string]*InstanceType
+	managedNodegroupCache *managedNodegroupCache
 }
 
 type asgTemplate struct {
@@ -211,10 +212,13 @@ func createAWSManagerInternal(
 		return nil, err
 	}
 
+	mngCache := newManagedNodeGroupCache(awsService)
+
 	manager := &AwsManager{
-		awsService:    *awsService,
-		asgCache:      cache,
-		instanceTypes: instanceTypes,
+		awsService:            *awsService,
+		asgCache:              cache,
+		instanceTypes:         instanceTypes,
+		managedNodegroupCache: mngCache,
 	}
 
 	if err := manager.forceRefresh(); err != nil {
@@ -410,18 +414,54 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 
 	// GenericLabels
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, buildGenericLabels(template, nodeName))
+
 	// NodeLabels
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, extractLabelsFromAsg(template.Tags))
 
+	node.Spec.Taints = extractTaintsFromAsg(template.Tags)
+
 	if nodegroupName, clusterName := node.Labels["nodegroup-name"], node.Labels["cluster-name"]; nodegroupName != "" && clusterName != "" {
 		klog.V(5).Infof("Nodegroup %s in cluster %s is an EKS managed nodegroup.", nodegroupName, clusterName)
-		// TODO: Call AWS EKS DescribeNodegroup API, check if keys already exist in Labels and do NOT overwrite
-	}
 
-	node.Spec.Taints = extractTaintsFromAsg(template.Tags)
+		// Call AWS EKS DescribeNodegroup API, check if keys already exist in Labels and do NOT overwrite
+		mngLabels, err := m.managedNodegroupCache.getManagedNodegroupLabels(nodegroupName, clusterName)
+		if err != nil {
+			klog.Errorf("Failed to get labels from EKS DescribeNodegroup API for nodegroup %s in cluster %s because %s.", nodegroupName, clusterName, err)
+		} else if mngLabels != nil && len(mngLabels) > 0 {
+			node.Labels = joinNodeLabelsChoosingUserValuesOverAPIValues(node.Labels, mngLabels)
+			klog.V(5).Infof("node.Labels : %+v\n", node.Labels)
+		}
+
+		mngTaints, err := m.managedNodegroupCache.getManagedNodegroupTaints(nodegroupName, clusterName)
+		if err != nil {
+			klog.Errorf("Failed to get taints from EKS DescribeNodegroup API for nodegroup %s in cluster %s because %s.", nodegroupName, clusterName, err)
+		} else if mngTaints != nil && len(mngTaints) > 0 {
+			node.Spec.Taints = append(node.Spec.Taints, mngTaints...)
+			klog.V(5).Infof("node.Spec.Taints : %+v\n", node.Spec.Taints)
+		}
+	}
 
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
 	return &node, nil
+}
+
+func joinNodeLabelsChoosingUserValuesOverAPIValues(extractedLabels map[string]string, mngLabels map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	// Copy Generic Labels and Labels from ASG
+	for k, v := range extractedLabels {
+		result[k] = v
+	}
+
+	// Copy Labels from EKS DescribeNodegroup API call
+	// If the there is a duplicate key, this will overwrite the ASG Tag specified values with the EKS DescribeNodegroup API values
+	// We are overwriting them because it seems like EKS isn't sending the ASG Tags to Kubernetes itself
+	//     so scale ups based on the ASG Tag aren't working
+	for k, v := range mngLabels {
+		result[k] = v
+	}
+
+	return result
 }
 
 func buildGenericLabels(template *asgTemplate, nodeName string) map[string]string {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -68,6 +68,8 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		return nil, nil, err
 	}
 
+	klog.V(6).Infof("DescribeNodegroup output : %+v\n", r)
+
 	taints := make([]apiv1.Taint, 0)
 	labels := make(map[string]string)
 

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/cache"
+	klog "k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const (
+	managedNodegroupCachedTTL = time.Minute * 6
+	mngCacheMinTTL            = 5
+	mngCacheMaxTTL            = 60
+)
+
+// managedNodegroupCache caches the managed nodegroup information.
+// The store expires its keys based on a TTL. This TTL can have a jitter applied to it.
+// This allows to get a better repartition of the AWS queries.
+type managedNodegroupCache struct {
+	cache.Store
+	mngJitterClock clock.Clock
+	awsService     *awsWrapper
+}
+
+// This struct will be used to hold some information from the describeNodegroup call
+// There are more options that can be added in the future
+// https://docs.aws.amazon.com/cli/latest/reference/eks/describe-nodegroup.html
+type managedNodegroupCachedObject struct {
+	name        string
+	clusterName string
+	taints      []apiv1.Taint
+	labels      map[string]string
+}
+
+type mngJitterClock struct {
+	clock.Clock
+
+	jitter bool
+	sync.RWMutex
+}
+
+func newManagedNodeGroupCache(awsService *awsWrapper) *managedNodegroupCache {
+	jc := &mngJitterClock{}
+	return newManagedNodeGroupCacheWithClock(
+		awsService,
+		jc,
+		cache.NewExpirationStore(func(obj interface{}) (s string, e error) {
+			return obj.(managedNodegroupCachedObject).name, nil
+		}, &cache.TTLPolicy{
+			TTL:   managedNodegroupCachedTTL,
+			Clock: jc,
+		}),
+	)
+}
+
+func newManagedNodeGroupCacheWithClock(awsService *awsWrapper, jc clock.Clock, store cache.Store) *managedNodegroupCache {
+	return &managedNodegroupCache{
+		store,
+		jc,
+		awsService,
+	}
+}
+
+func (c *mngJitterClock) Since(ts time.Time) time.Duration {
+	since := time.Since(ts)
+	c.RLock()
+	defer c.RUnlock()
+	if c.jitter {
+		return since + (time.Second * time.Duration(rand.IntnRange(mngCacheMinTTL, mngCacheMaxTTL)))
+	}
+	return since
+}
+
+func (m *managedNodegroupCache) getManagedNodegroup(nodegroupName string, clusterName string) (*managedNodegroupCachedObject, error) {
+	taintList, labelMap, err := m.awsService.getManagedNodegroupInfo(nodegroupName, clusterName)
+	if err != nil {
+		// If there's an error cache an empty nodegroup to limit failed calls to the EKS API
+		newEmptyNodegroup := managedNodegroupCachedObject{
+			name:        nodegroupName,
+			clusterName: clusterName,
+			taints:      nil,
+			labels:      nil,
+		}
+
+		m.Add(newEmptyNodegroup)
+		return nil, err
+	}
+
+	newNodegroup := managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      taintList,
+		labels:      labelMap,
+	}
+
+	m.Add(newNodegroup)
+
+	return &newNodegroup, nil
+}
+
+func (m managedNodegroupCache) getManagedNodegroupInfoObject(nodegroupName string, clusterName string) (*managedNodegroupCachedObject, error) {
+	// List expires old entries
+	cacheList := m.List()
+	klog.V(5).Infof("Current ManagedNodegroup cache: %+v\n", cacheList)
+
+	if obj, found, err := m.GetByKey(nodegroupName); err == nil && found {
+		foundNodeGroup := obj.(managedNodegroupCachedObject)
+		return &foundNodeGroup, nil
+	}
+
+	managedNodegroupInfo, err := m.getManagedNodegroup(nodegroupName, clusterName)
+	if err != nil {
+		klog.Errorf("Failed to query the managed nodegroup %s for the cluster %s while looking for labels/taints: %v", nodegroupName, clusterName, err)
+		return nil, err
+	}
+	return managedNodegroupInfo, nil
+}
+
+func (m managedNodegroupCache) getManagedNodegroupLabels(nodegroupName string, clusterName string) (map[string]string, error) {
+	getManagedNodegroupInfoObject, err := m.getManagedNodegroupInfoObject(nodegroupName, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return getManagedNodegroupInfoObject.labels, nil
+}
+
+func (m managedNodegroupCache) getManagedNodegroupTaints(nodegroupName string, clusterName string) ([]apiv1.Taint, error) {
+	getManagedNodegroupInfoObject, err := m.getManagedNodegroupInfoObject(nodegroupName, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return getManagedNodegroupInfoObject.taints, nil
+}

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -1,0 +1,583 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	test_clock "k8s.io/utils/clock/testing"
+)
+
+func TestManagedNodegroupCache(t *testing.T) {
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+
+	c := newManagedNodeGroupCache(nil)
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+	})
+	require.NoError(t, err)
+	obj, ok, err := c.GetByKey(nodegroupName)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, nodegroupName, obj.(managedNodegroupCachedObject).name)
+	assert.Equal(t, clusterName, obj.(managedNodegroupCachedObject).clusterName)
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).labels), 1)
+	assert.Equal(t, labelValue, obj.(managedNodegroupCachedObject).labels[labelKey])
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).taints), 1)
+	assert.Equal(t, apiv1.TaintEffect(taintEffect), obj.(managedNodegroupCachedObject).taints[0].Effect)
+	assert.Equal(t, taintKey, obj.(managedNodegroupCachedObject).taints[0].Key)
+	assert.Equal(t, taintValue, obj.(managedNodegroupCachedObject).taints[0].Value)
+}
+
+func TestGetManagedNodegroupWithError(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(nil, errors.New("AccessDenied"))
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	// Make sure there's an error but no cache object returned
+	_, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.Error(t, err)
+
+	// Make sure an empty cache object was saved
+	obj, ok, err := c.GetByKey(nodegroupName)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, nodegroupName, obj.(managedNodegroupCachedObject).name)
+	assert.Equal(t, clusterName, obj.(managedNodegroupCachedObject).clusterName)
+	assert.Nil(t, obj.(managedNodegroupCachedObject).labels)
+	assert.Nil(t, obj.(managedNodegroupCachedObject).taints)
+}
+
+func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      nil,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 0)
+	assert.Equal(t, len(cacheObj.labels), 3)
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+}
+
+func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
+	k := &eksMock{}
+
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+
+	labelKey1 := "labelKey 1"
+	labelKey2 := "labelKey 2"
+	labelValue1 := "testValue 1"
+	labelValue2 := "testValue 2"
+
+	taintEffect1 := "effect 1"
+	taintKey1 := "key 1"
+	taintValue1 := "value 1"
+	taint1 := eks.Taint{
+		Effect: &taintEffect1,
+		Key:    &taintKey1,
+		Value:  &taintValue1,
+	}
+
+	taintEffect2 := "effect 2"
+	taintKey2 := "key 2"
+	taintValue2 := "value 2"
+	taint2 := eks.Taint{
+		Effect: &taintEffect2,
+		Key:    &taintKey2,
+		Value:  &taintValue2,
+	}
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        map[string]*string{labelKey1: &labelValue1, labelKey2: &labelValue2},
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        []*eks.Taint{&taint1, &taint2},
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 2)
+	assert.Equal(t, cacheObj.taints[0].Effect, apiv1.TaintEffect(taintEffect1))
+	assert.Equal(t, cacheObj.taints[0].Key, taintKey1)
+	assert.Equal(t, cacheObj.taints[0].Value, taintValue1)
+	assert.Equal(t, cacheObj.taints[1].Effect, apiv1.TaintEffect(taintEffect2))
+	assert.Equal(t, cacheObj.taints[1].Key, taintKey2)
+	assert.Equal(t, cacheObj.taints[1].Value, taintValue2)
+	assert.Equal(t, len(cacheObj.labels), 6)
+	assert.Equal(t, cacheObj.labels[labelKey1], labelValue1)
+	assert.Equal(t, cacheObj.labels[labelKey2], labelValue2)
+	assert.Equal(t, cacheObj.labels["diskSize"], strconv.FormatInt(diskSize, 10))
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+}
+
+func TestGetManagedNodegroupInfoObjectWithError(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(nil, errors.New("AccessDenied"))
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	// Make sure there's an error
+	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
+	require.Error(t, err)
+
+	// Make sure an object isn't returned
+	assert.Nil(t, mngInfoObject)
+}
+
+func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+	})
+
+	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(mngInfoObject.labels), 1)
+	assert.Equal(t, mngInfoObject.labels[labelKey], labelValue)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	labelKey1 := "labelKey 1"
+	labelKey2 := "labelKey 2"
+	labelValue1 := "testValue 1"
+	labelValue2 := "testValue 2"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        map[string]*string{labelKey1: &labelValue1, labelKey2: &labelValue2},
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(mngInfoObject.labels), 6)
+	assert.Equal(t, mngInfoObject.labels[labelKey1], labelValue1)
+	assert.Equal(t, mngInfoObject.labels[labelKey2], labelValue2)
+	assert.Equal(t, mngInfoObject.labels["diskSize"], strconv.FormatInt(diskSize, 10))
+	assert.Equal(t, mngInfoObject.labels["amiType"], amiType)
+	assert.Equal(t, mngInfoObject.labels["capacityType"], capacityType)
+	assert.Equal(t, mngInfoObject.labels["k8sVersion"], k8sVersion)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+	})
+
+	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(labelsMap), 1)
+	assert.Equal(t, labelsMap[labelKey], labelValue)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupLabelsNoCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	labelKey1 := "labelKey 1"
+	labelKey2 := "labelKey 2"
+	labelValue1 := "testValue 1"
+	labelValue2 := "testValue 2"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        map[string]*string{labelKey1: &labelValue1, labelKey2: &labelValue2},
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(labelsMap), 6)
+	assert.Equal(t, labelsMap[labelKey1], labelValue1)
+	assert.Equal(t, labelsMap[labelKey2], labelValue2)
+	assert.Equal(t, labelsMap["diskSize"], strconv.FormatInt(diskSize, 10))
+	assert.Equal(t, labelsMap["amiType"], amiType)
+	assert.Equal(t, labelsMap["capacityType"], capacityType)
+	assert.Equal(t, labelsMap["k8sVersion"], k8sVersion)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupLabelsWithCachedNodegroupThatExpires(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	labelKey1 := "labelKey 1"
+	labelKey2 := "labelKey 2"
+	labelValue1 := "testValue 1"
+	labelValue2 := "testValue 2"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        map[string]*string{labelKey1: &labelValue1, labelKey2: &labelValue2},
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	fakeClock := test_clock.NewFakeClock(time.Unix(0, 0))
+	fakeStore := cache.NewFakeExpirationStore(
+		func(obj interface{}) (s string, e error) {
+			return obj.(managedNodegroupCachedObject).name, nil
+		},
+		nil,
+		&cache.TTLPolicy{
+			TTL:   managedNodegroupCachedTTL,
+			Clock: fakeClock,
+		},
+		fakeClock,
+	)
+
+	// Create cache with fake clock
+	c := newManagedNodeGroupCacheWithClock(&awsWrapper{nil, nil, k}, fakeClock, fakeStore)
+
+	// Add nodegroup entry that will expire
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      make([]apiv1.Taint, 0),
+		labels:      map[string]string{labelKey1: labelValue1},
+	})
+	require.NoError(t, err)
+	obj, ok, err := c.GetByKey(nodegroupName)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, nodegroupName, obj.(managedNodegroupCachedObject).name)
+	assert.Equal(t, clusterName, obj.(managedNodegroupCachedObject).clusterName)
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).labels), 1)
+	assert.Equal(t, labelValue1, obj.(managedNodegroupCachedObject).labels[labelKey1])
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).taints), 0)
+
+	// Query for nodegroup entry before it expires
+	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(labelsMap), 1)
+	assert.Equal(t, labelsMap[labelKey1], labelValue1)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+
+	// Expire nodegroup
+	fakeClock.SetTime(time.Unix(0, 0).Add(managedNodegroupCachedTTL + 1*time.Minute))
+
+	// Query for nodegroup entry after it expires - should have the new labels added
+	newLabelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(newLabelsMap), 6)
+	assert.Equal(t, newLabelsMap[labelKey1], labelValue1)
+	assert.Equal(t, newLabelsMap[labelKey2], labelValue2)
+	assert.Equal(t, newLabelsMap["diskSize"], strconv.FormatInt(diskSize, 10))
+	assert.Equal(t, newLabelsMap["amiType"], amiType)
+	assert.Equal(t, newLabelsMap["capacityType"], capacityType)
+	assert.Equal(t, newLabelsMap["k8sVersion"], k8sVersion)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTaintsWithCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+	})
+
+	taintsList, err := c.getManagedNodegroupTaints(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(taintsList), 1)
+	assert.Equal(t, taintsList[0].Effect, apiv1.TaintEffect(taintEffect))
+	assert.Equal(t, taintsList[0].Key, taintKey)
+	assert.Equal(t, taintsList[0].Value, taintValue)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	taintEffect1 := "effect 1"
+	taintKey1 := "key 1"
+	taintValue1 := "value 1"
+	taint1 := eks.Taint{
+		Effect: &taintEffect1,
+		Key:    &taintKey1,
+		Value:  &taintValue1,
+	}
+
+	taintEffect2 := "effect 2"
+	taintKey2 := "key 2"
+	taintValue2 := "value 2"
+	taint2 := eks.Taint{
+		Effect: &taintEffect2,
+		Key:    &taintKey2,
+		Value:  &taintValue2,
+	}
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        []*eks.Taint{&taint1, &taint2},
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	taintsList, err := c.getManagedNodegroupTaints(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(taintsList), 2)
+	assert.Equal(t, taintsList[0].Effect, apiv1.TaintEffect(taintEffect1))
+	assert.Equal(t, taintsList[0].Key, taintKey1)
+	assert.Equal(t, taintsList[0].Value, taintValue1)
+	assert.Equal(t, taintsList[1].Effect, apiv1.TaintEffect(taintEffect2))
+	assert.Equal(t, taintsList[1].Key, taintKey2)
+	assert.Equal(t, taintsList[1].Value, taintValue2)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}


### PR DESCRIPTION
Related to https://github.com/kubernetes/autoscaler/pull/3968

This change adds a Managed Nodegroup cache that will hold labels and taints from the AWS EKS DescribeNodegroup API output. It will be used to get more information for EKS managed nodegroups that are scaled to 0 nodes. Currently this code will only run when the managed nodegroup has 0 nodes and CAS doesn't have a node info object cached already.

To use this new functionality, users will need to add `"eks:DescribeNodegroup"` to their IAM policy. If they don't add the permissions, the AWS EKS DescribeNodegroup API call will fail and the error will be logged, but CAS will not be killed. A managed nodegroup cache object with nil list & nil map will be saved even if permissions are missing to stop CAS from causing throttling from EKS.

##### Not included in this PR, but information for the future:

To use the Managed nodegroup cache and call AWS EKS DescribeNodegroup API whenever the nodegroup is scaled to 0 nodes (even if it previously had more than 0 nodes) we'd have to make a change in the general CAS code [around here](https://github.com/kubernetes/autoscaler/blob/10451c2032411c543fd76bd5c1cda7be4a8ce1f1/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go#L114).
This general code change would be related to the discussion in this old PR about node cache info: https://github.com/kubernetes/autoscaler/pull/4258

Another future change is to add CAS user agent information to the API calls so EKS can tell it's CAS calling.

### Testing 

The example logs are from when I had the cache set to 2 minutes expiring. I increased it to 6 minutes to help mitigate constant customer errors since the new permissions missing would cause failures that the service team will see. We can revisit this expiration time in the future. 

##### Test with one nodegroup entry expiring:


* Have one 0 node nodegroup and watch the entry expire

```
I1125 11:29:59.438977       1 aws_manager.go:366] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1125 11:29:59.438990       1 expiration_cache.go:102] Entry test-nodegroup-0: {name:test-nodegroup-0 clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64 capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} has expired
I1125 11:29:59.439011       1 managed_nodegroup_cache.go:121] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 11:29:59.439033       1 aws_manager.go:373] node.Labels : map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d-asg-7953541088651226 kubernetes.io/os:linux node.kubernetes.io/instance-type:g4dn.xlarge nodegroup-name:test-cas-ng-gpu topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1125 11:29:59.439059       1 managed_nodegroup_cache.go:138] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 11:29:59.439070       1 aws_manager.go:380] node.Spec.Taints : []
```
* Watch entry renew again

```
I1125 11:31:09.877752       1 aws_manager.go:366] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1125 11:31:09.877762       1 managed_nodegroup_cache.go:121] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 11:31:09.877789       1 aws_manager.go:373] node.Labels : map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d-asg-7699942160670559221 kubernetes.io/os:linux node.kubernetes.io/instance-type:g4dn.xlarge nodegroup-name:test-cas-ng-gpu topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1125 11:31:09.877825       1 managed_nodegroup_cache.go:138] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 11:31:09.877837       1 aws_manager.go:380] node.Spec.Taints : []
```

##### Test new taint is picked up when new nodegroup still has 0 nodes:

```
I1130 20:31:13.704894       1 static_autoscaler.go:230] Starting main loop
I1130 20:31:13.705142       1 aws_manager.go:310] Found multiple availability zones for ASG "eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d"; using us-west-2a for failure-domain.beta.kubernetes.io/zone label
I1130 20:31:13.705234       1 aws_manager.go:366] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1130 20:31:13.705242       1 expiration_cache.go:102] Entry test-cas-ng-gpu: {name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} has expired
I1130 20:31:13.705259       1 managed_nodegroup_cache.go:121] []
I1130 20:31:13.824210       1 aws_manager.go:373] node.Labels : map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d-asg-4540671904613464399 kubernetes.io/os:linux node.kubernetes.io/instance-type:g4dn.xlarge nodegroup-name:test-cas-ng-gpu topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1130 20:31:13.824261       1 managed_nodegroup_cache.go:138] [{name:test-cas-ng-gpu clusterName:cas-test taints:[{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1130 20:31:13.824277       1 aws_manager.go:380] node.Spec.Taints : [{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}]

```

##### Test new label is picked up when new nodegroup still has 0 nodes:


* Have one 0 node nodegroup
```
I1125 12:00:03.249635       1 aws_manager.go:366] Nodegroup test-nodegroup-label-0 in cluster cas-test is an EKS managed nodegroup.
I1125 12:00:03.249643       1 managed_nodegroup_cache.go:121] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} {name:test-nodegroup-label-0 clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64 capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 12:00:03.249659       1 aws_manager.go:373] node.Labels : map[amiType:AL2_x86_64 capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-nodegroup-label-0-66beab7b-074f-7daa-b9e0-cc9470333298-asg-1005486431700268949 kubernetes.io/os:linux node.kubernetes.io/instance-type:t3.medium nodegroup-name:test-nodegroup-label-0 topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1125 12:00:03.249670       1 managed_nodegroup_cache.go:138] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} {name:test-nodegroup-label-0 clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64 capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1125 12:00:03.249682       1 aws_manager.go:380] node.Spec.Taints : []
```

* Add label to 0 node nodegroup and watch it appear on list
```
I1125 12:03:56.003761       1 aws_manager.go:366] Nodegroup test-nodegroup-label-0 in cluster cas-test is an EKS managed nodegroup.
I1125 12:03:56.003767       1 managed_nodegroup_cache.go:121] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} {name:test-nodegroup-label-0 clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64 capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21 testlabel:testthislabel]}]
I1125 12:03:56.003782       1 aws_manager.go:373] node.Labels : map[amiType:AL2_x86_64 capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-nodegroup-label-0-66beab7b-074f-7daa-b9e0-cc9470333298-asg-4564694500601871063 kubernetes.io/os:linux node.kubernetes.io/instance-type:t3.medium nodegroup-name:test-nodegroup-label-0 testlabel:testthislabel topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1125 12:03:56.003806       1 managed_nodegroup_cache.go:138] [{name:test-cas-ng-gpu clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} {name:test-nodegroup-label-0 clusterName:cas-test taints:[] labels:map[amiType:AL2_x86_64 capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21 testlabel:testthislabel]}]
I1125 12:03:56.003821       1 aws_manager.go:380] node.Spec.Taints : []
```

* See 0 node nodegroup have 1 node spin up because it has the label for the pod now. Then pod starts successfully.``
```
$ kubectl get pods
NAME                 READY   STATUS    RESTARTS   AGE
static-web           1/1     Running   0          4m48s
```


##### Test DescribeNodegroup failing with missing permissions:

* Example of logs when DescribeNodegroup permissions are missing. CAS does not fail. It just logs the error and moves on.
```
I1125 05:39:53.506484       1 aws_manager.go:366] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1125 05:39:53.506491       1 managed_nodegroup_cache.go:112] []
E1125 05:39:53.519280       1 managed_nodegroup_cache.go:120] Failed to query the managed nodegroup test-cas-ng-gpu for the cluster cas-test while looking for labels: AccessDeniedException: 
    status code: 403, request id: 34b15f94-1c3c-481c-a877-a441453c4574
I1125 05:39:53.519311       1 aws_manager.go:370] Failed to get labels from EKS DescribeNodegroup API for nodegroup test-cas-ng-gpu in cluster cas-test because AccessDeniedException: 
    status code: 403, request id: 34b15f94-1c3c-481c-a877-a441453c4574.
I1125 05:39:53.519323       1 managed_nodegroup_cache.go:129] []
E1125 05:39:53.527256       1 managed_nodegroup_cache.go:137] Failed to query the managed nodegroup test-cas-ng-gpu for the cluster cas-test while looking for taints: AccessDeniedException: 
    status code: 403, request id: 842b3960-5fe9-4da0-83d4-89639499f346
I1125 05:39:53.527284       1 aws_manager.go:376] Failed to get taints from EKS DescribeNodegroup API for nodegroup test-cas-ng-gpu in cluster cas-test because AccessDeniedException: 
    status code: 403, request id: 842b3960-5fe9-4da0-83d4-89639499f346.
```

##### Test level 6 log verbosity

```
I1130 21:30:29.750611       1 aws_manager.go:419] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1130 21:30:29.750616       1 managed_nodegroup_cache.go:124] Current ManagedNodegroup cache: []
I1130 21:30:29.909952       1 aws_wrapper.go:70] DescribeNodegroup output : {
  Nodegroup: {
    AmiType: "AL2_x86_64_GPU",
    CapacityType: "ON_DEMAND",
    ClusterName: "cas-test",
    CreatedAt: 2021-09-03 00:07:09.508 +0000 UTC,
    DiskSize: 20,
    Health: {
      Issues: []
    },
    InstanceTypes: ["g4dn.xlarge"],
    Labels: {

    },
    ModifiedAt: 2021-11-30 21:27:19.748 +0000 UTC,
    NodeRole: "arn:aws:iam::...:role/eksdev-...",
    NodegroupArn: "arn:aws:eks:us-west-2:...:nodegroup/cas-test/test-cas-ng-gpu/...",
    NodegroupName: "test-cas-ng-gpu",
    ReleaseVersion: "1.21.2-20210830",
    Resources: {
      AutoScalingGroups: [{
          Name: "eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d"
        }]
    },
    ScalingConfig: {
      DesiredSize: 0,
      MaxSize: 2,
      MinSize: 0
    },
    Status: "ACTIVE",
    Subnets: [
      "subnet-02695765",
      "subnet-1dfcaa54",
      "subnet-200ed07b",
      "subnet-e0cb1acb"
    ],
    Tags: {

    },
    Taints: [{
        Effect: "PREFER_NO_SCHEDULE",
        Key: "test",
        Value: "testThis"
      }],
    Version: "1.21"
  }
}
I1130 21:30:29.910032       1 aws_manager.go:427] node.Labels : map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d-asg-5486140987150761883 kubernetes.io/os:linux node.kubernetes.io/instance-type:g4dn.xlarge nodegroup-name:test-cas-ng-gpu topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1130 21:30:29.910054       1 managed_nodegroup_cache.go:141] Current ManagedNodegroup cache: [{name:test-cas-ng-gpu clusterName:cas-test taints:[{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1130 21:30:29.910067       1 aws_manager.go:435] node.Spec.Taints : [{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}]
```

##### Test that the entry expires after about 2 minutes so the EKS DescribeNodegroup API is called about every 2 minutes

```
I1130 21:32:30.610068       1 aws_manager.go:419] Nodegroup test-cas-ng-gpu in cluster cas-test is an EKS managed nodegroup.
I1130 21:32:30.610076       1 expiration_cache.go:102] Entry test-cas-ng-gpu: {name:test-cas-ng-gpu clusterName:cas-test taints:[{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]} has expired
I1130 21:32:30.610094       1 managed_nodegroup_cache.go:124] Current ManagedNodegroup cache: []
I1130 21:32:30.758870       1 aws_wrapper.go:70] DescribeNodegroup output : {
  Nodegroup: {
    AmiType: "AL2_x86_64_GPU",
    CapacityType: "ON_DEMAND",
    ClusterName: "cas-test",
    CreatedAt: 2021-09-03 00:07:09.508 +0000 UTC,
    DiskSize: 20,
    Health: {
      Issues: []
    },
    InstanceTypes: ["g4dn.xlarge"],
    Labels: {

    },
    ModifiedAt: 2021-11-30 21:27:19.748 +0000 UTC,
    NodeRole: "arn:aws:iam::...:role/eksdev-...",
    NodegroupArn: "arn:aws:eks:us-west-2:..:nodegroup/cas-test/test-cas-ng-gpu/...",
    NodegroupName: "test-cas-ng-gpu",
    ReleaseVersion: "1.21.2-20210830",
    Resources: {
      AutoScalingGroups: [{
          Name: "eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d"
        }]
    },
    ScalingConfig: {
      DesiredSize: 0,
      MaxSize: 2,
      MinSize: 0
    },
    Status: "ACTIVE",
    Subnets: [
      "subnet-02695765",
      "subnet-1dfcaa54",
      "subnet-200ed07b",
      "subnet-e0cb1acb"
    ],
    Tags: {

    },
    Taints: [{
        Effect: "PREFER_NO_SCHEDULE",
        Key: "test",
        Value: "testThis"
      }],
    Version: "1.21"
  }
}
I1130 21:32:30.758979       1 aws_manager.go:427] node.Labels : map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND cluster-name:cas-test diskSize:20 k8sVersion:1.21 kubernetes.io/arch:amd64 kubernetes.io/hostname:eks-test-cas-ng-gpu-d8bdd47d-8232-234e-0544-7d7b3f16519d-asg-3778061770029050113 kubernetes.io/os:linux node.kubernetes.io/instance-type:g4dn.xlarge nodegroup-name:test-cas-ng-gpu topology.kubernetes.io/region:us-west-2 topology.kubernetes.io/zone:us-west-2a]
I1130 21:32:30.758998       1 managed_nodegroup_cache.go:141] Current ManagedNodegroup cache: [{name:test-cas-ng-gpu clusterName:cas-test taints:[{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}] labels:map[amiType:AL2_x86_64_GPU capacityType:ON_DEMAND diskSize:20 k8sVersion:1.21]}]
I1130 21:32:30.759011       1 aws_manager.go:435] node.Spec.Taints : [{Key:test Value:testThis Effect:PREFER_NO_SCHEDULE TimeAdded:<nil>}]
```