### PR TITLE
add a100 gpu type

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	availableGPUTypes = map[string]struct{}{
+		"nvidia-tesla-a100": {},
 		"nvidia-tesla-k80":  {},
 		"nvidia-tesla-p100": {},
 		"nvidia-tesla-v100": {},


### PR DESCRIPTION
Adds a100 to the list of azure available gpu types

/area provider/azure