### PR TITLE
Issue#4340 -- Update klog version to v2 --part3

### DIFF
--- a/vertical-pod-autoscaler/go.mod
+++ b/vertical-pod-autoscaler/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v0.18.3
 	k8s.io/component-base v0.18.3
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/metrics v0.18.3
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -29,7 +29,7 @@ import (
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 	kube_flag "k8s.io/component-base/cli/flag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // DefaultRecommenderName denotes the current recommender name as the "default" one.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -27,7 +27,7 @@ import (
 	labels "k8s.io/apimachinery/pkg/labels"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var (

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_flag "k8s.io/component-base/cli/flag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var (

--- a/vertical-pod-autoscaler/vendor/modules.txt
+++ b/vertical-pod-autoscaler/vendor/modules.txt
@@ -428,7 +428,6 @@ k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/restclient
 k8s.io/component-base/version
 # k8s.io/klog v1.0.0
-## explicit
 k8s.io/klog
 # k8s.io/klog/v2 v2.9.0
 ## explicit


### PR DESCRIPTION
Issue: https://github.com/kubernetes/autoscaler/issues/4340

This PR is to update klog version to v2 for the following files:
```
./pkg/updater/main.go:	"k8s.io/klog"
./pkg/recommender/model/cluster_test.go:	"k8s.io/klog"
./pkg/recommender/main.go:	"k8s.io/klog"
```

The only part left is files in e2e, however, it will make the PR big, we need to break them into smaller scope.