### PR TITLE
Implement ASG filtering based on tags

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -128,30 +128,15 @@ func TestAutoDiscoveredNodeGroups(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAutoAsgs(t, a, nil, []string{}, []asgAutoDiscoveryConfig{
 		{
-			Tags: map[string]string{"test": ""},
+			Tags: map[string]string{"testKey": ""},
 		},
 	}))
 
-	a.On("DescribeTagsPages",
-		&autoscaling.DescribeTagsInput{
-			Filters: []*autoscaling.Filter{
-				{Name: aws.String("key"), Values: aws.StringSlice([]string{"test"})},
-			},
-			MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
-		},
-		mock.AnythingOfType("func(*autoscaling.DescribeTagsOutput, bool) bool"),
-	).Run(func(args mock.Arguments) {
-		fn := args.Get(1).(func(*autoscaling.DescribeTagsOutput, bool) bool)
-		fn(&autoscaling.DescribeTagsOutput{
-			Tags: []*autoscaling.TagDescription{
-				{ResourceId: aws.String("auto-asg")},
-			}}, false)
-	}).Return(nil).Once()
-
 	a.On("DescribeAutoScalingGroupsPages",
 		&autoscaling.DescribeAutoScalingGroupsInput{
-			AutoScalingGroupNames: aws.StringSlice([]string{"auto-asg"}),
-			MaxRecords:            aws.Int64(maxRecordsReturnedByAPI),
+			Filters: []*autoscaling.Filter{
+				{Name: aws.String("tag-key"), Values: aws.StringSlice([]string{"testKey"})},
+			}, MaxRecords: aws.Int64(maxRecordsReturnedByAPI),
 		},
 		mock.AnythingOfType("func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool"),
 	).Run(func(args mock.Arguments) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -235,7 +235,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 }
 
-func TestMoreThen100Groups(t *testing.T) {
+func TestMoreThan100Groups(t *testing.T) {
 	a := &autoScalingMock{}
 	awsWrapper := &awsWrapper{
 		autoScalingI: a,
@@ -273,7 +273,7 @@ func TestMoreThen100Groups(t *testing.T) {
 		fn(testNamedDescribeAutoScalingGroupsOutput("asg-2", 1, "test-instance-id"), false)
 	}).Return(nil)
 
-	asgs, err := awsWrapper.getAutoscalingGroupsByNames(names)
+	asgs, err := awsWrapper.getAutoScalingGroupsByNames(names)
 	assert.Nil(t, err)
 	assert.Equal(t, len(asgs), 2)
 	assert.Equal(t, *asgs[0].AutoScalingGroupName, "asg-1")
@@ -313,7 +313,7 @@ func TestGetInstanceTypesForAsgs(t *testing.T) {
 		},
 	})
 
-	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
+	// #1449 Without AWS_REGION, getRegion() lookup runs until timeout during tests.
 	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
 	os.Setenv("AWS_REGION", "fanghorn")
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -45,11 +45,6 @@ func (a *autoScalingMock) DescribeLaunchConfigurations(i *autoscaling.DescribeLa
 	return args.Get(0).(*autoscaling.DescribeLaunchConfigurationsOutput), nil
 }
 
-func (a *autoScalingMock) DescribeTagsPages(i *autoscaling.DescribeTagsInput, fn func(*autoscaling.DescribeTagsOutput, bool) bool) error {
-	args := a.Called(i, fn)
-	return args.Error(0)
-}
-
 func (a *autoScalingMock) SetDesiredCapacity(input *autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error) {
 	args := a.Called(input)
 	return args.Get(0).(*autoscaling.SetDesiredCapacityOutput), nil

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0
-	github.com/aws/aws-sdk-go v1.38.49
+	github.com/aws/aws-sdk-go v1.42.11
 	github.com/digitalocean/godo v1.27.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.5.0

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -112,6 +112,8 @@ github.com/auth0/go-jwt-middleware v1.0.1/go.mod h1:YSeUX3z6+TF2H+7padiEqNJ73Zy9
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49 h1:E31vxjCe6a5I+mJLmUGaZobiWmg9KdWaud9IfceYeYQ=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.42.11 h1:5wfKuNcbch3IFZth5+j2Ud/+UOxCR0zfgLGPoiK1p4s=
+github.com/aws/aws-sdk-go v1.42.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -860,6 +862,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
@@ -50,9 +50,19 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		for i, n := range names {
 			val := v.FieldByName(n)
+			ft, ok := v.Type().FieldByName(n)
+			if !ok {
+				panic(fmt.Sprintf("expected to find field %v on type %v, but was not found", n, v.Type()))
+			}
+
 			buf.WriteString(strings.Repeat(" ", indent+2))
 			buf.WriteString(n + ": ")
-			prettify(val, indent+2, buf)
+
+			if tag := ft.Tag.Get("sensitive"); tag == "true" {
+				buf.WriteString("<sensitive>")
+			} else {
+				prettify(val, indent+2, buf)
+			}
 
 			if i < len(names)-1 {
 				buf.WriteString(",\n")

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/string_value.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/awsutil/string_value.go
@@ -8,6 +8,8 @@ import (
 )
 
 // StringValue returns the string representation of a value.
+//
+// Deprecated: Use Prettify instead.
 func StringValue(i interface{}) string {
 	var buf bytes.Buffer
 	stringValue(reflect.ValueOf(i), 0, &buf)

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
@@ -10,12 +10,13 @@ import (
 
 // A Config provides configuration to a service client instance.
 type Config struct {
-	Config        *aws.Config
-	Handlers      request.Handlers
-	PartitionID   string
-	Endpoint      string
-	SigningRegion string
-	SigningName   string
+	Config         *aws.Config
+	Handlers       request.Handlers
+	PartitionID    string
+	Endpoint       string
+	SigningRegion  string
+	SigningName    string
+	ResolvedRegion string
 
 	// States that the signing name did not come from a modeled source but
 	// was derived based on other data. Used by service client constructors

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
@@ -53,7 +53,7 @@ var LogHTTPRequestHandler = request.NamedHandler{
 }
 
 func logRequest(r *request.Request) {
-	if !r.Config.LogLevel.AtLeast(aws.LogDebug) {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) || r.Config.Logger == nil {
 		return
 	}
 
@@ -94,6 +94,10 @@ var LogHTTPRequestHeaderHandler = request.NamedHandler{
 }
 
 func logRequestHeader(r *request.Request) {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) || r.Config.Logger == nil {
+		return
+	}
+
 	b, err := httputil.DumpRequestOut(r.HTTPRequest, false)
 	if err != nil {
 		r.Config.Logger.Log(fmt.Sprintf(logReqErrMsg,
@@ -124,7 +128,7 @@ var LogHTTPResponseHandler = request.NamedHandler{
 }
 
 func logResponse(r *request.Request) {
-	if !r.Config.LogLevel.AtLeast(aws.LogDebug) {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) || r.Config.Logger == nil {
 		return
 	}
 
@@ -186,7 +190,7 @@ var LogHTTPResponseHeaderHandler = request.NamedHandler{
 }
 
 func logResponseHeader(r *request.Request) {
-	if r.Config.Logger == nil {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) || r.Config.Logger == nil {
 		return
 	}
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
@@ -2,13 +2,14 @@ package metadata
 
 // ClientInfo wraps immutable data from the client.Client structure.
 type ClientInfo struct {
-	ServiceName   string
-	ServiceID     string
-	APIVersion    string
-	PartitionID   string
-	Endpoint      string
-	SigningName   string
-	SigningRegion string
-	JSONVersion   string
-	TargetPrefix  string
+	ServiceName    string
+	ServiceID      string
+	APIVersion     string
+	PartitionID    string
+	Endpoint       string
+	SigningName    string
+	SigningRegion  string
+	JSONVersion    string
+	TargetPrefix   string
+	ResolvedRegion string
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/config.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/config.go
@@ -208,7 +208,18 @@ type Config struct {
 	//     svc := s3.New(sess, &aws.Config{
 	//         UseDualStack: aws.Bool(true),
 	//     })
+	//
+	// Deprecated: This option will continue to function for S3 and S3 Control for backwards compatibility.
+	// UseDualStackEndpoint should be used to enable usage of a service's dual-stack endpoint for all service clients
+	// moving forward. For S3 and S3 Control, when UseDualStackEndpoint is set to a non-zero value it takes higher
+	// precedence then this option.
 	UseDualStack *bool
+
+	// Sets the resolver to resolve a dual-stack endpoint for the service.
+	UseDualStackEndpoint endpoints.DualStackEndpointState
+
+	// UseFIPSEndpoint specifies the resolver must resolve a FIPS endpoint.
+	UseFIPSEndpoint endpoints.FIPSEndpointState
 
 	// SleepDelay is an override for the func the SDK will call when sleeping
 	// during the lifecycle of a request. Specifically this will be used for
@@ -554,6 +565,10 @@ func mergeInConfig(dst *Config, other *Config) {
 		dst.UseDualStack = other.UseDualStack
 	}
 
+	if other.UseDualStackEndpoint != endpoints.DualStackEndpointStateUnset {
+		dst.UseDualStackEndpoint = other.UseDualStackEndpoint
+	}
+
 	if other.EC2MetadataDisableTimeoutOverride != nil {
 		dst.EC2MetadataDisableTimeoutOverride = other.EC2MetadataDisableTimeoutOverride
 	}
@@ -588,6 +603,14 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.LowerCaseHeaderMaps != nil {
 		dst.LowerCaseHeaderMaps = other.LowerCaseHeaderMaps
+	}
+
+	if other.UseDualStackEndpoint != endpoints.DualStackEndpointStateUnset {
+		dst.UseDualStackEndpoint = other.UseDualStackEndpoint
+	}
+
+	if other.UseFIPSEndpoint != endpoints.FIPSEndpointStateUnset {
+		dst.UseFIPSEndpoint = other.UseFIPSEndpoint
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_1_5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.9
 // +build !go1.9
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_1_9.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_1_9.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package credentials

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package credentials

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.9
 // +build !go1.9
 
 package credentials

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package credentials

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/os.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/os.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package ssocreds

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
@@ -13,7 +13,6 @@ package ec2metadata
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -234,7 +233,8 @@ func unmarshalError(r *request.Request) {
 
 	// Response body format is not consistent between metadata endpoints.
 	// Grab the error message as a string and include that as the source error
-	r.Error = awserr.NewRequestFailure(awserr.New("EC2MetadataError", "failed to make EC2Metadata request", errors.New(b.String())),
+	r.Error = awserr.NewRequestFailure(
+		awserr.New("EC2MetadataError", "failed to make EC2Metadata request\n"+b.String(), nil),
 		r.HTTPResponse.StatusCode, r.RequestID)
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
@@ -81,8 +81,6 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 	// Customization
 	for i := 0; i < len(ps); i++ {
 		p := &ps[i]
-		custAddEC2Metadata(p)
-		custAddS3DualStack(p)
 		custRegionalS3(p)
 		custRmIotDataService(p)
 		custFixAppAutoscalingChina(p)
@@ -90,15 +88,6 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 	}
 
 	return ps, nil
-}
-
-func custAddS3DualStack(p *partition) {
-	if !(p.ID == "aws" || p.ID == "aws-cn" || p.ID == "aws-us-gov") {
-		return
-	}
-
-	custAddDualstack(p, "s3")
-	custAddDualstack(p, "s3-control")
 }
 
 func custRegionalS3(p *partition) {
@@ -111,46 +100,26 @@ func custRegionalS3(p *partition) {
 		return
 	}
 
+	const awsGlobal = "aws-global"
+	const usEast1 = "us-east-1"
+
 	// If global endpoint already exists no customization needed.
-	if _, ok := service.Endpoints["aws-global"]; ok {
+	if _, ok := service.Endpoints[endpointKey{Region: awsGlobal}]; ok {
 		return
 	}
 
-	service.PartitionEndpoint = "aws-global"
-	service.Endpoints["us-east-1"] = endpoint{}
-	service.Endpoints["aws-global"] = endpoint{
+	service.PartitionEndpoint = awsGlobal
+	if _, ok := service.Endpoints[endpointKey{Region: usEast1}]; !ok {
+		service.Endpoints[endpointKey{Region: usEast1}] = endpoint{}
+	}
+	service.Endpoints[endpointKey{Region: awsGlobal}] = endpoint{
 		Hostname: "s3.amazonaws.com",
 		CredentialScope: credentialScope{
-			Region: "us-east-1",
+			Region: usEast1,
 		},
 	}
 
 	p.Services["s3"] = service
-}
-
-func custAddDualstack(p *partition, svcName string) {
-	s, ok := p.Services[svcName]
-	if !ok {
-		return
-	}
-
-	s.Defaults.HasDualStack = boxedTrue
-	s.Defaults.DualStackHostname = "{service}.dualstack.{region}.{dnsSuffix}"
-
-	p.Services[svcName] = s
-}
-
-func custAddEC2Metadata(p *partition) {
-	p.Services["ec2metadata"] = service{
-		IsRegionalized:    boxedFalse,
-		PartitionEndpoint: "aws-global",
-		Endpoints: endpoints{
-			"aws-global": endpoint{
-				Hostname:  "169.254.169.254/latest",
-				Protocols: []string{"http"},
-			},
-		},
-	}
 }
 
 func custRmIotDataService(p *partition) {
@@ -169,12 +138,13 @@ func custFixAppAutoscalingChina(p *partition) {
 	}
 
 	const expectHostname = `autoscaling.{region}.amazonaws.com`
-	if e, a := s.Defaults.Hostname, expectHostname; e != a {
+	serviceDefault := s.Defaults[defaultKey{}]
+	if e, a := expectHostname, serviceDefault.Hostname; e != a {
 		fmt.Printf("custFixAppAutoscalingChina: ignoring customization, expected %s, got %s\n", e, a)
 		return
 	}
-
-	s.Defaults.Hostname = expectHostname + ".cn"
+	serviceDefault.Hostname = expectHostname + ".cn"
+	s.Defaults[defaultKey{}] = serviceDefault
 	p.Services[serviceName] = s
 }
 
@@ -189,18 +159,25 @@ func custFixAppAutoscalingUsGov(p *partition) {
 		return
 	}
 
-	if a := s.Defaults.CredentialScope.Service; a != "" {
+	serviceDefault := s.Defaults[defaultKey{}]
+	if a := serviceDefault.CredentialScope.Service; a != "" {
 		fmt.Printf("custFixAppAutoscalingUsGov: ignoring customization, expected empty credential scope service, got %s\n", a)
 		return
 	}
 
-	if a := s.Defaults.Hostname; a != "" {
+	if a := serviceDefault.Hostname; a != "" {
 		fmt.Printf("custFixAppAutoscalingUsGov: ignoring customization, expected empty hostname, got %s\n", a)
 		return
 	}
 
-	s.Defaults.CredentialScope.Service = "application-autoscaling"
-	s.Defaults.Hostname = "autoscaling.{region}.amazonaws.com"
+	serviceDefault.CredentialScope.Service = "application-autoscaling"
+	serviceDefault.Hostname = "autoscaling.{region}.amazonaws.com"
+
+	if s.Defaults == nil {
+		s.Defaults = make(endpointDefaults)
+	}
+
+	s.Defaults[defaultKey{}] = serviceDefault
 
 	p.Services[serviceName] = s
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -55,6 +55,7 @@ const (
 // AWS ISO (US) partition's regions.
 const (
 	UsIsoEast1RegionID = "us-iso-east-1" // US ISO East.
+	UsIsoWest1RegionID = "us-iso-west-1" // US ISO WEST.
 )
 
 // AWS ISOB (US) partition's regions.
@@ -104,10 +105,36 @@ var awsPartition = partition{
 			return reg
 		}(),
 	},
-	Defaults: endpoint{
-		Hostname:          "{service}.{region}.{dnsSuffix}",
-		Protocols:         []string{"https"},
-		SignatureVersions: []string{"v4"},
+	Defaults: endpointDefaults{
+		defaultKey{}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.aws",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "amazonaws.com",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant | dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.aws",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
 	},
 	Regions: regions{
 		"af-south-1": region{
@@ -176,436 +203,1090 @@ var awsPartition = partition{
 	},
 	Services: services{
 		"a4b": service{
-
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"access-analyzer": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"account": service{
+			PartitionEndpoint: "aws-global",
+			IsRegionalized:    boxedFalse,
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
+					Hostname: "account.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
 			},
 		},
 		"acm": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"ca-central-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "acm-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-south-1":   endpoint{},
-				"eu-west-1":    endpoint{},
-				"eu-west-2":    endpoint{},
-				"eu-west-3":    endpoint{},
-				"me-south-1":   endpoint{},
-				"sa-east-1":    endpoint{},
-				"us-east-1":    endpoint{},
-				"us-east-1-fips": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "acm-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "acm-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "acm-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "acm-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"acm-pca": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "acm-pca-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "acm-pca-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "acm-pca-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "acm-pca-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"airflow": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"amplify": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"amplifybackend": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"api.detective": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"api.ecr": service{
-
-			Endpoints: endpoints{
-				"af-south-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{
 					Hostname: "api.ecr.af-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "af-south-1",
 					},
 				},
-				"ap-east-1": endpoint{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.ap-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-east-1",
 					},
 				},
-				"ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "api.ecr.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "api.ecr.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-northeast-3": endpoint{
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{
 					Hostname: "api.ecr.ap-northeast-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-3",
 					},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Hostname: "api.ecr.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "api.ecr.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "api.ecr.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname: "api.ecr.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "dkr-us-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "dkr-us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "dkr-us-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "dkr-us-west-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "api.ecr.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-north-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
 					Hostname: "api.ecr.eu-north-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
 				},
-				"eu-south-1": endpoint{
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{
 					Hostname: "api.ecr.eu-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-south-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "api.ecr.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "api.ecr.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"eu-west-3": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
 					Hostname: "api.ecr.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
 				},
-				"fips-dkr-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-east-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-dkr-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-east-2",
+				}: endpoint{
 					Hostname: "ecr-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-dkr-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-west-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-dkr-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-west-2",
+				}: endpoint{
 					Hostname: "ecr-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ecr-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ecr-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{
 					Hostname: "api.ecr.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "api.ecr.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "api.ecr.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
@@ -613,475 +1294,1510 @@ var awsPartition = partition{
 			},
 		},
 		"api.elastic-inference": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "api.elastic-inference.ap-northeast-1.amazonaws.com",
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "api.elastic-inference.ap-northeast-2.amazonaws.com",
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "api.elastic-inference.eu-west-1.amazonaws.com",
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "api.elastic-inference.us-east-1.amazonaws.com",
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "api.elastic-inference.us-east-2.amazonaws.com",
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "api.elastic-inference.us-west-2.amazonaws.com",
 				},
 			},
 		},
 		"api.fleethub.iot": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"api.iotwireless": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "api.iotwireless.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
+					Hostname: "api.iotwireless.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
+					Hostname: "api.iotwireless.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
+					Hostname: "api.iotwireless.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
+					Hostname: "api.iotwireless.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 			},
 		},
 		"api.mediatailor": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"api.pricing": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "pricing",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "pricing",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-south-1": endpoint{},
-				"us-east-1":  endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"api.sagemaker": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"apigateway": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"app-integrations": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"appconfigdata": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"appflow": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"application-autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"applicationinsights": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"appmesh": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"apprunner": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"appstream2": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
-				CredentialScope: credentialScope{
-					Service: "appstream",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+					CredentialScope: credentialScope{
+						Service: "appstream",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "appstream2-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "appstream2-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "appstream2-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "appstream2-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "appstream2-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"appsync": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"aps": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"athena": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "athena-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "athena-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "athena-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "athena-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"auditmanager": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"autoscaling-plans": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"backup": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"batch": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.batch.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "fips.batch.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "fips.batch.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "fips.batch.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "fips.batch.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.batch.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.batch.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.batch.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.batch.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"braket": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"budgets": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "budgets.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
@@ -1092,9 +2808,10 @@ var awsPartition = partition{
 		"ce": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "ce.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
@@ -1105,11 +2822,15 @@ var awsPartition = partition{
 		"chime": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname:  "chime.us-east-1.amazonaws.com",
 					Protocols: []string{"https"},
 					CredentialScope: credentialScope{
@@ -1119,99 +2840,379 @@ var awsPartition = partition{
 			},
 		},
 		"cloud9": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"cloudcontrolapi": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"clouddirectory": service{
-
-			Endpoints: endpoints{
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"cloudformation": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudformation-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "cloudformation-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudformation-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "cloudformation-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudformation-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "cloudformation-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudformation-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "cloudformation-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"cloudfront": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname:  "cloudfront.amazonaws.com",
 					Protocols: []string{"http", "https"},
 					CredentialScope: credentialScope{
@@ -1221,911 +3222,2606 @@ var awsPartition = partition{
 			},
 		},
 		"cloudhsm": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"cloudhsmv2": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "cloudhsm",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "cloudhsm",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"cloudsearch": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"cloudtrail": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"codeartifact": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"codebuild": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"codecommit": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "codecommit-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"codedeploy": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"codeguru-reviewer": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"codepipeline": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "codepipeline-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "codepipeline-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "codepipeline-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "codepipeline-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"codestar": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"codestar-connections": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"cognito-identity": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"cognito-idp": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"cognito-sync": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"comprehend": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "comprehend-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "comprehend-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "comprehend-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehend-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehend-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehend-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"comprehendmedical": service{
-
-			Endpoints: endpoints{
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
-		"config": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
-					Hostname: "config-fips.us-east-1.amazonaws.com",
+		"compute-optimizer": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "us-east-1",
+						Region: "ap-northeast-1",
 					},
 				},
-				"fips-us-east-2": endpoint{
-					Hostname: "config-fips.us-east-2.amazonaws.com",
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
+					Hostname: "compute-optimizer.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "us-east-2",
+						Region: "ap-northeast-2",
 					},
 				},
-				"fips-us-west-1": endpoint{
-					Hostname: "config-fips.us-west-1.amazonaws.com",
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "us-west-1",
+						Region: "ap-south-1",
 					},
 				},
-				"fips-us-west-2": endpoint{
-					Hostname: "config-fips.us-west-2.amazonaws.com",
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "us-west-2",
+						Region: "ap-southeast-1",
 					},
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
-			},
-		},
-		"connect": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
-			},
-		},
-		"contact-lens": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
-			},
-		},
-		"cur": service{
-
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
-			},
-		},
-		"data.mediastore": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
-			},
-		},
-		"dataexchange": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
-			},
-		},
-		"datapipeline": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
-			},
-		},
-		"datasync": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
-					Hostname: "datasync-fips.ca-central-1.amazonaws.com",
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
+					Hostname: "compute-optimizer.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.eu-north-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
+					Hostname: "compute-optimizer.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
+					Hostname: "compute-optimizer.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
+					Hostname: "compute-optimizer.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
+					Hostname: "compute-optimizer.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+		"config": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "config-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "config-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "config-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "config-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"connect": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"contact-lens": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"cur": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+			},
+		},
+		"data.jobs.iot": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"data.mediastore": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"databrew": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"dataexchange": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"datapipeline": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"datasync": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "datasync-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "datasync-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "datasync-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "datasync-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "datasync-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"dax": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"devicefarm": service{
-
-			Endpoints: endpoints{
-				"us-west-2": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"directconnect": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "directconnect-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "directconnect-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "directconnect-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "directconnect-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "directconnect-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "directconnect-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "directconnect-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "directconnect-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"discovery": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"dms": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"dms-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "dms",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dms",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "dms-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-south-1":   endpoint{},
-				"eu-west-1":    endpoint{},
-				"eu-west-2":    endpoint{},
-				"eu-west-3":    endpoint{},
-				"me-south-1":   endpoint{},
-				"sa-east-1":    endpoint{},
-				"us-east-1":    endpoint{},
-				"us-east-2":    endpoint{},
-				"us-west-1":    endpoint{},
-				"us-west-2":    endpoint{},
+				endpointKey{
+					Region: "dms-fips",
+				}: endpoint{
+					Hostname: "dms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "dms-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "dms-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "dms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "dms-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"docdb": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "rds.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "rds.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Hostname: "rds.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "rds.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "rds.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname: "rds.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "rds.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "rds.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "rds.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"eu-west-3": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
 					Hostname: "rds.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname: "rds.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "rds.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "rds.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "rds.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
@@ -2133,1441 +5829,4155 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"drs": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
 		"ds": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "ds-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ds-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ds-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ds-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ds-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"ca-central-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-south-1":   endpoint{},
-				"eu-west-1":    endpoint{},
-				"eu-west-2":    endpoint{},
-				"eu-west-3":    endpoint{},
-				"local": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "local",
+				}: endpoint{
 					Hostname:  "localhost:8000",
 					Protocols: []string{"http"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-1-fips": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "dynamodb-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "dynamodb-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "dynamodb-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "dynamodb-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"ebs": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ebs-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "ebs-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ebs-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ebs-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ebs-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ebs-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ebs-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ebs-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ebs-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ebs-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"ec2": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.ap-south-1.aws",
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ec2-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.eu-west-1.aws",
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "ec2-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ec2-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ec2-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ec2-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ec2-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
-			},
-		},
-		"ec2metadata": service{
-			PartitionEndpoint: "aws-global",
-			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
-					Hostname:  "169.254.169.254/latest",
-					Protocols: []string{"http"},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.sa-east-1.aws",
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.us-east-1.aws",
+				},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ec2-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.us-east-2.aws",
+				},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ec2-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ec2-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "api.ec2.us-west-2.aws",
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ec2-fips.us-west-2.amazonaws.com",
 				},
 			},
 		},
 		"ecs": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ecs-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ecs-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ecs-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ecs-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"eks": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "fips.eks.{region}.{dnsSuffix}",
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "fips.eks.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "fips.eks.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "fips.eks.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "fips.eks.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.eks.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.eks.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.eks.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.eks.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"elasticache": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "elasticache-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "elasticache-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "elasticache-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "elasticache-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "elasticache-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"elasticbeanstalk": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"elasticfilesystem": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-af-south-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "af-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "fips-af-south-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "af-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-east-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-east-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-2",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-3": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-3",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-3",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-south-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-south-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-2",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ca-central-1": endpoint{
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-central-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-central-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-north-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-north-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-south-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-south-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-2": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-2",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-3": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-3",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-me-south-1": endpoint{
+				endpointKey{
+					Region: "fips-me-south-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-sa-east-1": endpoint{
+				endpointKey{
+					Region: "fips-sa-east-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "me-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"elasticloadbalancing": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"elasticmapreduce": service{
-			Defaults: endpoint{
-				SSLCommonName: "{region}.{service}.{dnsSuffix}",
-				Protocols:     []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SSLCommonName: "{region}.{service}.{dnsSuffix}",
+					Protocols:     []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					SSLCommonName: "{service}.{region}.{dnsSuffix}",
 				},
-				"eu-north-1": endpoint{},
-				"eu-south-1": endpoint{},
-				"eu-west-1":  endpoint{},
-				"eu-west-2":  endpoint{},
-				"eu-west-3":  endpoint{},
-				"fips-ca-central-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					SSLCommonName: "{service}.{region}.{dnsSuffix}",
 				},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:      "elasticmapreduce-fips.us-east-1.amazonaws.com",
+					SSLCommonName: "{service}.{region}.{dnsSuffix}",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"elastictranscoder": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"email": service{
-
-			Endpoints: endpoints{
-				"ap-south-1":     endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"emr-containers": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "emr-containers-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"entitlement.marketplace": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "aws-marketplace",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "aws-marketplace",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"es": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "es-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"events": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "events-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "events-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "events-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "events-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"finspace": service{
-
-			Endpoints: endpoints{
-				"ca-central-1": endpoint{},
-				"eu-west-1":    endpoint{},
-				"us-east-1":    endpoint{},
-				"us-east-2":    endpoint{},
-				"us-west-2":    endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"finspace-api": service{
-
-			Endpoints: endpoints{
-				"ca-central-1": endpoint{},
-				"eu-west-1":    endpoint{},
-				"us-east-1":    endpoint{},
-				"us-east-2":    endpoint{},
-				"us-west-2":    endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"firehose": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "firehose-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "firehose-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "firehose-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "firehose-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"fms": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-af-south-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "af-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.af-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-northeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-northeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-southeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ap-southeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.eu-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.eu-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.eu-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.eu-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.eu-west-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "fips-af-south-1",
+				}: endpoint{
 					Hostname: "fms-fips.af-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "af-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-east-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-east-1",
+				}: endpoint{
 					Hostname: "fms-fips.ap-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-1",
+				}: endpoint{
 					Hostname: "fms-fips.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-2",
+				}: endpoint{
 					Hostname: "fms-fips.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-south-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-south-1",
+				}: endpoint{
 					Hostname: "fms-fips.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-1",
+				}: endpoint{
 					Hostname: "fms-fips.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-2",
+				}: endpoint{
 					Hostname: "fms-fips.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ca-central-1": endpoint{
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "fms-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-central-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-central-1",
+				}: endpoint{
 					Hostname: "fms-fips.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-south-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-south-1",
+				}: endpoint{
 					Hostname: "fms-fips.eu-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-1",
+				}: endpoint{
 					Hostname: "fms-fips.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-2": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-2",
+				}: endpoint{
 					Hostname: "fms-fips.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-3": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-3",
+				}: endpoint{
 					Hostname: "fms-fips.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-me-south-1": endpoint{
+				endpointKey{
+					Region: "fips-me-south-1",
+				}: endpoint{
 					Hostname: "fms-fips.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-sa-east-1": endpoint{
+				endpointKey{
+					Region: "fips-sa-east-1",
+				}: endpoint{
 					Hostname: "fms-fips.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "fms-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "fms-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "fms-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "fms-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "me-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.me-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.sa-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"forecast": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "forecast-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "forecast-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "forecast-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecast-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecast-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecast-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"forecastquery": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "forecastquery-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"frauddetector": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"fsx": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-prod-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "fsx-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-prod-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-prod-ca-central-1",
+				}: endpoint{
+					Hostname: "fsx-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-prod-us-east-1",
+				}: endpoint{
 					Hostname: "fsx-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-prod-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-prod-us-east-2",
+				}: endpoint{
 					Hostname: "fsx-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-prod-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-prod-us-west-1",
+				}: endpoint{
 					Hostname: "fsx-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-prod-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-prod-us-west-2",
+				}: endpoint{
 					Hostname: "fsx-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "prod-ca-central-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-west-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"gamelift": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"glacier": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glacier-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "glacier-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "glacier-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "glacier-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "glacier-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "glacier-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glacier-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glacier-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glacier-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glacier-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"glue": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "glue-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "glue-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "glue-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "glue-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"grafana": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "grafana.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
+					Hostname: "grafana.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
+					Hostname: "grafana.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
+					Hostname: "grafana.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
+					Hostname: "grafana.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
+					Hostname: "grafana.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
+					Hostname: "grafana.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
+					Hostname: "grafana.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
+					Hostname: "grafana.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
+					Hostname: "grafana.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 			},
 		},
 		"greengrass": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"groundstation": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "groundstation-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "groundstation-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "groundstation-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "groundstation-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "groundstation-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "groundstation-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"guardduty": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "guardduty-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "guardduty-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "guardduty-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "guardduty-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"health": service{
-
-			Endpoints: endpoints{
-				"fips-us-east-2": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "health-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "health-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"healthlake": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"honeycode": service{
-
-			Endpoints: endpoints{
-				"us-west-2": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"iam": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "iam.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"iam-fips": endpoint{
+				endpointKey{
+					Region:  "aws-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "iam-fips.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region: "aws-global-fips",
+				}: endpoint{
+					Hostname: "iam-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "iam",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "iam",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iam-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "iam-fips",
+				}: endpoint{
+					Hostname: "iam-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"identity-chime": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"identitystore": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"importexport": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname:          "importexport.amazonaws.com",
 					SignatureVersions: []string{"v2", "v4"},
 					CredentialScope: credentialScope{
@@ -3578,158 +9988,395 @@ var awsPartition = partition{
 			},
 		},
 		"inspector": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "inspector-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "inspector-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "inspector-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "inspector-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"iot": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "execute-api",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"iotanalytics": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"iotevents": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"ioteventsdata": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "data.iotevents.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "data.iotevents.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
+					Hostname: "data.iotevents.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "data.iotevents.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "data.iotevents.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "data.iotevents.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "data.iotevents.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "data.iotevents.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "data.iotevents.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "data.iotevents.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "data.iotevents.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
@@ -3738,971 +10385,3011 @@ var awsPartition = partition{
 			},
 		},
 		"iotsecuredtunneling": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"iotsitewise": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"iotthingsgraph": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "iotthingsgraph",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "iotthingsgraph",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"iotwireless": service{
-
-			Endpoints: endpoints{
-				"eu-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "api.iotwireless.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
+					Hostname: "api.iotwireless.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "api.iotwireless.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "api.iotwireless.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
+					Hostname: "api.iotwireless.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+		"ivs": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"kafka": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"kafkaconnect": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"kendra": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "kendra-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "kendra-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "kendra-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kendra-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kendra-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kendra-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"kinesis": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "kinesis-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "kinesis-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "kinesis-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "kinesis-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kinesis-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kinesis-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kinesis-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kinesis-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"kinesisanalytics": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"kinesisvideo": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"kms": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "af-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.af-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "af-south-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.af-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "af-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-2-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-3-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-northeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-south-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-southeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ap-southeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-2-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ap-southeast-3-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ap-southeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-3",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-north-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-north-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-north-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-south-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-2-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-3-fips",
+				}: endpoint{
+					Hostname: "kms-fips.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "me-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.me-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "me-south-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.me-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "me-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.sa-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "sa-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"lakeformation": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "lakeformation-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "lakeformation-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "lakeformation-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "lakeformation-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lakeformation-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lakeformation-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lakeformation-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lakeformation-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"lambda": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "lambda-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "lambda-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "lambda-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "lambda-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"license-manager": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"lightsail": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"logs": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "logs-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "logs-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "logs-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "logs-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"lookoutequipment": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"lookoutvision": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"machinelearning": service{
-
-			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"macie": service{
-
-			Endpoints: endpoints{
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "macie-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "macie-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"macie2": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "macie2-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "macie2-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "macie2-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "macie2-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie2-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie2-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie2-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "macie2-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"managedblockchain": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"marketplacecommerceanalytics": service{
-
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"mediaconnect": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"mediaconvert": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"medialive": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "medialive-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "medialive-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "medialive-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "medialive-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "medialive-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "medialive-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"mediapackage": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"mediapackage-vod": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"mediastore": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"messaging-chime": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"metering.marketplace": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "aws-marketplace",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "aws-marketplace",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"mgh": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"mgn": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"migrationhub-strategy": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"mobileanalytics": service{
-
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+			},
+		},
+		"models-v2-lex": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"models.lex": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "lex",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "models-fips.lex.{region}.{dnsSuffix}",
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "models-fips.lex.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "models-fips.lex.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "models-fips.lex.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "models-fips.lex.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"monitoring": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "monitoring-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "monitoring-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "monitoring-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "monitoring-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"mq": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "mq-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "mq-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "mq-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "mq-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"mturk-requester": service{
 			IsRegionalized: boxedFalse,
-
-			Endpoints: endpoints{
-				"sandbox": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "sandbox",
+				}: endpoint{
 					Hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
 				},
-				"us-east-1": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"neptune": service{
-
-			Endpoints: endpoints{
-				"ap-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{
 					Hostname: "rds.ap-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-east-1",
 					},
 				},
-				"ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "rds.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "rds.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Hostname: "rds.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "rds.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "rds.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname: "rds.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "rds.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-north-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
 					Hostname: "rds.eu-north-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "rds.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "rds.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"eu-west-3": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
 					Hostname: "rds.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
 				},
-				"me-south-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{
 					Hostname: "rds.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname: "rds.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "rds.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "rds.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Hostname: "rds.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "rds.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
@@ -4710,82 +13397,298 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"network-firewall": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"networkmanager": service{
+			PartitionEndpoint: "aws-global",
+			IsRegionalized:    boxedFalse,
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
+					Hostname: "networkmanager.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+		"nimble": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
 		"oidc": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname: "oidc.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname: "oidc.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Hostname: "oidc.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "oidc.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "oidc.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname: "oidc.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "oidc.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-north-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
 					Hostname: "oidc.eu-north-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "oidc.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "oidc.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
+					Hostname: "oidc.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
+					Hostname: "oidc.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "oidc.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "oidc.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "oidc.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
@@ -4794,165 +13697,380 @@ var awsPartition = partition{
 			},
 		},
 		"opsworks": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"opsworks-cm": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"organizations": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "organizations.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"fips-aws-global": endpoint{
+				endpointKey{
+					Region:  "aws-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "organizations-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region: "fips-aws-global",
+				}: endpoint{
+					Hostname: "organizations-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"outposts": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "outposts-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "outposts-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "outposts-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "outposts-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "outposts-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "outposts-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "outposts-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "outposts-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "outposts-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "outposts-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"personalize": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"pinpoint": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "mobiletargeting",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "mobiletargeting",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "pinpoint-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "pinpoint-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "pinpoint.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "pinpoint-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "pinpoint.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "pinpoint-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
@@ -4960,104 +14078,243 @@ var awsPartition = partition{
 			},
 		},
 		"polly": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "polly-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "polly-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "polly-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "polly-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "polly-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "polly-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "polly-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "polly-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"portal.sso": service{
-
-			Endpoints: endpoints{
-				"ap-southeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "portal.sso.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
+					Hostname: "portal.sso.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
+					Hostname: "portal.sso.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname: "portal.sso.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname: "portal.sso.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname: "portal.sso.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname: "portal.sso.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
+					Hostname: "portal.sso.eu-north-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname: "portal.sso.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname: "portal.sso.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
+					Hostname: "portal.sso.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
+					Hostname: "portal.sso.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "portal.sso.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "portal.sso.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "portal.sso.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
@@ -5066,819 +14323,2407 @@ var awsPartition = partition{
 			},
 		},
 		"profile": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"projects.iot1click": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"qldb": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "qldb-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "qldb-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "qldb-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "qldb-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "qldb-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "qldb-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"quicksight": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "api",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"ram": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ram-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "ram-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ram-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ram-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ram-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ram-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ram-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ram-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ram-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ram-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"rds": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"rds-fips.ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "rds-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rds-fips.us-east-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "rds-fips.ca-central-1",
+				}: endpoint{
+					Hostname: "rds-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rds-fips.us-east-1",
+				}: endpoint{
 					Hostname: "rds-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rds-fips.us-east-2": endpoint{
+				endpointKey{
+					Region: "rds-fips.us-east-2",
+				}: endpoint{
 					Hostname: "rds-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rds-fips.us-west-1": endpoint{
+				endpointKey{
+					Region: "rds-fips.us-west-1",
+				}: endpoint{
 					Hostname: "rds-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rds-fips.us-west-2": endpoint{
+				endpointKey{
+					Region: "rds-fips.us-west-2",
+				}: endpoint{
 					Hostname: "rds-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "rds.ca-central-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rds.ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rds.us-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rds.us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rds.us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rds.us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rds.us-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rds.us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rds.us-west-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rds.us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					SSLCommonName: "{service}.{dnsSuffix}",
 				},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:      "rds-fips.us-east-1.amazonaws.com",
+					SSLCommonName: "{service}.{dnsSuffix}",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "rds-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "rds-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "rds-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "rds-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"redshift": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "redshift-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "redshift-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "redshift-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "redshift-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "redshift-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "redshift-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "redshift-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "redshift-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "redshift-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "redshift-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"rekognition": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"rekognition-fips.ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "rekognition-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rekognition-fips.us-east-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "rekognition-fips.ca-central-1",
+				}: endpoint{
+					Hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rekognition-fips.us-east-1",
+				}: endpoint{
 					Hostname: "rekognition-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rekognition-fips.us-east-2": endpoint{
+				endpointKey{
+					Region: "rekognition-fips.us-east-2",
+				}: endpoint{
 					Hostname: "rekognition-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rekognition-fips.us-west-1": endpoint{
+				endpointKey{
+					Region: "rekognition-fips.us-west-1",
+				}: endpoint{
 					Hostname: "rekognition-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rekognition-fips.us-west-2": endpoint{
+				endpointKey{
+					Region: "rekognition-fips.us-west-2",
+				}: endpoint{
 					Hostname: "rekognition-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "rekognition.ca-central-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rekognition.us-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rekognition.us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rekognition.us-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "rekognition.us-west-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "rekognition-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "rekognition-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"resource-groups": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "resource-groups-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "resource-groups-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "resource-groups-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "resource-groups-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"robomaker": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"route53": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "route53.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"fips-aws-global": endpoint{
+				endpointKey{
+					Region:  "aws-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "route53-fips.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region: "fips-aws-global",
+				}: endpoint{
+					Hostname: "route53-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"route53-recovery-control-config": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
+					Hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 			},
 		},
 		"route53domains": service{
-
-			Endpoints: endpoints{
-				"us-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
 			},
 		},
 		"route53resolver": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"runtime-v2-lex": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"runtime.lex": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "lex",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.lex.{region}.{dnsSuffix}",
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"runtime.sagemaker": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.sagemaker.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"s3": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedTrue,
-			Defaults: endpoint{
-				Protocols:         []string{"http", "https"},
-				SignatureVersions: []string{"s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}-fips.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"accesspoint-af-south-1": endpoint{
-					Hostname:          "s3-accesspoint.af-south-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "af-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.af-south-1.amazonaws.com",
 				},
-				"accesspoint-ap-east-1": endpoint{
-					Hostname:          "s3-accesspoint.ap-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.ap-east-1.amazonaws.com",
 				},
-				"accesspoint-ap-northeast-1": endpoint{
-					Hostname:          "s3-accesspoint.ap-northeast-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ap-northeast-2": endpoint{
-					Hostname:          "s3-accesspoint.ap-northeast-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ap-northeast-3": endpoint{
-					Hostname:          "s3-accesspoint.ap-northeast-3.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ap-south-1": endpoint{
-					Hostname:          "s3-accesspoint.ap-south-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ap-southeast-1": endpoint{
-					Hostname:          "s3-accesspoint.ap-southeast-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ap-southeast-2": endpoint{
-					Hostname:          "s3-accesspoint.ap-southeast-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-ca-central-1": endpoint{
-					Hostname:          "s3-accesspoint.ca-central-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-central-1": endpoint{
-					Hostname:          "s3-accesspoint.eu-central-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-north-1": endpoint{
-					Hostname:          "s3-accesspoint.eu-north-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-south-1": endpoint{
-					Hostname:          "s3-accesspoint.eu-south-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-west-1": endpoint{
-					Hostname:          "s3-accesspoint.eu-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-west-2": endpoint{
-					Hostname:          "s3-accesspoint.eu-west-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-eu-west-3": endpoint{
-					Hostname:          "s3-accesspoint.eu-west-3.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-me-south-1": endpoint{
-					Hostname:          "s3-accesspoint.me-south-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-sa-east-1": endpoint{
-					Hostname:          "s3-accesspoint.sa-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-us-east-1": endpoint{
-					Hostname:          "s3-accesspoint.us-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-us-east-2": endpoint{
-					Hostname:          "s3-accesspoint.us-east-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-us-west-1": endpoint{
-					Hostname:          "s3-accesspoint.us-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"accesspoint-us-west-2": endpoint{
-					Hostname:          "s3-accesspoint.us-west-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"af-south-1": endpoint{},
-				"ap-east-1":  endpoint{},
-				"ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname:          "s3.ap-northeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.ap-northeast-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.ap-northeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.ap-northeast-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.ap-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname:          "s3.ap-southeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.ap-southeast-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname:          "s3.ap-southeast-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"aws-global": endpoint{
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.ap-southeast-2.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname:          "s3.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"ca-central-1": endpoint{},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-south-1":   endpoint{},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "s3-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname: "s3-fips.dualstack.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.eu-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-north-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.eu-north-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.eu-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname:          "s3.eu-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"eu-west-2": endpoint{},
-				"eu-west-3": endpoint{},
-				"fips-accesspoint-ca-central-1": endpoint{
-					Hostname:          "s3-accesspoint-fips.ca-central-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.eu-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"fips-accesspoint-us-east-1": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.eu-west-2.amazonaws.com",
 				},
-				"fips-accesspoint-us-east-2": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-east-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.eu-west-3.amazonaws.com",
 				},
-				"fips-accesspoint-us-west-1": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "s3-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
 				},
-				"fips-accesspoint-us-west-2": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-west-2.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "s3-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"s3-external-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "s3-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "s3-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "s3-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "me-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.me-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "s3-external-1",
+				}: endpoint{
 					Hostname:          "s3-external-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname:          "s3.sa-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.sa-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname:          "s3.us-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.dualstack.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "s3-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname: "s3-fips.dualstack.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Hostname:          "s3.us-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.dualstack.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname:          "s3.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3.dualstack.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-fips.dualstack.us-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
 			},
 		},
 		"s3-control": service{
-			Defaults: endpoint{
-				Protocols:         []string{"https"},
-				SignatureVersions: []string{"s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}-fips.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Hostname:          "s3-control.ap-northeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-northeast-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Hostname:          "s3-control.ap-northeast-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"ap-northeast-3": endpoint{
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-northeast-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{
 					Hostname:          "s3-control.ap-northeast-3.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-3",
 					},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-northeast-3.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
+					},
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Hostname:          "s3-control.ap-south-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-south-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Hostname:          "s3-control.ap-southeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-southeast-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Hostname:          "s3-control.ap-southeast-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ap-southeast-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Hostname:          "s3-control.ca-central-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"ca-central-1-fips": endpoint{
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.ca-central-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.ca-central-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.ca-central-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.ca-central-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Hostname:          "s3-control.eu-central-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"eu-north-1": endpoint{
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.eu-central-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
 					Hostname:          "s3-control.eu-north-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region:  "eu-north-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.eu-north-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Hostname:          "s3-control.eu-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.eu-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Hostname:          "s3-control.eu-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"eu-west-3": endpoint{
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.eu-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
 					Hostname:          "s3-control.eu-west-3.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.eu-west-3.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname:          "s3-control.sa-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.sa-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname:          "s3-control.us-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-1-fips": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname:          "s3-control.us-east-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-east-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-east-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-east-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-east-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Hostname:          "s3-control.us-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
 				},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname:          "s3-control.us-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
 				},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
 				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-west-2.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"savingsplans": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "savingsplans.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
@@ -5887,909 +16732,2467 @@ var awsPartition = partition{
 			},
 		},
 		"schemas": service{
-
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"sdb": service{
-			Defaults: endpoint{
-				Protocols:         []string{"http", "https"},
-				SignatureVersions: []string{"v2"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"v2"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "sdb.amazonaws.com",
 				},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"secretsmanager": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"securityhub": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"serverlessrepo": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"eu-north-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"eu-west-3": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"me-south-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
 			},
 		},
 		"servicecatalog": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"servicecatalog-appregistry": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
 				},
 			},
 		},
 		"servicediscovery": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"servicediscovery-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "servicediscovery",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "servicediscovery",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "servicediscovery-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"servicequotas": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"session.qldb": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "session.qldb-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "session.qldb-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "session.qldb-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "session.qldb-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "session.qldb-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "session.qldb-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"shield": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-			Defaults: endpoint{
-				SSLCommonName: "shield.us-east-1.amazonaws.com",
-				Protocols:     []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SSLCommonName: "shield.us-east-1.amazonaws.com",
+					Protocols:     []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "shield.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"fips-aws-global": endpoint{
+				endpointKey{
+					Region:  "aws-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "shield-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region: "fips-aws-global",
+				}: endpoint{
+					Hostname: "shield-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"sms": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "sms-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "sms-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "sms-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "sms-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"snowball": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ap-northeast-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-south-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.eu-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.eu-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.eu-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.eu-west-3.amazonaws.com",
+				},
+				endpointKey{
+					Region: "fips-ap-northeast-1",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-2",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-northeast-3": endpoint{
+				endpointKey{
+					Region: "fips-ap-northeast-3",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-3",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-south-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-south-1",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-1",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "fips-ap-southeast-2",
+				}: endpoint{
 					Hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-ca-central-1": endpoint{
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "snowball-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-central-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-central-1",
+				}: endpoint{
 					Hostname: "snowball-fips.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-1": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-1",
+				}: endpoint{
 					Hostname: "snowball-fips.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-2": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-2",
+				}: endpoint{
 					Hostname: "snowball-fips.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-eu-west-3": endpoint{
+				endpointKey{
+					Region: "fips-eu-west-3",
+				}: endpoint{
 					Hostname: "snowball-fips.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-sa-east-1": endpoint{
+				endpointKey{
+					Region: "fips-sa-east-1",
+				}: endpoint{
 					Hostname: "snowball-fips.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "snowball-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "snowball-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "snowball-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "snowball-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.sa-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"sns": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "sns-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "sns-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "sns-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "sns-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sns-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sns-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sns-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sns-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"sqs": service{
-			Defaults: endpoint{
-				SSLCommonName: "{region}.queue.{dnsSuffix}",
-				Protocols:     []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SSLCommonName: "{region}.queue.{dnsSuffix}",
+					Protocols:     []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "sqs-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "sqs-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "sqs-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "sqs-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					SSLCommonName: "queue.{dnsSuffix}",
 				},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:      "sqs-fips.us-east-1.amazonaws.com",
+					SSLCommonName: "queue.{dnsSuffix}",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sqs-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sqs-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sqs-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"ssm": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "ssm-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "ssm-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "ssm-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "ssm-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "ssm-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"ssm-incidents": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"states": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "states-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "states-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "states-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "states-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"storagegateway": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "ca-central-1-fips",
+				}: endpoint{
 					Hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
-			},
-		},
-		"streams.dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "dynamodb",
-				},
-			},
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"ca-central-1-fips": endpoint{
-					Hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-west-1":    endpoint{},
-				"eu-west-2":    endpoint{},
-				"eu-west-3":    endpoint{},
-				"local": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"streams.dynamodb": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "local",
+				}: endpoint{
 					Hostname:  "localhost:8000",
 					Protocols: []string{"http"},
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-1-fips": endpoint{
-					Hostname: "dynamodb-fips.us-east-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "us-east-1",
-					},
-				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
-					Hostname: "dynamodb-fips.us-east-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "us-east-2",
-					},
-				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
-					Hostname: "dynamodb-fips.us-west-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "us-west-1",
-					},
-				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
-					Hostname: "dynamodb-fips.us-west-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "us-west-2",
-					},
-				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"sts": service{
 			PartitionEndpoint: "aws-global",
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "sts.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"ca-central-1": endpoint{},
-				"eu-central-1": endpoint{},
-				"eu-north-1":   endpoint{},
-				"eu-south-1":   endpoint{},
-				"eu-west-1":    endpoint{},
-				"eu-west-2":    endpoint{},
-				"eu-west-3":    endpoint{},
-				"me-south-1":   endpoint{},
-				"sa-east-1":    endpoint{},
-				"us-east-1":    endpoint{},
-				"us-east-1-fips": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "sts-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "sts-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1-fips",
+				}: endpoint{
 					Hostname: "sts-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "sts-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"support": service{
 			PartitionEndpoint: "aws-global",
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "support.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
@@ -6798,615 +19201,1771 @@ var awsPartition = partition{
 			},
 		},
 		"swf": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "swf-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "swf-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "swf-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "swf-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "swf-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "swf-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "swf-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "swf-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"tagging": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+			},
+		},
+		"textract": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "textract-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "textract-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "textract-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "textract-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "textract-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"transcribe": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "fips.transcribe.{region}.{dnsSuffix}",
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "fips.transcribe.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"transcribestreaming": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "transcribestreaming-ca-central-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "transcribestreaming-ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-fips-ca-central-1",
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-fips-us-east-1",
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-fips-us-east-2",
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-fips-us-west-2",
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-us-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "transcribestreaming-us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-us-east-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "transcribestreaming-us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "transcribestreaming-us-west-2",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "transcribestreaming-us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transcribestreaming-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"transfer": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-ca-central-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
 					Hostname: "transfer-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "transfer-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "transfer-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "transfer-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "transfer-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"translate": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "translate-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-1-fips",
+				}: endpoint{
 					Hostname: "translate-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-2": endpoint{},
-				"us-east-2-fips": endpoint{
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "translate-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2-fips",
+				}: endpoint{
 					Hostname: "translate-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
-				"us-west-2-fips": endpoint{
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "translate-fips.us-west-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2-fips",
+				}: endpoint{
 					Hostname: "translate-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
+			},
+		},
+		"voiceid": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"waf": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "aws",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-fips.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"aws-global": endpoint{
+				endpointKey{
+					Region: "aws-fips",
+				}: endpoint{
+					Hostname: "waf-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
 					Hostname: "waf.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
+				endpointKey{
+					Region:  "aws-global",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "aws-global-fips",
+				}: endpoint{
+					Hostname: "waf-fips.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"waf-regional": service{
-
-			Endpoints: endpoints{
-				"af-south-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{
 					Hostname: "waf-regional.af-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "af-south-1",
 					},
 				},
-				"ap-east-1": endpoint{
-					Hostname: "waf-regional.ap-east-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-east-1",
-					},
-				},
-				"ap-northeast-1": endpoint{
-					Hostname: "waf-regional.ap-northeast-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-northeast-1",
-					},
-				},
-				"ap-northeast-2": endpoint{
-					Hostname: "waf-regional.ap-northeast-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-northeast-2",
-					},
-				},
-				"ap-south-1": endpoint{
-					Hostname: "waf-regional.ap-south-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-south-1",
-					},
-				},
-				"ap-southeast-1": endpoint{
-					Hostname: "waf-regional.ap-southeast-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-southeast-1",
-					},
-				},
-				"ap-southeast-2": endpoint{
-					Hostname: "waf-regional.ap-southeast-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ap-southeast-2",
-					},
-				},
-				"ca-central-1": endpoint{
-					Hostname: "waf-regional.ca-central-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "ca-central-1",
-					},
-				},
-				"eu-central-1": endpoint{
-					Hostname: "waf-regional.eu-central-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-central-1",
-					},
-				},
-				"eu-north-1": endpoint{
-					Hostname: "waf-regional.eu-north-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-north-1",
-					},
-				},
-				"eu-south-1": endpoint{
-					Hostname: "waf-regional.eu-south-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-south-1",
-					},
-				},
-				"eu-west-1": endpoint{
-					Hostname: "waf-regional.eu-west-1.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-west-1",
-					},
-				},
-				"eu-west-2": endpoint{
-					Hostname: "waf-regional.eu-west-2.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-west-2",
-					},
-				},
-				"eu-west-3": endpoint{
-					Hostname: "waf-regional.eu-west-3.amazonaws.com",
-					CredentialScope: credentialScope{
-						Region: "eu-west-3",
-					},
-				},
-				"fips-af-south-1": endpoint{
+				endpointKey{
+					Region:  "af-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.af-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "af-south-1",
 					},
 				},
-				"fips-ap-east-1": endpoint{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{
+					Hostname: "waf-regional.ap-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-east-1",
+					},
+				},
+				endpointKey{
+					Region:  "ap-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-east-1",
 					},
 				},
-				"fips-ap-northeast-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{
+					Hostname: "waf-regional.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				endpointKey{
+					Region:  "ap-northeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-northeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-1",
 					},
 				},
-				"fips-ap-northeast-2": endpoint{
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{
+					Hostname: "waf-regional.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				endpointKey{
+					Region:  "ap-northeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-northeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-northeast-2",
 					},
 				},
-				"fips-ap-south-1": endpoint{
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{
+					Hostname: "waf-regional.ap-northeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
+					},
+				},
+				endpointKey{
+					Region:  "ap-northeast-3",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-northeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
+					},
+				},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{
+					Hostname: "waf-regional.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				endpointKey{
+					Region:  "ap-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-south-1",
 					},
 				},
-				"fips-ap-southeast-1": endpoint{
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{
+					Hostname: "waf-regional.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				endpointKey{
+					Region:  "ap-southeast-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-1",
 					},
 				},
-				"fips-ap-southeast-2": endpoint{
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{
+					Hostname: "waf-regional.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				endpointKey{
+					Region:  "ap-southeast-2",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ap-southeast-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ap-southeast-2",
 					},
 				},
-				"fips-ca-central-1": endpoint{
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{
+					Hostname: "waf-regional.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.ca-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "ca-central-1",
 					},
 				},
-				"fips-eu-central-1": endpoint{
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{
+					Hostname: "waf-regional.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				endpointKey{
+					Region:  "eu-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-central-1",
 					},
 				},
-				"fips-eu-north-1": endpoint{
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{
+					Hostname: "waf-regional.eu-north-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+				},
+				endpointKey{
+					Region:  "eu-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-north-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-north-1",
 					},
 				},
-				"fips-eu-south-1": endpoint{
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{
+					Hostname: "waf-regional.eu-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-south-1",
+					},
+				},
+				endpointKey{
+					Region:  "eu-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-south-1",
 					},
 				},
-				"fips-eu-west-1": endpoint{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{
+					Hostname: "waf-regional.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "eu-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-1",
 					},
 				},
-				"fips-eu-west-2": endpoint{
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{
+					Hostname: "waf-regional.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				endpointKey{
+					Region:  "eu-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
 					},
 				},
-				"fips-eu-west-3": endpoint{
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{
+					Hostname: "waf-regional.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				endpointKey{
+					Region:  "eu-west-3",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "waf-regional-fips.eu-west-3.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-3",
 					},
 				},
-				"fips-me-south-1": endpoint{
+				endpointKey{
+					Region: "fips-af-south-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.af-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "af-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-east-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-northeast-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-northeast-2",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-northeast-3",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-northeast-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-3",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-south-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-southeast-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ap-southeast-2",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-central-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-north-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-north-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-north-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-south-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-south-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-west-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-west-2",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-eu-west-3",
+				}: endpoint{
+					Hostname: "waf-regional-fips.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-me-south-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-sa-east-1": endpoint{
+				endpointKey{
+					Region: "fips-sa-east-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{
 					Hostname: "waf-regional.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "me-south-1",
 					},
 				},
-				"sa-east-1": endpoint{
+				endpointKey{
+					Region:  "me-south-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.me-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "me-south-1",
+					},
+				},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{
 					Hostname: "waf-regional.sa-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "sa-east-1",
 					},
 				},
-				"us-east-1": endpoint{
+				endpointKey{
+					Region:  "sa-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{
 					Hostname: "waf-regional.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
 				},
-				"us-east-2": endpoint{
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{
 					Hostname: "waf-regional.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
 				},
-				"us-west-1": endpoint{
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{
 					Hostname: "waf-regional.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
 				},
-				"us-west-2": endpoint{
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{
 					Hostname: "waf-regional.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
 				},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+		"wisdom": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"workdocs": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-west-1":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "workdocs-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "workdocs-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "workdocs-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "workdocs-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"workmail": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"workspaces": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "workspaces-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "workspaces-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "workspaces-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "workspaces-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"xray": service{
-
-			Endpoints: endpoints{
-				"af-south-1":     endpoint{},
-				"ap-east-1":      endpoint{},
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-northeast-3": endpoint{},
-				"ap-south-1":     endpoint{},
-				"ap-southeast-1": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-south-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"fips-us-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
 					Hostname: "xray-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-east-2": endpoint{
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
 					Hostname: "xray-fips.us-east-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-east-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
 					Hostname: "xray-fips.us-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-west-2": endpoint{
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
 					Hostname: "xray-fips.us-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-west-2",
 					},
+					Deprecated: boxedTrue,
 				},
-				"me-south-1": endpoint{},
-				"sa-east-1":  endpoint{},
-				"us-east-1":  endpoint{},
-				"us-east-2":  endpoint{},
-				"us-west-1":  endpoint{},
-				"us-west-2":  endpoint{},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 	},
@@ -7427,10 +20986,36 @@ var awscnPartition = partition{
 			return reg
 		}(),
 	},
-	Defaults: endpoint{
-		Hostname:          "{service}.{region}.{dnsSuffix}",
-		Protocols:         []string{"https"},
-		SignatureVersions: []string{"v4"},
+	Defaults: endpointDefaults{
+		defaultKey{}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.amazonwebservices.com.cn",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "amazonaws.com.cn",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant | dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.amazonwebservices.com.cn",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
 	},
 	Regions: regions{
 		"cn-north-1": region{
@@ -7442,29 +21027,52 @@ var awscnPartition = partition{
 	},
 	Services: services{
 		"access-analyzer": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"account": service{
+			PartitionEndpoint: "aws-cn-global",
+			IsRegionalized:    boxedFalse,
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
+					Hostname: "account.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
 			},
 		},
 		"acm": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"api.ecr": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
 					Hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
 				},
-				"cn-northwest-1": endpoint{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -7473,80 +21081,147 @@ var awscnPartition = partition{
 			},
 		},
 		"api.sagemaker": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"apigateway": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"appconfigdata": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"application-autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"applicationinsights": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"appmesh": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"appsync": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"athena": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"autoscaling-plans": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"backup": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"batch": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"budgets": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "budgets.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -7557,9 +21232,10 @@ var awscnPartition = partition{
 		"ce": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "ce.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -7568,18 +21244,22 @@ var awscnPartition = partition{
 			},
 		},
 		"cloudformation": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"cloudfront": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname:  "cloudfront.cn-northwest-1.amazonaws.com.cn",
 					Protocols: []string{"http", "https"},
 					CredentialScope: credentialScope{
@@ -7589,76 +21269,144 @@ var awscnPartition = partition{
 			},
 		},
 		"cloudtrail": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"codebuild": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"codecommit": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"codedeploy": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"cognito-identity": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+			},
+		},
+		"compute-optimizer": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
+					Hostname: "compute-optimizer.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
 			},
 		},
 		"config": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"cur": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"data.jobs.iot": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"databrew": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"dax": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"directconnect": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"dms": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"docdb": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname: "rds.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -7667,197 +21415,316 @@ var awscnPartition = partition{
 			},
 		},
 		"ds": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"ebs": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"ec2": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
-			},
-		},
-		"ec2metadata": service{
-			PartitionEndpoint: "aws-global",
-			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
-					Hostname:  "169.254.169.254/latest",
-					Protocols: []string{"http"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
 				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"ecs": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"eks": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"elasticache": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"elasticbeanstalk": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"elasticfilesystem": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
-				"fips-cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
+				},
+				endpointKey{
+					Region: "fips-cn-north-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-cn-northwest-1": endpoint{
+				endpointKey{
+					Region: "fips-cn-northwest-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"elasticloadbalancing": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"elasticmapreduce": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"emr-containers": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"es": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"events": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"firehose": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"fms": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"fsx": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"gamelift": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"glacier": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"glue": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"greengrass": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 			},
 		},
 		"guardduty": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"health": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"iam": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "iam.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
@@ -7866,32 +21733,41 @@ var awscnPartition = partition{
 			},
 		},
 		"iot": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "execute-api",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"iotanalytics": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 			},
 		},
 		"iotevents": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 			},
 		},
 		"ioteventsdata": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
 					Hostname: "data.iotevents.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
@@ -7900,72 +21776,107 @@ var awscnPartition = partition{
 			},
 		},
 		"iotsecuredtunneling": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"iotsitewise": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 			},
 		},
 		"kafka": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"kinesis": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"kinesisanalytics": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"kms": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"lakeformation": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"lambda": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"license-manager": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"logs": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"mediaconvert": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -7974,25 +21885,43 @@ var awscnPartition = partition{
 			},
 		},
 		"monitoring": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"mq": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"neptune": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
+					Hostname: "rds.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname: "rds.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -8003,9 +21932,10 @@ var awscnPartition = partition{
 		"organizations": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -8014,51 +21944,66 @@ var awscnPartition = partition{
 			},
 		},
 		"personalize": service{
-
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 			},
 		},
 		"polly": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"ram": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"rds": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"redshift": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"resource-groups": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"route53": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "route53.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -8067,60 +22012,115 @@ var awscnPartition = partition{
 			},
 		},
 		"route53resolver": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"runtime.sagemaker": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"s3": service{
-			Defaults: endpoint{
-				Protocols:         []string{"http", "https"},
-				SignatureVersions: []string{"s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com.cn",
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"accesspoint-cn-north-1": endpoint{
-					Hostname:          "s3-accesspoint.cn-north-1.amazonaws.com.cn",
-					SignatureVersions: []string{"s3v4"},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-north-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.cn-north-1.amazonaws.com.cn",
 				},
-				"accesspoint-cn-northwest-1": endpoint{
-					Hostname:          "s3-accesspoint.cn-northwest-1.amazonaws.com.cn",
-					SignatureVersions: []string{"s3v4"},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "s3.dualstack.cn-northwest-1.amazonaws.com.cn",
 				},
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
 			},
 		},
 		"s3-control": service{
-			Defaults: endpoint{
-				Protocols:         []string{"https"},
-				SignatureVersions: []string{"s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com.cn",
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
 					Hostname:          "s3-control.cn-north-1.amazonaws.com.cn",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
 				},
-				"cn-northwest-1": endpoint{
+				endpointKey{
+					Region:  "cn-north-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.cn-north-1.amazonaws.com.cn",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname:          "s3-control.cn-northwest-1.amazonaws.com.cn",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.cn-northwest-1.amazonaws.com.cn",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -8129,136 +22129,209 @@ var awscnPartition = partition{
 			},
 		},
 		"secretsmanager": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"securityhub": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"serverlessrepo": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
-			},
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
 					Protocols: []string{"https"},
 				},
-				"cn-northwest-1": endpoint{
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
+					Protocols: []string{"https"},
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
 			},
 		},
 		"servicecatalog": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"servicediscovery": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"sms": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"snowball": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
-				"fips-cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
+				},
+				endpointKey{
+					Region: "fips-cn-north-1",
+				}: endpoint{
 					Hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-cn-northwest-1": endpoint{
+				endpointKey{
+					Region: "fips-cn-northwest-1",
+				}: endpoint{
 					Hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"sns": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"sqs": service{
-			Defaults: endpoint{
-				SSLCommonName: "{region}.queue.{dnsSuffix}",
-				Protocols:     []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SSLCommonName: "{region}.queue.{dnsSuffix}",
+					Protocols:     []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"ssm": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"states": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"storagegateway": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"streams.dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "dynamodb",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"sts": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"support": service{
 			PartitionEndpoint: "aws-cn-global",
-
-			Endpoints: endpoints{
-				"aws-cn-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-cn-global",
+				}: endpoint{
 					Hostname: "support.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
@@ -8267,31 +22340,43 @@ var awscnPartition = partition{
 			},
 		},
 		"swf": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"tagging": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"transcribe": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"cn-north-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
 					Hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-north-1",
 					},
 				},
-				"cn-northwest-1": endpoint{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
 					Hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
 					CredentialScope: credentialScope{
 						Region: "cn-northwest-1",
@@ -8299,17 +22384,97 @@ var awscnPartition = partition{
 				},
 			},
 		},
+		"transcribestreaming": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"transfer": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"waf-regional": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{
+					Hostname: "waf-regional.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				endpointKey{
+					Region:  "cn-north-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{
+					Hostname: "waf-regional.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
+				endpointKey{
+					Region: "fips-cn-north-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-cn-northwest-1",
+				}: endpoint{
+					Hostname: "waf-regional-fips.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
 		"workspaces": service{
-
-			Endpoints: endpoints{
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 		"xray": service{
-
-			Endpoints: endpoints{
-				"cn-north-1":     endpoint{},
-				"cn-northwest-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
 			},
 		},
 	},
@@ -8330,10 +22495,36 @@ var awsusgovPartition = partition{
 			return reg
 		}(),
 	},
-	Defaults: endpoint{
-		Hostname:          "{service}.{region}.{dnsSuffix}",
-		Protocols:         []string{"https"},
-		SignatureVersions: []string{"v4"},
+	Defaults: endpointDefaults{
+		defaultKey{}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.aws",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "amazonaws.com",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant | dualStackVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "api.aws",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
 	},
 	Regions: regions{
 		"us-gov-east-1": region{
@@ -8345,15 +22536,18 @@ var awsusgovPartition = partition{
 	},
 	Services: services{
 		"access-analyzer": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "access-analyzer.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "access-analyzer.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8362,15 +22556,18 @@ var awsusgovPartition = partition{
 			},
 		},
 		"acm": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "acm.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "acm.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8379,82 +22576,213 @@ var awsusgovPartition = partition{
 			},
 		},
 		"acm-pca": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "acm-pca.{region}.{dnsSuffix}",
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "acm-pca.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "acm-pca.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"api.detective": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"api.ecr": service{
-
-			Endpoints: endpoints{
-				"fips-dkr-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "dkr-us-gov-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-dkr-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "dkr-us-gov-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dkr-us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-gov-east-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-dkr-us-gov-west-1",
+				}: endpoint{
 					Hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
@@ -8462,149 +22790,355 @@ var awsusgovPartition = partition{
 			},
 		},
 		"api.sagemaker": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1-fips-secondary": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1-fips-secondary",
+				}: endpoint{
 					Hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1-secondary",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "us-gov-west-1-secondary",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"apigateway": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
+		"appconfigdata": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"application-autoscaling": service{
-			Defaults: endpoint{
-				Hostname:  "autoscaling.{region}.amazonaws.com",
-				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "application-autoscaling",
-				},
-			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Hostname:  "autoscaling.{region}.amazonaws.com",
 					Protocols: []string{"http", "https"},
-				},
-				"us-gov-west-1": endpoint{
-					Protocols: []string{"http", "https"},
-				},
-			},
-		},
-		"appstream2": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
-				CredentialScope: credentialScope{
-					Service: "appstream",
-				},
-			},
-			Endpoints: endpoints{
-				"fips": endpoint{
-					Hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
-						Region: "us-gov-west-1",
+						Service: "application-autoscaling",
 					},
 				},
-				"us-gov-west-1": endpoint{},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
 		},
-		"athena": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
-					Hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+		"applicationinsights": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
+					Hostname: "applicationinsights.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"fips-us-gov-west-1": endpoint{
-					Hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Hostname: "applicationinsights.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			},
+		},
+		"appstream2": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+					CredentialScope: credentialScope{
+						Service: "appstream",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
+					Hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"athena": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"autoscaling": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
 			},
 		},
 		"autoscaling-plans": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
-				"us-gov-west-1": endpoint{
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
 			},
 		},
 		"backup": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"batch": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "batch.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "batch.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "batch.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "batch.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "batch.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"cloudcontrolapi": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"clouddirectory": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"cloudformation": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "cloudformation.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "cloudformation.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8613,32 +23147,42 @@ var awsusgovPartition = partition{
 			},
 		},
 		"cloudhsm": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"cloudhsmv2": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "cloudhsm",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "cloudhsm",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"cloudtrail": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8647,172 +23191,404 @@ var awsusgovPartition = partition{
 			},
 		},
 		"codebuild": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"codecommit": service{
-
-			Endpoints: endpoints{
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"codedeploy": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"codepipeline": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"cognito-identity": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"cognito-idp": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"comprehend": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"comprehendmedical": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"config": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "config.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "config.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "config.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"connect": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
+		"data.jobs.iot": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"databrew": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"datasync": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"directconnect": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "directconnect.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "directconnect.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8821,22 +23597,85 @@ var awsusgovPartition = partition{
 			},
 		},
 		"dms": service{
-
-			Endpoints: endpoints{
-				"dms-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "dms",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dms",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "dms.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "dms-fips",
+				}: endpoint{
+					Hostname: "dms.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "dms.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "dms.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"docdb": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "rds.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8845,60 +23684,116 @@ var awsusgovPartition = partition{
 			},
 		},
 		"ds": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "ds-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "ds-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ds-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"dynamodb": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "dynamodb.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "dynamodb.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"ebs": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"ec2": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "ec2.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "ec2.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8906,80 +23801,152 @@ var awsusgovPartition = partition{
 				},
 			},
 		},
-		"ec2metadata": service{
-			PartitionEndpoint: "aws-global",
-			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
-					Hostname:  "169.254.169.254/latest",
-					Protocols: []string{"http"},
-				},
-			},
-		},
 		"ecs": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"eks": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "eks.{region}.{dnsSuffix}",
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "eks.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "eks.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "eks.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "eks.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"elasticache": service{
-
-			Endpoints: endpoints{
-				"fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "elasticache.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticache.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "elasticache.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"elasticbeanstalk": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -8988,101 +23955,231 @@ var awsusgovPartition = partition{
 			},
 		},
 		"elasticfilesystem": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"elasticloadbalancing": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "elasticloadbalancing.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
 				},
 			},
 		},
 		"elasticmapreduce": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Protocols: []string{"https"},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "elasticmapreduce.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"https"},
 				},
 			},
 		},
 		"email": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "email-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "email-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"es": service{
-
-			Endpoints: endpoints{
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "es-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "es-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "es-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"events": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "events.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "events.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9091,74 +24188,197 @@ var awsusgovPartition = partition{
 			},
 		},
 		"firehose": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"fms": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "fms-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "fms-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fms-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"fsx": service{
-
-			Endpoints: endpoints{
-				"fips-prod-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-prod-us-gov-east-1",
+				}: endpoint{
 					Hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-prod-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-prod-us-gov-west-1",
+				}: endpoint{
 					Hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-gov-east-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "prod-us-gov-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "prod-us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"glacier": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "glacier.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:  "glacier.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
 					CredentialScope: credentialScope{
@@ -9168,55 +24388,98 @@ var awsusgovPartition = partition{
 			},
 		},
 		"glue": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "glue-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "glue-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "glue-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"greengrass": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"dataplane-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "dataplane-us-gov-east-1",
+				}: endpoint{
 					Hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"dataplane-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "dataplane-us-gov-west-1",
+				}: endpoint{
 					Hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"fips-us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "greengrass.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "greengrass.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9226,110 +24489,382 @@ var awsusgovPartition = partition{
 		},
 		"guardduty": service{
 			IsRegionalized: boxedTrue,
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "guardduty.{region}.{dnsSuffix}",
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "guardduty.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "guardduty.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "guardduty.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"health": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "health-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "health-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"iam": service{
 			PartitionEndpoint: "aws-us-gov-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-us-gov-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-us-gov-global",
+				}: endpoint{
 					Hostname: "iam.us-gov.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"iam-govcloud-fips": endpoint{
+				endpointKey{
+					Region:  "aws-us-gov-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "iam.us-gov.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+				},
+				endpointKey{
+					Region: "aws-us-gov-global-fips",
+				}: endpoint{
+					Hostname: "iam.us-gov.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "iam-govcloud",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "iam-govcloud",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iam.us-gov.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "iam-govcloud-fips",
+				}: endpoint{
+					Hostname: "iam.us-gov.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"identitystore": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "identitystore.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "identitystore.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "identitystore.us-gov-west-1.amazonaws.com",
 				},
 			},
 		},
 		"inspector": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"iot": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "execute-api",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"iotevents": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
+		"ioteventsdata": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Hostname: "data.iotevents.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 			},
 		},
 		"iotsecuredtunneling": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"iotsitewise": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"kafka": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
+		"kendra": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"kinesis": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "kinesis.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "kinesis.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9338,85 +24873,179 @@ var awsusgovPartition = partition{
 			},
 		},
 		"kinesisanalytics": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"kms": service{
-
-			Endpoints: endpoints{
-				"ProdFips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ProdFips",
+				}: endpoint{
 					Hostname: "kms-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"lakeformation": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"lambda": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"license-manager": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"logs": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "logs.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "logs.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9425,9 +25054,10 @@ var awsusgovPartition = partition{
 			},
 		},
 		"mediaconvert": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9436,62 +25066,227 @@ var awsusgovPartition = partition{
 			},
 		},
 		"metering.marketplace": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "aws-marketplace",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "aws-marketplace",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"models.lex": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "lex",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "models-fips.lex.{region}.{dnsSuffix}",
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"monitoring": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "monitoring.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "monitoring.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "monitoring.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"mq": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "mq-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "mq-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "mq-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"neptune": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "rds.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "rds.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+			},
+		},
+		"network-firewall": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"networkmanager": service{
+			PartitionEndpoint: "aws-us-gov-global",
+			IsRegionalized:    boxedFalse,
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-us-gov-global",
+				}: endpoint{
+					Hostname: "networkmanager.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+			},
+		},
+		"oidc": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Hostname: "oidc.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
@@ -9501,32 +25296,48 @@ var awsusgovPartition = partition{
 		"organizations": service{
 			PartitionEndpoint: "aws-us-gov-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-us-gov-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-us-gov-global",
+				}: endpoint{
 					Hostname: "organizations.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"fips-aws-us-gov-global": endpoint{
+				endpointKey{
+					Region:  "aws-us-gov-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "organizations.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+				},
+				endpointKey{
+					Region: "fips-aws-us-gov-global",
+				}: endpoint{
+					Hostname: "organizations.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"outposts": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "outposts.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "outposts.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9535,20 +25346,36 @@ var awsusgovPartition = partition{
 			},
 		},
 		"pinpoint": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "mobiletargeting",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "mobiletargeting",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "pinpoint-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "pinpoint.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "pinpoint-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
@@ -9556,27 +25383,62 @@ var awsusgovPartition = partition{
 			},
 		},
 		"polly": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "polly-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "polly-fips.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"portal.sso": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					Hostname: "portal.sso.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+			},
+		},
+		"quicksight": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "api",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"ram": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "ram.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "ram.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9585,34 +25447,84 @@ var awsusgovPartition = partition{
 			},
 		},
 		"rds": service{
-
-			Endpoints: endpoints{
-				"rds.us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "rds.us-gov-east-1",
+				}: endpoint{
 					Hostname: "rds.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"rds.us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "rds.us-gov-west-1",
+				}: endpoint{
 					Hostname: "rds.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "rds.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rds.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "rds.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"redshift": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "redshift.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "redshift.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -9621,220 +25533,515 @@ var awsusgovPartition = partition{
 			},
 		},
 		"rekognition": service{
-
-			Endpoints: endpoints{
-				"rekognition-fips.us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "rekognition-fips.us-gov-west-1",
+				}: endpoint{
 					Hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "rekognition.us-gov-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "rekognition.us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"resource-groups": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "resource-groups.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "resource-groups.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"route53": service{
 			PartitionEndpoint: "aws-us-gov-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-us-gov-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-us-gov-global",
+				}: endpoint{
 					Hostname: "route53.us-gov.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"fips-aws-us-gov-global": endpoint{
+				endpointKey{
+					Region:  "aws-us-gov-global",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "route53.us-gov.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+				},
+				endpointKey{
+					Region: "fips-aws-us-gov-global",
+				}: endpoint{
+					Hostname: "route53.us-gov.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"route53resolver": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
 			},
 		},
 		"runtime.lex": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "lex",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.lex.{region}.{dnsSuffix}",
+					CredentialScope: credentialScope{
+						Service: "lex",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"runtime.sagemaker": service{
-
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime.sagemaker.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"s3": service{
-			Defaults: endpoint{
-				SignatureVersions: []string{"s3", "s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
+				defaultKey{
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}-fips.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					SignatureVersions: []string{"s3", "s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"accesspoint-us-gov-east-1": endpoint{
-					Hostname:          "s3-accesspoint.us-gov-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "s3-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
 				},
-				"accesspoint-us-gov-west-1": endpoint{
-					Hostname:          "s3-accesspoint.us-gov-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"fips-accesspoint-us-gov-east-1": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-gov-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"fips-accesspoint-us-gov-west-1": endpoint{
-					Hostname:          "s3-accesspoint-fips.us-gov-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3v4"},
-				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "s3-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname:  "s3.us-gov-east-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:  "s3.dualstack.us-gov-east-1.amazonaws.com",
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "s3-fips.us-gov-east-1.amazonaws.com",
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:  "s3.us-gov-west-1.amazonaws.com",
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:  "s3.dualstack.us-gov-west-1.amazonaws.com",
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "s3-fips.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
 				},
 			},
 		},
 		"s3-control": service{
-			Defaults: endpoint{
-				Protocols:         []string{"https"},
-				SignatureVersions: []string{"s3v4"},
-
-				HasDualStack:      boxedTrue,
-				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				defaultKey{
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "{service}-fips.dualstack.{region}.{dnsSuffix}",
+					DNSSuffix:         "amazonaws.com",
+					Protocols:         []string{"https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname:          "s3-control.us-gov-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-east-1-fips": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-gov-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-gov-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-gov-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-gov-east-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:          "s3-control.us-gov-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control.dualstack.us-gov-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:          "s3-control-fips.us-gov-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3v4"},
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant | dualStackVariant,
+				}: endpoint{
+					Hostname:          "s3-control-fips.dualstack.us-gov-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname:          "s3-control-fips.us-gov-west-1.amazonaws.com",
+					SignatureVersions: []string{"s3v4"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"secretsmanager": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"securityhub": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"serverlessrepo": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname:  "serverlessrepo.us-gov-east-1.amazonaws.com",
 					Protocols: []string{"https"},
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:  "serverlessrepo.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"https"},
 					CredentialScope: credentialScope{
@@ -9844,93 +26051,304 @@ var awsusgovPartition = partition{
 			},
 		},
 		"servicecatalog": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"servicecatalog-appregistry": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+				},
+			},
+		},
+		"servicediscovery": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "servicediscovery",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "servicediscovery",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "servicediscovery-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"servicequotas": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "servicequotas.{region}.{dnsSuffix}",
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "servicequotas.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "servicequotas.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"sms": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "sms-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "sms-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sms-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"snowball": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"sns": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "sns.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:  "sns.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
 					CredentialScope: credentialScope{
@@ -9940,15 +26358,18 @@ var awsusgovPartition = partition{
 			},
 		},
 		"sqs": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "sqs.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname:      "sqs.us-gov-west-1.amazonaws.com",
 					SSLCommonName: "{region}.queue.{dnsSuffix}",
 					Protocols:     []string{"http", "https"},
@@ -9959,126 +26380,298 @@ var awsusgovPartition = partition{
 			},
 		},
 		"ssm": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "ssm.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "ssm.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "ssm.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"states": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "states-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "states.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "states.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"storagegateway": service{
-
-			Endpoints: endpoints{
-				"fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips",
+				}: endpoint{
 					Hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
-			},
-		},
-		"streams.dynamodb": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "dynamodb",
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
 				},
-			},
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
-					Hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
-					Hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"streams.dynamodb": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "streams.dynamodb.{region}.{dnsSuffix}",
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "streams.dynamodb.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "streams.dynamodb.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "streams.dynamodb.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "streams.dynamodb.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"sts": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-east-1-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
 					Hostname: "sts.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sts.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "sts.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"support": service{
 			PartitionEndpoint: "aws-us-gov-global",
-
-			Endpoints: endpoints{
-				"aws-us-gov-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-us-gov-global",
+				}: endpoint{
 					Hostname: "support.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "support.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "support.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"swf": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "swf.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "swf.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
@@ -10087,89 +26680,223 @@ var awsusgovPartition = partition{
 			},
 		},
 		"tagging": service{
-
-			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
+		"textract": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "textract-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "textract-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "textract-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"transcribe": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname:  "fips.transcribe.{region}.{dnsSuffix}",
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"transfer": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"translate": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-gov-west-1": endpoint{},
-				"us-gov-west-1-fips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "translate-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
 					Hostname: "translate-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
 		"waf-regional": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "waf-regional-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{
 					Hostname: "waf-regional.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
 				},
-				"us-gov-west-1": endpoint{
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{
 					Hostname: "waf-regional.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "waf-regional-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
@@ -10177,34 +26904,65 @@ var awsusgovPartition = partition{
 			},
 		},
 		"workspaces": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-west-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"xray": service{
-
-			Endpoints: endpoints{
-				"fips-us-gov-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
 					Hostname: "xray-fips.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"fips-us-gov-west-1": endpoint{
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
 					Hostname: "xray-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "xray-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 	},
@@ -10225,221 +26983,369 @@ var awsisoPartition = partition{
 			return reg
 		}(),
 	},
-	Defaults: endpoint{
-		Hostname:          "{service}.{region}.{dnsSuffix}",
-		Protocols:         []string{"https"},
-		SignatureVersions: []string{"v4"},
+	Defaults: endpointDefaults{
+		defaultKey{}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "c2s.ic.gov",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
 	},
 	Regions: regions{
 		"us-iso-east-1": region{
 			Description: "US ISO East",
 		},
+		"us-iso-west-1": region{
+			Description: "US ISO WEST",
+		},
 	},
 	Services: services{
 		"api.ecr": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
 					},
 				},
-			},
-		},
-		"api.sagemaker": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
-			},
-		},
-		"apigateway": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
-			},
-		},
-		"application-autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
-			},
-		},
-		"autoscaling": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
-					Protocols: []string{"http", "https"},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{
+					Hostname: "api.ecr.us-iso-west-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-west-1",
+					},
 				},
 			},
 		},
+		"api.sagemaker": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
+		"apigateway": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
+		"application-autoscaling": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+			},
+		},
+		"autoscaling": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+			},
+		},
 		"cloudformation": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"cloudtrail": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"codedeploy": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"comprehend": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"config": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"datapipeline": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"directconnect": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"dms": service{
-
-			Endpoints: endpoints{
-				"dms-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "dms",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dms",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "dms.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-iso-east-1": endpoint{},
+				endpointKey{
+					Region: "dms-fips",
+				}: endpoint{
+					Hostname: "dms.us-iso-east-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-iso-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.us-iso-east-1.c2s.ic.gov",
+				},
+				endpointKey{
+					Region: "us-iso-east-1-fips",
+				}: endpoint{
+					Hostname: "dms.us-iso-east-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"ds": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"dynamodb": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+			},
+		},
+		"ebs": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"ec2": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
-			},
-		},
-		"ec2metadata": service{
-			PartitionEndpoint: "aws-global",
-			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
-					Hostname:  "169.254.169.254/latest",
-					Protocols: []string{"http"},
-				},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"ecs": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"elasticache": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"elasticfilesystem": service{
-
-			Endpoints: endpoints{
-				"fips-us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-iso-east-1",
+				}: endpoint{
 					Hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-iso-east-1": endpoint{},
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-iso-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
+				},
 			},
 		},
 		"elasticloadbalancing": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"elasticmapreduce": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"es": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"events": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"firehose": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"glacier": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"health": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"iam": service{
 			PartitionEndpoint: "aws-iso-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-iso-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-global",
+				}: endpoint{
 					Hostname: "iam.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
@@ -10448,77 +27354,156 @@ var awsisoPartition = partition{
 			},
 		},
 		"kinesis": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"kms": service{
-
-			Endpoints: endpoints{
-				"ProdFips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ProdFips",
+				}: endpoint{
 					Hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-iso-east-1": endpoint{},
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-iso-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
+				},
+				endpointKey{
+					Region: "us-iso-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-iso-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
+				},
+				endpointKey{
+					Region: "us-iso-west-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"lambda": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+			},
+		},
+		"license-manager": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"logs": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"medialive": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"mediapackage": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"monitoring": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"outposts": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
+		"ram": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"rds": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"redshift": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"route53": service{
 			PartitionEndpoint: "aws-iso-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-iso-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-global",
+				}: endpoint{
 					Hostname: "route53.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
@@ -10526,87 +27511,123 @@ var awsisoPartition = partition{
 				},
 			},
 		},
+		"route53resolver": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
 		"runtime.sagemaker": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"s3": service{
-			Defaults: endpoint{
-				SignatureVersions: []string{"s3v4"},
-			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
-					Protocols:         []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
 					SignatureVersions: []string{"s3v4"},
 				},
 			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
+			},
 		},
 		"secretsmanager": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"snowball": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"sns": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"sqs": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{
 					Protocols: []string{"http", "https"},
 				},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"ssm": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"states": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"streams.dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "dynamodb",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{
-					Protocols: []string{"http", "https"},
-				},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"sts": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"support": service{
 			PartitionEndpoint: "aws-iso-global",
-
-			Endpoints: endpoints{
-				"aws-iso-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-global",
+				}: endpoint{
 					Hostname: "support.us-iso-east-1.c2s.ic.gov",
 					CredentialScope: credentialScope{
 						Region: "us-iso-east-1",
@@ -10615,37 +27636,51 @@ var awsisoPartition = partition{
 			},
 		},
 		"swf": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-iso-west-1",
+				}: endpoint{},
 			},
 		},
 		"transcribe": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"transcribestreaming": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"translate": service{
-			Defaults: endpoint{
-				Protocols: []string{"https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 		"workspaces": service{
-
-			Endpoints: endpoints{
-				"us-iso-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
 			},
 		},
 	},
@@ -10666,10 +27701,20 @@ var awsisobPartition = partition{
 			return reg
 		}(),
 	},
-	Defaults: endpoint{
-		Hostname:          "{service}.{region}.{dnsSuffix}",
-		Protocols:         []string{"https"},
-		SignatureVersions: []string{"v4"},
+	Defaults: endpointDefaults{
+		defaultKey{}: endpoint{
+			Hostname:          "{service}.{region}.{dnsSuffix}",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
+		defaultKey{
+			Variant: fipsVariant,
+		}: endpoint{
+			Hostname:          "{service}-fips.{region}.{dnsSuffix}",
+			DNSSuffix:         "sc2s.sgov.gov",
+			Protocols:         []string{"https"},
+			SignatureVersions: []string{"v4"},
+		},
 	},
 	Regions: regions{
 		"us-isob-east-1": region{
@@ -10678,9 +27723,10 @@ var awsisobPartition = partition{
 	},
 	Services: services{
 		"api.ecr": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{
 					Hostname: "api.ecr.us-isob-east-1.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
@@ -10689,146 +27735,224 @@ var awsisobPartition = partition{
 			},
 		},
 		"application-autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"autoscaling": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"cloudformation": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"cloudtrail": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"codedeploy": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"config": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"directconnect": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"dms": service{
-
-			Endpoints: endpoints{
-				"dms-fips": endpoint{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.{region}.{dnsSuffix}",
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "dms",
+				}: endpoint{
+					CredentialScope: credentialScope{
+						Region: "us-isob-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region:  "dms",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-isob-east-1": endpoint{},
+				endpointKey{
+					Region: "dms-fips",
+				}: endpoint{
+					Hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+					CredentialScope: credentialScope{
+						Region: "us-isob-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-isob-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+				},
+				endpointKey{
+					Region: "us-isob-east-1-fips",
+				}: endpoint{
+					Hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+					CredentialScope: credentialScope{
+						Region: "us-isob-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+			},
+		},
+		"ds": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
+			},
+		},
+		"ebs": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"ec2": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
-			},
-		},
-		"ec2metadata": service{
-			PartitionEndpoint: "aws-global",
-			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-global": endpoint{
-					Hostname:  "169.254.169.254/latest",
-					Protocols: []string{"http"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
 				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"ecs": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"elasticache": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"elasticloadbalancing": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{
 					Protocols: []string{"https"},
 				},
 			},
 		},
 		"elasticmapreduce": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"es": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"events": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"glacier": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"health": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"iam": service{
 			PartitionEndpoint: "aws-iso-b-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-iso-b-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-b-global",
+				}: endpoint{
 					Hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
@@ -10837,65 +27961,92 @@ var awsisobPartition = partition{
 			},
 		},
 		"kinesis": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"kms": service{
-
-			Endpoints: endpoints{
-				"ProdFips": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ProdFips",
+				}: endpoint{
 					Hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
-				"us-isob-east-1": endpoint{},
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-isob-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
+				},
+				endpointKey{
+					Region: "us-isob-east-1-fips",
+				}: endpoint{
+					Hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
+					CredentialScope: credentialScope{
+						Region: "us-isob-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
 			},
 		},
 		"lambda": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"license-manager": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"logs": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"monitoring": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"rds": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"redshift": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"route53": service{
 			PartitionEndpoint: "aws-iso-b-global",
 			IsRegionalized:    boxedFalse,
-
-			Endpoints: endpoints{
-				"aws-iso-b-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-b-global",
+				}: endpoint{
 					Hostname: "route53.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
@@ -10904,71 +28055,92 @@ var awsisobPartition = partition{
 			},
 		},
 		"s3": service{
-			Defaults: endpoint{
-				Protocols:         []string{"http", "https"},
-				SignatureVersions: []string{"s3v4"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols:         []string{"http", "https"},
+					SignatureVersions: []string{"s3v4"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"snowball": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"sns": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"sqs": service{
-			Defaults: endpoint{
-				SSLCommonName: "{region}.queue.{dnsSuffix}",
-				Protocols:     []string{"http", "https"},
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					SSLCommonName: "{region}.queue.{dnsSuffix}",
+					Protocols:     []string{"http", "https"},
+				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"ssm": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"states": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"streams.dynamodb": service{
-			Defaults: endpoint{
-				Protocols: []string{"http", "https"},
-				CredentialScope: credentialScope{
-					Service: "dynamodb",
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+					CredentialScope: credentialScope{
+						Service: "dynamodb",
+					},
 				},
 			},
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"sts": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 		"support": service{
 			PartitionEndpoint: "aws-iso-b-global",
-
-			Endpoints: endpoints{
-				"aws-iso-b-global": endpoint{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-iso-b-global",
+				}: endpoint{
 					Hostname: "support.us-isob-east-1.sc2s.sgov.gov",
 					CredentialScope: credentialScope{
 						Region: "us-isob-east-1",
@@ -10977,9 +28149,17 @@ var awsisobPartition = partition{
 			},
 		},
 		"swf": service{
-
-			Endpoints: endpoints{
-				"us-isob-east-1": endpoint{},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
+			},
+		},
+		"tagging": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
 			},
 		},
 	},

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
@@ -8,6 +8,41 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// A Logger is a minimalistic interface for the SDK to log messages to.
+type Logger interface {
+	Log(...interface{})
+}
+
+// DualStackEndpointState is a constant to describe the dual-stack endpoint resolution
+// behavior.
+type DualStackEndpointState uint
+
+const (
+	// DualStackEndpointStateUnset is the default value behavior for dual-stack endpoint
+	// resolution.
+	DualStackEndpointStateUnset DualStackEndpointState = iota
+
+	// DualStackEndpointStateEnabled enable dual-stack endpoint resolution for endpoints.
+	DualStackEndpointStateEnabled
+
+	// DualStackEndpointStateDisabled disables dual-stack endpoint resolution for endpoints.
+	DualStackEndpointStateDisabled
+)
+
+// FIPSEndpointState is a constant to describe the FIPS endpoint resolution behavior.
+type FIPSEndpointState uint
+
+const (
+	// FIPSEndpointStateUnset is the default value behavior for FIPS endpoint resolution.
+	FIPSEndpointStateUnset FIPSEndpointState = iota
+
+	// FIPSEndpointStateEnabled enables FIPS endpoint resolution for service endpoints.
+	FIPSEndpointStateEnabled
+
+	// FIPSEndpointStateDisabled disables FIPS endpoint resolution for endpoints.
+	FIPSEndpointStateDisabled
+)
+
 // Options provide the configuration needed to direct how the
 // endpoints will be resolved.
 type Options struct {
@@ -21,7 +56,18 @@ type Options struct {
 	// be returned. This endpoint may not be valid. If StrictMatching is
 	// enabled only services that are known to support dualstack will return
 	// dualstack endpoints.
+	//
+	// Deprecated: This option will continue to function for S3 and S3 Control for backwards compatibility.
+	// UseDualStackEndpoint should be used to enable usage of a service's dual-stack endpoint for all service clients
+	// moving forward. For S3 and S3 Control, when UseDualStackEndpoint is set to a non-zero value it takes higher
+	// precedence then this option.
 	UseDualStack bool
+
+	// Sets the resolver to resolve a dual-stack endpoint for the service.
+	UseDualStackEndpoint DualStackEndpointState
+
+	// UseFIPSEndpoint specifies the resolver must resolve a FIPS endpoint.
+	UseFIPSEndpoint FIPSEndpointState
 
 	// Enables strict matching of services and regions resolved endpoints.
 	// If the partition doesn't enumerate the exact service and region an
@@ -48,11 +94,65 @@ type Options struct {
 	// This option is ignored if StrictMatching is enabled.
 	ResolveUnknownService bool
 
+	// Specifies the EC2 Instance Metadata Service default endpoint selection mode (IPv4 or IPv6)
+	EC2MetadataEndpointMode EC2IMDSEndpointModeState
+
 	// STS Regional Endpoint flag helps with resolving the STS endpoint
 	STSRegionalEndpoint STSRegionalEndpoint
 
 	// S3 Regional Endpoint flag helps with resolving the S3 endpoint
 	S3UsEast1RegionalEndpoint S3UsEast1RegionalEndpoint
+
+	// ResolvedRegion is the resolved region string. If provided (non-zero length) it takes priority
+	// over the region name passed to the ResolveEndpoint call.
+	ResolvedRegion string
+
+	// Logger is the logger that will be used to log messages.
+	Logger Logger
+
+	// Determines whether logging of deprecated endpoints usage is enabled.
+	LogDeprecated bool
+}
+
+func (o Options) getEndpointVariant(service string) (v endpointVariant) {
+	const s3 = "s3"
+	const s3Control = "s3-control"
+
+	if (o.UseDualStackEndpoint == DualStackEndpointStateEnabled) ||
+		((service == s3 || service == s3Control) && (o.UseDualStackEndpoint == DualStackEndpointStateUnset && o.UseDualStack)) {
+		v |= dualStackVariant
+	}
+	if o.UseFIPSEndpoint == FIPSEndpointStateEnabled {
+		v |= fipsVariant
+	}
+	return v
+}
+
+// EC2IMDSEndpointModeState is an enum configuration variable describing the client endpoint mode.
+type EC2IMDSEndpointModeState uint
+
+// Enumeration values for EC2IMDSEndpointModeState
+const (
+	EC2IMDSEndpointModeStateUnset EC2IMDSEndpointModeState = iota
+	EC2IMDSEndpointModeStateIPv4
+	EC2IMDSEndpointModeStateIPv6
+)
+
+// SetFromString sets the EC2IMDSEndpointModeState based on the provided string value. Unknown values will default to EC2IMDSEndpointModeStateUnset
+func (e *EC2IMDSEndpointModeState) SetFromString(v string) error {
+	v = strings.TrimSpace(v)
+
+	switch {
+	case len(v) == 0:
+		*e = EC2IMDSEndpointModeStateUnset
+	case strings.EqualFold(v, "IPv6"):
+		*e = EC2IMDSEndpointModeStateIPv6
+	case strings.EqualFold(v, "IPv4"):
+		*e = EC2IMDSEndpointModeStateIPv4
+	default:
+		return fmt.Errorf("unknown EC2 IMDS endpoint mode, must be either IPv6 or IPv4")
+	}
+	return nil
 }
 
 // STSRegionalEndpoint is an enum for the states of the STS Regional Endpoint
@@ -166,8 +266,23 @@ func DisableSSLOption(o *Options) {
 
 // UseDualStackOption sets the UseDualStack option. Can be used as a functional
 // option when resolving endpoints.
+//
+// Deprecated: UseDualStackEndpointOption should be used to enable usage of a service's dual-stack endpoint.
+// When DualStackEndpointState is set to a non-zero value it takes higher precedence then this option.
 func UseDualStackOption(o *Options) {
 	o.UseDualStack = true
+}
+
+// UseDualStackEndpointOption sets the UseDualStackEndpoint option to enabled. Can be used as a functional
+// option when resolving endpoints.
+func UseDualStackEndpointOption(o *Options) {
+	o.UseDualStackEndpoint = DualStackEndpointStateEnabled
+}
+
+// UseFIPSEndpointOption sets the UseFIPSEndpoint option to enabled. Can be used as a functional
+// option when resolving endpoints.
+func UseFIPSEndpointOption(o *Options) {
+	o.UseFIPSEndpoint = FIPSEndpointStateEnabled
 }
 
 // StrictMatchingOption sets the StrictMatching option. Can be used as a functional
@@ -247,7 +362,7 @@ func RegionsForService(ps []Partition, partitionID, serviceID string) (map[strin
 		if p.ID() != partitionID {
 			continue
 		}
-		if _, ok := p.p.Services[serviceID]; !ok {
+		if _, ok := p.p.Services[serviceID]; !(ok || serviceID == Ec2metadataServiceID) {
 			break
 		}
 
@@ -333,9 +448,19 @@ func (p Partition) Regions() map[string]Region {
 // enumerating over the services in a partition.
 func (p Partition) Services() map[string]Service {
 	ss := make(map[string]Service, len(p.p.Services))
+
 	for id := range p.p.Services {
 		ss[id] = Service{
 			id: id,
+			p:  p.p,
+		}
+	}
+
+	// Since we have removed the customization that injected this into the model
+	// we still need to pretend that this is a modeled service.
+	if _, ok := ss[Ec2metadataServiceID]; !ok {
+		ss[Ec2metadataServiceID] = Service{
+			id: Ec2metadataServiceID,
 			p:  p.p,
 		}
 	}
@@ -367,7 +492,7 @@ func (r Region) ResolveEndpoint(service string, opts ...func(*Options)) (Resolve
 func (r Region) Services() map[string]Service {
 	ss := map[string]Service{}
 	for id, s := range r.p.Services {
-		if _, ok := s.Endpoints[r.id]; ok {
+		if _, ok := s.Endpoints[endpointKey{Region: r.id}]; ok {
 			ss[id] = Service{
 				id: id,
 				p:  r.p,
@@ -400,10 +525,24 @@ func (s Service) ResolveEndpoint(region string, opts ...func(*Options)) (Resolve
 // an URL that can be resolved to a instance of a service.
 func (s Service) Regions() map[string]Region {
 	rs := map[string]Region{}
-	for id := range s.p.Services[s.id].Endpoints {
-		if r, ok := s.p.Regions[id]; ok {
-			rs[id] = Region{
-				id:   id,
+
+	service, ok := s.p.Services[s.id]
+
+	// Since ec2metadata customization has been removed we need to check
+	// if it was defined in non-standard endpoints.json file. If it's not
+	// then we can return the empty map as there is no regional-endpoints for IMDS.
+	// Otherwise, we iterate need to iterate the non-standard model.
+	if s.id == Ec2metadataServiceID && !ok {
+		return rs
+	}
+
+	for id := range service.Endpoints {
+		if id.Variant != 0 {
+			continue
+		}
+		if r, ok := s.p.Regions[id.Region]; ok {
+			rs[id.Region] = Region{
+				id:   id.Region,
 				desc: r.Description,
 				p:    s.p,
 			}
@@ -421,8 +560,11 @@ func (s Service) Regions() map[string]Region {
 func (s Service) Endpoints() map[string]Endpoint {
 	es := make(map[string]Endpoint, len(s.p.Services[s.id].Endpoints))
 	for id := range s.p.Services[s.id].Endpoints {
-		es[id] = Endpoint{
-			id:        id,
+		if id.Variant != 0 {
+			continue
+		}
+		es[id.Region] = Endpoint{
+			id:        id.Region,
 			serviceID: s.id,
 			p:         s.p,
 		}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
@@ -1,10 +1,44 @@
 package endpoints
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+)
+
+const (
+	ec2MetadataEndpointIPv6 = "http://[fd00:ec2::254]/latest"
+	ec2MetadataEndpointIPv4 = "http://169.254.169.254/latest"
+)
+
+const dnsSuffixTemplateKey = "{dnsSuffix}"
+
+// defaultKey is a compound map key of a variant and other values.
+type defaultKey struct {
+	Variant        endpointVariant
+	ServiceVariant serviceVariant
+}
+
+// endpointKey is a compound map key of a region and associated variant value.
+type endpointKey struct {
+	Region  string
+	Variant endpointVariant
+}
+
+// endpointVariant is a bit field to describe the endpoints attributes.
+type endpointVariant uint64
+
+// serviceVariant is a bit field to describe the service endpoint attributes.
+type serviceVariant uint64
+
+const (
+	// fipsVariant indicates that the endpoint is FIPS capable.
+	fipsVariant endpointVariant = 1 << (64 - 1 - iota)
+
+	// dualStackVariant indicates that the endpoint is DualStack capable.
+	dualStackVariant
 )
 
 var regionValidationRegex = regexp.MustCompile(`^[[:alnum:]]([[:alnum:]\-]*[[:alnum:]])?$`)
@@ -15,8 +49,12 @@ func (ps partitions) EndpointFor(service, region string, opts ...func(*Options))
 	var opt Options
 	opt.Set(opts...)
 
+	if len(opt.ResolvedRegion) > 0 {
+		region = opt.ResolvedRegion
+	}
+
 	for i := 0; i < len(ps); i++ {
-		if !ps[i].canResolveEndpoint(service, region, opt.StrictMatching) {
+		if !ps[i].canResolveEndpoint(service, region, opt) {
 			continue
 		}
 
@@ -44,14 +82,76 @@ func (ps partitions) Partitions() []Partition {
 	return parts
 }
 
+type endpointWithVariants struct {
+	endpoint
+	Variants []endpointWithTags `json:"variants"`
+}
+
+type endpointWithTags struct {
+	endpoint
+	Tags []string `json:"tags"`
+}
+
+type endpointDefaults map[defaultKey]endpoint
+
+func (p *endpointDefaults) UnmarshalJSON(data []byte) error {
+	if *p == nil {
+		*p = make(endpointDefaults)
+	}
+
+	var e endpointWithVariants
+	if err := json.Unmarshal(data, &e); err != nil {
+		return err
+	}
+
+	(*p)[defaultKey{Variant: 0}] = e.endpoint
+
+	e.Hostname = ""
+	e.DNSSuffix = ""
+
+	for _, variant := range e.Variants {
+		endpointVariant, unknown := parseVariantTags(variant.Tags)
+		if unknown {
+			continue
+		}
+
+		var ve endpoint
+		ve.mergeIn(e.endpoint)
+		ve.mergeIn(variant.endpoint)
+
+		(*p)[defaultKey{Variant: endpointVariant}] = ve
+	}
+
+	return nil
+}
+
+func parseVariantTags(tags []string) (ev endpointVariant, unknown bool) {
+	if len(tags) == 0 {
+		unknown = true
+		return
+	}
+
+	for _, tag := range tags {
+		switch {
+		case strings.EqualFold("fips", tag):
+			ev |= fipsVariant
+		case strings.EqualFold("dualstack", tag):
+			ev |= dualStackVariant
+		default:
+			unknown = true
+		}
+	}
+	return ev, unknown
+}
+
 type partition struct {
-	ID          string      `json:"partition"`
-	Name        string      `json:"partitionName"`
-	DNSSuffix   string      `json:"dnsSuffix"`
-	RegionRegex regionRegex `json:"regionRegex"`
-	Defaults    endpoint    `json:"defaults"`
-	Regions     regions     `json:"regions"`
-	Services    services    `json:"services"`
+	ID          string           `json:"partition"`
+	Name        string           `json:"partitionName"`
+	DNSSuffix   string           `json:"dnsSuffix"`
+	RegionRegex regionRegex      `json:"regionRegex"`
+	Defaults    endpointDefaults `json:"defaults"`
+	Regions     regions          `json:"regions"`
+	Services    services         `json:"services"`
 }
 
 func (p partition) Partition() Partition {
@@ -62,15 +162,18 @@ func (p partition) Partition() Partition {
 	}
 }
 
-func (p partition) canResolveEndpoint(service, region string, strictMatch bool) bool {
+func (p partition) canResolveEndpoint(service, region string, options Options) bool {
 	s, hasService := p.Services[service]
-	_, hasEndpoint := s.Endpoints[region]
+	_, hasEndpoint := s.Endpoints[endpointKey{
+		Region:  region,
+		Variant: options.getEndpointVariant(service),
+	}]
 
 	if hasEndpoint && hasService {
 		return true
 	}
 
-	if strictMatch {
+	if options.StrictMatching {
 		return false
 	}
 
@@ -101,7 +204,17 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 	var opt Options
 	opt.Set(opts...)
 
+	if len(opt.ResolvedRegion) > 0 {
+		region = opt.ResolvedRegion
+	}
+
 	s, hasService := p.Services[service]
+
+	if service == Ec2metadataServiceID && !hasService {
+		endpoint := getEC2MetadataEndpoint(p.ID, service, opt.EC2MetadataEndpointMode)
+		return endpoint, nil
+	}
+
 	if len(service) == 0 || !(hasService || opt.ResolveUnknownService) {
 		// Only return error if the resolver will not fallback to creating
 		// endpoint based on service endpoint ID passed in.
@@ -112,21 +225,94 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 		region = s.PartitionEndpoint
 	}
 
-	if (service == "sts" && opt.STSRegionalEndpoint != RegionalSTSEndpoint) ||
-		(service == "s3" && opt.S3UsEast1RegionalEndpoint != RegionalS3UsEast1Endpoint) {
+	if r, ok := isLegacyGlobalRegion(service, region, opt); ok {
+		region = r
+	}
+
+	variant := opt.getEndpointVariant(service)
+
+	endpoints := s.Endpoints
+
+	serviceDefaults, hasServiceDefault := s.Defaults[defaultKey{Variant: variant}]
+	// If we searched for a variant which may have no explicit service defaults,
+	// then we need to inherit the standard service defaults except the hostname and dnsSuffix
+	if variant != 0 && !hasServiceDefault {
+		serviceDefaults = s.Defaults[defaultKey{}]
+		serviceDefaults.Hostname = ""
+		serviceDefaults.DNSSuffix = ""
+	}
+
+	partitionDefaults, hasPartitionDefault := p.Defaults[defaultKey{Variant: variant}]
+
+	var dnsSuffix string
+	if len(serviceDefaults.DNSSuffix) > 0 {
+		dnsSuffix = serviceDefaults.DNSSuffix
+	} else if variant == 0 {
+		// For legacy reasons the partition dnsSuffix is not in the defaults, so if we looked for
+		// a non-variant endpoint then we need to set the dnsSuffix.
+		dnsSuffix = p.DNSSuffix
+	}
+
+	noDefaults := !hasServiceDefault && !hasPartitionDefault
+
+	e, hasEndpoint := s.endpointForRegion(region, endpoints, variant)
+	if len(region) == 0 || (!hasEndpoint && (opt.StrictMatching || noDefaults)) {
+		return resolved, NewUnknownEndpointError(p.ID, service, region, endpointList(endpoints, variant))
+	}
+
+	defs := []endpoint{partitionDefaults, serviceDefaults}
+
+	return e.resolve(service, p.ID, region, dnsSuffixTemplateKey, dnsSuffix, defs, opt)
+}
+
+func getEC2MetadataEndpoint(partitionID, service string, mode EC2IMDSEndpointModeState) ResolvedEndpoint {
+	switch mode {
+	case EC2IMDSEndpointModeStateIPv6:
+		return ResolvedEndpoint{
+			URL:                ec2MetadataEndpointIPv6,
+			PartitionID:        partitionID,
+			SigningRegion:      "aws-global",
+			SigningName:        service,
+			SigningNameDerived: true,
+			SigningMethod:      "v4",
+		}
+	case EC2IMDSEndpointModeStateIPv4:
+		fallthrough
+	default:
+		return ResolvedEndpoint{
+			URL:                ec2MetadataEndpointIPv4,
+			PartitionID:        partitionID,
+			SigningRegion:      "aws-global",
+			SigningName:        service,
+			SigningNameDerived: true,
+			SigningMethod:      "v4",
+		}
+	}
+}
+
+func isLegacyGlobalRegion(service string, region string, opt Options) (string, bool) {
+	if opt.getEndpointVariant(service) != 0 {
+		return "", false
+	}
+
+	const (
+		sts       = "sts"
+		s3        = "s3"
+		awsGlobal = "aws-global"
+	)
+
+	switch {
+	case service == sts && opt.STSRegionalEndpoint == RegionalSTSEndpoint:
+		return region, false
+	case service == s3 && opt.S3UsEast1RegionalEndpoint == RegionalS3UsEast1Endpoint:
+		return region, false
+	default:
 		if _, ok := legacyGlobalRegions[service][region]; ok {
-			region = "aws-global"
+			return awsGlobal, true
 		}
 	}
 
-	e, hasEndpoint := s.endpointForRegion(region)
-	if len(region) == 0 || (!hasEndpoint && opt.StrictMatching) {
-		return resolved, NewUnknownEndpointError(p.ID, service, region, endpointList(s.Endpoints))
-	}
-
-	defs := []endpoint{p.Defaults, s.Defaults}
-
-	return e.resolve(service, p.ID, region, p.DNSSuffix, defs, opt)
+	return region, false
 }
 
 func serviceList(ss services) []string {
@@ -136,10 +322,13 @@ func serviceList(ss services) []string {
 	}
 	return list
 }
-func endpointList(es endpoints) []string {
+func endpointList(es serviceEndpoints, variant endpointVariant) []string {
 	list := make([]string, 0, len(es))
 	for k := range es {
-		list = append(list, k)
+		if k.Variant != variant {
+			continue
+		}
+		list = append(list, k.Region)
 	}
 	return list
 }
@@ -171,19 +360,19 @@ type region struct {
 type services map[string]service
 
 type service struct {
-	PartitionEndpoint string    `json:"partitionEndpoint"`
-	IsRegionalized    boxedBool `json:"isRegionalized,omitempty"`
-	Defaults          endpoint  `json:"defaults"`
-	Endpoints         endpoints `json:"endpoints"`
+	PartitionEndpoint string           `json:"partitionEndpoint"`
+	IsRegionalized    boxedBool        `json:"isRegionalized,omitempty"`
+	Defaults          endpointDefaults `json:"defaults"`
+	Endpoints         serviceEndpoints `json:"endpoints"`
 }
 
-func (s *service) endpointForRegion(region string) (endpoint, bool) {
-	if e, ok := s.Endpoints[region]; ok {
+func (s *service) endpointForRegion(region string, endpoints serviceEndpoints, variant endpointVariant) (endpoint, bool) {
+	if e, ok := endpoints[endpointKey{Region: region, Variant: variant}]; ok {
 		return e, true
 	}
 
 	if s.IsRegionalized == boxedFalse {
-		return s.Endpoints[s.PartitionEndpoint], region == s.PartitionEndpoint
+		return endpoints[endpointKey{Region: s.PartitionEndpoint, Variant: variant}], region == s.PartitionEndpoint
 	}
 
 	// Unable to find any matching endpoint, return
@@ -191,22 +380,73 @@ func (s *service) endpointForRegion(region string) (endpoint, bool) {
 	return endpoint{}, false
 }
 
-type endpoints map[string]endpoint
+type serviceEndpoints map[endpointKey]endpoint
+
+func (s *serviceEndpoints) UnmarshalJSON(data []byte) error {
+	if *s == nil {
+		*s = make(serviceEndpoints)
+	}
+
+	var regionToEndpoint map[string]endpointWithVariants
+
+	if err := json.Unmarshal(data, &regionToEndpoint); err != nil {
+		return err
+	}
+
+	for region, e := range regionToEndpoint {
+		(*s)[endpointKey{Region: region}] = e.endpoint
+
+		e.Hostname = ""
+		e.DNSSuffix = ""
+
+		for _, variant := range e.Variants {
+			endpointVariant, unknown := parseVariantTags(variant.Tags)
+			if unknown {
+				continue
+			}
+
+			var ve endpoint
+			ve.mergeIn(e.endpoint)
+			ve.mergeIn(variant.endpoint)
+
+			(*s)[endpointKey{Region: region, Variant: endpointVariant}] = ve
+		}
+	}
+
+	return nil
+}
 
 type endpoint struct {
 	Hostname        string          `json:"hostname"`
 	Protocols       []string        `json:"protocols"`
 	CredentialScope credentialScope `json:"credentialScope"`
 
-	// Custom fields not modeled
-	HasDualStack      boxedBool `json:"-"`
-	DualStackHostname string    `json:"-"`
+	DNSSuffix string `json:"dnsSuffix"`
 
 	// Signature Version not used
 	SignatureVersions []string `json:"signatureVersions"`
 
 	// SSLCommonName not used.
 	SSLCommonName string `json:"sslCommonName"`
+
+	Deprecated boxedBool `json:"deprecated"`
+}
+
+// isZero returns whether the endpoint structure is an empty (zero) value.
+func (e endpoint) isZero() bool {
+	switch {
+	case len(e.Hostname) != 0:
+		return false
+	case len(e.Protocols) != 0:
+		return false
+	case e.CredentialScope != (credentialScope{}):
+		return false
+	case len(e.SignatureVersions) != 0:
+		return false
+	case len(e.SSLCommonName) != 0:
+		return false
+	}
+	return true
 }
 
 const (
@@ -235,7 +475,7 @@ func getByPriority(s []string, p []string, def string) string {
 	return s[0]
 }
 
-func (e endpoint) resolve(service, partitionID, region, dnsSuffix string, defs []endpoint, opts Options) (ResolvedEndpoint, error) {
+func (e endpoint) resolve(service, partitionID, region, dnsSuffixTemplateVariable, dnsSuffix string, defs []endpoint, opts Options) (ResolvedEndpoint, error) {
 	var merged endpoint
 	for _, def := range defs {
 		merged.mergeIn(def)
@@ -256,22 +496,25 @@ func (e endpoint) resolve(service, partitionID, region, dnsSuffix string, defs [
 	}
 
 	hostname := e.Hostname
-	// Offset the hostname for dualstack if enabled
-	if opts.UseDualStack && e.HasDualStack == boxedTrue {
-		hostname = e.DualStackHostname
-		region = signingRegion
-	}
 
 	if !validateInputRegion(region) {
 		return ResolvedEndpoint{}, fmt.Errorf("invalid region identifier format provided")
 	}
 
+	if len(merged.DNSSuffix) > 0 {
+		dnsSuffix = merged.DNSSuffix
+	}
+
 	u := strings.Replace(hostname, "{service}", service, 1)
 	u = strings.Replace(u, "{region}", region, 1)
-	u = strings.Replace(u, "{dnsSuffix}", dnsSuffix, 1)
+	u = strings.Replace(u, dnsSuffixTemplateVariable, dnsSuffix, 1)
 
 	scheme := getEndpointScheme(e.Protocols, opts.DisableSSL)
 	u = fmt.Sprintf("%s://%s", scheme, u)
+
+	if e.Deprecated == boxedTrue && opts.LogDeprecated && opts.Logger != nil {
+		opts.Logger.Log(fmt.Sprintf("endpoint identifier %q, url %q marked as deprecated", region, u))
+	}
 
 	return ResolvedEndpoint{
 		URL:                u,
@@ -310,11 +553,11 @@ func (e *endpoint) mergeIn(other endpoint) {
 	if len(other.SSLCommonName) > 0 {
 		e.SSLCommonName = other.SSLCommonName
 	}
-	if other.HasDualStack != boxedBoolUnset {
-		e.HasDualStack = other.HasDualStack
+	if len(other.DNSSuffix) > 0 {
+		e.DNSSuffix = other.DNSSuffix
 	}
-	if len(other.DualStackHostname) > 0 {
-		e.DualStackHostname = other.DualStackHostname
+	if other.Deprecated != boxedBoolUnset {
+		e.Deprecated = other.Deprecated
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -77,6 +77,9 @@ const (
 	// wire unmarshaled message content of requests and responses made while
 	// using the SDK Will also enable LogDebug.
 	LogDebugWithEventStreamBody
+
+	// LogDebugWithDeprecated states the SDK should log details about deprecated functionality.
+	LogDebugWithDeprecated
 )
 
 // A Logger is a minimalistic interface for the SDK to log messages to. Should

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package request

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package request

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_context.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_context.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package request

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_context_1_6.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/request/request_context_1_6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package request

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package session

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.12.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.12.go
@@ -1,3 +1,4 @@
+//go:build !go1.13 && go1.7
 // +build !go1.13,go1.7
 
 package session

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.6 && go1.5
 // +build !go1.6,go1.5
 
 package session

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.6.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7 && go1.6
 // +build !go1.7,go1.6
 
 package session

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
@@ -283,7 +283,85 @@ component must be enclosed in square brackets.
 The custom EC2 IMDS endpoint can also be specified via the Session options.
 
   sess, err := session.NewSessionWithOptions(session.Options{
-      EC2IMDSEndpoint: "http://[::1]",
+      EC2MetadataEndpoint: "http://[::1]",
+  })
+
+FIPS and DualStack Endpoints
+
+The SDK can be configured to resolve an endpoint with certain capabilities such as FIPS and DualStack.
+
+You can configure a FIPS endpoint using an environment variable, shared config ($HOME/.aws/config),
+or programmatically.
+
+To configure a FIPS endpoint set the environment variable set the AWS_USE_FIPS_ENDPOINT to true or false to enable
+or disable FIPS endpoint resolution.
+
+  AWS_USE_FIPS_ENDPOINT=true
+
+To configure a FIPS endpoint using shared config, set use_fips_endpoint to true or false to enable
+or disable FIPS endpoint resolution.
+
+  [profile myprofile]
+  region=us-west-2
+  use_fips_endpoint=true
+
+To configure a FIPS endpoint programmatically
+
+  // Option 1: Configure it on a session for all clients
+  sess, err := session.NewSessionWithOptions(session.Options{
+      UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
+  })
+  if err != nil {
+      // handle error
+  }
+
+  client := s3.New(sess)
+
+  // Option 2: Configure it per client
+  sess, err := session.NewSession()
+  if err != nil {
+      // handle error
+  }
+
+  client := s3.New(sess, &aws.Config{
+      UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
+  })
+
+You can configure a DualStack endpoint using an environment variable, shared config ($HOME/.aws/config),
+or programmatically.
+
+To configure a DualStack endpoint set the environment variable set the AWS_USE_DUALSTACK_ENDPOINT to true or false to
+enable or disable DualStack endpoint resolution.
+
+  AWS_USE_DUALSTACK_ENDPOINT=true
+
+To configure a DualStack endpoint using shared config, set use_dualstack_endpoint to true or false to enable
+or disable DualStack endpoint resolution.
+
+  [profile myprofile]
+  region=us-west-2
+  use_dualstack_endpoint=true
+
+To configure a DualStack endpoint programmatically
+
+  // Option 1: Configure it on a session for all clients
+  sess, err := session.NewSessionWithOptions(session.Options{
+      UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
+  })
+  if err != nil {
+      // handle error
+  }
+
+  client := s3.New(sess)
+
+  // Option 2: Configure it per client
+  sess, err := session.NewSession()
+  if err != nil {
+      // handle error
+  }
+
+  client := s3.New(sess, &aws.Config{
+      UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
   })
 */
 package session

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/env_config.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/env_config.go
@@ -161,10 +161,27 @@ type envConfig struct {
 	// AWS_S3_USE_ARN_REGION=true
 	S3UseARNRegion bool
 
-	// Specifies the alternative endpoint to use for EC2 IMDS.
+	// Specifies the EC2 Instance Metadata Service endpoint to use. If specified it overrides EC2IMDSEndpointMode.
 	//
 	// AWS_EC2_METADATA_SERVICE_ENDPOINT=http://[::1]
 	EC2IMDSEndpoint string
+
+	// Specifies the EC2 Instance Metadata Service default endpoint selection mode (IPv4 or IPv6)
+	//
+	// AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6
+	EC2IMDSEndpointMode endpoints.EC2IMDSEndpointModeState
+
+	// Specifies that SDK clients must resolve a dual-stack endpoint for
+	// services.
+	//
+	// AWS_USE_DUALSTACK_ENDPOINT=true
+	UseDualStackEndpoint endpoints.DualStackEndpointState
+
+	// Specifies that SDK clients must resolve a FIPS endpoint for
+	// services.
+	//
+	// AWS_USE_FIPS_ENDPOINT=true
+	UseFIPSEndpoint endpoints.FIPSEndpointState
 }
 
 var (
@@ -231,6 +248,9 @@ var (
 	ec2IMDSEndpointEnvKey = []string{
 		"AWS_EC2_METADATA_SERVICE_ENDPOINT",
 	}
+	ec2IMDSEndpointModeEnvKey = []string{
+		"AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE",
+	}
 	useCABundleKey = []string{
 		"AWS_CA_BUNDLE",
 	}
@@ -239,6 +259,12 @@ var (
 	}
 	useClientTLSKey = []string{
 		"AWS_SDK_GO_CLIENT_TLS_KEY",
+	}
+	awsUseDualStackEndpoint = []string{
+		"AWS_USE_DUALSTACK_ENDPOINT",
+	}
+	awsUseFIPSEndpoint = []string{
+		"AWS_USE_FIPS_ENDPOINT",
 	}
 )
 
@@ -364,6 +390,17 @@ func envConfigLoad(enableSharedConfig bool) (envConfig, error) {
 	}
 
 	setFromEnvVal(&cfg.EC2IMDSEndpoint, ec2IMDSEndpointEnvKey)
+	if err := setEC2IMDSEndpointMode(&cfg.EC2IMDSEndpointMode, ec2IMDSEndpointModeEnvKey); err != nil {
+		return envConfig{}, err
+	}
+
+	if err := setUseDualStackEndpointFromEnvVal(&cfg.UseDualStackEndpoint, awsUseDualStackEndpoint); err != nil {
+		return cfg, err
+	}
+
+	if err := setUseFIPSEndpointFromEnvVal(&cfg.UseFIPSEndpoint, awsUseFIPSEndpoint); err != nil {
+		return cfg, err
+	}
 
 	return cfg, nil
 }
@@ -375,4 +412,60 @@ func setFromEnvVal(dst *string, keys []string) {
 			break
 		}
 	}
+}
+
+func setEC2IMDSEndpointMode(mode *endpoints.EC2IMDSEndpointModeState, keys []string) error {
+	for _, k := range keys {
+		value := os.Getenv(k)
+		if len(value) == 0 {
+			continue
+		}
+		if err := mode.SetFromString(value); err != nil {
+			return fmt.Errorf("invalid value for environment variable, %s=%s, %v", k, value, err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func setUseDualStackEndpointFromEnvVal(dst *endpoints.DualStackEndpointState, keys []string) error {
+	for _, k := range keys {
+		value := os.Getenv(k)
+		if len(value) == 0 {
+			continue // skip if empty
+		}
+
+		switch {
+		case strings.EqualFold(value, "true"):
+			*dst = endpoints.DualStackEndpointStateEnabled
+		case strings.EqualFold(value, "false"):
+			*dst = endpoints.DualStackEndpointStateDisabled
+		default:
+			return fmt.Errorf(
+				"invalid value for environment variable, %s=%s, need true, false",
+				k, value)
+		}
+	}
+	return nil
+}
+
+func setUseFIPSEndpointFromEnvVal(dst *endpoints.FIPSEndpointState, keys []string) error {
+	for _, k := range keys {
+		value := os.Getenv(k)
+		if len(value) == 0 {
+			continue // skip if empty
+		}
+
+		switch {
+		case strings.EqualFold(value, "true"):
+			*dst = endpoints.FIPSEndpointStateEnabled
+		case strings.EqualFold(value, "false"):
+			*dst = endpoints.FIPSEndpointStateDisabled
+		default:
+			return fmt.Errorf(
+				"invalid value for environment variable, %s=%s, need true, false",
+				k, value)
+		}
+	}
+	return nil
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -283,8 +284,8 @@ type Options struct {
 	Handlers request.Handlers
 
 	// Allows specifying a custom endpoint to be used by the EC2 IMDS client
-	// when making requests to the EC2 IMDS API. The must endpoint value must
-	// include protocol prefix.
+	// when making requests to the EC2 IMDS API. The endpoint value should
+	// include the URI scheme. If the scheme is not present it will be defaulted to http.
 	//
 	// If unset, will the EC2 IMDS client will use its default endpoint.
 	//
@@ -298,6 +299,11 @@ type Options struct {
 	//
 	//   AWS_EC2_METADATA_SERVICE_ENDPOINT=http://[::1]
 	EC2IMDSEndpoint string
+
+	// Specifies the EC2 Instance Metadata Service default endpoint selection mode (IPv4 or IPv6)
+	//
+	// AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6
+	EC2IMDSEndpointMode endpoints.EC2IMDSEndpointModeState
 }
 
 // NewSessionWithOptions returns a new Session created from SDK defaults, config files,
@@ -375,19 +381,23 @@ func Must(sess *Session, err error) *Session {
 
 // Wraps the endpoint resolver with a resolver that will return a custom
 // endpoint for EC2 IMDS.
-func wrapEC2IMDSEndpoint(resolver endpoints.Resolver, endpoint string) endpoints.Resolver {
+func wrapEC2IMDSEndpoint(resolver endpoints.Resolver, endpoint string, mode endpoints.EC2IMDSEndpointModeState) endpoints.Resolver {
 	return endpoints.ResolverFunc(
 		func(service, region string, opts ...func(*endpoints.Options)) (
 			endpoints.ResolvedEndpoint, error,
 		) {
-			if service == ec2MetadataServiceID {
+			if service == ec2MetadataServiceID && len(endpoint) > 0 {
 				return endpoints.ResolvedEndpoint{
 					URL:           endpoint,
 					SigningName:   ec2MetadataServiceID,
 					SigningRegion: region,
 				}, nil
+			} else if service == ec2MetadataServiceID {
+				opts = append(opts, func(o *endpoints.Options) {
+					o.EC2MetadataEndpointMode = mode
+				})
 			}
-			return resolver.EndpointFor(service, region)
+			return resolver.EndpointFor(service, region, opts...)
 		})
 }
 
@@ -404,8 +414,8 @@ func deprecatedNewSession(envCfg envConfig, cfgs ...*aws.Config) *Session {
 		cfg.EndpointResolver = endpoints.DefaultResolver()
 	}
 
-	if len(envCfg.EC2IMDSEndpoint) != 0 {
-		cfg.EndpointResolver = wrapEC2IMDSEndpoint(cfg.EndpointResolver, envCfg.EC2IMDSEndpoint)
+	if !(len(envCfg.EC2IMDSEndpoint) == 0 && envCfg.EC2IMDSEndpointMode == endpoints.EC2IMDSEndpointModeStateUnset) {
+		cfg.EndpointResolver = wrapEC2IMDSEndpoint(cfg.EndpointResolver, envCfg.EC2IMDSEndpoint, envCfg.EC2IMDSEndpointMode)
 	}
 
 	cfg.Credentials = defaults.CredChain(cfg, handlers)
@@ -737,12 +747,32 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 		endpoints.LegacyS3UsEast1Endpoint,
 	})
 
-	ec2IMDSEndpoint := sessOpts.EC2IMDSEndpoint
-	if len(ec2IMDSEndpoint) == 0 {
-		ec2IMDSEndpoint = envCfg.EC2IMDSEndpoint
+	var ec2IMDSEndpoint string
+	for _, v := range []string{
+		sessOpts.EC2IMDSEndpoint,
+		envCfg.EC2IMDSEndpoint,
+		sharedCfg.EC2IMDSEndpoint,
+	} {
+		if len(v) != 0 {
+			ec2IMDSEndpoint = v
+			break
+		}
 	}
-	if len(ec2IMDSEndpoint) != 0 {
-		cfg.EndpointResolver = wrapEC2IMDSEndpoint(cfg.EndpointResolver, ec2IMDSEndpoint)
+
+	var endpointMode endpoints.EC2IMDSEndpointModeState
+	for _, v := range []endpoints.EC2IMDSEndpointModeState{
+		sessOpts.EC2IMDSEndpointMode,
+		envCfg.EC2IMDSEndpointMode,
+		sharedCfg.EC2IMDSEndpointMode,
+	} {
+		if v != endpoints.EC2IMDSEndpointModeStateUnset {
+			endpointMode = v
+			break
+		}
+	}
+
+	if len(ec2IMDSEndpoint) != 0 || endpointMode != endpoints.EC2IMDSEndpointModeStateUnset {
+		cfg.EndpointResolver = wrapEC2IMDSEndpoint(cfg.EndpointResolver, ec2IMDSEndpoint, endpointMode)
 	}
 
 	// Configure credentials if not already set by the user when creating the
@@ -761,6 +791,20 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 	}
 	if cfg.S3UseARNRegion == nil {
 		cfg.S3UseARNRegion = &sharedCfg.S3UseARNRegion
+	}
+
+	for _, v := range []endpoints.DualStackEndpointState{userCfg.UseDualStackEndpoint, envCfg.UseDualStackEndpoint, sharedCfg.UseDualStackEndpoint} {
+		if v != endpoints.DualStackEndpointStateUnset {
+			cfg.UseDualStackEndpoint = v
+			break
+		}
+	}
+
+	for _, v := range []endpoints.FIPSEndpointState{userCfg.UseFIPSEndpoint, envCfg.UseFIPSEndpoint, sharedCfg.UseFIPSEndpoint} {
+		if v != endpoints.FIPSEndpointStateUnset {
+			cfg.UseFIPSEndpoint = v
+			break
+		}
 	}
 
 	return nil
@@ -816,8 +860,10 @@ func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 
+	resolvedRegion := normalizeRegion(s.Config)
+
 	region := aws.StringValue(s.Config.Region)
-	resolved, err := s.resolveEndpoint(service, region, s.Config)
+	resolved, err := s.resolveEndpoint(service, region, resolvedRegion, s.Config)
 	if err != nil {
 		s.Handlers.Validate.PushBack(func(r *request.Request) {
 			if len(r.ClientInfo.Endpoint) != 0 {
@@ -838,12 +884,13 @@ func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Confi
 		SigningRegion:      resolved.SigningRegion,
 		SigningNameDerived: resolved.SigningNameDerived,
 		SigningName:        resolved.SigningName,
+		ResolvedRegion:     resolvedRegion,
 	}
 }
 
 const ec2MetadataServiceID = "ec2metadata"
 
-func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endpoints.ResolvedEndpoint, error) {
+func (s *Session) resolveEndpoint(service, region, resolvedRegion string, cfg *aws.Config) (endpoints.ResolvedEndpoint, error) {
 
 	if ep := aws.StringValue(cfg.Endpoint); len(ep) != 0 {
 		return endpoints.ResolvedEndpoint{
@@ -855,7 +902,12 @@ func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endp
 	resolved, err := cfg.EndpointResolver.EndpointFor(service, region,
 		func(opt *endpoints.Options) {
 			opt.DisableSSL = aws.BoolValue(cfg.DisableSSL)
+
 			opt.UseDualStack = aws.BoolValue(cfg.UseDualStack)
+			opt.UseDualStackEndpoint = cfg.UseDualStackEndpoint
+
+			opt.UseFIPSEndpoint = cfg.UseFIPSEndpoint
+
 			// Support for STSRegionalEndpoint where the STSRegionalEndpoint is
 			// provided in envConfig or sharedConfig with envConfig getting
 			// precedence.
@@ -869,6 +921,11 @@ func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endp
 			// Support the condition where the service is modeled but its
 			// endpoint metadata is not available.
 			opt.ResolveUnknownService = true
+
+			opt.ResolvedRegion = resolvedRegion
+
+			opt.Logger = cfg.Logger
+			opt.LogDeprecated = cfg.LogLevel.Matches(aws.LogDebugWithDeprecated)
 		},
 	)
 	if err != nil {
@@ -884,6 +941,8 @@ func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endp
 func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 
+	resolvedRegion := normalizeRegion(s.Config)
+
 	var resolved endpoints.ResolvedEndpoint
 	if ep := aws.StringValue(s.Config.Endpoint); len(ep) > 0 {
 		resolved.URL = endpoints.AddScheme(ep, aws.BoolValue(s.Config.DisableSSL))
@@ -897,6 +956,7 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 		SigningRegion:      resolved.SigningRegion,
 		SigningNameDerived: resolved.SigningNameDerived,
 		SigningName:        resolved.SigningName,
+		ResolvedRegion:     resolvedRegion,
 	}
 }
 
@@ -909,4 +969,24 @@ func (s *Session) logDeprecatedNewSessionError(msg string, err error, cfgs []*aw
 	s.Handlers.Validate.PushBack(func(r *request.Request) {
 		r.Error = err
 	})
+}
+
+// normalizeRegion resolves / normalizes the configured region (converts pseudo fips regions), and modifies the provided
+// config to have the equivalent options for resolution and returns the resolved region name.
+func normalizeRegion(cfg *aws.Config) (resolved string) {
+	const fipsInfix = "-fips-"
+	const fipsPrefix = "-fips"
+	const fipsSuffix = "fips-"
+
+	region := aws.StringValue(cfg.Region)
+
+	if strings.Contains(region, fipsInfix) ||
+		strings.Contains(region, fipsPrefix) ||
+		strings.Contains(region, fipsSuffix) {
+		resolved = strings.Replace(strings.Replace(strings.Replace(
+			region, fipsInfix, "-", -1), fipsPrefix, "", -1), fipsSuffix, "", -1)
+		cfg.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
+
+	return resolved
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/header_rules.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/header_rules.go
@@ -34,23 +34,23 @@ func (m mapRule) IsValid(value string) bool {
 	return ok
 }
 
-// whitelist is a generic rule for whitelisting
-type whitelist struct {
+// allowList is a generic rule for allow listing
+type allowList struct {
 	rule
 }
 
-// IsValid for whitelist checks if the value is within the whitelist
-func (w whitelist) IsValid(value string) bool {
+// IsValid for allow list checks if the value is within the allow list
+func (w allowList) IsValid(value string) bool {
 	return w.rule.IsValid(value)
 }
 
-// blacklist is a generic rule for blacklisting
-type blacklist struct {
+// excludeList is a generic rule for exclude listing
+type excludeList struct {
 	rule
 }
 
-// IsValid for whitelist checks if the value is within the whitelist
-func (b blacklist) IsValid(value string) bool {
+// IsValid for exclude list checks if the value is within the exclude list
+func (b excludeList) IsValid(value string) bool {
 	return !b.rule.IsValid(value)
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package v4

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package v4

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/uri_path.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/uri_path.go
@@ -1,3 +1,4 @@
+//go:build go1.5
 // +build go1.5
 
 package v4

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/url.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/url.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/url_1_7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/url_1_7.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package aws

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.38.49"
+const SDKVersion = "1.42.11"

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package context

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/doc.go
@@ -13,17 +13,30 @@
 //	}
 //
 // Below is the BNF that describes this parser
-//	Grammar:
-//	stmt -> value stmt'
-//	stmt' -> epsilon | op stmt
-//	value -> number | string | boolean | quoted_string
+//  Grammar:
+//  stmt -> section | stmt'
+//  stmt' -> epsilon | expr
+//  expr -> value (stmt)* | equal_expr (stmt)*
+//  equal_expr -> value ( ':' | '=' ) equal_expr'
+//  equal_expr' -> number | string | quoted_string
+//  quoted_string -> " quoted_string'
+//  quoted_string' -> string quoted_string_end
+//  quoted_string_end -> "
 //
-//	section -> [ section'
-//	section' -> value section_close
-//	section_close -> ]
+//  section -> [ section'
+//  section' -> section_value section_close
+//  section_value -> number | string_subset | boolean | quoted_string_subset
+//  quoted_string_subset -> " quoted_string_subset'
+//  quoted_string_subset' -> string_subset quoted_string_end
+//  quoted_string_subset -> "
+//  section_close -> ]
 //
-//	SkipState will skip (NL WS)+
+//  value -> number | string_subset | boolean
+//  string -> ? UTF-8 Code-Points except '\n' (U+000A) and '\r\n' (U+000D U+000A) ?
+//  string_subset -> ? Code-points excepted by <string> grammar except ':' (U+003A), '=' (U+003D), '[' (U+005B), and ']' (U+005D) ?
 //
-//	comment -> # comment' | ; comment'
-//	comment' -> epsilon | value
+//  SkipState will skip (NL WS)+
+//
+//  comment -> # comment' | ; comment'
+//  comment' -> epsilon | value
 package ini

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/fuzz.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package ini

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_parser.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_parser.go
@@ -5,9 +5,12 @@ import (
 	"io"
 )
 
+// ParseState represents the current state of the parser.
+type ParseState uint
+
 // State enums for the parse table
 const (
-	InvalidState = iota
+	InvalidState ParseState = iota
 	// stmt -> value stmt'
 	StatementState
 	// stmt' -> MarkComplete | op stmt
@@ -36,8 +39,8 @@ const (
 )
 
 // parseTable is a state machine to dictate the grammar above.
-var parseTable = map[ASTKind]map[TokenType]int{
-	ASTKindStart: map[TokenType]int{
+var parseTable = map[ASTKind]map[TokenType]ParseState{
+	ASTKindStart: {
 		TokenLit:     StatementState,
 		TokenSep:     OpenScopeState,
 		TokenWS:      SkipTokenState,
@@ -45,7 +48,7 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenComment: CommentState,
 		TokenNone:    TerminalState,
 	},
-	ASTKindCommentStatement: map[TokenType]int{
+	ASTKindCommentStatement: {
 		TokenLit:     StatementState,
 		TokenSep:     OpenScopeState,
 		TokenWS:      SkipTokenState,
@@ -53,7 +56,7 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenComment: CommentState,
 		TokenNone:    MarkCompleteState,
 	},
-	ASTKindExpr: map[TokenType]int{
+	ASTKindExpr: {
 		TokenOp:      StatementPrimeState,
 		TokenLit:     ValueState,
 		TokenSep:     OpenScopeState,
@@ -62,13 +65,15 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenComment: CommentState,
 		TokenNone:    MarkCompleteState,
 	},
-	ASTKindEqualExpr: map[TokenType]int{
-		TokenLit:     ValueState,
-		TokenWS:      SkipTokenState,
-		TokenNL:      SkipState,
-		TokenNone:    SkipState,
+	ASTKindEqualExpr: {
+		TokenLit:  ValueState,
+		TokenSep:  ValueState,
+		TokenOp:   ValueState,
+		TokenWS:   SkipTokenState,
+		TokenNL:   SkipState,
+		TokenNone: SkipState,
 	},
-	ASTKindStatement: map[TokenType]int{
+	ASTKindStatement: {
 		TokenLit:     SectionState,
 		TokenSep:     CloseScopeState,
 		TokenWS:      SkipTokenState,
@@ -76,9 +81,9 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenComment: CommentState,
 		TokenNone:    MarkCompleteState,
 	},
-	ASTKindExprStatement: map[TokenType]int{
+	ASTKindExprStatement: {
 		TokenLit:     ValueState,
-		TokenSep:     OpenScopeState,
+		TokenSep:     ValueState,
 		TokenOp:      ValueState,
 		TokenWS:      ValueState,
 		TokenNL:      MarkCompleteState,
@@ -86,14 +91,14 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenNone:    TerminalState,
 		TokenComma:   SkipState,
 	},
-	ASTKindSectionStatement: map[TokenType]int{
+	ASTKindSectionStatement: {
 		TokenLit: SectionState,
 		TokenOp:  SectionState,
 		TokenSep: CloseScopeState,
 		TokenWS:  SectionState,
 		TokenNL:  SkipTokenState,
 	},
-	ASTKindCompletedSectionStatement: map[TokenType]int{
+	ASTKindCompletedSectionStatement: {
 		TokenWS:      SkipTokenState,
 		TokenNL:      SkipTokenState,
 		TokenLit:     StatementState,
@@ -101,7 +106,7 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenComment: CommentState,
 		TokenNone:    MarkCompleteState,
 	},
-	ASTKindSkipStatement: map[TokenType]int{
+	ASTKindSkipStatement: {
 		TokenLit:     StatementState,
 		TokenSep:     OpenScopeState,
 		TokenWS:      SkipTokenState,
@@ -205,18 +210,6 @@ loop:
 		case ValueState:
 			// ValueState requires the previous state to either be an equal expression
 			// or an expression statement.
-			//
-			// This grammar occurs when the RHS is a number, word, or quoted string.
-			// equal_expr -> lit op equal_expr'
-			// equal_expr' -> number | string | quoted_string
-			// quoted_string -> " quoted_string'
-			// quoted_string' -> string quoted_string_end
-			// quoted_string_end -> "
-			//
-			// otherwise
-			// expr_stmt -> equal_expr (expr_stmt')*
-			// expr_stmt' -> ws S | op S | MarkComplete
-			// S -> equal_expr' expr_stmt'
 			switch k.Kind {
 			case ASTKindEqualExpr:
 				// assigning a value to some key
@@ -243,7 +236,7 @@ loop:
 				}
 
 				children[len(children)-1] = rhs
-				k.SetChildren(children)
+				root.SetChildren(children)
 
 				stack.Push(k)
 			}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/literal_tokens.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/literal_tokens.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -18,7 +19,7 @@ var literalValues = [][]rune{
 
 func isBoolValue(b []rune) bool {
 	for _, lv := range literalValues {
-		if isLitValue(lv, b) {
+		if isCaselessLitValue(lv, b) {
 			return true
 		}
 	}
@@ -32,6 +33,21 @@ func isLitValue(want, have []rune) bool {
 
 	for i := 0; i < len(want); i++ {
 		if want[i] != have[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isCaselessLitValue is a caseless value comparison, assumes want is already lower-cased for efficiency.
+func isCaselessLitValue(want, have []rune) bool {
+	if len(have) < len(want) {
+		return false
+	}
+
+	for i := 0; i < len(want); i++ {
+		if want[i] != unicode.ToLower(have[i]) {
 			return false
 		}
 	}
@@ -177,7 +193,7 @@ func newValue(t ValueType, base int, raw []rune) (Value, error) {
 	case QuotedStringType:
 		v.str = string(raw[1 : len(raw)-1])
 	case BoolType:
-		v.boolean = runeCompare(v.raw, runesTrue)
+		v.boolean = isCaselessLitValue(runesTrue, v.raw)
 	}
 
 	// issue 2253

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/value_util.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/value_util.go
@@ -57,7 +57,7 @@ func getBoolValue(b []rune) (int, error) {
 			continue
 		}
 
-		if isLitValue(lv, b) {
+		if isCaselessLitValue(lv, b) {
 			n = len(lv)
 		}
 	}

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/visitor.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/ini/visitor.go
@@ -50,7 +50,10 @@ func (v *DefaultVisitor) VisitExpr(expr AST) error {
 
 			rhs := children[1]
 
-			if rhs.Root.Type() != TokenLit {
+			// The right-hand value side the equality expression is allowed to contain '[', ']', ':', '=' in the values.
+			// If the token is not either a literal or one of the token types that identifies those four additional
+			// tokens then error.
+			if !(rhs.Root.Type() == TokenLit || rhs.Root.Type() == TokenOp || rhs.Root.Type() == TokenSep) {
 				return NewParseError("unexpected token type")
 			}
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package sdkio

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package sdkio

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package sdkmath

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor_go1.9.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor_go1.9.go
@@ -1,3 +1,4 @@
+//go:build !go1.10
 // +build !go1.10
 
 package sdkmath

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package sdkrand

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.6
 // +build !go1.6
 
 package sdkrand

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/json/jsonutil/build.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/json/jsonutil/build.go
@@ -82,13 +82,17 @@ func buildStruct(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) 
 		field, _ := value.Type().FieldByName(payload)
 		tag = field.Tag
 		value = elemOf(value.FieldByName(payload))
-
-		if !value.IsValid() {
+		if !value.IsValid() && tag.Get("type") != "structure" {
 			return nil
 		}
 	}
 
 	buf.WriteByte('{')
+	defer buf.WriteString("}")
+
+	if !value.IsValid() {
+		return nil
+	}
 
 	t := value.Type()
 	first := true
@@ -143,8 +147,6 @@ func buildStruct(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) 
 		}
 
 	}
-
-	buf.WriteString("}")
 
 	return nil
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/jsonrpc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/jsonrpc.go
@@ -49,9 +49,8 @@ func Build(req *request.Request) {
 		buf = emptyJSON
 	}
 
-	if req.ClientInfo.TargetPrefix != "" || string(buf) != "{}" {
-		req.SetBufferBody(buf)
-	}
+	// Always serialize the body, don't suppress it.
+	req.SetBufferBody(buf)
 
 	if req.ClientInfo.TargetPrefix != "" {
 		target := req.ClientInfo.TargetPrefix + "." + req.Operation.Name

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
@@ -98,7 +98,7 @@ func buildLocationElements(r *request.Request, v reflect.Value, buildGETQuery bo
 
 			// Support the ability to customize values to be marshaled as a
 			// blob even though they were modeled as a string. Required for S3
-			// API operations like SSECustomerKey is modeled as stirng but
+			// API operations like SSECustomerKey is modeled as string but
 			// required to be base64 encoded in request.
 			if field.Tag.Get("marshal-as") == "blob" {
 				m = m.Convert(byteSliceType)

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/payload.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/payload.go
@@ -28,18 +28,27 @@ func PayloadMember(i interface{}) interface{} {
 	return nil
 }
 
-// PayloadType returns the type of a payload field member of i if there is one, or "".
+const nopayloadPayloadType = "nopayload"
+
+// PayloadType returns the type of a payload field member of i if there is one,
+// or "".
 func PayloadType(i interface{}) string {
 	v := reflect.Indirect(reflect.ValueOf(i))
 	if !v.IsValid() {
 		return ""
 	}
+
 	if field, ok := v.Type().FieldByName("_"); ok {
+		if noPayload := field.Tag.Get(nopayloadPayloadType); noPayload != "" {
+			return nopayloadPayloadType
+		}
+
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			if member, ok := v.Type().FieldByName(payloadName); ok {
 				return member.Tag.Get("type")
 			}
 		}
 	}
+
 	return ""
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -530,9 +530,9 @@ func (c *AutoScaling) CancelInstanceRefreshRequest(input *CancelInstanceRefreshI
 // roll back any replacements that have already been completed, but it prevents
 // new replacements from being started.
 //
-// For more information, see Replacing Auto Scaling instances based on an instance
-// refresh (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
-// in the Amazon EC2 Auto Scaling User Guide.
+// This operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
+// Scaling group after you make configuration changes.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1655,6 +1655,9 @@ func (c *AutoScaling) DeleteWarmPoolRequest(input *DeleteWarmPoolInput) (req *re
 //
 // Deletes the warm pool for the specified Auto Scaling group.
 //
+// For more information, see Warm pools for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
+// in the Amazon EC2 Auto Scaling User Guide.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -1746,11 +1749,12 @@ func (c *AutoScaling) DescribeAccountLimitsRequest(input *DescribeAccountLimitsI
 
 // DescribeAccountLimits API operation for Auto Scaling.
 //
-// Describes the current Amazon EC2 Auto Scaling resource quotas for your AWS
-// account.
+// Describes the current Amazon EC2 Auto Scaling resource quotas for your account.
 //
-// For information about requesting an increase, see Amazon EC2 Auto Scaling
-// service quotas (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-account-limits.html)
+// When you establish an Amazon Web Services account, the account has initial
+// quotas on the maximum number of Auto Scaling groups and launch configurations
+// that you can create in a given Region. For more information, see Amazon EC2
+// Auto Scaling service quotas (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-account-limits.html)
 // in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1831,9 +1835,8 @@ func (c *AutoScaling) DescribeAdjustmentTypesRequest(input *DescribeAdjustmentTy
 
 // DescribeAdjustmentTypes API operation for Auto Scaling.
 //
-// Describes the available adjustment types for Amazon EC2 Auto Scaling scaling
-// policies. These settings apply to step scaling policies and simple scaling
-// policies; they do not apply to target tracking scaling policies.
+// Describes the available adjustment types for step scaling and simple scaling
+// policies.
 //
 // The following adjustment types are supported:
 //
@@ -1927,9 +1930,15 @@ func (c *AutoScaling) DescribeAutoScalingGroupsRequest(input *DescribeAutoScalin
 
 // DescribeAutoScalingGroups API operation for Auto Scaling.
 //
-// Describes one or more Auto Scaling groups.
+// Gets information about the Auto Scaling groups in the account and Region.
 //
-// This operation returns information about instances in Auto Scaling groups.
+// If you specify Auto Scaling group names, the output includes information
+// for only the specified Auto Scaling groups. If you specify filters, the output
+// includes information for only those Auto Scaling groups that meet the filter
+// criteria. If you do not specify group names or filters, the output includes
+// information for all Auto Scaling groups.
+//
+// This operation also returns information about instances in Auto Scaling groups.
 // To retrieve information about the instances in a warm pool, you must call
 // the DescribeWarmPool API.
 //
@@ -2072,7 +2081,7 @@ func (c *AutoScaling) DescribeAutoScalingInstancesRequest(input *DescribeAutoSca
 
 // DescribeAutoScalingInstances API operation for Auto Scaling.
 //
-// Describes one or more Auto Scaling instances.
+// Gets information about the Auto Scaling instances in the account and Region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2287,9 +2296,19 @@ func (c *AutoScaling) DescribeInstanceRefreshesRequest(input *DescribeInstanceRe
 
 // DescribeInstanceRefreshes API operation for Auto Scaling.
 //
-// Describes one or more instance refreshes.
+// Gets information about the instance refreshes for the specified Auto Scaling
+// group.
 //
-// You can determine the status of a request by looking at the Status parameter.
+// This operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
+// Scaling group after you make configuration changes.
+//
+// To help you determine the status of an instance refresh, this operation returns
+// information about the instance refreshes you previously initiated, including
+// their status, end time, the percentage of the instance refresh that is complete,
+// and the number of instances remaining to update before the instance refresh
+// is complete.
+//
 // The following are the possible statuses:
 //
 //    * Pending - The request was created, but the operation has not started.
@@ -2306,10 +2325,6 @@ func (c *AutoScaling) DescribeInstanceRefreshesRequest(input *DescribeInstanceRe
 //    prevents new replacements from being started.
 //
 //    * Cancelled - The operation is cancelled.
-//
-// For more information, see Replacing Auto Scaling instances based on an instance
-// refresh (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
-// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2398,7 +2413,7 @@ func (c *AutoScaling) DescribeLaunchConfigurationsRequest(input *DescribeLaunchC
 
 // DescribeLaunchConfigurations API operation for Auto Scaling.
 //
-// Describes one or more launch configurations.
+// Gets information about the launch configurations in the account and Region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2619,7 +2634,8 @@ func (c *AutoScaling) DescribeLifecycleHooksRequest(input *DescribeLifecycleHook
 
 // DescribeLifecycleHooks API operation for Auto Scaling.
 //
-// Describes the lifecycle hooks for the specified Auto Scaling group.
+// Gets information about the lifecycle hooks for the specified Auto Scaling
+// group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2699,7 +2715,30 @@ func (c *AutoScaling) DescribeLoadBalancerTargetGroupsRequest(input *DescribeLoa
 
 // DescribeLoadBalancerTargetGroups API operation for Auto Scaling.
 //
-// Describes the target groups for the specified Auto Scaling group.
+// Gets information about the load balancer target groups for the specified
+// Auto Scaling group.
+//
+// To determine the availability of registered instances, use the State element
+// in the response. When you attach a target group to an Auto Scaling group,
+// the initial State value is Adding. The state transitions to Added after all
+// Auto Scaling instances are registered with the target group. If Elastic Load
+// Balancing health checks are enabled for the Auto Scaling group, the state
+// transitions to InService after at least one Auto Scaling instance passes
+// the health check. When the target group is in the InService state, Amazon
+// EC2 Auto Scaling can terminate and replace any instances that are reported
+// as unhealthy. If no registered instances pass the health checks, the target
+// group doesn't enter the InService state.
+//
+// Target groups also have an InService state if you attach them in the CreateAutoScalingGroup
+// API call. If your target group state is InService, but it is not working
+// properly, check the scaling activities by calling DescribeScalingActivities
+// and take any corrective actions necessary.
+//
+// For help with failed health checks, see Troubleshooting Amazon EC2 Auto Scaling:
+// Health checks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
+// in the Amazon EC2 Auto Scaling User Guide. For more information, see Elastic
+// Load Balancing and Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2712,6 +2751,9 @@ func (c *AutoScaling) DescribeLoadBalancerTargetGroupsRequest(input *DescribeLoa
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Amazon EC2 Auto Scaling resource
 //   (for example, an Auto Scaling group, instance, or load balancer).
+//
+//   * ErrCodeInvalidNextToken "InvalidNextToken"
+//   The NextToken value is not valid.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancerTargetGroups
 func (c *AutoScaling) DescribeLoadBalancerTargetGroups(input *DescribeLoadBalancerTargetGroupsInput) (*DescribeLoadBalancerTargetGroupsOutput, error) {
@@ -2779,11 +2821,34 @@ func (c *AutoScaling) DescribeLoadBalancersRequest(input *DescribeLoadBalancersI
 
 // DescribeLoadBalancers API operation for Auto Scaling.
 //
-// Describes the load balancers for the specified Auto Scaling group.
+// Gets information about the load balancers for the specified Auto Scaling
+// group.
 //
 // This operation describes only Classic Load Balancers. If you have Application
 // Load Balancers, Network Load Balancers, or Gateway Load Balancers, use the
 // DescribeLoadBalancerTargetGroups API instead.
+//
+// To determine the availability of registered instances, use the State element
+// in the response. When you attach a load balancer to an Auto Scaling group,
+// the initial State value is Adding. The state transitions to Added after all
+// Auto Scaling instances are registered with the load balancer. If Elastic
+// Load Balancing health checks are enabled for the Auto Scaling group, the
+// state transitions to InService after at least one Auto Scaling instance passes
+// the health check. When the load balancer is in the InService state, Amazon
+// EC2 Auto Scaling can terminate and replace any instances that are reported
+// as unhealthy. If no registered instances pass the health checks, the load
+// balancer doesn't enter the InService state.
+//
+// Load balancers also have an InService state if you attach them in the CreateAutoScalingGroup
+// API call. If your load balancer state is InService, but it is not working
+// properly, check the scaling activities by calling DescribeScalingActivities
+// and take any corrective actions necessary.
+//
+// For help with failed health checks, see Troubleshooting Amazon EC2 Auto Scaling:
+// Health checks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
+// in the Amazon EC2 Auto Scaling User Guide. For more information, see Elastic
+// Load Balancing and Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2796,6 +2861,9 @@ func (c *AutoScaling) DescribeLoadBalancersRequest(input *DescribeLoadBalancersI
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Amazon EC2 Auto Scaling resource
 //   (for example, an Auto Scaling group, instance, or load balancer).
+//
+//   * ErrCodeInvalidNextToken "InvalidNextToken"
+//   The NextToken value is not valid.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancers
 func (c *AutoScaling) DescribeLoadBalancers(input *DescribeLoadBalancersInput) (*DescribeLoadBalancersOutput, error) {
@@ -2952,8 +3020,8 @@ func (c *AutoScaling) DescribeNotificationConfigurationsRequest(input *DescribeN
 
 // DescribeNotificationConfigurations API operation for Auto Scaling.
 //
-// Describes the notification actions associated with the specified Auto Scaling
-// group.
+// Gets information about the Amazon SNS notifications that are configured for
+// one or more Auto Scaling groups.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3094,7 +3162,7 @@ func (c *AutoScaling) DescribePoliciesRequest(input *DescribePoliciesInput) (req
 
 // DescribePolicies API operation for Auto Scaling.
 //
-// Describes the policies for the specified Auto Scaling group.
+// Gets information about the scaling policies in the account and Region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3238,12 +3306,18 @@ func (c *AutoScaling) DescribeScalingActivitiesRequest(input *DescribeScalingAct
 
 // DescribeScalingActivities API operation for Auto Scaling.
 //
-// Describes one or more scaling activities for the specified Auto Scaling group.
+// Gets information about the scaling activities in the account and Region.
 //
-// To view the scaling activities from the Amazon EC2 Auto Scaling console,
-// choose the Activity tab of the Auto Scaling group. When scaling events occur,
-// you see scaling activity messages in the Activity history. For more information,
-// see Verifying a scaling activity for an Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-verify-scaling-activity.html)
+// When scaling events occur, you see a record of the scaling activity in the
+// scaling activities. For more information, see Verifying a scaling activity
+// for an Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-verify-scaling-activity.html)
+// in the Amazon EC2 Auto Scaling User Guide.
+//
+// If the scaling event succeeds, the value of the StatusCode element in the
+// response is Successful. If an attempt to launch instances failed, the StatusCode
+// value is Failed or Cancelled and the StatusMessage element in the response
+// indicates the cause of the failure. For help interpreting the StatusMessage,
+// see Troubleshooting Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/CHAP_Troubleshooting.html)
 // in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3466,9 +3540,11 @@ func (c *AutoScaling) DescribeScheduledActionsRequest(input *DescribeScheduledAc
 
 // DescribeScheduledActions API operation for Auto Scaling.
 //
-// Describes the actions scheduled for your Auto Scaling group that haven't
-// run or that have not reached their end time. To describe the actions that
-// have already run, call the DescribeScalingActivities API.
+// Gets information about the scheduled actions that haven't run or that have
+// not reached their end time.
+//
+// To describe the scaling activities for scheduled actions that have already
+// run, call the DescribeScalingActivities API.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3840,7 +3916,10 @@ func (c *AutoScaling) DescribeWarmPoolRequest(input *DescribeWarmPoolInput) (req
 
 // DescribeWarmPool API operation for Auto Scaling.
 //
-// Describes a warm pool and its instances.
+// Gets information about a warm pool and its instances.
+//
+// For more information, see Warm pools for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5712,19 +5791,23 @@ func (c *AutoScaling) StartInstanceRefreshRequest(input *StartInstanceRefreshInp
 
 // StartInstanceRefresh API operation for Auto Scaling.
 //
-// Starts a new instance refresh operation, which triggers a rolling replacement
-// of previously launched instances in the Auto Scaling group with a new group
-// of instances.
+// Starts a new instance refresh operation. An instance refresh performs a rolling
+// replacement of all or some instances in an Auto Scaling group. Each instance
+// is terminated first and then replaced, which temporarily reduces the capacity
+// available within your Auto Scaling group.
 //
-// If successful, this call creates a new instance refresh request with a unique
+// This operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
+// Scaling group. This feature is helpful, for example, when you have a new
+// AMI or a new user data script. You just need to create a new launch template
+// that specifies the new AMI or user data script. Then start an instance refresh
+// to immediately begin the process of updating instances in the group.
+//
+// If the call succeeds, it creates a new instance refresh request with a unique
 // ID that you can use to track its progress. To query its status, call the
 // DescribeInstanceRefreshes API. To describe the instance refreshes that have
 // already run, call the DescribeInstanceRefreshes API. To cancel an instance
 // refresh operation in progress, use the CancelInstanceRefresh API.
-//
-// For more information, see Replacing Auto Scaling instances based on an instance
-// refresh (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
-// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6091,6 +6174,90 @@ func (c *AutoScaling) UpdateAutoScalingGroupWithContext(ctx aws.Context, input *
 	return out, req.Send()
 }
 
+// Specifies the minimum and maximum for the AcceleratorCount object when you
+// specify InstanceRequirements for an Auto Scaling group.
+type AcceleratorCountRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum value.
+	Max *int64 `type:"integer"`
+
+	// The minimum value.
+	Min *int64 `type:"integer"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s AcceleratorCountRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s AcceleratorCountRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *AcceleratorCountRequest) SetMax(v int64) *AcceleratorCountRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *AcceleratorCountRequest) SetMin(v int64) *AcceleratorCountRequest {
+	s.Min = &v
+	return s
+}
+
+// Specifies the minimum and maximum for the AcceleratorTotalMemoryMiB object
+// when you specify InstanceRequirements for an Auto Scaling group.
+type AcceleratorTotalMemoryMiBRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The memory maximum in MiB.
+	Max *int64 `type:"integer"`
+
+	// The memory minimum in MiB.
+	Min *int64 `type:"integer"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s AcceleratorTotalMemoryMiBRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s AcceleratorTotalMemoryMiBRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *AcceleratorTotalMemoryMiBRequest) SetMax(v int64) *AcceleratorTotalMemoryMiBRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *AcceleratorTotalMemoryMiBRequest) SetMin(v int64) *AcceleratorTotalMemoryMiBRequest {
+	s.Min = &v
+	return s
+}
+
 // Describes scaling activity, which is a long-running process that represents
 // a change to your Auto Scaling group, such as changing its size or replacing
 // an instance.
@@ -6144,12 +6311,20 @@ type Activity struct {
 	StatusMessage *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Activity) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Activity) GoString() string {
 	return s.String()
 }
@@ -6235,12 +6410,20 @@ type AdjustmentType struct {
 	AdjustmentType *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AdjustmentType) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AdjustmentType) GoString() string {
 	return s.String()
 }
@@ -6262,12 +6445,20 @@ type Alarm struct {
 	AlarmName *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Alarm) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Alarm) GoString() string {
 	return s.String()
 }
@@ -6296,12 +6487,20 @@ type AttachInstancesInput struct {
 	InstanceIds []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachInstancesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachInstancesInput) GoString() string {
 	return s.String()
 }
@@ -6338,12 +6537,20 @@ type AttachInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachInstancesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachInstancesOutput) GoString() string {
 	return s.String()
 }
@@ -6365,12 +6572,20 @@ type AttachLoadBalancerTargetGroupsInput struct {
 	TargetGroupARNs []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerTargetGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerTargetGroupsInput) GoString() string {
 	return s.String()
 }
@@ -6410,12 +6625,20 @@ type AttachLoadBalancerTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerTargetGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -6434,12 +6657,20 @@ type AttachLoadBalancersInput struct {
 	LoadBalancerNames []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancersInput) GoString() string {
 	return s.String()
 }
@@ -6479,14 +6710,64 @@ type AttachLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancersOutput) GoString() string {
 	return s.String()
+}
+
+// Specifies the minimum and maximum for the BaselineEbsBandwidthMbps object
+// when you specify InstanceRequirements for an Auto Scaling group.
+type BaselineEbsBandwidthMbpsRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum value in Mbps.
+	Max *int64 `type:"integer"`
+
+	// The minimum value in Mbps.
+	Min *int64 `type:"integer"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s BaselineEbsBandwidthMbpsRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s BaselineEbsBandwidthMbpsRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *BaselineEbsBandwidthMbpsRequest) SetMax(v int64) *BaselineEbsBandwidthMbpsRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *BaselineEbsBandwidthMbpsRequest) SetMin(v int64) *BaselineEbsBandwidthMbpsRequest {
+	s.Min = &v
+	return s
 }
 
 type BatchDeleteScheduledActionInput struct {
@@ -6504,12 +6785,20 @@ type BatchDeleteScheduledActionInput struct {
 	ScheduledActionNames []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteScheduledActionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteScheduledActionInput) GoString() string {
 	return s.String()
 }
@@ -6553,12 +6842,20 @@ type BatchDeleteScheduledActionOutput struct {
 	FailedScheduledActions []*FailedScheduledUpdateGroupActionRequest `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteScheduledActionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteScheduledActionOutput) GoString() string {
 	return s.String()
 }
@@ -6583,12 +6880,20 @@ type BatchPutScheduledUpdateGroupActionInput struct {
 	ScheduledUpdateGroupActions []*ScheduledUpdateGroupActionRequest `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchPutScheduledUpdateGroupActionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchPutScheduledUpdateGroupActionInput) GoString() string {
 	return s.String()
 }
@@ -6642,12 +6947,20 @@ type BatchPutScheduledUpdateGroupActionOutput struct {
 	FailedScheduledUpdateGroupActions []*FailedScheduledUpdateGroupActionRequest `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchPutScheduledUpdateGroupActionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchPutScheduledUpdateGroupActionOutput) GoString() string {
 	return s.String()
 }
@@ -6689,12 +7002,20 @@ type BlockDeviceMapping struct {
 	VirtualName *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BlockDeviceMapping) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BlockDeviceMapping) GoString() string {
 	return s.String()
 }
@@ -6756,12 +7077,20 @@ type CancelInstanceRefreshInput struct {
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelInstanceRefreshInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelInstanceRefreshInput) GoString() string {
 	return s.String()
 }
@@ -6795,12 +7124,20 @@ type CancelInstanceRefreshOutput struct {
 	InstanceRefreshId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelInstanceRefreshOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelInstanceRefreshOutput) GoString() string {
 	return s.String()
 }
@@ -6828,12 +7165,20 @@ type CapacityForecast struct {
 	Values []*float64 `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CapacityForecast) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CapacityForecast) GoString() string {
 	return s.String()
 }
@@ -6878,12 +7223,20 @@ type CompleteLifecycleActionInput struct {
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLifecycleActionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLifecycleActionInput) GoString() string {
 	return s.String()
 }
@@ -6953,12 +7306,20 @@ type CompleteLifecycleActionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLifecycleActionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLifecycleActionOutput) GoString() string {
 	return s.String()
 }
@@ -6989,6 +7350,9 @@ type CreateAutoScalingGroupInput struct {
 	// in the Amazon EC2 Auto Scaling User Guide.
 	CapacityRebalance *bool `type:"boolean"`
 
+	// Reserved.
+	Context *string `type:"string"`
+
 	// The amount of time, in seconds, after a scaling activity completes before
 	// another scaling activity can start. The default value is 300. This setting
 	// applies when using simple scaling policies, but not when using other scaling
@@ -7004,6 +7368,18 @@ type CreateAutoScalingGroupInput struct {
 	// equal to the maximum size of the group. If you do not specify a desired capacity,
 	// the default is the minimum size of the group.
 	DesiredCapacity *int64 `type:"integer"`
+
+	// The unit of measurement for the value specified for desired capacity. Amazon
+	// EC2 Auto Scaling supports DesiredCapacityType for attribute-based instance
+	// type selection only. For more information, see Creating an Auto Scaling group
+	// using attribute-based instance type selection (https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-instance-type-requirements.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
+	//
+	// By default, Amazon EC2 Auto Scaling specifies units, which translates into
+	// number of instances.
+	//
+	// Valid values: units | vcpu | memory-mib
+	DesiredCapacityType *string `min:"1" type:"string"`
 
 	// The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before
 	// checking the health status of an EC2 instance that has come into service.
@@ -7084,18 +7460,10 @@ type CreateAutoScalingGroupInput struct {
 	// MinSize is a required field
 	MinSize *int64 `type:"integer" required:"true"`
 
-	// An embedded object that specifies a mixed instances policy. The required
-	// properties must be specified. If optional properties are unspecified, their
-	// default values are used.
+	// An embedded object that specifies a mixed instances policy.
 	//
-	// The policy includes properties that not only define the distribution of On-Demand
-	// Instances and Spot Instances, the maximum price to pay for Spot Instances,
-	// and how the Auto Scaling group allocates instance types to fulfill On-Demand
-	// and Spot capacities, but also the properties that specify the instance configuration
-	// information—the launch template and instance types. The policy can also
-	// include a weight for each instance type and different launch templates for
-	// individual instance types. For more information, see Auto Scaling groups
-	// with multiple instance types and purchase options (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
+	// For more information, see Auto Scaling groups with multiple instance types
+	// and purchase options (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	MixedInstancesPolicy *MixedInstancesPolicy `type:"structure"`
 
@@ -7114,8 +7482,8 @@ type CreateAutoScalingGroupInput struct {
 	PlacementGroup *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
-	// group uses to call other AWS services on your behalf. By default, Amazon
-	// EC2 Auto Scaling uses a service-linked role named AWSServiceRoleForAutoScaling,
+	// group uses to call other Amazon Web Services on your behalf. By default,
+	// Amazon EC2 Auto Scaling uses a service-linked role named AWSServiceRoleForAutoScaling,
 	// which it creates if it does not exist. For more information, see Service-linked
 	// roles (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-service-linked-role.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
@@ -7155,12 +7523,20 @@ type CreateAutoScalingGroupInput struct {
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAutoScalingGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAutoScalingGroupInput) GoString() string {
 	return s.String()
 }
@@ -7173,6 +7549,9 @@ func (s *CreateAutoScalingGroupInput) Validate() error {
 	}
 	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.DesiredCapacityType != nil && len(*s.DesiredCapacityType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DesiredCapacityType", 1))
 	}
 	if s.HealthCheckType != nil && len(*s.HealthCheckType) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("HealthCheckType", 1))
@@ -7253,6 +7632,12 @@ func (s *CreateAutoScalingGroupInput) SetCapacityRebalance(v bool) *CreateAutoSc
 	return s
 }
 
+// SetContext sets the Context field's value.
+func (s *CreateAutoScalingGroupInput) SetContext(v string) *CreateAutoScalingGroupInput {
+	s.Context = &v
+	return s
+}
+
 // SetDefaultCooldown sets the DefaultCooldown field's value.
 func (s *CreateAutoScalingGroupInput) SetDefaultCooldown(v int64) *CreateAutoScalingGroupInput {
 	s.DefaultCooldown = &v
@@ -7262,6 +7647,12 @@ func (s *CreateAutoScalingGroupInput) SetDefaultCooldown(v int64) *CreateAutoSca
 // SetDesiredCapacity sets the DesiredCapacity field's value.
 func (s *CreateAutoScalingGroupInput) SetDesiredCapacity(v int64) *CreateAutoScalingGroupInput {
 	s.DesiredCapacity = &v
+	return s
+}
+
+// SetDesiredCapacityType sets the DesiredCapacityType field's value.
+func (s *CreateAutoScalingGroupInput) SetDesiredCapacityType(v string) *CreateAutoScalingGroupInput {
+	s.DesiredCapacityType = &v
 	return s
 }
 
@@ -7377,12 +7768,20 @@ type CreateAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAutoScalingGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAutoScalingGroupOutput) GoString() string {
 	return s.String()
 }
@@ -7436,8 +7835,8 @@ type CreateLaunchConfigurationInput struct {
 	// EBS and an optimized configuration stack to provide optimal I/O performance.
 	// This optimization is not available with all instance types. Additional fees
 	// are incurred when you enable EBS optimization for an instance type that is
-	// not EBS-optimized by default. For more information, see Amazon EBS-Optimized
-	// Instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html)
+	// not EBS-optimized by default. For more information, see Amazon EBS-optimized
+	// instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html)
 	// in the Amazon EC2 User Guide for Linux Instances.
 	//
 	// The default value is false.
@@ -7565,12 +7964,20 @@ type CreateLaunchConfigurationInput struct {
 	UserData *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLaunchConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLaunchConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -7754,12 +8161,20 @@ type CreateLaunchConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLaunchConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLaunchConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -7773,12 +8188,20 @@ type CreateOrUpdateTagsInput struct {
 	Tags []*Tag `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateOrUpdateTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateOrUpdateTagsInput) GoString() string {
 	return s.String()
 }
@@ -7816,12 +8239,20 @@ type CreateOrUpdateTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateOrUpdateTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateOrUpdateTagsOutput) GoString() string {
 	return s.String()
 }
@@ -7871,12 +8302,20 @@ type CustomizedMetricSpecification struct {
 	Unit *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomizedMetricSpecification) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomizedMetricSpecification) GoString() string {
 	return s.String()
 }
@@ -7955,12 +8394,20 @@ type DeleteAutoScalingGroupInput struct {
 	ForceDelete *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAutoScalingGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAutoScalingGroupInput) GoString() string {
 	return s.String()
 }
@@ -7997,12 +8444,20 @@ type DeleteAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAutoScalingGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAutoScalingGroupOutput) GoString() string {
 	return s.String()
 }
@@ -8016,12 +8471,20 @@ type DeleteLaunchConfigurationInput struct {
 	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLaunchConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLaunchConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -8052,12 +8515,20 @@ type DeleteLaunchConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLaunchConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLaunchConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -8076,12 +8547,20 @@ type DeleteLifecycleHookInput struct {
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecycleHookInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecycleHookInput) GoString() string {
 	return s.String()
 }
@@ -8124,12 +8603,20 @@ type DeleteLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecycleHookOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecycleHookOutput) GoString() string {
 	return s.String()
 }
@@ -8149,12 +8636,20 @@ type DeleteNotificationConfigurationInput struct {
 	TopicARN *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteNotificationConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteNotificationConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -8197,12 +8692,20 @@ type DeleteNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteNotificationConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteNotificationConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -8219,12 +8722,20 @@ type DeletePolicyInput struct {
 	PolicyName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeletePolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeletePolicyInput) GoString() string {
 	return s.String()
 }
@@ -8264,12 +8775,20 @@ type DeletePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeletePolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeletePolicyOutput) GoString() string {
 	return s.String()
 }
@@ -8288,12 +8807,20 @@ type DeleteScheduledActionInput struct {
 	ScheduledActionName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteScheduledActionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteScheduledActionInput) GoString() string {
 	return s.String()
 }
@@ -8336,12 +8863,20 @@ type DeleteScheduledActionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteScheduledActionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteScheduledActionOutput) GoString() string {
 	return s.String()
 }
@@ -8355,12 +8890,20 @@ type DeleteTagsInput struct {
 	Tags []*Tag `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTagsInput) GoString() string {
 	return s.String()
 }
@@ -8398,12 +8941,20 @@ type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTagsOutput) GoString() string {
 	return s.String()
 }
@@ -8423,12 +8974,20 @@ type DeleteWarmPoolInput struct {
 	ForceDelete *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteWarmPoolInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteWarmPoolInput) GoString() string {
 	return s.String()
 }
@@ -8465,12 +9024,20 @@ type DeleteWarmPoolOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteWarmPoolOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteWarmPoolOutput) GoString() string {
 	return s.String()
 }
@@ -8479,12 +9046,20 @@ type DescribeAccountLimitsInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) GoString() string {
 	return s.String()
 }
@@ -8492,27 +9067,35 @@ func (s DescribeAccountLimitsInput) GoString() string {
 type DescribeAccountLimitsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The maximum number of groups allowed for your AWS account. The default is
-	// 200 groups per AWS Region.
+	// The maximum number of groups allowed for your account. The default is 200
+	// groups per Region.
 	MaxNumberOfAutoScalingGroups *int64 `type:"integer"`
 
-	// The maximum number of launch configurations allowed for your AWS account.
-	// The default is 200 launch configurations per AWS Region.
+	// The maximum number of launch configurations allowed for your account. The
+	// default is 200 launch configurations per Region.
 	MaxNumberOfLaunchConfigurations *int64 `type:"integer"`
 
-	// The current number of groups for your AWS account.
+	// The current number of groups for your account.
 	NumberOfAutoScalingGroups *int64 `type:"integer"`
 
-	// The current number of launch configurations for your AWS account.
+	// The current number of launch configurations for your account.
 	NumberOfLaunchConfigurations *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) GoString() string {
 	return s.String()
 }
@@ -8545,12 +9128,20 @@ type DescribeAdjustmentTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAdjustmentTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAdjustmentTypesInput) GoString() string {
 	return s.String()
 }
@@ -8562,12 +9153,20 @@ type DescribeAdjustmentTypesOutput struct {
 	AdjustmentTypes []*AdjustmentType `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAdjustmentTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAdjustmentTypesOutput) GoString() string {
 	return s.String()
 }
@@ -8588,6 +9187,9 @@ type DescribeAutoScalingGroupsInput struct {
 	// If you omit this parameter, all Auto Scaling groups are described.
 	AutoScalingGroupNames []*string `type:"list"`
 
+	// One or more filters to limit the results based on specific tags.
+	Filters []*Filter `type:"list"`
+
 	// The maximum number of items to return with this call. The default value is
 	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
@@ -8597,12 +9199,20 @@ type DescribeAutoScalingGroupsInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingGroupsInput) GoString() string {
 	return s.String()
 }
@@ -8610,6 +9220,12 @@ func (s DescribeAutoScalingGroupsInput) GoString() string {
 // SetAutoScalingGroupNames sets the AutoScalingGroupNames field's value.
 func (s *DescribeAutoScalingGroupsInput) SetAutoScalingGroupNames(v []*string) *DescribeAutoScalingGroupsInput {
 	s.AutoScalingGroupNames = v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeAutoScalingGroupsInput) SetFilters(v []*Filter) *DescribeAutoScalingGroupsInput {
+	s.Filters = v
 	return s
 }
 
@@ -8640,12 +9256,20 @@ type DescribeAutoScalingGroupsOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -8665,9 +9289,11 @@ func (s *DescribeAutoScalingGroupsOutput) SetNextToken(v string) *DescribeAutoSc
 type DescribeAutoScalingInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The IDs of the instances. You can specify up to MaxRecords IDs. If you omit
-	// this parameter, all Auto Scaling instances are described. If you specify
-	// an ID that does not exist, it is ignored with no error.
+	// The IDs of the instances. If you omit this parameter, all Auto Scaling instances
+	// are described. If you specify an ID that does not exist, it is ignored with
+	// no error.
+	//
+	// Array Members: Maximum number of 50 items.
 	InstanceIds []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -8679,12 +9305,20 @@ type DescribeAutoScalingInstancesInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingInstancesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingInstancesInput) GoString() string {
 	return s.String()
 }
@@ -8720,12 +9354,20 @@ type DescribeAutoScalingInstancesOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingInstancesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingInstancesOutput) GoString() string {
 	return s.String()
 }
@@ -8746,12 +9388,20 @@ type DescribeAutoScalingNotificationTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingNotificationTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingNotificationTypesInput) GoString() string {
 	return s.String()
 }
@@ -8763,12 +9413,20 @@ type DescribeAutoScalingNotificationTypesOutput struct {
 	AutoScalingNotificationTypes []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingNotificationTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAutoScalingNotificationTypesOutput) GoString() string {
 	return s.String()
 }
@@ -8799,12 +9457,20 @@ type DescribeInstanceRefreshesInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceRefreshesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceRefreshesInput) GoString() string {
 	return s.String()
 }
@@ -8862,12 +9528,20 @@ type DescribeInstanceRefreshesOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceRefreshesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceRefreshesOutput) GoString() string {
 	return s.String()
 }
@@ -8889,6 +9563,8 @@ type DescribeLaunchConfigurationsInput struct {
 
 	// The launch configuration names. If you omit this parameter, all launch configurations
 	// are described.
+	//
+	// Array Members: Maximum number of 50 items.
 	LaunchConfigurationNames []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -8900,12 +9576,20 @@ type DescribeLaunchConfigurationsInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLaunchConfigurationsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLaunchConfigurationsInput) GoString() string {
 	return s.String()
 }
@@ -8943,12 +9627,20 @@ type DescribeLaunchConfigurationsOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLaunchConfigurationsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLaunchConfigurationsOutput) GoString() string {
 	return s.String()
 }
@@ -8969,12 +9661,20 @@ type DescribeLifecycleHookTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHookTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHookTypesInput) GoString() string {
 	return s.String()
 }
@@ -8986,12 +9686,20 @@ type DescribeLifecycleHookTypesOutput struct {
 	LifecycleHookTypes []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHookTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHookTypesOutput) GoString() string {
 	return s.String()
 }
@@ -9015,12 +9723,20 @@ type DescribeLifecycleHooksInput struct {
 	LifecycleHookNames []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHooksInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHooksInput) GoString() string {
 	return s.String()
 }
@@ -9060,12 +9776,20 @@ type DescribeLifecycleHooksOutput struct {
 	LifecycleHooks []*LifecycleHook `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHooksOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLifecycleHooksOutput) GoString() string {
 	return s.String()
 }
@@ -9093,12 +9817,20 @@ type DescribeLoadBalancerTargetGroupsInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerTargetGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerTargetGroupsInput) GoString() string {
 	return s.String()
 }
@@ -9150,12 +9882,20 @@ type DescribeLoadBalancerTargetGroupsOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerTargetGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -9189,12 +9929,20 @@ type DescribeLoadBalancersInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) GoString() string {
 	return s.String()
 }
@@ -9246,12 +9994,20 @@ type DescribeLoadBalancersOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
 }
@@ -9272,12 +10028,20 @@ type DescribeMetricCollectionTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeMetricCollectionTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeMetricCollectionTypesInput) GoString() string {
 	return s.String()
 }
@@ -9292,12 +10056,20 @@ type DescribeMetricCollectionTypesOutput struct {
 	Metrics []*MetricCollectionType `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeMetricCollectionTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeMetricCollectionTypesOutput) GoString() string {
 	return s.String()
 }
@@ -9329,12 +10101,20 @@ type DescribeNotificationConfigurationsInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeNotificationConfigurationsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeNotificationConfigurationsInput) GoString() string {
 	return s.String()
 }
@@ -9372,12 +10152,20 @@ type DescribeNotificationConfigurationsOutput struct {
 	NotificationConfigurations []*NotificationConfiguration `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeNotificationConfigurationsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeNotificationConfigurationsOutput) GoString() string {
 	return s.String()
 }
@@ -9410,8 +10198,9 @@ type DescribePoliciesInput struct {
 
 	// The names of one or more policies. If you omit this parameter, all policies
 	// are described. If a group name is provided, the results are limited to that
-	// group. This list is limited to 50 items. If you specify an unknown policy
-	// name, it is ignored with no error.
+	// group. If you specify an unknown policy name, it is ignored with no error.
+	//
+	// Array Members: Maximum number of 50 items.
 	PolicyNames []*string `type:"list"`
 
 	// One or more policy types. The valid values are SimpleScaling, StepScaling,
@@ -9419,12 +10208,20 @@ type DescribePoliciesInput struct {
 	PolicyTypes []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribePoliciesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribePoliciesInput) GoString() string {
 	return s.String()
 }
@@ -9485,12 +10282,20 @@ type DescribePoliciesOutput struct {
 	ScalingPolicies []*ScalingPolicy `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribePoliciesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribePoliciesOutput) GoString() string {
 	return s.String()
 }
@@ -9510,11 +10315,12 @@ func (s *DescribePoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *Describ
 type DescribeScalingActivitiesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The activity IDs of the desired scaling activities. You can specify up to
-	// 50 IDs. If you omit this parameter, all activities for the past six weeks
-	// are described. If unknown activities are requested, they are ignored with
-	// no error. If you specify an Auto Scaling group, the results are limited to
-	// that group.
+	// The activity IDs of the desired scaling activities. If you omit this parameter,
+	// all activities for the past six weeks are described. If unknown activities
+	// are requested, they are ignored with no error. If you specify an Auto Scaling
+	// group, the results are limited to that group.
+	//
+	// Array Members: Maximum number of 50 IDs.
 	ActivityIds []*string `type:"list"`
 
 	// The name of the Auto Scaling group.
@@ -9532,12 +10338,20 @@ type DescribeScalingActivitiesInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingActivitiesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingActivitiesInput) GoString() string {
 	return s.String()
 }
@@ -9601,12 +10415,20 @@ type DescribeScalingActivitiesOutput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingActivitiesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingActivitiesOutput) GoString() string {
 	return s.String()
 }
@@ -9627,12 +10449,20 @@ type DescribeScalingProcessTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingProcessTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingProcessTypesInput) GoString() string {
 	return s.String()
 }
@@ -9644,12 +10474,20 @@ type DescribeScalingProcessTypesOutput struct {
 	Processes []*ProcessType `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingProcessTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScalingProcessTypesOutput) GoString() string {
 	return s.String()
 }
@@ -9678,9 +10516,11 @@ type DescribeScheduledActionsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	// The names of one or more scheduled actions. You can specify up to 50 actions.
-	// If you omit this parameter, all scheduled actions are described. If you specify
-	// an unknown scheduled action, it is ignored with no error.
+	// The names of one or more scheduled actions. If you omit this parameter, all
+	// scheduled actions are described. If you specify an unknown scheduled action,
+	// it is ignored with no error.
+	//
+	// Array Members: Maximum number of 50 actions.
 	ScheduledActionNames []*string `type:"list"`
 
 	// The earliest scheduled start time to return. If scheduled action names are
@@ -9688,12 +10528,20 @@ type DescribeScheduledActionsInput struct {
 	StartTime *time.Time `type:"timestamp"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScheduledActionsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScheduledActionsInput) GoString() string {
 	return s.String()
 }
@@ -9760,12 +10608,20 @@ type DescribeScheduledActionsOutput struct {
 	ScheduledUpdateGroupActions []*ScheduledUpdateGroupAction `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScheduledActionsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeScheduledActionsOutput) GoString() string {
 	return s.String()
 }
@@ -9798,12 +10654,20 @@ type DescribeTagsInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
@@ -9839,12 +10703,20 @@ type DescribeTagsOutput struct {
 	Tags []*TagDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
 }
@@ -9865,12 +10737,20 @@ type DescribeTerminationPolicyTypesInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTerminationPolicyTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTerminationPolicyTypesInput) GoString() string {
 	return s.String()
 }
@@ -9884,12 +10764,20 @@ type DescribeTerminationPolicyTypesOutput struct {
 	TerminationPolicyTypes []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTerminationPolicyTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTerminationPolicyTypesOutput) GoString() string {
 	return s.String()
 }
@@ -9917,12 +10805,20 @@ type DescribeWarmPoolInput struct {
 	NextToken *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeWarmPoolInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeWarmPoolInput) GoString() string {
 	return s.String()
 }
@@ -9975,12 +10871,20 @@ type DescribeWarmPoolOutput struct {
 	WarmPoolConfiguration *WarmPoolConfiguration `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeWarmPoolOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeWarmPoolOutput) GoString() string {
 	return s.String()
 }
@@ -10003,6 +10907,78 @@ func (s *DescribeWarmPoolOutput) SetWarmPoolConfiguration(v *WarmPoolConfigurati
 	return s
 }
 
+// Describes the desired configuration for an instance refresh.
+//
+// If you specify a desired configuration, you must specify either a LaunchTemplate
+// or a MixedInstancesPolicy.
+type DesiredConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the launch template and the version of the launch template that
+	// Amazon EC2 Auto Scaling uses to launch Amazon EC2 instances. For more information
+	// about launch templates, see Launch templates (https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
+
+	// Describes a mixed instances policy. A mixed instances policy contains the
+	// instance types that Amazon EC2 Auto Scaling can launch and other information
+	// that Amazon EC2 Auto Scaling can use to launch instances and help optimize
+	// your costs. For more information, see Auto Scaling groups with multiple instance
+	// types and purchase options (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
+	MixedInstancesPolicy *MixedInstancesPolicy `type:"structure"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DesiredConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DesiredConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DesiredConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DesiredConfiguration"}
+	if s.LaunchTemplate != nil {
+		if err := s.LaunchTemplate.Validate(); err != nil {
+			invalidParams.AddNested("LaunchTemplate", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.MixedInstancesPolicy != nil {
+		if err := s.MixedInstancesPolicy.Validate(); err != nil {
+			invalidParams.AddNested("MixedInstancesPolicy", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *DesiredConfiguration) SetLaunchTemplate(v *LaunchTemplateSpecification) *DesiredConfiguration {
+	s.LaunchTemplate = v
+	return s
+}
+
+// SetMixedInstancesPolicy sets the MixedInstancesPolicy field's value.
+func (s *DesiredConfiguration) SetMixedInstancesPolicy(v *MixedInstancesPolicy) *DesiredConfiguration {
+	s.MixedInstancesPolicy = v
+	return s
+}
+
 type DetachInstancesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10021,12 +10997,20 @@ type DetachInstancesInput struct {
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachInstancesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachInstancesInput) GoString() string {
 	return s.String()
 }
@@ -10075,12 +11059,20 @@ type DetachInstancesOutput struct {
 	Activities []*Activity `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachInstancesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachInstancesOutput) GoString() string {
 	return s.String()
 }
@@ -10106,12 +11098,20 @@ type DetachLoadBalancerTargetGroupsInput struct {
 	TargetGroupARNs []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerTargetGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerTargetGroupsInput) GoString() string {
 	return s.String()
 }
@@ -10151,12 +11151,20 @@ type DetachLoadBalancerTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerTargetGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -10175,12 +11183,20 @@ type DetachLoadBalancersInput struct {
 	LoadBalancerNames []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancersInput) GoString() string {
 	return s.String()
 }
@@ -10220,12 +11236,20 @@ type DetachLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancersOutput) GoString() string {
 	return s.String()
 }
@@ -10284,12 +11308,20 @@ type DisableMetricsCollectionInput struct {
 	Metrics []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableMetricsCollectionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableMetricsCollectionInput) GoString() string {
 	return s.String()
 }
@@ -10326,12 +11358,20 @@ type DisableMetricsCollectionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableMetricsCollectionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableMetricsCollectionOutput) GoString() string {
 	return s.String()
 }
@@ -10347,36 +11387,41 @@ type Ebs struct {
 
 	// Specifies whether the volume should be encrypted. Encrypted EBS volumes can
 	// only be attached to instances that support Amazon EBS encryption. For more
-	// information, see Supported Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances).
+	// information, see Supported instance types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances).
 	// If your AMI uses encrypted volumes, you can also only launch it on supported
 	// instance types.
 	//
-	// If you are creating a volume from a snapshot, you cannot specify an encryption
-	// value. Volumes that are created from encrypted snapshots are automatically
-	// encrypted, and volumes that are created from unencrypted snapshots are automatically
-	// unencrypted. By default, encrypted snapshots use the AWS managed CMK that
-	// is used for EBS encryption, but you can specify a custom CMK when you create
-	// the snapshot. The ability to encrypt a snapshot during copying also allows
-	// you to apply a new CMK to an already-encrypted snapshot. Volumes restored
-	// from the resulting copy are only accessible using the new CMK.
+	// If you are creating a volume from a snapshot, you cannot create an unencrypted
+	// volume from an encrypted snapshot. Also, you cannot specify a KMS key ID
+	// when using a launch configuration.
 	//
-	// Enabling encryption by default (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default)
-	// results in all EBS volumes being encrypted with the AWS managed CMK or a
-	// customer managed CMK, whether or not the snapshot was encrypted.
+	// If you enable encryption by default, the EBS volumes that you create are
+	// always encrypted, either using the Amazon Web Services managed KMS key or
+	// a customer-managed KMS key, regardless of whether the snapshot was encrypted.
 	//
-	// For more information, see Using Encryption with EBS-Backed AMIs (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIEncryption.html)
-	// in the Amazon EC2 User Guide for Linux Instances and Required CMK key policy
-	// for use with encrypted volumes (https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html)
+	// For more information, see Using Amazon Web Services KMS keys to encrypt Amazon
+	// EBS volumes (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-data-protection.html#encryption)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	Encrypted *bool `type:"boolean"`
 
-	// The number of I/O operations per second (IOPS) to provision for the volume.
-	// The maximum ratio of IOPS to volume size (in GiB) is 50:1. For more information,
-	// see Amazon EBS Volume Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
-	// in the Amazon EC2 User Guide for Linux Instances.
+	// The number of input/output (I/O) operations per second (IOPS) to provision
+	// for the volume. For gp3 and io1 volumes, this represents the number of IOPS
+	// that are provisioned for the volume. For gp2 volumes, this represents the
+	// baseline performance of the volume and the rate at which the volume accumulates
+	// I/O credits for bursting.
 	//
-	// Required when the volume type is io1. (Not used with standard, gp2, st1,
-	// or sc1 volumes.)
+	// The following are the supported values for each volume type:
+	//
+	//    * gp3: 3,000-16,000 IOPS
+	//
+	//    * io1: 100-64,000 IOPS
+	//
+	// For io1 volumes, we guarantee 64,000 IOPS only for Instances built on the
+	// Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+	// Other instance families guarantee performance up to 32,000 IOPS.
+	//
+	// Iops is supported when the volume type is gp3 or io1 and required only when
+	// the volume type is io1. (Not used with standard, gp2, st1, or sc1 volumes.)
 	Iops *int64 `min:"100" type:"integer"`
 
 	// The snapshot ID of the volume to use.
@@ -10384,35 +11429,46 @@ type Ebs struct {
 	// You must specify either a VolumeSize or a SnapshotId.
 	SnapshotId *string `min:"1" type:"string"`
 
-	// The volume size, in Gibibytes (GiB).
+	// The throughput (MiBps) to provision for a gp3 volume.
+	Throughput *int64 `min:"125" type:"integer"`
+
+	// The volume size, in GiBs. The following are the supported volumes sizes for
+	// each volume type:
 	//
-	// This can be a number from 1-1,024 for standard, 4-16,384 for io1, 1-16,384
-	// for gp2, and 500-16,384 for st1 and sc1. If you specify a snapshot, the volume
-	// size must be equal to or larger than the snapshot size.
+	//    * gp2 and gp3: 1-16,384
 	//
-	// Default: If you create a volume from a snapshot and you don't specify a volume
-	// size, the default is the snapshot size.
+	//    * io1: 4-16,384
 	//
-	// You must specify either a VolumeSize or a SnapshotId. If you specify both
+	//    * st1 and sc1: 125-16,384
+	//
+	//    * standard: 1-1,024
+	//
+	// You must specify either a SnapshotId or a VolumeSize. If you specify both
 	// SnapshotId and VolumeSize, the volume size must be equal or greater than
 	// the size of the snapshot.
 	VolumeSize *int64 `min:"1" type:"integer"`
 
-	// The volume type, which can be standard for Magnetic, io1 for Provisioned
-	// IOPS SSD, gp2 for General Purpose SSD, st1 for Throughput Optimized HDD,
-	// or sc1 for Cold HDD. For more information, see Amazon EBS Volume Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+	// The volume type. For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon EC2 User Guide for Linux Instances.
 	//
-	// Valid Values: standard | io1 | gp2 | st1 | sc1
+	// Valid Values: standard | io1 | gp2 | st1 | sc1 | gp3
 	VolumeType *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Ebs) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Ebs) GoString() string {
 	return s.String()
 }
@@ -10425,6 +11481,9 @@ func (s *Ebs) Validate() error {
 	}
 	if s.SnapshotId != nil && len(*s.SnapshotId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("SnapshotId", 1))
+	}
+	if s.Throughput != nil && *s.Throughput < 125 {
+		invalidParams.Add(request.NewErrParamMinValue("Throughput", 125))
 	}
 	if s.VolumeSize != nil && *s.VolumeSize < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("VolumeSize", 1))
@@ -10460,6 +11519,12 @@ func (s *Ebs) SetIops(v int64) *Ebs {
 // SetSnapshotId sets the SnapshotId field's value.
 func (s *Ebs) SetSnapshotId(v string) *Ebs {
 	s.SnapshotId = &v
+	return s
+}
+
+// SetThroughput sets the Throughput field's value.
+func (s *Ebs) SetThroughput(v int64) *Ebs {
+	s.Throughput = &v
 	return s
 }
 
@@ -10540,12 +11605,20 @@ type EnableMetricsCollectionInput struct {
 	Metrics []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableMetricsCollectionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableMetricsCollectionInput) GoString() string {
 	return s.String()
 }
@@ -10594,12 +11667,20 @@ type EnableMetricsCollectionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableMetricsCollectionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableMetricsCollectionOutput) GoString() string {
 	return s.String()
 }
@@ -10655,12 +11736,20 @@ type EnabledMetric struct {
 	Metric *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnabledMetric) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnabledMetric) GoString() string {
 	return s.String()
 }
@@ -10695,12 +11784,20 @@ type EnterStandbyInput struct {
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnterStandbyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnterStandbyInput) GoString() string {
 	return s.String()
 }
@@ -10749,12 +11846,20 @@ type EnterStandbyOutput struct {
 	Activities []*Activity `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnterStandbyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnterStandbyOutput) GoString() string {
 	return s.String()
 }
@@ -10802,12 +11907,20 @@ type ExecutePolicyInput struct {
 	PolicyName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExecutePolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExecutePolicyInput) GoString() string {
 	return s.String()
 }
@@ -10865,12 +11978,20 @@ type ExecutePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExecutePolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExecutePolicyOutput) GoString() string {
 	return s.String()
 }
@@ -10887,12 +12008,20 @@ type ExitStandbyInput struct {
 	InstanceIds []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExitStandbyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExitStandbyInput) GoString() string {
 	return s.String()
 }
@@ -10932,12 +12061,20 @@ type ExitStandbyOutput struct {
 	Activities []*Activity `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExitStandbyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExitStandbyOutput) GoString() string {
 	return s.String()
 }
@@ -10964,12 +12101,20 @@ type FailedScheduledUpdateGroupActionRequest struct {
 	ScheduledActionName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FailedScheduledUpdateGroupActionRequest) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FailedScheduledUpdateGroupActionRequest) GoString() string {
 	return s.String()
 }
@@ -10993,27 +12138,80 @@ func (s *FailedScheduledUpdateGroupActionRequest) SetScheduledActionName(v strin
 }
 
 // Describes a filter that is used to return a more specific list of results
-// when describing tags.
+// from a describe operation.
+//
+// If you specify multiple filters, the filters are automatically logically
+// joined with an AND, and the request returns only the results that match all
+// of the specified filters.
 //
 // For more information, see Tagging Auto Scaling groups and instances (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-tagging.html)
 // in the Amazon EC2 Auto Scaling User Guide.
 type Filter struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the filter. The valid values are: auto-scaling-group, key, value,
-	// and propagate-at-launch.
+	// The name of the filter.
+	//
+	// The valid values for Name depend on which API operation you're using with
+	// the filter (DescribeAutoScalingGroups or DescribeTags).
+	//
+	// DescribeAutoScalingGroups
+	//
+	// Valid values for Name include the following:
+	//
+	//    * tag-key - Accepts tag keys. The results only include information about
+	//    the Auto Scaling groups associated with these tag keys.
+	//
+	//    * tag-value - Accepts tag values. The results only include information
+	//    about the Auto Scaling groups associated with these tag values.
+	//
+	//    * tag:<key> - Accepts the key/value combination of the tag. Use the tag
+	//    key in the filter name and the tag value as the filter value. The results
+	//    only include information about the Auto Scaling groups associated with
+	//    the specified key/value combination.
+	//
+	// DescribeTags
+	//
+	// Valid values for Name include the following:
+	//
+	//    * auto-scaling-group - Accepts the names of Auto Scaling groups. The results
+	//    only include information about the tags associated with these Auto Scaling
+	//    groups.
+	//
+	//    * key - Accepts tag keys. The results only include information about the
+	//    tags associated with these tag keys.
+	//
+	//    * value - Accepts tag values. The results only include information about
+	//    the tags associated with these tag values.
+	//
+	//    * propagate-at-launch - Accepts a Boolean value, which specifies whether
+	//    tags propagate to instances at launch. The results only include information
+	//    about the tags associated with the specified Boolean value.
 	Name *string `type:"string"`
 
 	// One or more filter values. Filter values are case-sensitive.
+	//
+	// If you specify multiple values for a filter, the values are automatically
+	// logically joined with an OR, and the request returns all results that match
+	// any of the specified values. For example, specify "tag:environment" for the
+	// filter name and "production,development" for the filter values to find Auto
+	// Scaling groups with the tag "environment=production" or "environment=development".
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Filter) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Filter) GoString() string {
 	return s.String()
 }
@@ -11060,12 +12258,20 @@ type GetPredictiveScalingForecastInput struct {
 	StartTime *time.Time `type:"timestamp" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPredictiveScalingForecastInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPredictiveScalingForecastInput) GoString() string {
 	return s.String()
 }
@@ -11141,12 +12347,20 @@ type GetPredictiveScalingForecastOutput struct {
 	UpdateTime *time.Time `type:"timestamp" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPredictiveScalingForecastOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPredictiveScalingForecastOutput) GoString() string {
 	return s.String()
 }
@@ -11189,6 +12403,9 @@ type Group struct {
 	// Indicates whether Capacity Rebalancing is enabled.
 	CapacityRebalance *bool `type:"boolean"`
 
+	// Reserved.
+	Context *string `type:"string"`
+
 	// The date and time the group was created.
 	//
 	// CreatedTime is a required field
@@ -11203,6 +12420,18 @@ type Group struct {
 	//
 	// DesiredCapacity is a required field
 	DesiredCapacity *int64 `type:"integer" required:"true"`
+
+	// The unit of measurement for the value specified for desired capacity. Amazon
+	// EC2 Auto Scaling supports DesiredCapacityType for attribute-based instance
+	// type selection only. For more information, see Creating an Auto Scaling group
+	// using attribute-based instance type selection (https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-instance-type-requirements.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
+	//
+	// By default, Amazon EC2 Auto Scaling specifies units, which translates into
+	// number of instances.
+	//
+	// Valid values: units | vcpu | memory-mib
+	DesiredCapacityType *string `min:"1" type:"string"`
 
 	// The metrics enabled for the group.
 	EnabledMetrics []*EnabledMetric `type:"list"`
@@ -11260,7 +12489,7 @@ type Group struct {
 	PredictedCapacity *int64 `type:"integer"`
 
 	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
-	// group uses to call other AWS services on your behalf.
+	// group uses to call other Amazon Web Services on your behalf.
 	ServiceLinkedRoleARN *string `min:"1" type:"string"`
 
 	// The current state of the group when the DeleteAutoScalingGroup operation
@@ -11289,12 +12518,20 @@ type Group struct {
 	WarmPoolSize *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Group) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Group) GoString() string {
 	return s.String()
 }
@@ -11323,6 +12560,12 @@ func (s *Group) SetCapacityRebalance(v bool) *Group {
 	return s
 }
 
+// SetContext sets the Context field's value.
+func (s *Group) SetContext(v string) *Group {
+	s.Context = &v
+	return s
+}
+
 // SetCreatedTime sets the CreatedTime field's value.
 func (s *Group) SetCreatedTime(v time.Time) *Group {
 	s.CreatedTime = &v
@@ -11338,6 +12581,12 @@ func (s *Group) SetDefaultCooldown(v int64) *Group {
 // SetDesiredCapacity sets the DesiredCapacity field's value.
 func (s *Group) SetDesiredCapacity(v int64) *Group {
 	s.DesiredCapacity = &v
+	return s
+}
+
+// SetDesiredCapacityType sets the DesiredCapacityType field's value.
+func (s *Group) SetDesiredCapacityType(v string) *Group {
+	s.DesiredCapacityType = &v
 	return s
 }
 
@@ -11530,12 +12779,20 @@ type Instance struct {
 	WeightedCapacity *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Instance) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Instance) GoString() string {
 	return s.String()
 }
@@ -11657,12 +12914,20 @@ type InstanceDetails struct {
 	WeightedCapacity *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceDetails) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceDetails) GoString() string {
 	return s.String()
 }
@@ -11762,12 +13027,20 @@ type InstanceMetadataOptions struct {
 	HttpTokens *string `type:"string" enum:"InstanceMetadataHttpTokensState"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceMetadataOptions) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceMetadataOptions) GoString() string {
 	return s.String()
 }
@@ -11811,12 +13084,20 @@ type InstanceMonitoring struct {
 	Enabled *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceMonitoring) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceMonitoring) GoString() string {
 	return s.String()
 }
@@ -11834,6 +13115,9 @@ type InstanceRefresh struct {
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
+	// Describes the specific update you want to deploy.
+	DesiredConfiguration *DesiredConfiguration `type:"structure"`
+
 	// The date and time at which the instance refresh ended.
 	EndTime *time.Time `type:"timestamp"`
 
@@ -11850,6 +13134,9 @@ type InstanceRefresh struct {
 	// the specified warm-up time passes, the instance is considered updated and
 	// is added to the percentage complete.
 	PercentageComplete *int64 `type:"integer"`
+
+	// Describes the preferences for an instance refresh.
+	Preferences *RefreshPreferences `type:"structure"`
 
 	// Additional progress details for an Auto Scaling group that has a warm pool.
 	ProgressDetails *InstanceRefreshProgressDetails `type:"structure"`
@@ -11879,12 +13166,20 @@ type InstanceRefresh struct {
 	StatusReason *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefresh) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefresh) GoString() string {
 	return s.String()
 }
@@ -11892,6 +13187,12 @@ func (s InstanceRefresh) GoString() string {
 // SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
 func (s *InstanceRefresh) SetAutoScalingGroupName(v string) *InstanceRefresh {
 	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDesiredConfiguration sets the DesiredConfiguration field's value.
+func (s *InstanceRefresh) SetDesiredConfiguration(v *DesiredConfiguration) *InstanceRefresh {
+	s.DesiredConfiguration = v
 	return s
 }
 
@@ -11916,6 +13217,12 @@ func (s *InstanceRefresh) SetInstancesToUpdate(v int64) *InstanceRefresh {
 // SetPercentageComplete sets the PercentageComplete field's value.
 func (s *InstanceRefresh) SetPercentageComplete(v int64) *InstanceRefresh {
 	s.PercentageComplete = &v
+	return s
+}
+
+// SetPreferences sets the Preferences field's value.
+func (s *InstanceRefresh) SetPreferences(v *RefreshPreferences) *InstanceRefresh {
+	s.Preferences = v
 	return s
 }
 
@@ -11959,12 +13266,20 @@ type InstanceRefreshLivePoolProgress struct {
 	PercentageComplete *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshLivePoolProgress) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshLivePoolProgress) GoString() string {
 	return s.String()
 }
@@ -11996,12 +13311,20 @@ type InstanceRefreshProgressDetails struct {
 	WarmPoolProgress *InstanceRefreshWarmPoolProgress `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshProgressDetails) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshProgressDetails) GoString() string {
 	return s.String()
 }
@@ -12034,12 +13357,20 @@ type InstanceRefreshWarmPoolProgress struct {
 	PercentageComplete *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshWarmPoolProgress) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceRefreshWarmPoolProgress) GoString() string {
 	return s.String()
 }
@@ -12056,52 +13387,422 @@ func (s *InstanceRefreshWarmPoolProgress) SetPercentageComplete(v int64) *Instan
 	return s
 }
 
-// Describes an instances distribution for an Auto Scaling group with a MixedInstancesPolicy.
+// When you specify multiple parameters, you get instance types that satisfy
+// all of the specified parameters. If you specify multiple values for a parameter,
+// you get instance types that satisfy any of the specified values.
 //
-// The instances distribution specifies the distribution of On-Demand Instances
-// and Spot Instances, the maximum price to pay for Spot Instances, and how
-// the Auto Scaling group allocates instance types to fulfill On-Demand and
-// Spot capacities.
+// Represents requirements for the types of instances that can be launched.
+// You must specify VCpuCount and MemoryMiB, but all other parameters are optional.
+// For more information, see Creating an Auto Scaling group using attribute-based
+// instance type selection (https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-instance-type-requirements.html)
+// in the Amazon EC2 Auto Scaling User Guide.
+type InstanceRequirements struct {
+	_ struct{} `type:"structure"`
+
+	// The minimum and maximum number of accelerators (GPUs, FPGAs, or Amazon Web
+	// Services Inferentia chips) for an instance type.
+	//
+	// To exclude accelerator-enabled instance types, set Max to 0.
+	//
+	// Default: No minimum or maximum
+	AcceleratorCount *AcceleratorCountRequest `type:"structure"`
+
+	// Indicates whether instance types must have accelerators by specific manufacturers.
+	//
+	//    * For instance types with NVIDIA devices, specify nvidia.
+	//
+	//    * For instance types with AMD devices, specify amd.
+	//
+	//    * For instance types with Amazon Web Services devices, specify amazon-web-services.
+	//
+	//    * For instance types with Xilinx devices, specify xilinx.
+	//
+	// Default: Any manufacturer
+	AcceleratorManufacturers []*string `type:"list"`
+
+	// Lists the accelerators that must be on an instance type.
+	//
+	//    * For instance types with NVIDIA A100 GPUs, specify a100.
+	//
+	//    * For instance types with NVIDIA V100 GPUs, specify v100.
+	//
+	//    * For instance types with NVIDIA K80 GPUs, specify k80.
+	//
+	//    * For instance types with NVIDIA T4 GPUs, specify t4.
+	//
+	//    * For instance types with NVIDIA M60 GPUs, specify m60.
+	//
+	//    * For instance types with AMD Radeon Pro V520 GPUs, specify radeon-pro-v520.
+	//
+	//    * For instance types with Xilinx VU9P FPGAs, specify vu9p.
+	//
+	// Default: Any accelerator
+	AcceleratorNames []*string `type:"list"`
+
+	// The minimum and maximum total memory size for the accelerators on an instance
+	// type, in MiB.
+	//
+	// Default: No minimum or maximum
+	AcceleratorTotalMemoryMiB *AcceleratorTotalMemoryMiBRequest `type:"structure"`
+
+	// Lists the accelerator types that must be on an instance type.
+	//
+	//    * For instance types with GPU accelerators, specify gpu.
+	//
+	//    * For instance types with FPGA accelerators, specify fpga.
+	//
+	//    * For instance types with inference accelerators, specify inference.
+	//
+	// Default: Any accelerator type
+	AcceleratorTypes []*string `type:"list"`
+
+	// Indicates whether bare metal instance types are included, excluded, or required.
+	//
+	// Default: excluded
+	BareMetal *string `type:"string" enum:"BareMetal"`
+
+	// The minimum and maximum baseline bandwidth performance for an instance type,
+	// in Mbps. For more information, see Amazon EBS–optimized instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html)
+	// in the Amazon EC2 User Guide for Linux Instances.
+	//
+	// Default: No minimum or maximum
+	BaselineEbsBandwidthMbps *BaselineEbsBandwidthMbpsRequest `type:"structure"`
+
+	// Indicates whether burstable performance instance types are included, excluded,
+	// or required. For more information, see Burstable performance instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)
+	// in the Amazon EC2 User Guide for Linux Instances.
+	//
+	// Default: excluded
+	BurstablePerformance *string `type:"string" enum:"BurstablePerformance"`
+
+	// Lists which specific CPU manufacturers to include.
+	//
+	//    * For instance types with Intel CPUs, specify intel.
+	//
+	//    * For instance types with AMD CPUs, specify amd.
+	//
+	//    * For instance types with Amazon Web Services CPUs, specify amazon-web-services.
+	//
+	// Don't confuse the CPU hardware manufacturer with the CPU hardware architecture.
+	// Instances will be launched with a compatible CPU architecture based on the
+	// Amazon Machine Image (AMI) that you specify in your launch template.
+	//
+	// Default: Any manufacturer
+	CpuManufacturers []*string `type:"list"`
+
+	// Lists which instance types to exclude. You can use strings with one or more
+	// wild cards, represented by an asterisk (*). The following are examples: c5*,
+	// m5a.*, r*, *3*.
+	//
+	// For example, if you specify c5*, you are excluding the entire C5 instance
+	// family, which includes all C5a and C5n instance types. If you specify m5a.*,
+	// you are excluding all the M5a instance types, but not the M5n instance types.
+	//
+	// Default: No excluded instance types
+	ExcludedInstanceTypes []*string `type:"list"`
+
+	// Indicates whether current or previous generation instance types are included.
+	//
+	//    * For current generation instance types, specify current. The current
+	//    generation includes EC2 instance types currently recommended for use.
+	//    This typically includes the latest two to three generations in each instance
+	//    family. For more information, see Instance types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+	//    in the Amazon EC2 User Guide for Linux Instances.
+	//
+	//    * For previous generation instance types, specify previous.
+	//
+	// Default: Any current or previous generation
+	InstanceGenerations []*string `type:"list"`
+
+	// Indicates whether instance types with instance store volumes are included,
+	// excluded, or required. For more information, see Amazon EC2 instance store
+	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html)
+	// in the Amazon EC2 User Guide for Linux Instances.
+	//
+	// Default: included
+	LocalStorage *string `type:"string" enum:"LocalStorage"`
+
+	// Indicates the type of local storage that is required.
+	//
+	//    * For instance types with hard disk drive (HDD) storage, specify hdd.
+	//
+	//    * For instance types with solid state drive (SSD) storage, specify sdd.
+	//
+	// Default: Any local storage type
+	LocalStorageTypes []*string `type:"list"`
+
+	// The minimum and maximum amount of memory per vCPU for an instance type, in
+	// GiB.
+	//
+	// Default: No minimum or maximum
+	MemoryGiBPerVCpu *MemoryGiBPerVCpuRequest `type:"structure"`
+
+	// The minimum and maximum instance memory size for an instance type, in MiB.
+	//
+	// MemoryMiB is a required field
+	MemoryMiB *MemoryMiBRequest `type:"structure" required:"true"`
+
+	// The minimum and maximum number of network interfaces for an instance type.
+	//
+	// Default: No minimum or maximum
+	NetworkInterfaceCount *NetworkInterfaceCountRequest `type:"structure"`
+
+	// The price protection threshold for On-Demand Instances. This is the maximum
+	// you’ll pay for an On-Demand Instance, expressed as a percentage higher
+	// than the cheapest M, C, or R instance type with your specified attributes.
+	// When Amazon EC2 Auto Scaling selects instance types with your attributes,
+	// we will exclude instance types whose price is higher than your threshold.
+	// The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets
+	// as a percentage. To turn off price protection, specify a high value, such
+	// as 999999.
+	//
+	// Default: 20
+	OnDemandMaxPricePercentageOverLowestPrice *int64 `type:"integer"`
+
+	// Indicates whether instance types must provide On-Demand Instance hibernation
+	// support.
+	//
+	// Default: false
+	RequireHibernateSupport *bool `type:"boolean"`
+
+	// The price protection threshold for Spot Instances. This is the maximum you’ll
+	// pay for a Spot Instance, expressed as a percentage higher than the cheapest
+	// M, C, or R instance type with your specified attributes. When Amazon EC2
+	// Auto Scaling selects instance types with your attributes, we will exclude
+	// instance types whose price is higher than your threshold. The parameter accepts
+	// an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To
+	// turn off price protection, specify a high value, such as 999999.
+	//
+	// Default: 100
+	SpotMaxPricePercentageOverLowestPrice *int64 `type:"integer"`
+
+	// The minimum and maximum total local storage size for an instance type, in
+	// GB.
+	//
+	// Default: No minimum or maximum
+	TotalLocalStorageGB *TotalLocalStorageGBRequest `type:"structure"`
+
+	// The minimum and maximum number of vCPUs for an instance type.
+	//
+	// VCpuCount is a required field
+	VCpuCount *VCpuCountRequest `type:"structure" required:"true"`
+}
+
+// String returns the string representation.
 //
-// When you update SpotAllocationStrategy, SpotInstancePools, or SpotMaxPrice,
-// this update action does not deploy any changes across the running Amazon
-// EC2 instances in the group. Your existing Spot Instances continue to run
-// as long as the maximum price for those instances is higher than the current
-// Spot price. When scale out occurs, Amazon EC2 Auto Scaling launches instances
-// based on the new settings. When scale in occurs, Amazon EC2 Auto Scaling
-// terminates instances according to the group's termination policies.
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s InstanceRequirements) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s InstanceRequirements) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InstanceRequirements) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InstanceRequirements"}
+	if s.MemoryMiB == nil {
+		invalidParams.Add(request.NewErrParamRequired("MemoryMiB"))
+	}
+	if s.VCpuCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("VCpuCount"))
+	}
+	if s.MemoryMiB != nil {
+		if err := s.MemoryMiB.Validate(); err != nil {
+			invalidParams.AddNested("MemoryMiB", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.VCpuCount != nil {
+		if err := s.VCpuCount.Validate(); err != nil {
+			invalidParams.AddNested("VCpuCount", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAcceleratorCount sets the AcceleratorCount field's value.
+func (s *InstanceRequirements) SetAcceleratorCount(v *AcceleratorCountRequest) *InstanceRequirements {
+	s.AcceleratorCount = v
+	return s
+}
+
+// SetAcceleratorManufacturers sets the AcceleratorManufacturers field's value.
+func (s *InstanceRequirements) SetAcceleratorManufacturers(v []*string) *InstanceRequirements {
+	s.AcceleratorManufacturers = v
+	return s
+}
+
+// SetAcceleratorNames sets the AcceleratorNames field's value.
+func (s *InstanceRequirements) SetAcceleratorNames(v []*string) *InstanceRequirements {
+	s.AcceleratorNames = v
+	return s
+}
+
+// SetAcceleratorTotalMemoryMiB sets the AcceleratorTotalMemoryMiB field's value.
+func (s *InstanceRequirements) SetAcceleratorTotalMemoryMiB(v *AcceleratorTotalMemoryMiBRequest) *InstanceRequirements {
+	s.AcceleratorTotalMemoryMiB = v
+	return s
+}
+
+// SetAcceleratorTypes sets the AcceleratorTypes field's value.
+func (s *InstanceRequirements) SetAcceleratorTypes(v []*string) *InstanceRequirements {
+	s.AcceleratorTypes = v
+	return s
+}
+
+// SetBareMetal sets the BareMetal field's value.
+func (s *InstanceRequirements) SetBareMetal(v string) *InstanceRequirements {
+	s.BareMetal = &v
+	return s
+}
+
+// SetBaselineEbsBandwidthMbps sets the BaselineEbsBandwidthMbps field's value.
+func (s *InstanceRequirements) SetBaselineEbsBandwidthMbps(v *BaselineEbsBandwidthMbpsRequest) *InstanceRequirements {
+	s.BaselineEbsBandwidthMbps = v
+	return s
+}
+
+// SetBurstablePerformance sets the BurstablePerformance field's value.
+func (s *InstanceRequirements) SetBurstablePerformance(v string) *InstanceRequirements {
+	s.BurstablePerformance = &v
+	return s
+}
+
+// SetCpuManufacturers sets the CpuManufacturers field's value.
+func (s *InstanceRequirements) SetCpuManufacturers(v []*string) *InstanceRequirements {
+	s.CpuManufacturers = v
+	return s
+}
+
+// SetExcludedInstanceTypes sets the ExcludedInstanceTypes field's value.
+func (s *InstanceRequirements) SetExcludedInstanceTypes(v []*string) *InstanceRequirements {
+	s.ExcludedInstanceTypes = v
+	return s
+}
+
+// SetInstanceGenerations sets the InstanceGenerations field's value.
+func (s *InstanceRequirements) SetInstanceGenerations(v []*string) *InstanceRequirements {
+	s.InstanceGenerations = v
+	return s
+}
+
+// SetLocalStorage sets the LocalStorage field's value.
+func (s *InstanceRequirements) SetLocalStorage(v string) *InstanceRequirements {
+	s.LocalStorage = &v
+	return s
+}
+
+// SetLocalStorageTypes sets the LocalStorageTypes field's value.
+func (s *InstanceRequirements) SetLocalStorageTypes(v []*string) *InstanceRequirements {
+	s.LocalStorageTypes = v
+	return s
+}
+
+// SetMemoryGiBPerVCpu sets the MemoryGiBPerVCpu field's value.
+func (s *InstanceRequirements) SetMemoryGiBPerVCpu(v *MemoryGiBPerVCpuRequest) *InstanceRequirements {
+	s.MemoryGiBPerVCpu = v
+	return s
+}
+
+// SetMemoryMiB sets the MemoryMiB field's value.
+func (s *InstanceRequirements) SetMemoryMiB(v *MemoryMiBRequest) *InstanceRequirements {
+	s.MemoryMiB = v
+	return s
+}
+
+// SetNetworkInterfaceCount sets the NetworkInterfaceCount field's value.
+func (s *InstanceRequirements) SetNetworkInterfaceCount(v *NetworkInterfaceCountRequest) *InstanceRequirements {
+	s.NetworkInterfaceCount = v
+	return s
+}
+
+// SetOnDemandMaxPricePercentageOverLowestPrice sets the OnDemandMaxPricePercentageOverLowestPrice field's value.
+func (s *InstanceRequirements) SetOnDemandMaxPricePercentageOverLowestPrice(v int64) *InstanceRequirements {
+	s.OnDemandMaxPricePercentageOverLowestPrice = &v
+	return s
+}
+
+// SetRequireHibernateSupport sets the RequireHibernateSupport field's value.
+func (s *InstanceRequirements) SetRequireHibernateSupport(v bool) *InstanceRequirements {
+	s.RequireHibernateSupport = &v
+	return s
+}
+
+// SetSpotMaxPricePercentageOverLowestPrice sets the SpotMaxPricePercentageOverLowestPrice field's value.
+func (s *InstanceRequirements) SetSpotMaxPricePercentageOverLowestPrice(v int64) *InstanceRequirements {
+	s.SpotMaxPricePercentageOverLowestPrice = &v
+	return s
+}
+
+// SetTotalLocalStorageGB sets the TotalLocalStorageGB field's value.
+func (s *InstanceRequirements) SetTotalLocalStorageGB(v *TotalLocalStorageGBRequest) *InstanceRequirements {
+	s.TotalLocalStorageGB = v
+	return s
+}
+
+// SetVCpuCount sets the VCpuCount field's value.
+func (s *InstanceRequirements) SetVCpuCount(v *VCpuCountRequest) *InstanceRequirements {
+	s.VCpuCount = v
+	return s
+}
+
+// Describes an instances distribution for an Auto Scaling group.
 type InstancesDistribution struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates how to allocate instance types to fulfill On-Demand capacity. The
-	// only valid value is prioritized, which is also the default value. This strategy
-	// uses the order of instance types in the LaunchTemplateOverrides to define
-	// the launch priority of each instance type. The first instance type in the
-	// array is prioritized higher than the last. If all your On-Demand capacity
-	// cannot be fulfilled using your highest priority instance, then the Auto Scaling
-	// groups launches the remaining capacity using the second priority instance
-	// type, and so on.
+	// The order of the launch template overrides to use in fulfilling On-Demand
+	// capacity.
+	//
+	// If you specify lowest-price, Amazon EC2 Auto Scaling uses price to determine
+	// the order, launching the lowest price first.
+	//
+	// If you specify prioritized, Amazon EC2 Auto Scaling uses the priority that
+	// you assigned to each launch template override, launching the highest priority
+	// first. If all your On-Demand capacity cannot be fulfilled using your highest
+	// priority instance, then Amazon EC2 Auto Scaling launches the remaining capacity
+	// using the second priority instance type, and so on.
+	//
+	// Default: lowest-price for Auto Scaling groups that specify InstanceRequirements
+	// in the overrides and prioritized for Auto Scaling groups that don't.
 	OnDemandAllocationStrategy *string `type:"string"`
 
 	// The minimum amount of the Auto Scaling group's capacity that must be fulfilled
-	// by On-Demand Instances. This base portion is provisioned first as your group
-	// scales. Defaults to 0 if not specified. If you specify weights for the instance
-	// types in the overrides, set the value of OnDemandBaseCapacity in terms of
-	// the number of capacity units, and not the number of instances.
+	// by On-Demand Instances. This base portion is launched first as your group
+	// scales.
+	//
+	// If you specify weights for the instance types in the overrides, the base
+	// capacity is measured in the same unit of measurement as the instance types.
+	// If you specify InstanceRequirements in the overrides, the base capacity is
+	// measured in the same unit of measurement as your group's desired capacity.
+	//
+	// Default: 0
 	OnDemandBaseCapacity *int64 `type:"integer"`
 
 	// Controls the percentages of On-Demand Instances and Spot Instances for your
 	// additional capacity beyond OnDemandBaseCapacity. Expressed as a number (for
-	// example, 20 specifies 20% On-Demand Instances, 80% Spot Instances). Defaults
-	// to 100 if not specified. If set to 100, only On-Demand Instances are provisioned.
+	// example, 20 specifies 20% On-Demand Instances, 80% Spot Instances). If set
+	// to 100, only On-Demand Instances are used.
+	//
+	// Default: 100
 	OnDemandPercentageAboveBaseCapacity *int64 `type:"integer"`
 
 	// Indicates how to allocate instances across Spot Instance pools.
 	//
 	// If the allocation strategy is lowest-price, the Auto Scaling group launches
 	// instances using the Spot pools with the lowest price, and evenly allocates
-	// your instances across the number of Spot pools that you specify. Defaults
-	// to lowest-price if not specified.
+	// your instances across the number of Spot pools that you specify.
 	//
 	// If the allocation strategy is capacity-optimized (recommended), the Auto
 	// Scaling group launches instances using Spot pools that are optimally chosen
@@ -12110,28 +13811,40 @@ type InstancesDistribution struct {
 	// from highest to lowest priority (from first to last in the list). Amazon
 	// EC2 Auto Scaling honors the instance type priorities on a best-effort basis
 	// but optimizes for capacity first.
+	//
+	// Default: lowest-price
 	SpotAllocationStrategy *string `type:"string"`
 
 	// The number of Spot Instance pools across which to allocate your Spot Instances.
 	// The Spot pools are determined from the different instance types in the overrides.
 	// Valid only when the Spot allocation strategy is lowest-price. Value must
-	// be in the range of 1 to 20. Defaults to 2 if not specified.
+	// be in the range of 1–20.
+	//
+	// Default: 2
 	SpotInstancePools *int64 `type:"integer"`
 
 	// The maximum price per unit hour that you are willing to pay for a Spot Instance.
-	// If you leave the value at its default (empty), Amazon EC2 Auto Scaling uses
-	// the On-Demand price as the maximum Spot price. To remove a value that you
-	// previously set, include the property but specify an empty string ("") for
-	// the value.
+	// If you keep the value at its default (unspecified), Amazon EC2 Auto Scaling
+	// uses the On-Demand price as the maximum Spot price. To remove a value that
+	// you previously set, include the property but specify an empty string ("")
+	// for the value.
 	SpotMaxPrice *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstancesDistribution) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstancesDistribution) GoString() string {
 	return s.String()
 }
@@ -12300,12 +14013,20 @@ type LaunchConfiguration struct {
 	UserData *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchConfiguration) GoString() string {
 	return s.String()
 }
@@ -12430,14 +14151,8 @@ func (s *LaunchConfiguration) SetUserData(v string) *LaunchConfiguration {
 	return s
 }
 
-// Describes a launch template and overrides.
-//
-// You specify these properties as part of a mixed instances policy.
-//
-// When you update the launch template or overrides, existing Amazon EC2 instances
-// continue to run. When scale out occurs, Amazon EC2 Auto Scaling launches
-// instances to match the new settings. When scale in occurs, Amazon EC2 Auto
-// Scaling terminates instances according to the group's termination policies.
+// Describes a launch template and overrides. You specify these properties as
+// part of a mixed instances policy.
 type LaunchTemplate struct {
 	_ struct{} `type:"structure"`
 
@@ -12446,16 +14161,28 @@ type LaunchTemplate struct {
 
 	// Any properties that you specify override the same properties in the launch
 	// template. If not provided, Amazon EC2 Auto Scaling uses the instance type
-	// specified in the launch template when it launches an instance.
+	// or instance type requirements specified in the launch template when it launches
+	// an instance.
+	//
+	// The overrides can include either one or more instance types or a set of instance
+	// requirements, but not both.
 	Overrides []*LaunchTemplateOverrides `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplate) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplate) GoString() string {
 	return s.String()
 }
@@ -12497,14 +14224,18 @@ func (s *LaunchTemplate) SetOverrides(v []*LaunchTemplateOverrides) *LaunchTempl
 	return s
 }
 
-// Describes an override for a launch template. The maximum number of instance
-// types that can be associated with an Auto Scaling group is 40. The maximum
-// number of distinct launch templates you can define for an Auto Scaling group
-// is 20. For more information about configuring overrides, see Configuring
+// Describes an override for a launch template. For more information, see Configuring
 // overrides (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-override-options.html)
 // in the Amazon EC2 Auto Scaling User Guide.
 type LaunchTemplateOverrides struct {
 	_ struct{} `type:"structure"`
+
+	// The instance requirements. When you specify instance requirements, Amazon
+	// EC2 Auto Scaling finds instance types that satisfy your requirements, and
+	// then uses your On-Demand and Spot allocation strategies to launch instances
+	// from these instance types, in the same way as when you specify a list of
+	// specific instance types.
+	InstanceRequirements *InstanceRequirements `type:"structure"`
 
 	// The instance type, such as m3.xlarge. You must use an instance type that
 	// is supported in your requested Region and Availability Zones. For more information,
@@ -12512,35 +14243,44 @@ type LaunchTemplateOverrides struct {
 	// in the Amazon Elastic Compute Cloud User Guide.
 	InstanceType *string `min:"1" type:"string"`
 
-	// Provides the launch template to be used when launching the instance type.
-	// For example, some instance types might require a launch template with a different
-	// AMI. If not provided, Amazon EC2 Auto Scaling uses the launch template that's
-	// defined for your mixed instances policy. For more information, see Specifying
-	// a different launch template for an instance type (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-template-overrides.html)
+	// Provides the launch template to be used when launching the instance type
+	// specified in InstanceType. For example, some instance types might require
+	// a launch template with a different AMI. If not provided, Amazon EC2 Auto
+	// Scaling uses the launch template that's defined for your mixed instances
+	// policy. For more information, see Specifying a different launch template
+	// for an instance type (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-template-overrides.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	LaunchTemplateSpecification *LaunchTemplateSpecification `type:"structure"`
 
-	// The number of capacity units provided by the specified instance type in terms
-	// of virtual CPUs, memory, storage, throughput, or other relative performance
-	// characteristic. When a Spot or On-Demand Instance is provisioned, the capacity
-	// units count toward the desired capacity. Amazon EC2 Auto Scaling provisions
-	// instances until the desired capacity is totally fulfilled, even if this results
-	// in an overage. For example, if there are 2 units remaining to fulfill capacity,
-	// and Amazon EC2 Auto Scaling can only provision an instance with a WeightedCapacity
-	// of 5 units, the instance is provisioned, and the desired capacity is exceeded
-	// by 3 units. For more information, see Instance weighting for Amazon EC2 Auto
-	// Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-weighting.html)
+	// The number of capacity units provided by the instance type specified in InstanceType
+	// in terms of virtual CPUs, memory, storage, throughput, or other relative
+	// performance characteristic. When a Spot or On-Demand Instance is launched,
+	// the capacity units count toward the desired capacity. Amazon EC2 Auto Scaling
+	// launches instances until the desired capacity is totally fulfilled, even
+	// if this results in an overage. For example, if there are two units remaining
+	// to fulfill capacity, and Amazon EC2 Auto Scaling can only launch an instance
+	// with a WeightedCapacity of five units, the instance is launched, and the
+	// desired capacity is exceeded by three units. For more information, see Instance
+	// weighting for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-weighting.html)
 	// in the Amazon EC2 Auto Scaling User Guide. Value must be in the range of
-	// 1 to 999.
+	// 1–999.
 	WeightedCapacity *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplateOverrides) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplateOverrides) GoString() string {
 	return s.String()
 }
@@ -12554,6 +14294,11 @@ func (s *LaunchTemplateOverrides) Validate() error {
 	if s.WeightedCapacity != nil && len(*s.WeightedCapacity) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("WeightedCapacity", 1))
 	}
+	if s.InstanceRequirements != nil {
+		if err := s.InstanceRequirements.Validate(); err != nil {
+			invalidParams.AddNested("InstanceRequirements", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.LaunchTemplateSpecification != nil {
 		if err := s.LaunchTemplateSpecification.Validate(); err != nil {
 			invalidParams.AddNested("LaunchTemplateSpecification", err.(request.ErrInvalidParams))
@@ -12564,6 +14309,12 @@ func (s *LaunchTemplateOverrides) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceRequirements sets the InstanceRequirements field's value.
+func (s *LaunchTemplateOverrides) SetInstanceRequirements(v *InstanceRequirements) *LaunchTemplateOverrides {
+	s.InstanceRequirements = v
+	return s
 }
 
 // SetInstanceType sets the InstanceType field's value.
@@ -12584,12 +14335,9 @@ func (s *LaunchTemplateOverrides) SetWeightedCapacity(v string) *LaunchTemplateO
 	return s
 }
 
-// Describes the Amazon EC2 launch template and the launch template version
-// that can be used by an Auto Scaling group to configure Amazon EC2 instances.
-//
-// The launch template that is specified must be configured for use with an
-// Auto Scaling group. For more information, see Creating a launch template
-// for an Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-template.html)
+// Describes the launch template and the version of the launch template that
+// Amazon EC2 Auto Scaling uses to launch Amazon EC2 instances. For more information
+// about launch templates, see Launch templates (https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html)
 // in the Amazon EC2 Auto Scaling User Guide.
 type LaunchTemplateSpecification struct {
 	_ struct{} `type:"structure"`
@@ -12623,12 +14371,20 @@ type LaunchTemplateSpecification struct {
 	Version *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplateSpecification) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LaunchTemplateSpecification) GoString() string {
 	return s.String()
 }
@@ -12718,12 +14474,20 @@ type LifecycleHook struct {
 	RoleARN *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecycleHook) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecycleHook) GoString() string {
 	return s.String()
 }
@@ -12856,12 +14620,20 @@ type LifecycleHookSpecification struct {
 	RoleARN *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecycleHookSpecification) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecycleHookSpecification) GoString() string {
 	return s.String()
 }
@@ -12934,17 +14706,6 @@ func (s *LifecycleHookSpecification) SetRoleARN(v string) *LifecycleHookSpecific
 }
 
 // Describes the state of a Classic Load Balancer.
-//
-// If you specify a load balancer when creating the Auto Scaling group, the
-// state of the load balancer is InService.
-//
-// If you attach a load balancer to an existing Auto Scaling group, the initial
-// state is Adding. The state transitions to Added after all instances in the
-// group are registered with the load balancer. If Elastic Load Balancing health
-// checks are enabled for the load balancer, the state transitions to InService
-// after at least one instance in the group passes the health check. If EC2
-// health checks are enabled instead, the load balancer remains in the Added
-// state.
 type LoadBalancerState struct {
 	_ struct{} `type:"structure"`
 
@@ -12953,29 +14714,37 @@ type LoadBalancerState struct {
 
 	// One of the following load balancer states:
 	//
-	//    * Adding - The instances in the group are being registered with the load
+	//    * Adding - The Auto Scaling instances are being registered with the load
 	//    balancer.
 	//
-	//    * Added - All instances in the group are registered with the load balancer.
+	//    * Added - All Auto Scaling instances are registered with the load balancer.
 	//
-	//    * InService - At least one instance in the group passed an ELB health
+	//    * InService - At least one Auto Scaling instance passed an ELB health
 	//    check.
 	//
-	//    * Removing - The instances in the group are being deregistered from the
+	//    * Removing - The Auto Scaling instances are being deregistered from the
 	//    load balancer. If connection draining is enabled, Elastic Load Balancing
 	//    waits for in-flight requests to complete before deregistering the instances.
 	//
-	//    * Removed - All instances in the group are deregistered from the load
+	//    * Removed - All Auto Scaling instances are deregistered from the load
 	//    balancer.
 	State *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerState) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerState) GoString() string {
 	return s.String()
 }
@@ -12993,13 +14762,6 @@ func (s *LoadBalancerState) SetState(v string) *LoadBalancerState {
 }
 
 // Describes the state of a target group.
-//
-// If you attach a target group to an existing Auto Scaling group, the initial
-// state is Adding. The state transitions to Added after all Auto Scaling instances
-// are registered with the target group. If Elastic Load Balancing health checks
-// are enabled, the state transitions to InService after at least one Auto Scaling
-// instance passes the health check. If EC2 health checks are enabled instead,
-// the target group remains in the Added state.
 type LoadBalancerTargetGroupState struct {
 	_ struct{} `type:"structure"`
 
@@ -13025,12 +14787,20 @@ type LoadBalancerTargetGroupState struct {
 	State *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerTargetGroupState) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerTargetGroupState) GoString() string {
 	return s.String()
 }
@@ -13069,12 +14839,20 @@ type LoadForecast struct {
 	Values []*float64 `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadForecast) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadForecast) GoString() string {
 	return s.String()
 }
@@ -13094,6 +14872,105 @@ func (s *LoadForecast) SetTimestamps(v []*time.Time) *LoadForecast {
 // SetValues sets the Values field's value.
 func (s *LoadForecast) SetValues(v []*float64) *LoadForecast {
 	s.Values = v
+	return s
+}
+
+// Specifies the minimum and maximum for the MemoryGiBPerVCpu object when you
+// specify InstanceRequirements for an Auto Scaling group.
+type MemoryGiBPerVCpuRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The memory maximum in GiB.
+	Max *float64 `type:"double"`
+
+	// The memory minimum in GiB.
+	Min *float64 `type:"double"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MemoryGiBPerVCpuRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MemoryGiBPerVCpuRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *MemoryGiBPerVCpuRequest) SetMax(v float64) *MemoryGiBPerVCpuRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *MemoryGiBPerVCpuRequest) SetMin(v float64) *MemoryGiBPerVCpuRequest {
+	s.Min = &v
+	return s
+}
+
+// Specifies the minimum and maximum for the MemoryMiB object when you specify
+// InstanceRequirements for an Auto Scaling group.
+type MemoryMiBRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The memory maximum in MiB.
+	Max *int64 `type:"integer"`
+
+	// The memory minimum in MiB.
+	//
+	// Min is a required field
+	Min *int64 `type:"integer" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MemoryMiBRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MemoryMiBRequest) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MemoryMiBRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MemoryMiBRequest"}
+	if s.Min == nil {
+		invalidParams.Add(request.NewErrParamRequired("Min"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMax sets the Max field's value.
+func (s *MemoryMiBRequest) SetMax(v int64) *MemoryMiBRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *MemoryMiBRequest) SetMin(v int64) *MemoryMiBRequest {
+	s.Min = &v
 	return s
 }
 
@@ -13145,12 +15022,20 @@ type MetricCollectionType struct {
 	Metric *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricCollectionType) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricCollectionType) GoString() string {
 	return s.String()
 }
@@ -13176,12 +15061,20 @@ type MetricDimension struct {
 	Value *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricDimension) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricDimension) GoString() string {
 	return s.String()
 }
@@ -13222,12 +15115,20 @@ type MetricGranularityType struct {
 	Granularity *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricGranularityType) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MetricGranularityType) GoString() string {
 	return s.String()
 }
@@ -13238,36 +15139,38 @@ func (s *MetricGranularityType) SetGranularity(v string) *MetricGranularityType 
 	return s
 }
 
-// Describes a mixed instances policy for an Auto Scaling group. With mixed
-// instances, your Auto Scaling group can provision a combination of On-Demand
-// Instances and Spot Instances across multiple instance types. For more information,
-// see Auto Scaling groups with multiple instance types and purchase options
-// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
+// Describes a mixed instances policy. A mixed instances policy contains the
+// instance types that Amazon EC2 Auto Scaling can launch and other information
+// that Amazon EC2 Auto Scaling can use to launch instances and help optimize
+// your costs. For more information, see Auto Scaling groups with multiple instance
+// types and purchase options (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
 // in the Amazon EC2 Auto Scaling User Guide.
-//
-// You can create a mixed instances policy for a new Auto Scaling group, or
-// you can create it for an existing group by updating the group to specify
-// MixedInstancesPolicy as the top-level property instead of a launch configuration
-// or launch template.
 type MixedInstancesPolicy struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the instances distribution. If not provided, the value for each
-	// property in InstancesDistribution uses a default value.
+	// Specifies the instances distribution.
 	InstancesDistribution *InstancesDistribution `type:"structure"`
 
-	// Specifies the launch template to use and optionally the instance types (overrides)
-	// that are used to provision EC2 instances to fulfill On-Demand and Spot capacities.
+	// Specifies the launch template to use and the instance types (overrides) that
+	// are used to launch EC2 instances to fulfill On-Demand and Spot capacities.
 	// Required when creating a mixed instances policy.
 	LaunchTemplate *LaunchTemplate `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MixedInstancesPolicy) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MixedInstancesPolicy) GoString() string {
 	return s.String()
 }
@@ -13299,6 +15202,48 @@ func (s *MixedInstancesPolicy) SetLaunchTemplate(v *LaunchTemplate) *MixedInstan
 	return s
 }
 
+// Specifies the minimum and maximum for the NetworkInterfaceCount object when
+// you specify InstanceRequirements for an Auto Scaling group.
+type NetworkInterfaceCountRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of network interfaces.
+	Max *int64 `type:"integer"`
+
+	// The minimum number of network interfaces.
+	Min *int64 `type:"integer"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s NetworkInterfaceCountRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s NetworkInterfaceCountRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *NetworkInterfaceCountRequest) SetMax(v int64) *NetworkInterfaceCountRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *NetworkInterfaceCountRequest) SetMin(v int64) *NetworkInterfaceCountRequest {
+	s.Min = &v
+	return s
+}
+
 // Describes a notification.
 type NotificationConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -13324,12 +15269,20 @@ type NotificationConfiguration struct {
 	TopicARN *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s NotificationConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s NotificationConfiguration) GoString() string {
 	return s.String()
 }
@@ -13374,22 +15327,25 @@ type PredefinedMetricSpecification struct {
 	// PredefinedMetricType is a required field
 	PredefinedMetricType *string `type:"string" required:"true" enum:"MetricType"`
 
-	// Identifies the resource associated with the metric type. You can't specify
-	// a resource label unless the metric type is ALBRequestCountPerTarget and there
-	// is a target group attached to the Auto Scaling group.
+	// A label that uniquely identifies a specific Application Load Balancer target
+	// group from which to determine the average request count served by your Auto
+	// Scaling group. You can't specify a resource label unless the target group
+	// is attached to the Auto Scaling group.
 	//
 	// You create the resource label by appending the final portion of the load
 	// balancer ARN and the final portion of the target group ARN into a single
-	// value, separated by a forward slash (/). The format is app/<load-balancer-name>/<load-balancer-id>/targetgroup/<target-group-name>/<target-group-id>,
-	// where:
+	// value, separated by a forward slash (/). The format of the resource label
+	// is:
+	//
+	// app/my-alb/778d41231b141a0f/targetgroup/my-alb-target-group/943f017f100becff.
+	//
+	// Where:
 	//
 	//    * app/<load-balancer-name>/<load-balancer-id> is the final portion of
 	//    the load balancer ARN
 	//
 	//    * targetgroup/<target-group-name>/<target-group-id> is the final portion
 	//    of the target group ARN.
-	//
-	// This is an example: app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2Co-Defau-LDNM7Q3ZH1ZN/6d4ea56ca2d6a18d.
 	//
 	// To find the ARN for an Application Load Balancer, use the DescribeLoadBalancers
 	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html)
@@ -13399,12 +15355,20 @@ type PredefinedMetricSpecification struct {
 	ResourceLabel *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredefinedMetricSpecification) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredefinedMetricSpecification) GoString() string {
 	return s.String()
 }
@@ -13497,12 +15461,20 @@ type PredictiveScalingConfiguration struct {
 	SchedulingBufferTime *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingConfiguration) GoString() string {
 	return s.String()
 }
@@ -13615,12 +15587,20 @@ type PredictiveScalingMetricSpecification struct {
 	TargetValue *float64 `type:"double" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingMetricSpecification) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingMetricSpecification) GoString() string {
 	return s.String()
 }
@@ -13700,7 +15680,7 @@ type PredictiveScalingPredefinedLoadMetric struct {
 	// value, separated by a forward slash (/). The format of the resource label
 	// is:
 	//
-	// app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2Co-Defau-LDNM7Q3ZH1ZN/6d4ea56ca2d6a18d.
+	// app/my-alb/778d41231b141a0f/targetgroup/my-alb-target-group/943f017f100becff.
 	//
 	// Where:
 	//
@@ -13718,12 +15698,20 @@ type PredictiveScalingPredefinedLoadMetric struct {
 	ResourceLabel *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedLoadMetric) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedLoadMetric) GoString() string {
 	return s.String()
 }
@@ -13770,16 +15758,16 @@ type PredictiveScalingPredefinedMetricPair struct {
 	PredefinedMetricType *string `type:"string" required:"true" enum:"PredefinedMetricPairType"`
 
 	// A label that uniquely identifies a specific Application Load Balancer target
-	// group from which to determine the request count served by your Auto Scaling
-	// group. You can't specify a resource label unless the target group is attached
-	// to the Auto Scaling group.
+	// group from which to determine the total and average request count served
+	// by your Auto Scaling group. You can't specify a resource label unless the
+	// target group is attached to the Auto Scaling group.
 	//
 	// You create the resource label by appending the final portion of the load
 	// balancer ARN and the final portion of the target group ARN into a single
 	// value, separated by a forward slash (/). The format of the resource label
 	// is:
 	//
-	// app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2Co-Defau-LDNM7Q3ZH1ZN/6d4ea56ca2d6a18d.
+	// app/my-alb/778d41231b141a0f/targetgroup/my-alb-target-group/943f017f100becff.
 	//
 	// Where:
 	//
@@ -13797,12 +15785,20 @@ type PredictiveScalingPredefinedMetricPair struct {
 	ResourceLabel *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedMetricPair) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedMetricPair) GoString() string {
 	return s.String()
 }
@@ -13849,16 +15845,16 @@ type PredictiveScalingPredefinedScalingMetric struct {
 	PredefinedMetricType *string `type:"string" required:"true" enum:"PredefinedScalingMetricType"`
 
 	// A label that uniquely identifies a specific Application Load Balancer target
-	// group from which to determine the request count served by your Auto Scaling
-	// group. You can't specify a resource label unless the target group is attached
-	// to the Auto Scaling group.
+	// group from which to determine the average request count served by your Auto
+	// Scaling group. You can't specify a resource label unless the target group
+	// is attached to the Auto Scaling group.
 	//
 	// You create the resource label by appending the final portion of the load
 	// balancer ARN and the final portion of the target group ARN into a single
 	// value, separated by a forward slash (/). The format of the resource label
 	// is:
 	//
-	// app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2Co-Defau-LDNM7Q3ZH1ZN/6d4ea56ca2d6a18d.
+	// app/my-alb/778d41231b141a0f/targetgroup/my-alb-target-group/943f017f100becff.
 	//
 	// Where:
 	//
@@ -13876,12 +15872,20 @@ type PredictiveScalingPredefinedScalingMetric struct {
 	ResourceLabel *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedScalingMetric) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PredictiveScalingPredefinedScalingMetric) GoString() string {
 	return s.String()
 }
@@ -13945,12 +15949,20 @@ type ProcessType struct {
 	ProcessName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ProcessType) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ProcessType) GoString() string {
 	return s.String()
 }
@@ -14025,12 +16037,20 @@ type PutLifecycleHookInput struct {
 	RoleARN *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecycleHookInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecycleHookInput) GoString() string {
 	return s.String()
 }
@@ -14115,12 +16135,20 @@ type PutLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecycleHookOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecycleHookOutput) GoString() string {
 	return s.String()
 }
@@ -14147,12 +16175,20 @@ type PutNotificationConfigurationInput struct {
 	TopicARN *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutNotificationConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutNotificationConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -14204,12 +16240,20 @@ type PutNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutNotificationConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutNotificationConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -14343,12 +16387,20 @@ type PutScalingPolicyInput struct {
 	TargetTrackingConfiguration *TargetTrackingConfiguration `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScalingPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScalingPolicyInput) GoString() string {
 	return s.String()
 }
@@ -14499,12 +16551,20 @@ type PutScalingPolicyOutput struct {
 	PolicyARN *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScalingPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScalingPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -14583,12 +16643,20 @@ type PutScheduledUpdateGroupActionInput struct {
 	TimeZone *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScheduledUpdateGroupActionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScheduledUpdateGroupActionInput) GoString() string {
 	return s.String()
 }
@@ -14685,12 +16753,20 @@ type PutScheduledUpdateGroupActionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScheduledUpdateGroupActionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutScheduledUpdateGroupActionOutput) GoString() string {
 	return s.String()
 }
@@ -14735,12 +16811,20 @@ type PutWarmPoolInput struct {
 	PoolState *string `type:"string" enum:"WarmPoolState"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutWarmPoolInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutWarmPoolInput) GoString() string {
 	return s.String()
 }
@@ -14792,12 +16876,20 @@ type PutWarmPoolOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutWarmPoolOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutWarmPoolOutput) GoString() string {
 	return s.String()
 }
@@ -14824,12 +16916,20 @@ type RecordLifecycleActionHeartbeatInput struct {
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RecordLifecycleActionHeartbeatInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RecordLifecycleActionHeartbeatInput) GoString() string {
 	return s.String()
 }
@@ -14890,20 +16990,25 @@ type RecordLifecycleActionHeartbeatOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RecordLifecycleActionHeartbeatOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RecordLifecycleActionHeartbeatOutput) GoString() string {
 	return s.String()
 }
 
-// Describes information used to start an instance refresh.
-//
-// All properties are optional. However, if you specify a value for CheckpointDelay,
-// you must also provide a value for CheckpointPercentages.
+// Describes the preferences for an instance refresh.
 type RefreshPreferences struct {
 	_ struct{} `type:"structure"`
 
@@ -14928,18 +17033,37 @@ type RefreshPreferences struct {
 	InstanceWarmup *int64 `type:"integer"`
 
 	// The amount of capacity in the Auto Scaling group that must remain healthy
-	// during an instance refresh to allow the operation to continue, as a percentage
-	// of the desired capacity of the Auto Scaling group (rounded up to the nearest
-	// integer). The default is 90.
+	// during an instance refresh to allow the operation to continue. The value
+	// is expressed as a percentage of the desired capacity of the Auto Scaling
+	// group (rounded up to the nearest integer). The default is 90.
+	//
+	// Setting the minimum healthy percentage to 100 percent limits the rate of
+	// replacement to one instance at a time. In contrast, setting it to 0 percent
+	// has the effect of replacing all instances at the same time.
 	MinHealthyPercentage *int64 `type:"integer"`
+
+	// A boolean value that indicates whether skip matching is enabled. If true,
+	// then Amazon EC2 Auto Scaling skips replacing instances that match the desired
+	// configuration. If no desired configuration is specified, then it skips replacing
+	// instances that have the same configuration that is already set on the group.
+	// The default is false.
+	SkipMatching *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RefreshPreferences) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RefreshPreferences) GoString() string {
 	return s.String()
 }
@@ -14968,16 +17092,30 @@ func (s *RefreshPreferences) SetMinHealthyPercentage(v int64) *RefreshPreference
 	return s
 }
 
+// SetSkipMatching sets the SkipMatching field's value.
+func (s *RefreshPreferences) SetSkipMatching(v bool) *RefreshPreferences {
+	s.SkipMatching = &v
+	return s
+}
+
 type ResumeProcessesOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ResumeProcessesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ResumeProcessesOutput) GoString() string {
 	return s.String()
 }
@@ -15054,12 +17192,20 @@ type ScalingPolicy struct {
 	TargetTrackingConfiguration *TargetTrackingConfiguration `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScalingPolicy) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScalingPolicy) GoString() string {
 	return s.String()
 }
@@ -15192,12 +17338,20 @@ type ScalingProcessQuery struct {
 	ScalingProcesses []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScalingProcessQuery) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScalingProcessQuery) GoString() string {
 	return s.String()
 }
@@ -15273,12 +17427,20 @@ type ScheduledUpdateGroupAction struct {
 	TimeZone *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduledUpdateGroupAction) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduledUpdateGroupAction) GoString() string {
 	return s.String()
 }
@@ -15404,12 +17566,20 @@ type ScheduledUpdateGroupActionRequest struct {
 	TimeZone *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduledUpdateGroupActionRequest) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduledUpdateGroupActionRequest) GoString() string {
 	return s.String()
 }
@@ -15505,12 +17675,20 @@ type SetDesiredCapacityInput struct {
 	HonorCooldown *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetDesiredCapacityInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetDesiredCapacityInput) GoString() string {
 	return s.String()
 }
@@ -15556,12 +17734,20 @@ type SetDesiredCapacityOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetDesiredCapacityOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetDesiredCapacityOutput) GoString() string {
 	return s.String()
 }
@@ -15592,12 +17778,20 @@ type SetInstanceHealthInput struct {
 	ShouldRespectGracePeriod *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceHealthInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceHealthInput) GoString() string {
 	return s.String()
 }
@@ -15646,12 +17840,20 @@ type SetInstanceHealthOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceHealthOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceHealthOutput) GoString() string {
 	return s.String()
 }
@@ -15676,12 +17878,20 @@ type SetInstanceProtectionInput struct {
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceProtectionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceProtectionInput) GoString() string {
 	return s.String()
 }
@@ -15730,12 +17940,20 @@ type SetInstanceProtectionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceProtectionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetInstanceProtectionOutput) GoString() string {
 	return s.String()
 }
@@ -15748,32 +17966,47 @@ type StartInstanceRefreshInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// Set of preferences associated with the instance refresh request.
+	// The desired configuration. For example, the desired configuration can specify
+	// a new launch template or a new version of the current launch template.
 	//
-	// If not provided, the default values are used. For MinHealthyPercentage, the
-	// default value is 90. For InstanceWarmup, the default is to use the value
-	// specified for the health check grace period for the Auto Scaling group.
+	// Once the instance refresh succeeds, Amazon EC2 Auto Scaling updates the settings
+	// of the Auto Scaling group to reflect the new desired configuration.
 	//
-	// For more information, see RefreshPreferences (https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_RefreshPreferences.html)
-	// in the Amazon EC2 Auto Scaling API Reference.
+	// When you specify a new launch template or a new version of the current launch
+	// template for your desired configuration, consider enabling the SkipMatching
+	// property in preferences. If it's enabled, Amazon EC2 Auto Scaling skips replacing
+	// instances that already use the specified launch template and version. This
+	// can help you reduce the number of replacements that are required to apply
+	// updates.
+	DesiredConfiguration *DesiredConfiguration `type:"structure"`
+
+	// Set of preferences associated with the instance refresh request. If not provided,
+	// the default values are used.
 	Preferences *RefreshPreferences `type:"structure"`
 
 	// The strategy to use for the instance refresh. The only valid value is Rolling.
 	//
-	// A rolling update is an update that is applied to all instances in an Auto
-	// Scaling group until all instances have been updated. A rolling update can
-	// fail due to failed health checks or if instances are on standby or are protected
-	// from scale in. If the rolling update process fails, any instances that were
-	// already replaced are not rolled back to their previous configuration.
+	// A rolling update helps you update your instances gradually. A rolling update
+	// can fail due to failed health checks or if instances are on standby or are
+	// protected from scale in. If the rolling update process fails, any instances
+	// that are replaced are not rolled back to their previous configuration.
 	Strategy *string `type:"string" enum:"RefreshStrategy"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartInstanceRefreshInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartInstanceRefreshInput) GoString() string {
 	return s.String()
 }
@@ -15787,6 +18020,11 @@ func (s *StartInstanceRefreshInput) Validate() error {
 	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
 	}
+	if s.DesiredConfiguration != nil {
+		if err := s.DesiredConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("DesiredConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15797,6 +18035,12 @@ func (s *StartInstanceRefreshInput) Validate() error {
 // SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
 func (s *StartInstanceRefreshInput) SetAutoScalingGroupName(v string) *StartInstanceRefreshInput {
 	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDesiredConfiguration sets the DesiredConfiguration field's value.
+func (s *StartInstanceRefreshInput) SetDesiredConfiguration(v *DesiredConfiguration) *StartInstanceRefreshInput {
+	s.DesiredConfiguration = v
 	return s
 }
 
@@ -15819,12 +18063,20 @@ type StartInstanceRefreshOutput struct {
 	InstanceRefreshId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartInstanceRefreshOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartInstanceRefreshOutput) GoString() string {
 	return s.String()
 }
@@ -15893,12 +18145,20 @@ type StepAdjustment struct {
 	ScalingAdjustment *int64 `type:"integer" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StepAdjustment) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StepAdjustment) GoString() string {
 	return s.String()
 }
@@ -15938,12 +18198,20 @@ type SuspendProcessesOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SuspendProcessesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SuspendProcessesOutput) GoString() string {
 	return s.String()
 }
@@ -15962,12 +18230,20 @@ type SuspendedProcess struct {
 	SuspensionReason *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SuspendedProcess) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SuspendedProcess) GoString() string {
 	return s.String()
 }
@@ -15997,7 +18273,7 @@ type Tag struct {
 	// in the group.
 	PropagateAtLaunch *bool `type:"boolean"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	ResourceId *string `type:"string"`
 
 	// The type of resource. The only supported value is auto-scaling-group.
@@ -16007,12 +18283,20 @@ type Tag struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }
@@ -16084,12 +18368,20 @@ type TagDescription struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) GoString() string {
 	return s.String()
 }
@@ -16149,12 +18441,20 @@ type TargetTrackingConfiguration struct {
 	TargetValue *float64 `type:"double" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetTrackingConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetTrackingConfiguration) GoString() string {
 	return s.String()
 }
@@ -16221,12 +18521,20 @@ type TerminateInstanceInAutoScalingGroupInput struct {
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TerminateInstanceInAutoScalingGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TerminateInstanceInAutoScalingGroupInput) GoString() string {
 	return s.String()
 }
@@ -16269,12 +18577,20 @@ type TerminateInstanceInAutoScalingGroupOutput struct {
 	Activity *Activity `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TerminateInstanceInAutoScalingGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TerminateInstanceInAutoScalingGroupOutput) GoString() string {
 	return s.String()
 }
@@ -16282,6 +18598,48 @@ func (s TerminateInstanceInAutoScalingGroupOutput) GoString() string {
 // SetActivity sets the Activity field's value.
 func (s *TerminateInstanceInAutoScalingGroupOutput) SetActivity(v *Activity) *TerminateInstanceInAutoScalingGroupOutput {
 	s.Activity = v
+	return s
+}
+
+// Specifies the minimum and maximum for the TotalLocalStorageGB object when
+// you specify InstanceRequirements for an Auto Scaling group.
+type TotalLocalStorageGBRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The storage maximum in GB.
+	Max *float64 `type:"double"`
+
+	// The storage minimum in GB.
+	Min *float64 `type:"double"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TotalLocalStorageGBRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s TotalLocalStorageGBRequest) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *TotalLocalStorageGBRequest) SetMax(v float64) *TotalLocalStorageGBRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *TotalLocalStorageGBRequest) SetMin(v float64) *TotalLocalStorageGBRequest {
+	s.Min = &v
 	return s
 }
 
@@ -16301,6 +18659,9 @@ type UpdateAutoScalingGroupInput struct {
 	// in the Amazon EC2 Auto Scaling User Guide.
 	CapacityRebalance *bool `type:"boolean"`
 
+	// Reserved.
+	Context *string `type:"string"`
+
 	// The amount of time, in seconds, after a scaling activity completes before
 	// another scaling activity can start. The default value is 300. This setting
 	// applies when using simple scaling policies, but not when using other scaling
@@ -16314,6 +18675,18 @@ type UpdateAutoScalingGroupInput struct {
 	// must be greater than or equal to the minimum size of the group and less than
 	// or equal to the maximum size of the group.
 	DesiredCapacity *int64 `type:"integer"`
+
+	// The unit of measurement for the value specified for desired capacity. Amazon
+	// EC2 Auto Scaling supports DesiredCapacityType for attribute-based instance
+	// type selection only. For more information, see Creating an Auto Scaling group
+	// using attribute-based instance type selection (https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-instance-type-requirements.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
+	//
+	// By default, Amazon EC2 Auto Scaling specifies units, which translates into
+	// number of instances.
+	//
+	// Valid values: units | vcpu | memory-mib
+	DesiredCapacityType *string `min:"1" type:"string"`
 
 	// The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before
 	// checking the health status of an EC2 instance that has come into service.
@@ -16359,10 +18732,9 @@ type UpdateAutoScalingGroupInput struct {
 	// The minimum size of the Auto Scaling group.
 	MinSize *int64 `type:"integer"`
 
-	// An embedded object that specifies a mixed instances policy. When you make
-	// changes to an existing policy, all optional properties are left unchanged
-	// if not specified. For more information, see Auto Scaling groups with multiple
-	// instance types and purchase options (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
+	// An embedded object that specifies a mixed instances policy. For more information,
+	// see Auto Scaling groups with multiple instance types and purchase options
+	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	MixedInstancesPolicy *MixedInstancesPolicy `type:"structure"`
 
@@ -16381,7 +18753,7 @@ type UpdateAutoScalingGroupInput struct {
 	PlacementGroup *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
-	// group uses to call other AWS services on your behalf. For more information,
+	// group uses to call other Amazon Web Services on your behalf. For more information,
 	// see Service-linked roles (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-service-linked-role.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	ServiceLinkedRoleARN *string `min:"1" type:"string"`
@@ -16398,12 +18770,20 @@ type UpdateAutoScalingGroupInput struct {
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAutoScalingGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAutoScalingGroupInput) GoString() string {
 	return s.String()
 }
@@ -16416,6 +18796,9 @@ func (s *UpdateAutoScalingGroupInput) Validate() error {
 	}
 	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.DesiredCapacityType != nil && len(*s.DesiredCapacityType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DesiredCapacityType", 1))
 	}
 	if s.HealthCheckType != nil && len(*s.HealthCheckType) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("HealthCheckType", 1))
@@ -16467,6 +18850,12 @@ func (s *UpdateAutoScalingGroupInput) SetCapacityRebalance(v bool) *UpdateAutoSc
 	return s
 }
 
+// SetContext sets the Context field's value.
+func (s *UpdateAutoScalingGroupInput) SetContext(v string) *UpdateAutoScalingGroupInput {
+	s.Context = &v
+	return s
+}
+
 // SetDefaultCooldown sets the DefaultCooldown field's value.
 func (s *UpdateAutoScalingGroupInput) SetDefaultCooldown(v int64) *UpdateAutoScalingGroupInput {
 	s.DefaultCooldown = &v
@@ -16476,6 +18865,12 @@ func (s *UpdateAutoScalingGroupInput) SetDefaultCooldown(v int64) *UpdateAutoSca
 // SetDesiredCapacity sets the DesiredCapacity field's value.
 func (s *UpdateAutoScalingGroupInput) SetDesiredCapacity(v int64) *UpdateAutoScalingGroupInput {
 	s.DesiredCapacity = &v
+	return s
+}
+
+// SetDesiredCapacityType sets the DesiredCapacityType field's value.
+func (s *UpdateAutoScalingGroupInput) SetDesiredCapacityType(v string) *UpdateAutoScalingGroupInput {
+	s.DesiredCapacityType = &v
 	return s
 }
 
@@ -16561,14 +18956,79 @@ type UpdateAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAutoScalingGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAutoScalingGroupOutput) GoString() string {
 	return s.String()
+}
+
+// Specifies the minimum and maximum for the VCpuCount object when you specify
+// InstanceRequirements for an Auto Scaling group.
+type VCpuCountRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of vCPUs.
+	Max *int64 `type:"integer"`
+
+	// The minimum number of vCPUs.
+	//
+	// Min is a required field
+	Min *int64 `type:"integer" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s VCpuCountRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s VCpuCountRequest) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VCpuCountRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VCpuCountRequest"}
+	if s.Min == nil {
+		invalidParams.Add(request.NewErrParamRequired("Min"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMax sets the Max field's value.
+func (s *VCpuCountRequest) SetMax(v int64) *VCpuCountRequest {
+	s.Max = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *VCpuCountRequest) SetMin(v int64) *VCpuCountRequest {
+	s.Min = &v
+	return s
 }
 
 // Describes a warm pool configuration.
@@ -16589,12 +19049,20 @@ type WarmPoolConfiguration struct {
 	Status *string `type:"string" enum:"WarmPoolStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s WarmPoolConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s WarmPoolConfiguration) GoString() string {
 	return s.String()
 }
@@ -16621,6 +19089,162 @@ func (s *WarmPoolConfiguration) SetPoolState(v string) *WarmPoolConfiguration {
 func (s *WarmPoolConfiguration) SetStatus(v string) *WarmPoolConfiguration {
 	s.Status = &v
 	return s
+}
+
+const (
+	// AcceleratorManufacturerNvidia is a AcceleratorManufacturer enum value
+	AcceleratorManufacturerNvidia = "nvidia"
+
+	// AcceleratorManufacturerAmd is a AcceleratorManufacturer enum value
+	AcceleratorManufacturerAmd = "amd"
+
+	// AcceleratorManufacturerAmazonWebServices is a AcceleratorManufacturer enum value
+	AcceleratorManufacturerAmazonWebServices = "amazon-web-services"
+
+	// AcceleratorManufacturerXilinx is a AcceleratorManufacturer enum value
+	AcceleratorManufacturerXilinx = "xilinx"
+)
+
+// AcceleratorManufacturer_Values returns all elements of the AcceleratorManufacturer enum
+func AcceleratorManufacturer_Values() []string {
+	return []string{
+		AcceleratorManufacturerNvidia,
+		AcceleratorManufacturerAmd,
+		AcceleratorManufacturerAmazonWebServices,
+		AcceleratorManufacturerXilinx,
+	}
+}
+
+const (
+	// AcceleratorNameA100 is a AcceleratorName enum value
+	AcceleratorNameA100 = "a100"
+
+	// AcceleratorNameV100 is a AcceleratorName enum value
+	AcceleratorNameV100 = "v100"
+
+	// AcceleratorNameK80 is a AcceleratorName enum value
+	AcceleratorNameK80 = "k80"
+
+	// AcceleratorNameT4 is a AcceleratorName enum value
+	AcceleratorNameT4 = "t4"
+
+	// AcceleratorNameM60 is a AcceleratorName enum value
+	AcceleratorNameM60 = "m60"
+
+	// AcceleratorNameRadeonProV520 is a AcceleratorName enum value
+	AcceleratorNameRadeonProV520 = "radeon-pro-v520"
+
+	// AcceleratorNameVu9p is a AcceleratorName enum value
+	AcceleratorNameVu9p = "vu9p"
+)
+
+// AcceleratorName_Values returns all elements of the AcceleratorName enum
+func AcceleratorName_Values() []string {
+	return []string{
+		AcceleratorNameA100,
+		AcceleratorNameV100,
+		AcceleratorNameK80,
+		AcceleratorNameT4,
+		AcceleratorNameM60,
+		AcceleratorNameRadeonProV520,
+		AcceleratorNameVu9p,
+	}
+}
+
+const (
+	// AcceleratorTypeGpu is a AcceleratorType enum value
+	AcceleratorTypeGpu = "gpu"
+
+	// AcceleratorTypeFpga is a AcceleratorType enum value
+	AcceleratorTypeFpga = "fpga"
+
+	// AcceleratorTypeInference is a AcceleratorType enum value
+	AcceleratorTypeInference = "inference"
+)
+
+// AcceleratorType_Values returns all elements of the AcceleratorType enum
+func AcceleratorType_Values() []string {
+	return []string{
+		AcceleratorTypeGpu,
+		AcceleratorTypeFpga,
+		AcceleratorTypeInference,
+	}
+}
+
+const (
+	// BareMetalIncluded is a BareMetal enum value
+	BareMetalIncluded = "included"
+
+	// BareMetalExcluded is a BareMetal enum value
+	BareMetalExcluded = "excluded"
+
+	// BareMetalRequired is a BareMetal enum value
+	BareMetalRequired = "required"
+)
+
+// BareMetal_Values returns all elements of the BareMetal enum
+func BareMetal_Values() []string {
+	return []string{
+		BareMetalIncluded,
+		BareMetalExcluded,
+		BareMetalRequired,
+	}
+}
+
+const (
+	// BurstablePerformanceIncluded is a BurstablePerformance enum value
+	BurstablePerformanceIncluded = "included"
+
+	// BurstablePerformanceExcluded is a BurstablePerformance enum value
+	BurstablePerformanceExcluded = "excluded"
+
+	// BurstablePerformanceRequired is a BurstablePerformance enum value
+	BurstablePerformanceRequired = "required"
+)
+
+// BurstablePerformance_Values returns all elements of the BurstablePerformance enum
+func BurstablePerformance_Values() []string {
+	return []string{
+		BurstablePerformanceIncluded,
+		BurstablePerformanceExcluded,
+		BurstablePerformanceRequired,
+	}
+}
+
+const (
+	// CpuManufacturerIntel is a CpuManufacturer enum value
+	CpuManufacturerIntel = "intel"
+
+	// CpuManufacturerAmd is a CpuManufacturer enum value
+	CpuManufacturerAmd = "amd"
+
+	// CpuManufacturerAmazonWebServices is a CpuManufacturer enum value
+	CpuManufacturerAmazonWebServices = "amazon-web-services"
+)
+
+// CpuManufacturer_Values returns all elements of the CpuManufacturer enum
+func CpuManufacturer_Values() []string {
+	return []string{
+		CpuManufacturerIntel,
+		CpuManufacturerAmd,
+		CpuManufacturerAmazonWebServices,
+	}
+}
+
+const (
+	// InstanceGenerationCurrent is a InstanceGeneration enum value
+	InstanceGenerationCurrent = "current"
+
+	// InstanceGenerationPrevious is a InstanceGeneration enum value
+	InstanceGenerationPrevious = "previous"
+)
+
+// InstanceGeneration_Values returns all elements of the InstanceGeneration enum
+func InstanceGeneration_Values() []string {
+	return []string{
+		InstanceGenerationCurrent,
+		InstanceGenerationPrevious,
+	}
 }
 
 const (
@@ -16780,6 +19404,42 @@ func LifecycleState_Values() []string {
 		LifecycleStateWarmedTerminated,
 		LifecycleStateWarmedStopped,
 		LifecycleStateWarmedRunning,
+	}
+}
+
+const (
+	// LocalStorageIncluded is a LocalStorage enum value
+	LocalStorageIncluded = "included"
+
+	// LocalStorageExcluded is a LocalStorage enum value
+	LocalStorageExcluded = "excluded"
+
+	// LocalStorageRequired is a LocalStorage enum value
+	LocalStorageRequired = "required"
+)
+
+// LocalStorage_Values returns all elements of the LocalStorage enum
+func LocalStorage_Values() []string {
+	return []string{
+		LocalStorageIncluded,
+		LocalStorageExcluded,
+		LocalStorageRequired,
+	}
+}
+
+const (
+	// LocalStorageTypeHdd is a LocalStorageType enum value
+	LocalStorageTypeHdd = "hdd"
+
+	// LocalStorageTypeSsd is a LocalStorageType enum value
+	LocalStorageTypeSsd = "ssd"
+)
+
+// LocalStorageType_Values returns all elements of the LocalStorageType enum
+func LocalStorageType_Values() []string {
+	return []string{
+		LocalStorageTypeHdd,
+		LocalStorageTypeSsd,
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/autoscaling/service.go
@@ -48,22 +48,23 @@ const (
 //     svc := autoscaling.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AutoScaling {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *AutoScaling {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *AutoScaling {
 	svc := &AutoScaling{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2011-01-01",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2011-01-01",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
@@ -68,6 +68,10 @@ func fillPresignedURL(r *request.Request) {
 		func(opt *endpoints.Options) {
 			opt.DisableSSL = aws.BoolValue(cfg.DisableSSL)
 			opt.UseDualStack = aws.BoolValue(cfg.UseDualStack)
+			opt.UseDualStackEndpoint = cfg.UseDualStackEndpoint
+			opt.UseFIPSEndpoint = cfg.UseFIPSEndpoint
+			opt.Logger = r.Config.Logger
+			opt.LogDeprecated = r.Config.LogLevel.Matches(aws.LogDebugWithDeprecated)
 		},
 	)
 	if err != nil {

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/service.go
@@ -48,22 +48,23 @@ const (
 //     svc := ec2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *EC2 {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *EC2 {
 	svc := &EC2{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2016-11-15",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2016-11-15",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
@@ -1030,6 +1030,11 @@ func (c *EC2) WaitUntilSnapshotCompletedWithContext(ctx aws.Context, input *Desc
 				Matcher: request.PathAllWaiterMatch, Argument: "Snapshots[].State",
 				Expected: "completed",
 			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Snapshots[].State",
+				Expected: "error",
+			},
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
@@ -454,7 +454,7 @@ func (c *ECR) CreateRepositoryRequest(input *CreateRepositoryInput) (req *reques
 
 // CreateRepository API operation for Amazon EC2 Container Registry.
 //
-// Creates a repository. For more information, see Amazon ECR Repositories (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html)
+// Creates a repository. For more information, see Amazon ECR repositories (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -486,7 +486,7 @@ func (c *ECR) CreateRepositoryRequest(input *CreateRepositoryInput) (req *reques
 //
 //   * LimitExceededException
 //   The operation did not succeed because it would have exceeded a service limit
-//   for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+//   for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 //   in the Amazon Elastic Container Registry User Guide.
 //
 //   * KmsException
@@ -667,6 +667,9 @@ func (c *ECR) DeleteRegistryPolicyRequest(input *DeleteRegistryPolicyInput) (req
 //
 //   * RegistryPolicyNotFoundException
 //   The registry doesn't have an associated registry policy.
+//
+//   * ValidationException
+//   There was an exception validating this request.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/DeleteRegistryPolicy
 func (c *ECR) DeleteRegistryPolicy(input *DeleteRegistryPolicyInput) (*DeleteRegistryPolicyOutput, error) {
@@ -872,6 +875,99 @@ func (c *ECR) DeleteRepositoryPolicy(input *DeleteRepositoryPolicyInput) (*Delet
 // for more information on using Contexts.
 func (c *ECR) DeleteRepositoryPolicyWithContext(ctx aws.Context, input *DeleteRepositoryPolicyInput, opts ...request.Option) (*DeleteRepositoryPolicyOutput, error) {
 	req, out := c.DeleteRepositoryPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeImageReplicationStatus = "DescribeImageReplicationStatus"
+
+// DescribeImageReplicationStatusRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeImageReplicationStatus operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeImageReplicationStatus for more information on using the DescribeImageReplicationStatus
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeImageReplicationStatusRequest method.
+//    req, resp := client.DescribeImageReplicationStatusRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/DescribeImageReplicationStatus
+func (c *ECR) DescribeImageReplicationStatusRequest(input *DescribeImageReplicationStatusInput) (req *request.Request, output *DescribeImageReplicationStatusOutput) {
+	op := &request.Operation{
+		Name:       opDescribeImageReplicationStatus,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeImageReplicationStatusInput{}
+	}
+
+	output = &DescribeImageReplicationStatusOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeImageReplicationStatus API operation for Amazon EC2 Container Registry.
+//
+// Returns the replication status for a specified image.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation DescribeImageReplicationStatus for usage and error information.
+//
+// Returned Error Types:
+//   * ServerException
+//   These errors are usually caused by a server-side issue.
+//
+//   * InvalidParameterException
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ImageNotFoundException
+//   The image requested does not exist in the specified repository.
+//
+//   * RepositoryNotFoundException
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ValidationException
+//   There was an exception validating this request.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/DescribeImageReplicationStatus
+func (c *ECR) DescribeImageReplicationStatus(input *DescribeImageReplicationStatusInput) (*DescribeImageReplicationStatusOutput, error) {
+	req, out := c.DescribeImageReplicationStatusRequest(input)
+	return out, req.Send()
+}
+
+// DescribeImageReplicationStatusWithContext is the same as DescribeImageReplicationStatus with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeImageReplicationStatus for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) DescribeImageReplicationStatusWithContext(ctx aws.Context, input *DescribeImageReplicationStatusInput, opts ...request.Option) (*DescribeImageReplicationStatusOutput, error) {
+	req, out := c.DescribeImageReplicationStatusRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1465,9 +1561,9 @@ func (c *ECR) GetAuthorizationTokenRequest(input *GetAuthorizationTokenInput) (r
 // 12 hours.
 //
 // The authorizationToken returned is a base64 encoded string that can be decoded
-// and used in a docker login command to authenticate to a registry. The AWS
-// CLI offers an get-login-password command that simplifies the login process.
-// For more information, see Registry Authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
+// and used in a docker login command to authenticate to a registry. The CLI
+// offers an get-login-password command that simplifies the login process. For
+// more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1912,6 +2008,9 @@ func (c *ECR) GetRegistryPolicyRequest(input *GetRegistryPolicyInput) (req *requ
 //
 //   * RegistryPolicyNotFoundException
 //   The registry doesn't have an associated registry policy.
+//
+//   * ValidationException
+//   There was an exception validating this request.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/GetRegistryPolicy
 func (c *ECR) GetRegistryPolicy(input *GetRegistryPolicyInput) (*GetRegistryPolicyOutput, error) {
@@ -2449,7 +2548,7 @@ func (c *ECR) PutImageRequest(input *PutImageInput) (req *request.Request, outpu
 //
 //   * LimitExceededException
 //   The operation did not succeed because it would have exceeded a service limit
-//   for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+//   for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 //   in the Amazon Elastic Container Registry User Guide.
 //
 //   * ImageTagAlreadyExistsException
@@ -2617,7 +2716,7 @@ func (c *ECR) PutImageTagMutabilityRequest(input *PutImageTagMutabilityInput) (r
 // PutImageTagMutability API operation for Amazon EC2 Container Registry.
 //
 // Updates the image tag mutability settings for the specified repository. For
-// more information, see Image Tag Mutability (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
+// more information, see Image tag mutability (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2706,7 +2805,7 @@ func (c *ECR) PutLifecyclePolicyRequest(input *PutLifecyclePolicyInput) (req *re
 // PutLifecyclePolicy API operation for Amazon EC2 Container Registry.
 //
 // Creates or updates the lifecycle policy for the specified repository. For
-// more information, see Lifecycle Policy Template (https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html).
+// more information, see Lifecycle policy template (https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2795,9 +2894,9 @@ func (c *ECR) PutRegistryPolicyRequest(input *PutRegistryPolicyInput) (req *requ
 //
 // Creates or updates the permissions policy for your registry.
 //
-// A registry policy is used to specify permissions for another AWS account
-// and is used when configuring cross-account replication. For more information,
-// see Registry permissions (https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry-permissions.html)
+// A registry policy is used to specify permissions for another Amazon Web Services
+// account and is used when configuring cross-account replication. For more
+// information, see Registry permissions (https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry-permissions.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2814,6 +2913,9 @@ func (c *ECR) PutRegistryPolicyRequest(input *PutRegistryPolicyInput) (req *requ
 //   * InvalidParameterException
 //   The specified parameter is invalid. Review the available parameters for the
 //   API request.
+//
+//   * ValidationException
+//   There was an exception validating this request.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/PutRegistryPolicy
 func (c *ECR) PutRegistryPolicy(input *PutRegistryPolicyInput) (*PutRegistryPolicyOutput, error) {
@@ -2885,7 +2987,7 @@ func (c *ECR) PutReplicationConfigurationRequest(input *PutReplicationConfigurat
 // replication configuration for a repository can be retrieved with the DescribeRegistry
 // API action. The first time the PutReplicationConfiguration API is called,
 // a service-linked IAM role is created in your account for the replication
-// process. For more information, see Using Service-Linked Roles for Amazon
+// process. For more information, see Using service-linked roles for Amazon
 // ECR (https://docs.aws.amazon.com/AmazonECR/latest/userguide/using-service-linked-roles.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
@@ -2978,7 +3080,7 @@ func (c *ECR) SetRepositoryPolicyRequest(input *SetRepositoryPolicyInput) (req *
 // SetRepositoryPolicy API operation for Amazon EC2 Container Registry.
 //
 // Applies a repository policy to the specified repository to control access
-// permissions. For more information, see Amazon ECR Repository Policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html)
+// permissions. For more information, see Amazon ECR Repository policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3067,8 +3169,8 @@ func (c *ECR) StartImageScanRequest(input *StartImageScanInput) (req *request.Re
 // StartImageScan API operation for Amazon EC2 Container Registry.
 //
 // Starts an image vulnerability scan. An image scan can only be started once
-// per day on an individual image. This limit includes if an image was scanned
-// on initial push. For more information, see Image Scanning (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+// per 24 hours on an individual image. This limit includes if an image was
+// scanned on initial push. For more information, see Image scanning (https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
 // in the Amazon Elastic Container Registry User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3091,7 +3193,7 @@ func (c *ECR) StartImageScanRequest(input *StartImageScanInput) (req *request.Re
 //
 //   * LimitExceededException
 //   The operation did not succeed because it would have exceeded a service limit
-//   for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+//   for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 //   in the Amazon Elastic Container Registry User Guide.
 //
 //   * RepositoryNotFoundException
@@ -3497,7 +3599,7 @@ func (c *ECR) UploadLayerPartRequest(input *UploadLayerPartInput) (req *request.
 //
 //   * LimitExceededException
 //   The operation did not succeed because it would have exceeded a service limit
-//   for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+//   for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 //   in the Amazon Elastic Container Registry User Guide.
 //
 //   * KmsException
@@ -3538,12 +3640,20 @@ type Attribute struct {
 	Value *string `locationName:"value" min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Attribute) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Attribute) GoString() string {
 	return s.String()
 }
@@ -3579,12 +3689,20 @@ type AuthorizationData struct {
 	ProxyEndpoint *string `locationName:"proxyEndpoint" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthorizationData) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthorizationData) GoString() string {
 	return s.String()
 }
@@ -3615,8 +3733,9 @@ type BatchCheckLayerAvailabilityInput struct {
 	// LayerDigests is a required field
 	LayerDigests []*string `locationName:"layerDigests" min:"1" type:"list" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the image layers
-	// to check. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the image layers to check. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository that is associated with the image layers to check.
@@ -3625,12 +3744,20 @@ type BatchCheckLayerAvailabilityInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchCheckLayerAvailabilityInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchCheckLayerAvailabilityInput) GoString() string {
 	return s.String()
 }
@@ -3686,12 +3813,20 @@ type BatchCheckLayerAvailabilityOutput struct {
 	Layers []*Layer `locationName:"layers" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchCheckLayerAvailabilityOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchCheckLayerAvailabilityOutput) GoString() string {
 	return s.String()
 }
@@ -3719,8 +3854,9 @@ type BatchDeleteImageInput struct {
 	// ImageIds is a required field
 	ImageIds []*ImageIdentifier `locationName:"imageIds" min:"1" type:"list" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the image to
-	// delete. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the image to delete. If you do not specify a registry, the default registry
+	// is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The repository that contains the image to delete.
@@ -3729,12 +3865,20 @@ type BatchDeleteImageInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteImageInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteImageInput) GoString() string {
 	return s.String()
 }
@@ -3799,12 +3943,20 @@ type BatchDeleteImageOutput struct {
 	ImageIds []*ImageIdentifier `locationName:"imageIds" min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteImageOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchDeleteImageOutput) GoString() string {
 	return s.String()
 }
@@ -3836,8 +3988,9 @@ type BatchGetImageInput struct {
 	// ImageIds is a required field
 	ImageIds []*ImageIdentifier `locationName:"imageIds" min:"1" type:"list" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the images
-	// to describe. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the images to describe. If you do not specify a registry, the default registry
+	// is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The repository that contains the images to describe.
@@ -3846,12 +3999,20 @@ type BatchGetImageInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchGetImageInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchGetImageInput) GoString() string {
 	return s.String()
 }
@@ -3925,12 +4086,20 @@ type BatchGetImageOutput struct {
 	Images []*Image `locationName:"images" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchGetImageOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BatchGetImageOutput) GoString() string {
 	return s.String()
 }
@@ -3955,8 +4124,9 @@ type CompleteLayerUploadInput struct {
 	// LayerDigests is a required field
 	LayerDigests []*string `locationName:"layerDigests" min:"1" type:"list" required:"true"`
 
-	// The AWS account ID associated with the registry to which to upload layers.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry to which
+	// to upload layers. If you do not specify a registry, the default registry
+	// is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to associate with the image layer.
@@ -3971,12 +4141,20 @@ type CompleteLayerUploadInput struct {
 	UploadId *string `locationName:"uploadId" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLayerUploadInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLayerUploadInput) GoString() string {
 	return s.String()
 }
@@ -4046,12 +4224,20 @@ type CompleteLayerUploadOutput struct {
 	UploadId *string `locationName:"uploadId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLayerUploadOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CompleteLayerUploadOutput) GoString() string {
 	return s.String()
 }
@@ -4097,6 +4283,10 @@ type CreateRepositoryInput struct {
 	// will be immutable which will prevent them from being overwritten.
 	ImageTagMutability *string `locationName:"imageTagMutability" type:"string" enum:"ImageTagMutability"`
 
+	// The AWS account ID associated with the registry to create the repository.
+	// If you do not specify a registry, the default registry is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
 	// The name to use for the repository. The repository name may be specified
 	// on its own (such as nginx-web-app) or it can be prepended with a namespace
 	// to group the repository into a category (such as project-a/nginx-web-app).
@@ -4111,12 +4301,20 @@ type CreateRepositoryInput struct {
 	Tags []*Tag `locationName:"tags" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRepositoryInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRepositoryInput) GoString() string {
 	return s.String()
 }
@@ -4160,6 +4358,12 @@ func (s *CreateRepositoryInput) SetImageTagMutability(v string) *CreateRepositor
 	return s
 }
 
+// SetRegistryId sets the RegistryId field's value.
+func (s *CreateRepositoryInput) SetRegistryId(v string) *CreateRepositoryInput {
+	s.RegistryId = &v
+	return s
+}
+
 // SetRepositoryName sets the RepositoryName field's value.
 func (s *CreateRepositoryInput) SetRepositoryName(v string) *CreateRepositoryInput {
 	s.RepositoryName = &v
@@ -4179,12 +4383,20 @@ type CreateRepositoryOutput struct {
 	Repository *Repository `locationName:"repository" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRepositoryOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRepositoryOutput) GoString() string {
 	return s.String()
 }
@@ -4198,8 +4410,9 @@ func (s *CreateRepositoryOutput) SetRepository(v *Repository) *CreateRepositoryO
 type DeleteLifecyclePolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository.
@@ -4208,12 +4421,20 @@ type DeleteLifecyclePolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecyclePolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecyclePolicyInput) GoString() string {
 	return s.String()
 }
@@ -4262,12 +4483,20 @@ type DeleteLifecyclePolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecyclePolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLifecyclePolicyOutput) GoString() string {
 	return s.String()
 }
@@ -4300,12 +4529,20 @@ type DeleteRegistryPolicyInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRegistryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRegistryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -4320,12 +4557,20 @@ type DeleteRegistryPolicyOutput struct {
 	RegistryId *string `locationName:"registryId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRegistryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRegistryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -4348,8 +4593,9 @@ type DeleteRepositoryInput struct {
 	// If a repository contains images, forces the deletion.
 	Force *bool `locationName:"force" type:"boolean"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// to delete. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository to delete. If you do not specify a registry, the default registry
+	// is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to delete.
@@ -4358,12 +4604,20 @@ type DeleteRepositoryInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryInput) GoString() string {
 	return s.String()
 }
@@ -4409,12 +4663,20 @@ type DeleteRepositoryOutput struct {
 	Repository *Repository `locationName:"repository" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryOutput) GoString() string {
 	return s.String()
 }
@@ -4428,9 +4690,9 @@ func (s *DeleteRepositoryOutput) SetRepository(v *Repository) *DeleteRepositoryO
 type DeleteRepositoryPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// policy to delete. If you do not specify a registry, the default registry
-	// is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository policy to delete. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository that is associated with the repository policy
@@ -4440,12 +4702,20 @@ type DeleteRepositoryPolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -4491,12 +4761,20 @@ type DeleteRepositoryPolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRepositoryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -4519,10 +4797,137 @@ func (s *DeleteRepositoryPolicyOutput) SetRepositoryName(v string) *DeleteReposi
 	return s
 }
 
+type DescribeImageReplicationStatusInput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an image in an Amazon ECR repository.
+	//
+	// ImageId is a required field
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure" required:"true"`
+
+	// The Amazon Web Services account ID associated with the registry. If you do
+	// not specify a registry, the default registry is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The name of the repository that the image is in.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeImageReplicationStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeImageReplicationStatusInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeImageReplicationStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeImageReplicationStatusInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+	if s.ImageId != nil {
+		if err := s.ImageId.Validate(); err != nil {
+			invalidParams.AddNested("ImageId", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageReplicationStatusInput) SetImageId(v *ImageIdentifier) *DescribeImageReplicationStatusInput {
+	s.ImageId = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DescribeImageReplicationStatusInput) SetRegistryId(v string) *DescribeImageReplicationStatusInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DescribeImageReplicationStatusInput) SetRepositoryName(v string) *DescribeImageReplicationStatusInput {
+	s.RepositoryName = &v
+	return s
+}
+
+type DescribeImageReplicationStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object with identifying information for an image in an Amazon ECR repository.
+	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
+
+	// The replication status details for the images in the specified repository.
+	ReplicationStatuses []*ImageReplicationStatus `locationName:"replicationStatuses" type:"list"`
+
+	// The repository name associated with the request.
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeImageReplicationStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeImageReplicationStatusOutput) GoString() string {
+	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageReplicationStatusOutput) SetImageId(v *ImageIdentifier) *DescribeImageReplicationStatusOutput {
+	s.ImageId = v
+	return s
+}
+
+// SetReplicationStatuses sets the ReplicationStatuses field's value.
+func (s *DescribeImageReplicationStatusOutput) SetReplicationStatuses(v []*ImageReplicationStatus) *DescribeImageReplicationStatusOutput {
+	s.ReplicationStatuses = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DescribeImageReplicationStatusOutput) SetRepositoryName(v string) *DescribeImageReplicationStatusOutput {
+	s.RepositoryName = &v
+	return s
+}
+
 type DescribeImageScanFindingsInput struct {
 	_ struct{} `type:"structure"`
 
-	// An object with identifying information for an Amazon ECR image.
+	// An object with identifying information for an image in an Amazon ECR repository.
 	//
 	// ImageId is a required field
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure" required:"true"`
@@ -4544,9 +4949,9 @@ type DescribeImageScanFindingsInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to describe the image scan findings for. If you do not specify a
-	// registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to describe the image scan findings for. If you do
+	// not specify a registry, the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The repository for the image for which to describe the scan findings.
@@ -4555,12 +4960,20 @@ type DescribeImageScanFindingsInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImageScanFindingsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImageScanFindingsInput) GoString() string {
 	return s.String()
 }
@@ -4625,7 +5038,7 @@ func (s *DescribeImageScanFindingsInput) SetRepositoryName(v string) *DescribeIm
 type DescribeImageScanFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An object with identifying information for an Amazon ECR image.
+	// An object with identifying information for an image in an Amazon ECR repository.
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
 
 	// The information contained in the image scan findings.
@@ -4647,12 +5060,20 @@ type DescribeImageScanFindingsOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImageScanFindingsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImageScanFindingsOutput) GoString() string {
 	return s.String()
 }
@@ -4702,12 +5123,20 @@ type DescribeImagesFilter struct {
 	TagStatus *string `locationName:"tagStatus" type:"string" enum:"TagStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesFilter) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesFilter) GoString() string {
 	return s.String()
 }
@@ -4744,9 +5173,9 @@ type DescribeImagesInput struct {
 	// This option cannot be used when you specify images with imageIds.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to describe images. If you do not specify a registry, the default
-	// registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to describe images. If you do not specify a registry,
+	// the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The repository that contains the images to describe.
@@ -4755,12 +5184,20 @@ type DescribeImagesInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesInput) GoString() string {
 	return s.String()
 }
@@ -4846,12 +5283,20 @@ type DescribeImagesOutput struct {
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeImagesOutput) GoString() string {
 	return s.String()
 }
@@ -4872,12 +5317,20 @@ type DescribeRegistryInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRegistryInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRegistryInput) GoString() string {
 	return s.String()
 }
@@ -4892,12 +5345,20 @@ type DescribeRegistryOutput struct {
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"replicationConfiguration" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRegistryOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRegistryOutput) GoString() string {
 	return s.String()
 }
@@ -4938,9 +5399,9 @@ type DescribeRepositoriesInput struct {
 	// retrieve the next items in a list and not for other programmatic purposes.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repositories
-	// to be described. If you do not specify a registry, the default registry is
-	// assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repositories to be described. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// A list of repositories to describe. If this parameter is omitted, then all
@@ -4948,12 +5409,20 @@ type DescribeRepositoriesInput struct {
 	RepositoryNames []*string `locationName:"repositoryNames" min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRepositoriesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRepositoriesInput) GoString() string {
 	return s.String()
 }
@@ -5011,12 +5480,20 @@ type DescribeRepositoriesOutput struct {
 	Repositories []*Repository `locationName:"repositories" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRepositoriesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRepositoriesOutput) GoString() string {
 	return s.String()
 }
@@ -5042,12 +5519,20 @@ type EmptyUploadException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EmptyUploadException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EmptyUploadException) GoString() string {
 	return s.String()
 }
@@ -5099,9 +5584,9 @@ func (s *EmptyUploadException) RequestID() string {
 // algorithm. This does not require any action on your part.
 //
 // For more control over the encryption of the contents of your repository,
-// you can use server-side encryption with customer master keys (CMKs) stored
-// in AWS Key Management Service (AWS KMS) to encrypt your images. For more
-// information, see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+// you can use server-side encryption with Key Management Service key stored
+// in Key Management Service (KMS) to encrypt your images. For more information,
+// see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
 // in the Amazon Elastic Container Registry User Guide.
 type EncryptionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -5109,36 +5594,45 @@ type EncryptionConfiguration struct {
 	// The encryption type to use.
 	//
 	// If you use the KMS encryption type, the contents of the repository will be
-	// encrypted using server-side encryption with customer master keys (CMKs) stored
-	// in AWS KMS. When you use AWS KMS to encrypt your data, you can either use
-	// the default AWS managed CMK for Amazon ECR, or specify your own CMK, which
-	// you already created. For more information, see Protecting Data Using Server-Side
-	// Encryption with CMKs Stored in AWS Key Management Service (SSE-KMS) (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html)
+	// encrypted using server-side encryption with Key Management Service key stored
+	// in KMS. When you use KMS to encrypt your data, you can either use the default
+	// Amazon Web Services managed KMS key for Amazon ECR, or specify your own KMS
+	// key, which you already created. For more information, see Protecting data
+	// using server-side encryption with an KMS key stored in Key Management Service
+	// (SSE-KMS) (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html)
 	// in the Amazon Simple Storage Service Console Developer Guide..
 	//
 	// If you use the AES256 encryption type, Amazon ECR uses server-side encryption
 	// with Amazon S3-managed encryption keys which encrypts the images in the repository
 	// using an AES-256 encryption algorithm. For more information, see Protecting
-	// Data Using Server-Side Encryption with Amazon S3-Managed Encryption Keys
+	// data using server-side encryption with Amazon S3-managed encryption keys
 	// (SSE-S3) (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
 	// in the Amazon Simple Storage Service Console Developer Guide..
 	//
 	// EncryptionType is a required field
 	EncryptionType *string `locationName:"encryptionType" type:"string" required:"true" enum:"EncryptionType"`
 
-	// If you use the KMS encryption type, specify the CMK to use for encryption.
-	// The alias, key ID, or full ARN of the CMK can be specified. The key must
+	// If you use the KMS encryption type, specify the KMS key to use for encryption.
+	// The alias, key ID, or full ARN of the KMS key can be specified. The key must
 	// exist in the same Region as the repository. If no key is specified, the default
-	// AWS managed CMK for Amazon ECR will be used.
+	// Amazon Web Services managed KMS key for Amazon ECR will be used.
 	KmsKey *string `locationName:"kmsKey" min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptionConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptionConfiguration) GoString() string {
 	return s.String()
 }
@@ -5174,20 +5668,28 @@ func (s *EncryptionConfiguration) SetKmsKey(v string) *EncryptionConfiguration {
 type GetAuthorizationTokenInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of AWS account IDs that are associated with the registries for which
-	// to get AuthorizationData objects. If you do not specify a registry, the default
-	// registry is assumed.
+	// A list of Amazon Web Services account IDs that are associated with the registries
+	// for which to get AuthorizationData objects. If you do not specify a registry,
+	// the default registry is assumed.
 	//
 	// Deprecated: This field is deprecated. The returned authorization token can be used to access any Amazon ECR registry that the IAM principal has access to, specifying a registry ID doesn't change the permissions scope of the authorization token.
 	RegistryIds []*string `locationName:"registryIds" min:"1" deprecated:"true" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAuthorizationTokenInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAuthorizationTokenInput) GoString() string {
 	return s.String()
 }
@@ -5219,12 +5721,20 @@ type GetAuthorizationTokenOutput struct {
 	AuthorizationData []*AuthorizationData `locationName:"authorizationData" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAuthorizationTokenOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAuthorizationTokenOutput) GoString() string {
 	return s.String()
 }
@@ -5243,8 +5753,9 @@ type GetDownloadUrlForLayerInput struct {
 	// LayerDigest is a required field
 	LayerDigest *string `locationName:"layerDigest" type:"string" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the image layer
-	// to download. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the image layer to download. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository that is associated with the image layer to download.
@@ -5253,12 +5764,20 @@ type GetDownloadUrlForLayerInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetDownloadUrlForLayerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetDownloadUrlForLayerInput) GoString() string {
 	return s.String()
 }
@@ -5310,12 +5829,20 @@ type GetDownloadUrlForLayerOutput struct {
 	LayerDigest *string `locationName:"layerDigest" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetDownloadUrlForLayerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetDownloadUrlForLayerOutput) GoString() string {
 	return s.String()
 }
@@ -5335,8 +5862,9 @@ func (s *GetDownloadUrlForLayerOutput) SetLayerDigest(v string) *GetDownloadUrlF
 type GetLifecyclePolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository.
@@ -5345,12 +5873,20 @@ type GetLifecyclePolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyInput) GoString() string {
 	return s.String()
 }
@@ -5399,12 +5935,20 @@ type GetLifecyclePolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyOutput) GoString() string {
 	return s.String()
 }
@@ -5461,8 +6005,9 @@ type GetLifecyclePolicyPreviewInput struct {
 	// to return. This option cannot be used when you specify images with imageIds.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository.
@@ -5471,12 +6016,20 @@ type GetLifecyclePolicyPreviewInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyPreviewInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyPreviewInput) GoString() string {
 	return s.String()
 }
@@ -5577,12 +6130,20 @@ type GetLifecyclePolicyPreviewOutput struct {
 	Summary *LifecyclePolicyPreviewSummary `locationName:"summary" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyPreviewOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetLifecyclePolicyPreviewOutput) GoString() string {
 	return s.String()
 }
@@ -5633,12 +6194,20 @@ type GetRegistryPolicyInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRegistryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRegistryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -5653,12 +6222,20 @@ type GetRegistryPolicyOutput struct {
 	RegistryId *string `locationName:"registryId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRegistryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRegistryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -5678,8 +6255,9 @@ func (s *GetRegistryPolicyOutput) SetRegistryId(v string) *GetRegistryPolicyOutp
 type GetRepositoryPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository with the policy to retrieve.
@@ -5688,12 +6266,20 @@ type GetRepositoryPolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRepositoryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRepositoryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -5739,12 +6325,20 @@ type GetRepositoryPolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRepositoryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRepositoryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -5780,19 +6374,28 @@ type Image struct {
 	// The manifest media type of the image.
 	ImageManifestMediaType *string `locationName:"imageManifestMediaType" type:"string"`
 
-	// The AWS account ID associated with the registry containing the image.
+	// The Amazon Web Services account ID associated with the registry containing
+	// the image.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository associated with the image.
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Image) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Image) GoString() string {
 	return s.String()
 }
@@ -5837,12 +6440,20 @@ type ImageAlreadyExistsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageAlreadyExistsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageAlreadyExistsException) GoString() string {
 	return s.String()
 }
@@ -5922,19 +6533,28 @@ type ImageDetail struct {
 	// The list of tags associated with this image.
 	ImageTags []*string `locationName:"imageTags" type:"list"`
 
-	// The AWS account ID associated with the registry to which this image belongs.
+	// The Amazon Web Services account ID associated with the registry to which
+	// this image belongs.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to which this image belongs.
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageDetail) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageDetail) GoString() string {
 	return s.String()
 }
@@ -6008,12 +6628,20 @@ type ImageDigestDoesNotMatchException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageDigestDoesNotMatchException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageDigestDoesNotMatchException) GoString() string {
 	return s.String()
 }
@@ -6070,12 +6698,20 @@ type ImageFailure struct {
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageFailure) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageFailure) GoString() string {
 	return s.String()
 }
@@ -6098,7 +6734,7 @@ func (s *ImageFailure) SetImageId(v *ImageIdentifier) *ImageFailure {
 	return s
 }
 
-// An object with identifying information for an Amazon ECR image.
+// An object with identifying information for an image in an Amazon ECR repository.
 type ImageIdentifier struct {
 	_ struct{} `type:"structure"`
 
@@ -6109,12 +6745,20 @@ type ImageIdentifier struct {
 	ImageTag *string `locationName:"imageTag" min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageIdentifier) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageIdentifier) GoString() string {
 	return s.String()
 }
@@ -6152,12 +6796,20 @@ type ImageNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageNotFoundException) GoString() string {
 	return s.String()
 }
@@ -6200,6 +6852,65 @@ func (s *ImageNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+// The status of the replication process for an image.
+type ImageReplicationStatus struct {
+	_ struct{} `type:"structure"`
+
+	// The failure code for a replication that has failed.
+	FailureCode *string `locationName:"failureCode" type:"string"`
+
+	// The destination Region for the image replication.
+	Region *string `locationName:"region" min:"2" type:"string"`
+
+	// The AWS account ID associated with the registry to which the image belongs.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The image replication status.
+	Status *string `locationName:"status" type:"string" enum:"ReplicationStatus"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ImageReplicationStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ImageReplicationStatus) GoString() string {
+	return s.String()
+}
+
+// SetFailureCode sets the FailureCode field's value.
+func (s *ImageReplicationStatus) SetFailureCode(v string) *ImageReplicationStatus {
+	s.FailureCode = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *ImageReplicationStatus) SetRegion(v string) *ImageReplicationStatus {
+	s.Region = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *ImageReplicationStatus) SetRegistryId(v string) *ImageReplicationStatus {
+	s.RegistryId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ImageReplicationStatus) SetStatus(v string) *ImageReplicationStatus {
+	s.Status = &v
+	return s
+}
+
 // Contains information about an image scan finding.
 type ImageScanFinding struct {
 	_ struct{} `type:"structure"`
@@ -6220,12 +6931,20 @@ type ImageScanFinding struct {
 	Uri *string `locationName:"uri" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFinding) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFinding) GoString() string {
 	return s.String()
 }
@@ -6277,12 +6996,20 @@ type ImageScanFindings struct {
 	VulnerabilitySourceUpdatedAt *time.Time `locationName:"vulnerabilitySourceUpdatedAt" type:"timestamp"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFindings) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFindings) GoString() string {
 	return s.String()
 }
@@ -6325,12 +7052,20 @@ type ImageScanFindingsSummary struct {
 	VulnerabilitySourceUpdatedAt *time.Time `locationName:"vulnerabilitySourceUpdatedAt" type:"timestamp"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFindingsSummary) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanFindingsSummary) GoString() string {
 	return s.String()
 }
@@ -6364,12 +7099,20 @@ type ImageScanStatus struct {
 	Status *string `locationName:"status" type:"string" enum:"ScanStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanStatus) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanStatus) GoString() string {
 	return s.String()
 }
@@ -6393,17 +7136,26 @@ type ImageScanningConfiguration struct {
 	// The setting that determines whether images are scanned after being pushed
 	// to a repository. If set to true, images will be scanned after being pushed.
 	// If this parameter is not specified, it will default to false and images will
-	// not be scanned unless a scan is manually started with the StartImageScan
+	// not be scanned unless a scan is manually started with the API_StartImageScan
+	// (https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_StartImageScan.html)
 	// API.
 	ScanOnPush *bool `locationName:"scanOnPush" type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanningConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageScanningConfiguration) GoString() string {
 	return s.String()
 }
@@ -6423,12 +7175,20 @@ type ImageTagAlreadyExistsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageTagAlreadyExistsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImageTagAlreadyExistsException) GoString() string {
 	return s.String()
 }
@@ -6474,8 +7234,9 @@ func (s *ImageTagAlreadyExistsException) RequestID() string {
 type InitiateLayerUploadInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID associated with the registry to which you intend to upload
-	// layers. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry to which
+	// you intend to upload layers. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to which you intend to upload layers.
@@ -6484,12 +7245,20 @@ type InitiateLayerUploadInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InitiateLayerUploadInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InitiateLayerUploadInput) GoString() string {
 	return s.String()
 }
@@ -6534,12 +7303,20 @@ type InitiateLayerUploadOutput struct {
 	UploadId *string `locationName:"uploadId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InitiateLayerUploadOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InitiateLayerUploadOutput) GoString() string {
 	return s.String()
 }
@@ -6566,12 +7343,20 @@ type InvalidLayerException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidLayerException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidLayerException) GoString() string {
 	return s.String()
 }
@@ -6637,12 +7422,20 @@ type InvalidLayerPartException struct {
 	UploadId *string `locationName:"uploadId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidLayerPartException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidLayerPartException) GoString() string {
 	return s.String()
 }
@@ -6695,12 +7488,20 @@ type InvalidParameterException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidParameterException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidParameterException) GoString() string {
 	return s.String()
 }
@@ -6753,12 +7554,20 @@ type InvalidTagParameterException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidTagParameterException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidTagParameterException) GoString() string {
 	return s.String()
 }
@@ -6806,18 +7615,26 @@ type KmsException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
-	// The error code returned by AWS KMS.
+	// The error code returned by KMS.
 	KmsError *string `locationName:"kmsError" type:"string"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KmsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KmsException) GoString() string {
 	return s.String()
 }
@@ -6878,12 +7695,20 @@ type Layer struct {
 	MediaType *string `locationName:"mediaType" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Layer) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Layer) GoString() string {
 	return s.String()
 }
@@ -6921,12 +7746,20 @@ type LayerAlreadyExistsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerAlreadyExistsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerAlreadyExistsException) GoString() string {
 	return s.String()
 }
@@ -6983,12 +7816,20 @@ type LayerFailure struct {
 	LayerDigest *string `locationName:"layerDigest" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerFailure) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerFailure) GoString() string {
 	return s.String()
 }
@@ -7021,12 +7862,20 @@ type LayerInaccessibleException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerInaccessibleException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerInaccessibleException) GoString() string {
 	return s.String()
 }
@@ -7078,12 +7927,20 @@ type LayerPartTooSmallException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerPartTooSmallException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayerPartTooSmallException) GoString() string {
 	return s.String()
 }
@@ -7136,12 +7993,20 @@ type LayersNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayersNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LayersNotFoundException) GoString() string {
 	return s.String()
 }
@@ -7192,12 +8057,20 @@ type LifecyclePolicyNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyNotFoundException) GoString() string {
 	return s.String()
 }
@@ -7248,12 +8121,20 @@ type LifecyclePolicyPreviewFilter struct {
 	TagStatus *string `locationName:"tagStatus" type:"string" enum:"TagStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewFilter) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewFilter) GoString() string {
 	return s.String()
 }
@@ -7273,12 +8154,20 @@ type LifecyclePolicyPreviewInProgressException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewInProgressException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewInProgressException) GoString() string {
 	return s.String()
 }
@@ -7329,12 +8218,20 @@ type LifecyclePolicyPreviewNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewNotFoundException) GoString() string {
 	return s.String()
 }
@@ -7398,12 +8295,20 @@ type LifecyclePolicyPreviewResult struct {
 	ImageTags []*string `locationName:"imageTags" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewResult) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewResult) GoString() string {
 	return s.String()
 }
@@ -7446,12 +8351,20 @@ type LifecyclePolicyPreviewSummary struct {
 	ExpiringImageTotalCount *int64 `locationName:"expiringImageTotalCount" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewSummary) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyPreviewSummary) GoString() string {
 	return s.String()
 }
@@ -7470,12 +8383,20 @@ type LifecyclePolicyRuleAction struct {
 	Type *string `locationName:"type" type:"string" enum:"ImageActionType"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyRuleAction) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LifecyclePolicyRuleAction) GoString() string {
 	return s.String()
 }
@@ -7487,7 +8408,7 @@ func (s *LifecyclePolicyRuleAction) SetType(v string) *LifecyclePolicyRuleAction
 }
 
 // The operation did not succeed because it would have exceeded a service limit
-// for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+// for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 // in the Amazon Elastic Container Registry User Guide.
 type LimitExceededException struct {
 	_            struct{}                  `type:"structure"`
@@ -7497,12 +8418,20 @@ type LimitExceededException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LimitExceededException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LimitExceededException) GoString() string {
 	return s.String()
 }
@@ -7554,12 +8483,20 @@ type ListImagesFilter struct {
 	TagStatus *string `locationName:"tagStatus" type:"string" enum:"TagStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesFilter) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesFilter) GoString() string {
 	return s.String()
 }
@@ -7594,9 +8531,9 @@ type ListImagesInput struct {
 	// retrieve the next items in a list and not for other programmatic purposes.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to list images. If you do not specify a registry, the default registry
-	// is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to list images. If you do not specify a registry,
+	// the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The repository with image IDs to be listed.
@@ -7605,12 +8542,20 @@ type ListImagesInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesInput) GoString() string {
 	return s.String()
 }
@@ -7677,12 +8622,20 @@ type ListImagesOutput struct {
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListImagesOutput) GoString() string {
 	return s.String()
 }
@@ -7709,12 +8662,20 @@ type ListTagsForResourceInput struct {
 	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListTagsForResourceInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
 }
@@ -7745,12 +8706,20 @@ type ListTagsForResourceOutput struct {
 	Tags []*Tag `locationName:"tags" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListTagsForResourceOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
 }
@@ -7782,9 +8751,9 @@ type PutImageInput struct {
 	// (OCI) formats.
 	ImageTag *string `locationName:"imageTag" min:"1" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to put the image. If you do not specify a registry, the default
-	// registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to put the image. If you do not specify a registry,
+	// the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository in which to put the image.
@@ -7793,12 +8762,20 @@ type PutImageInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageInput) GoString() string {
 	return s.String()
 }
@@ -7871,12 +8848,20 @@ type PutImageOutput struct {
 	Image *Image `locationName:"image" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageOutput) GoString() string {
 	return s.String()
 }
@@ -7897,9 +8882,9 @@ type PutImageScanningConfigurationInput struct {
 	// ImageScanningConfiguration is a required field
 	ImageScanningConfiguration *ImageScanningConfiguration `locationName:"imageScanningConfiguration" type:"structure" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to update the image scanning configuration setting. If you do not
-	// specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to update the image scanning configuration setting.
+	// If you do not specify a registry, the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository in which to update the image scanning configuration
@@ -7909,12 +8894,20 @@ type PutImageScanningConfigurationInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageScanningConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageScanningConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -7969,12 +8962,20 @@ type PutImageScanningConfigurationOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageScanningConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageScanningConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -8007,9 +9008,9 @@ type PutImageTagMutabilityInput struct {
 	// ImageTagMutability is a required field
 	ImageTagMutability *string `locationName:"imageTagMutability" type:"string" required:"true" enum:"ImageTagMutability"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to update the image tag mutability settings. If you do not specify
-	// a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to update the image tag mutability settings. If you
+	// do not specify a registry, the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository in which to update the image tag mutability settings.
@@ -8018,12 +9019,20 @@ type PutImageTagMutabilityInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageTagMutabilityInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageTagMutabilityInput) GoString() string {
 	return s.String()
 }
@@ -8078,12 +9087,20 @@ type PutImageTagMutabilityOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageTagMutabilityOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutImageTagMutabilityOutput) GoString() string {
 	return s.String()
 }
@@ -8114,8 +9131,9 @@ type PutLifecyclePolicyInput struct {
 	// LifecyclePolicyText is a required field
 	LifecyclePolicyText *string `locationName:"lifecyclePolicyText" min:"100" type:"string" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to receive the policy.
@@ -8124,12 +9142,20 @@ type PutLifecyclePolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecyclePolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecyclePolicyInput) GoString() string {
 	return s.String()
 }
@@ -8187,12 +9213,20 @@ type PutLifecyclePolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecyclePolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutLifecyclePolicyOutput) GoString() string {
 	return s.String()
 }
@@ -8227,12 +9261,20 @@ type PutRegistryPolicyInput struct {
 	PolicyText *string `locationName:"policyText" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutRegistryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutRegistryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -8266,12 +9308,20 @@ type PutRegistryPolicyOutput struct {
 	RegistryId *string `locationName:"registryId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutRegistryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutRegistryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -8297,12 +9347,20 @@ type PutReplicationConfigurationInput struct {
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"replicationConfiguration" type:"structure" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutReplicationConfigurationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutReplicationConfigurationInput) GoString() string {
 	return s.String()
 }
@@ -8338,12 +9396,20 @@ type PutReplicationConfigurationOutput struct {
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"replicationConfiguration" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutReplicationConfigurationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutReplicationConfigurationOutput) GoString() string {
 	return s.String()
 }
@@ -8362,12 +9428,20 @@ type ReferencedImagesNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReferencedImagesNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReferencedImagesNotFoundException) GoString() string {
 	return s.String()
 }
@@ -8418,12 +9492,20 @@ type RegistryPolicyNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegistryPolicyNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegistryPolicyNotFoundException) GoString() string {
 	return s.String()
 }
@@ -8470,20 +9552,27 @@ func (s *RegistryPolicyNotFoundException) RequestID() string {
 type ReplicationConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// An array of objects representing the replication rules for a replication
-	// configuration. A replication configuration may contain only one replication
-	// rule but the rule may contain one or more replication destinations.
+	// An array of objects representing the replication destinations and repository
+	// filters for a replication configuration.
 	//
 	// Rules is a required field
 	Rules []*ReplicationRule `locationName:"rules" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationConfiguration) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationConfiguration) GoString() string {
 	return s.String()
 }
@@ -8517,27 +9606,37 @@ func (s *ReplicationConfiguration) SetRules(v []*ReplicationRule) *ReplicationCo
 	return s
 }
 
-// An array of objects representing the details of a replication destination.
+// An array of objects representing the destination for a replication rule.
 type ReplicationDestination struct {
 	_ struct{} `type:"structure"`
 
-	// A Region to replicate to.
+	// The Region to replicate to.
 	//
 	// Region is a required field
 	Region *string `locationName:"region" min:"2" type:"string" required:"true"`
 
-	// The account ID of the destination registry to replicate to.
+	// The Amazon Web Services account ID of the Amazon ECR private registry to
+	// replicate to. When configuring cross-Region replication within your own registry,
+	// specify your own account ID.
 	//
 	// RegistryId is a required field
 	RegistryId *string `locationName:"registryId" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationDestination) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationDestination) GoString() string {
 	return s.String()
 }
@@ -8573,24 +9672,36 @@ func (s *ReplicationDestination) SetRegistryId(v string) *ReplicationDestination
 	return s
 }
 
-// An array of objects representing the replication destinations for a replication
-// configuration. A replication configuration may contain only one replication
-// rule but the rule may contain one or more replication destinations.
+// An array of objects representing the replication destinations and repository
+// filters for a replication configuration.
 type ReplicationRule struct {
 	_ struct{} `type:"structure"`
 
-	// An array of objects representing the details of a replication destination.
+	// An array of objects representing the destination for a replication rule.
 	//
 	// Destinations is a required field
 	Destinations []*ReplicationDestination `locationName:"destinations" type:"list" required:"true"`
+
+	// An array of objects representing the filters for a replication rule. Specifying
+	// a repository filter for a replication rule provides a method for controlling
+	// which repositories in a private registry are replicated.
+	RepositoryFilters []*RepositoryFilter `locationName:"repositoryFilters" min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationRule) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReplicationRule) GoString() string {
 	return s.String()
 }
@@ -8601,6 +9712,9 @@ func (s *ReplicationRule) Validate() error {
 	if s.Destinations == nil {
 		invalidParams.Add(request.NewErrParamRequired("Destinations"))
 	}
+	if s.RepositoryFilters != nil && len(s.RepositoryFilters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryFilters", 1))
+	}
 	if s.Destinations != nil {
 		for i, v := range s.Destinations {
 			if v == nil {
@@ -8608,6 +9722,16 @@ func (s *ReplicationRule) Validate() error {
 			}
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Destinations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.RepositoryFilters != nil {
+		for i, v := range s.RepositoryFilters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RepositoryFilters", i), err.(request.ErrInvalidParams))
 			}
 		}
 	}
@@ -8621,6 +9745,12 @@ func (s *ReplicationRule) Validate() error {
 // SetDestinations sets the Destinations field's value.
 func (s *ReplicationRule) SetDestinations(v []*ReplicationDestination) *ReplicationRule {
 	s.Destinations = v
+	return s
+}
+
+// SetRepositoryFilters sets the RepositoryFilters field's value.
+func (s *ReplicationRule) SetRepositoryFilters(v []*RepositoryFilter) *ReplicationRule {
+	s.RepositoryFilters = v
 	return s
 }
 
@@ -8641,13 +9771,14 @@ type Repository struct {
 	// The tag mutability setting for the repository.
 	ImageTagMutability *string `locationName:"imageTagMutability" type:"string" enum:"ImageTagMutability"`
 
-	// The AWS account ID associated with the registry that contains the repository.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The Amazon Resource Name (ARN) that identifies the repository. The ARN contains
-	// the arn:aws:ecr namespace, followed by the region of the repository, AWS
-	// account ID of the repository owner, repository namespace, and repository
-	// name. For example, arn:aws:ecr:region:012345678910:repository/test.
+	// the arn:aws:ecr namespace, followed by the region of the repository, Amazon
+	// Web Services account ID of the repository owner, repository namespace, and
+	// repository name. For example, arn:aws:ecr:region:012345678910:repository/test.
 	RepositoryArn *string `locationName:"repositoryArn" type:"string"`
 
 	// The name of the repository.
@@ -8658,12 +9789,20 @@ type Repository struct {
 	RepositoryUri *string `locationName:"repositoryUri" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Repository) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Repository) GoString() string {
 	return s.String()
 }
@@ -8725,12 +9864,20 @@ type RepositoryAlreadyExistsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryAlreadyExistsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryAlreadyExistsException) GoString() string {
 	return s.String()
 }
@@ -8773,6 +9920,76 @@ func (s *RepositoryAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+// The filter settings used with image replication. Specifying a repository
+// filter to a replication rule provides a method for controlling which repositories
+// in a private registry are replicated. If no repository filter is specified,
+// all images in the repository are replicated.
+type RepositoryFilter struct {
+	_ struct{} `type:"structure"`
+
+	// The repository filter details. When the PREFIX_MATCH filter type is specified,
+	// this value is required and should be the repository name prefix to configure
+	// replication for.
+	//
+	// Filter is a required field
+	Filter *string `locationName:"filter" min:"2" type:"string" required:"true"`
+
+	// The repository filter type. The only supported value is PREFIX_MATCH, which
+	// is a repository name prefix specified with the filter parameter.
+	//
+	// FilterType is a required field
+	FilterType *string `locationName:"filterType" type:"string" required:"true" enum:"RepositoryFilterType"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s RepositoryFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s RepositoryFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RepositoryFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RepositoryFilter"}
+	if s.Filter == nil {
+		invalidParams.Add(request.NewErrParamRequired("Filter"))
+	}
+	if s.Filter != nil && len(*s.Filter) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("Filter", 2))
+	}
+	if s.FilterType == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilter sets the Filter field's value.
+func (s *RepositoryFilter) SetFilter(v string) *RepositoryFilter {
+	s.Filter = &v
+	return s
+}
+
+// SetFilterType sets the FilterType field's value.
+func (s *RepositoryFilter) SetFilterType(v string) *RepositoryFilter {
+	s.FilterType = &v
+	return s
+}
+
 // The specified repository contains images. To delete a repository that contains
 // images, you must force the deletion with the force parameter.
 type RepositoryNotEmptyException struct {
@@ -8783,12 +10000,20 @@ type RepositoryNotEmptyException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryNotEmptyException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryNotEmptyException) GoString() string {
 	return s.String()
 }
@@ -8841,12 +10066,20 @@ type RepositoryNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryNotFoundException) GoString() string {
 	return s.String()
 }
@@ -8899,12 +10132,20 @@ type RepositoryPolicyNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryPolicyNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RepositoryPolicyNotFoundException) GoString() string {
 	return s.String()
 }
@@ -8956,12 +10197,20 @@ type ScanNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScanNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScanNotFoundException) GoString() string {
 	return s.String()
 }
@@ -9013,12 +10262,20 @@ type ServerException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ServerException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ServerException) GoString() string {
 	return s.String()
 }
@@ -9070,14 +10327,15 @@ type SetRepositoryPolicyInput struct {
 	Force *bool `locationName:"force" type:"boolean"`
 
 	// The JSON repository policy text to apply to the repository. For more information,
-	// see Amazon ECR Repository Policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html)
+	// see Amazon ECR repository policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html)
 	// in the Amazon Elastic Container Registry User Guide.
 	//
 	// PolicyText is a required field
 	PolicyText *string `locationName:"policyText" type:"string" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to receive the policy.
@@ -9086,12 +10344,20 @@ type SetRepositoryPolicyInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRepositoryPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRepositoryPolicyInput) GoString() string {
 	return s.String()
 }
@@ -9152,12 +10418,20 @@ type SetRepositoryPolicyOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRepositoryPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRepositoryPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -9183,14 +10457,14 @@ func (s *SetRepositoryPolicyOutput) SetRepositoryName(v string) *SetRepositoryPo
 type StartImageScanInput struct {
 	_ struct{} `type:"structure"`
 
-	// An object with identifying information for an Amazon ECR image.
+	// An object with identifying information for an image in an Amazon ECR repository.
 	//
 	// ImageId is a required field
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure" required:"true"`
 
-	// The AWS account ID associated with the registry that contains the repository
-	// in which to start an image scan request. If you do not specify a registry,
-	// the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository in which to start an image scan request. If you do not specify
+	// a registry, the default registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository that contains the images to scan.
@@ -9199,12 +10473,20 @@ type StartImageScanInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartImageScanInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartImageScanInput) GoString() string {
 	return s.String()
 }
@@ -9254,7 +10536,7 @@ func (s *StartImageScanInput) SetRepositoryName(v string) *StartImageScanInput {
 type StartImageScanOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An object with identifying information for an Amazon ECR image.
+	// An object with identifying information for an image in an Amazon ECR repository.
 	ImageId *ImageIdentifier `locationName:"imageId" type:"structure"`
 
 	// The current state of the scan.
@@ -9267,12 +10549,20 @@ type StartImageScanOutput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartImageScanOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartImageScanOutput) GoString() string {
 	return s.String()
 }
@@ -9308,8 +10598,9 @@ type StartLifecyclePolicyPreviewInput struct {
 	// policy for the repository is used.
 	LifecyclePolicyText *string `locationName:"lifecyclePolicyText" min:"100" type:"string"`
 
-	// The AWS account ID associated with the registry that contains the repository.
-	// If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry that contains
+	// the repository. If you do not specify a registry, the default registry is
+	// assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to be evaluated.
@@ -9318,12 +10609,20 @@ type StartLifecyclePolicyPreviewInput struct {
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartLifecyclePolicyPreviewInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartLifecyclePolicyPreviewInput) GoString() string {
 	return s.String()
 }
@@ -9381,12 +10680,20 @@ type StartLifecyclePolicyPreviewOutput struct {
 	Status *string `locationName:"status" type:"string" enum:"LifecyclePolicyPreviewStatus"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartLifecyclePolicyPreviewOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s StartLifecyclePolicyPreviewOutput) GoString() string {
 	return s.String()
 }
@@ -9431,12 +10738,20 @@ type Tag struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }
@@ -9470,12 +10785,20 @@ type TagResourceInput struct {
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceInput) GoString() string {
 	return s.String()
 }
@@ -9512,12 +10835,20 @@ type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceOutput) GoString() string {
 	return s.String()
 }
@@ -9531,12 +10862,20 @@ type TooManyTagsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TooManyTagsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TooManyTagsException) GoString() string {
 	return s.String()
 }
@@ -9587,12 +10926,20 @@ type UnsupportedImageTypeException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnsupportedImageTypeException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnsupportedImageTypeException) GoString() string {
 	return s.String()
 }
@@ -9650,12 +10997,20 @@ type UntagResourceInput struct {
 	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceInput) GoString() string {
 	return s.String()
 }
@@ -9692,12 +11047,20 @@ type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
 }
@@ -9706,7 +11069,6 @@ type UploadLayerPartInput struct {
 	_ struct{} `type:"structure"`
 
 	// The base64-encoded layer part payload.
-	//
 	// LayerPartBlob is automatically base64 encoded/decoded by the SDK.
 	//
 	// LayerPartBlob is a required field
@@ -9724,8 +11086,9 @@ type UploadLayerPartInput struct {
 	// PartLastByte is a required field
 	PartLastByte *int64 `locationName:"partLastByte" type:"long" required:"true"`
 
-	// The AWS account ID associated with the registry to which you are uploading
-	// layer parts. If you do not specify a registry, the default registry is assumed.
+	// The Amazon Web Services account ID associated with the registry to which
+	// you are uploading layer parts. If you do not specify a registry, the default
+	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
 	// The name of the repository to which you are uploading layer parts.
@@ -9740,12 +11103,20 @@ type UploadLayerPartInput struct {
 	UploadId *string `locationName:"uploadId" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadLayerPartInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadLayerPartInput) GoString() string {
 	return s.String()
 }
@@ -9830,12 +11201,20 @@ type UploadLayerPartOutput struct {
 	UploadId *string `locationName:"uploadId" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadLayerPartOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadLayerPartOutput) GoString() string {
 	return s.String()
 }
@@ -9874,12 +11253,20 @@ type UploadNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UploadNotFoundException) GoString() string {
 	return s.String()
 }
@@ -9930,12 +11317,20 @@ type ValidationException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ValidationException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ValidationException) GoString() string {
 	return s.String()
 }
@@ -10143,6 +11538,38 @@ func LifecyclePolicyPreviewStatus_Values() []string {
 		LifecyclePolicyPreviewStatusComplete,
 		LifecyclePolicyPreviewStatusExpired,
 		LifecyclePolicyPreviewStatusFailed,
+	}
+}
+
+const (
+	// ReplicationStatusInProgress is a ReplicationStatus enum value
+	ReplicationStatusInProgress = "IN_PROGRESS"
+
+	// ReplicationStatusComplete is a ReplicationStatus enum value
+	ReplicationStatusComplete = "COMPLETE"
+
+	// ReplicationStatusFailed is a ReplicationStatus enum value
+	ReplicationStatusFailed = "FAILED"
+)
+
+// ReplicationStatus_Values returns all elements of the ReplicationStatus enum
+func ReplicationStatus_Values() []string {
+	return []string{
+		ReplicationStatusInProgress,
+		ReplicationStatusComplete,
+		ReplicationStatusFailed,
+	}
+}
+
+const (
+	// RepositoryFilterTypePrefixMatch is a RepositoryFilterType enum value
+	RepositoryFilterTypePrefixMatch = "PREFIX_MATCH"
+)
+
+// RepositoryFilterType_Values returns all elements of the RepositoryFilterType enum
+func RepositoryFilterType_Values() []string {
+	return []string{
+		RepositoryFilterTypePrefixMatch,
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/doc.go
@@ -11,6 +11,10 @@
 // using IAM so that specific users or Amazon EC2 instances can access repositories
 // and images.
 //
+// Amazon ECR has service endpoints in each supported Region. For more information,
+// see Amazon ECR endpoints (https://docs.aws.amazon.com/general/latest/gr/ecr.html)
+// in the Amazon Web Services General Reference.
+//
 // See https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21 for more information on this service.
 //
 // See ecr package documentation for more information.

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
@@ -125,7 +125,7 @@ const (
 	// "LimitExceededException".
 	//
 	// The operation did not succeed because it would have exceeded a service limit
-	// for your account. For more information, see Amazon ECR Service Quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
+	// for your account. For more information, see Amazon ECR service quotas (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)
 	// in the Amazon Elastic Container Registry User Guide.
 	ErrCodeLimitExceededException = "LimitExceededException"
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/ecr/service.go
@@ -52,24 +52,25 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *ECR {
 	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "ecr"
 	}
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ECR {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *ECR {
 	svc := &ECR{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2015-09-21",
-				JSONVersion:   "1.1",
-				TargetPrefix:  "AmazonEC2ContainerRegistry_V20150921",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2015-09-21",
+				ResolvedRegion: resolvedRegion,
+				JSONVersion:    "1.1",
+				TargetPrefix:   "AmazonEC2ContainerRegistry_V20150921",
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
@@ -2771,12 +2771,20 @@ type AccessLog struct {
 	S3BucketPrefix *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AccessLog) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AccessLog) GoString() string {
 	return s.String()
 }
@@ -2833,12 +2841,20 @@ type AddTagsInput struct {
 	Tags []*Tag `min:"1" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsInput) GoString() string {
 	return s.String()
 }
@@ -2889,12 +2905,20 @@ type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsOutput) GoString() string {
 	return s.String()
 }
@@ -2916,12 +2940,20 @@ type AdditionalAttribute struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AdditionalAttribute) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AdditionalAttribute) GoString() string {
 	return s.String()
 }
@@ -2950,12 +2982,20 @@ type AppCookieStickinessPolicy struct {
 	PolicyName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AppCookieStickinessPolicy) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AppCookieStickinessPolicy) GoString() string {
 	return s.String()
 }
@@ -2988,12 +3028,20 @@ type ApplySecurityGroupsToLoadBalancerInput struct {
 	SecurityGroups []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ApplySecurityGroupsToLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ApplySecurityGroupsToLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -3034,12 +3082,20 @@ type ApplySecurityGroupsToLoadBalancerOutput struct {
 	SecurityGroups []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ApplySecurityGroupsToLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ApplySecurityGroupsToLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -3066,12 +3122,20 @@ type AttachLoadBalancerToSubnetsInput struct {
 	Subnets []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerToSubnetsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerToSubnetsInput) GoString() string {
 	return s.String()
 }
@@ -3112,12 +3176,20 @@ type AttachLoadBalancerToSubnetsOutput struct {
 	Subnets []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerToSubnetsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AttachLoadBalancerToSubnetsOutput) GoString() string {
 	return s.String()
 }
@@ -3139,12 +3211,20 @@ type BackendServerDescription struct {
 	PolicyNames []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BackendServerDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s BackendServerDescription) GoString() string {
 	return s.String()
 }
@@ -3176,12 +3256,20 @@ type ConfigureHealthCheckInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConfigureHealthCheckInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConfigureHealthCheckInput) GoString() string {
 	return s.String()
 }
@@ -3227,12 +3315,20 @@ type ConfigureHealthCheckOutput struct {
 	HealthCheck *HealthCheck `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConfigureHealthCheckOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConfigureHealthCheckOutput) GoString() string {
 	return s.String()
 }
@@ -3257,12 +3353,20 @@ type ConnectionDraining struct {
 	Timeout *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectionDraining) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectionDraining) GoString() string {
 	return s.String()
 }
@@ -3303,12 +3407,20 @@ type ConnectionSettings struct {
 	IdleTimeout *int64 `min:"1" type:"integer" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectionSettings) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectionSettings) GoString() string {
 	return s.String()
 }
@@ -3357,12 +3469,20 @@ type CreateAppCookieStickinessPolicyInput struct {
 	PolicyName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAppCookieStickinessPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAppCookieStickinessPolicyInput) GoString() string {
 	return s.String()
 }
@@ -3409,12 +3529,20 @@ type CreateAppCookieStickinessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAppCookieStickinessPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAppCookieStickinessPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -3442,12 +3570,20 @@ type CreateLBCookieStickinessPolicyInput struct {
 	PolicyName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLBCookieStickinessPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLBCookieStickinessPolicyInput) GoString() string {
 	return s.String()
 }
@@ -3491,12 +3627,20 @@ type CreateLBCookieStickinessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLBCookieStickinessPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLBCookieStickinessPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -3557,12 +3701,20 @@ type CreateLoadBalancerInput struct {
 	Tags []*Tag `min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -3663,12 +3815,20 @@ type CreateLoadBalancerListenersInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerListenersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerListenersInput) GoString() string {
 	return s.String()
 }
@@ -3716,12 +3876,20 @@ type CreateLoadBalancerListenersOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerListenersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerListenersOutput) GoString() string {
 	return s.String()
 }
@@ -3734,12 +3902,20 @@ type CreateLoadBalancerOutput struct {
 	DNSName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -3774,12 +3950,20 @@ type CreateLoadBalancerPolicyInput struct {
 	PolicyTypeName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerPolicyInput) GoString() string {
 	return s.String()
 }
@@ -3832,12 +4016,20 @@ type CreateLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -3852,12 +4044,20 @@ type CrossZoneLoadBalancing struct {
 	Enabled *bool `type:"boolean" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CrossZoneLoadBalancing) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CrossZoneLoadBalancing) GoString() string {
 	return s.String()
 }
@@ -3891,12 +4091,20 @@ type DeleteLoadBalancerInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -3935,12 +4143,20 @@ type DeleteLoadBalancerListenersInput struct {
 	LoadBalancerPorts []*int64 `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerListenersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerListenersInput) GoString() string {
 	return s.String()
 }
@@ -3978,12 +4194,20 @@ type DeleteLoadBalancerListenersOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerListenersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerListenersOutput) GoString() string {
 	return s.String()
 }
@@ -3993,12 +4217,20 @@ type DeleteLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -4018,12 +4250,20 @@ type DeleteLoadBalancerPolicyInput struct {
 	PolicyName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerPolicyInput) GoString() string {
 	return s.String()
 }
@@ -4061,12 +4301,20 @@ type DeleteLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -4086,12 +4334,20 @@ type DeregisterInstancesFromLoadBalancerInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterInstancesFromLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterInstancesFromLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -4132,12 +4388,20 @@ type DeregisterInstancesFromLoadBalancerOutput struct {
 	Instances []*Instance `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterInstancesFromLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterInstancesFromLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -4159,12 +4423,20 @@ type DescribeAccountLimitsInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) GoString() string {
 	return s.String()
 }
@@ -4205,12 +4477,20 @@ type DescribeAccountLimitsOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) GoString() string {
 	return s.String()
 }
@@ -4240,12 +4520,20 @@ type DescribeInstanceHealthInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceHealthInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceHealthInput) GoString() string {
 	return s.String()
 }
@@ -4283,12 +4571,20 @@ type DescribeInstanceHealthOutput struct {
 	InstanceStates []*InstanceState `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceHealthOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeInstanceHealthOutput) GoString() string {
 	return s.String()
 }
@@ -4309,12 +4605,20 @@ type DescribeLoadBalancerAttributesInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesInput) GoString() string {
 	return s.String()
 }
@@ -4346,12 +4650,20 @@ type DescribeLoadBalancerAttributesOutput struct {
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -4373,12 +4685,20 @@ type DescribeLoadBalancerPoliciesInput struct {
 	PolicyNames []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPoliciesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPoliciesInput) GoString() string {
 	return s.String()
 }
@@ -4403,12 +4723,20 @@ type DescribeLoadBalancerPoliciesOutput struct {
 	PolicyDescriptions []*PolicyDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPoliciesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPoliciesOutput) GoString() string {
 	return s.String()
 }
@@ -4428,12 +4756,20 @@ type DescribeLoadBalancerPolicyTypesInput struct {
 	PolicyTypeNames []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPolicyTypesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPolicyTypesInput) GoString() string {
 	return s.String()
 }
@@ -4452,12 +4788,20 @@ type DescribeLoadBalancerPolicyTypesOutput struct {
 	PolicyTypeDescriptions []*PolicyTypeDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPolicyTypesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerPolicyTypesOutput) GoString() string {
 	return s.String()
 }
@@ -4484,12 +4828,20 @@ type DescribeLoadBalancersInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) GoString() string {
 	return s.String()
 }
@@ -4537,12 +4889,20 @@ type DescribeLoadBalancersOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
 }
@@ -4569,12 +4929,20 @@ type DescribeTagsInput struct {
 	LoadBalancerNames []*string `min:"1" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
@@ -4609,12 +4977,20 @@ type DescribeTagsOutput struct {
 	TagDescriptions []*TagDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
 }
@@ -4640,12 +5016,20 @@ type DetachLoadBalancerFromSubnetsInput struct {
 	Subnets []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerFromSubnetsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerFromSubnetsInput) GoString() string {
 	return s.String()
 }
@@ -4686,12 +5070,20 @@ type DetachLoadBalancerFromSubnetsOutput struct {
 	Subnets []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerFromSubnetsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DetachLoadBalancerFromSubnetsOutput) GoString() string {
 	return s.String()
 }
@@ -4717,12 +5109,20 @@ type DisableAvailabilityZonesForLoadBalancerInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableAvailabilityZonesForLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableAvailabilityZonesForLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -4763,12 +5163,20 @@ type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	AvailabilityZones []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableAvailabilityZonesForLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -4794,12 +5202,20 @@ type EnableAvailabilityZonesForLoadBalancerInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableAvailabilityZonesForLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableAvailabilityZonesForLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -4840,12 +5256,20 @@ type EnableAvailabilityZonesForLoadBalancerOutput struct {
 	AvailabilityZones []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableAvailabilityZonesForLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -4909,12 +5333,20 @@ type HealthCheck struct {
 	UnhealthyThreshold *int64 `min:"2" type:"integer" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HealthCheck) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HealthCheck) GoString() string {
 	return s.String()
 }
@@ -4994,12 +5426,20 @@ type Instance struct {
 	InstanceId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Instance) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Instance) GoString() string {
 	return s.String()
 }
@@ -5060,12 +5500,20 @@ type InstanceState struct {
 	State *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceState) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InstanceState) GoString() string {
 	return s.String()
 }
@@ -5108,12 +5556,20 @@ type LBCookieStickinessPolicy struct {
 	PolicyName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LBCookieStickinessPolicy) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LBCookieStickinessPolicy) GoString() string {
 	return s.String()
 }
@@ -5147,12 +5603,20 @@ type Limit struct {
 	Name *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Limit) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Limit) GoString() string {
 	return s.String()
 }
@@ -5213,12 +5677,20 @@ type Listener struct {
 	SSLCertificateId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Listener) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Listener) GoString() string {
 	return s.String()
 }
@@ -5286,12 +5758,20 @@ type ListenerDescription struct {
 	PolicyNames []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListenerDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListenerDescription) GoString() string {
 	return s.String()
 }
@@ -5346,12 +5826,20 @@ type LoadBalancerAttributes struct {
 	CrossZoneLoadBalancing *CrossZoneLoadBalancing `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAttributes) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAttributes) GoString() string {
 	return s.String()
 }
@@ -5482,12 +5970,20 @@ type LoadBalancerDescription struct {
 	VPCId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerDescription) GoString() string {
 	return s.String()
 }
@@ -5603,12 +6099,20 @@ type ModifyLoadBalancerAttributesInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesInput) GoString() string {
 	return s.String()
 }
@@ -5657,12 +6161,20 @@ type ModifyLoadBalancerAttributesOutput struct {
 	LoadBalancerName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -5693,12 +6205,20 @@ type Policies struct {
 	OtherPolicies []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Policies) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Policies) GoString() string {
 	return s.String()
 }
@@ -5732,12 +6252,20 @@ type PolicyAttribute struct {
 	AttributeValue *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttribute) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttribute) GoString() string {
 	return s.String()
 }
@@ -5765,12 +6293,20 @@ type PolicyAttributeDescription struct {
 	AttributeValue *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttributeDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttributeDescription) GoString() string {
 	return s.String()
 }
@@ -5817,12 +6353,20 @@ type PolicyAttributeTypeDescription struct {
 	Description *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttributeTypeDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyAttributeTypeDescription) GoString() string {
 	return s.String()
 }
@@ -5871,12 +6415,20 @@ type PolicyDescription struct {
 	PolicyTypeName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyDescription) GoString() string {
 	return s.String()
 }
@@ -5914,12 +6466,20 @@ type PolicyTypeDescription struct {
 	PolicyTypeName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyTypeDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyTypeDescription) GoString() string {
 	return s.String()
 }
@@ -5957,12 +6517,20 @@ type RegisterInstancesWithLoadBalancerInput struct {
 	LoadBalancerName *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterInstancesWithLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterInstancesWithLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -6003,12 +6571,20 @@ type RegisterInstancesWithLoadBalancerOutput struct {
 	Instances []*Instance `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterInstancesWithLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterInstancesWithLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -6035,12 +6611,20 @@ type RemoveTagsInput struct {
 	Tags []*TagKeyOnly `min:"1" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsInput) GoString() string {
 	return s.String()
 }
@@ -6091,12 +6675,20 @@ type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsOutput) GoString() string {
 	return s.String()
 }
@@ -6121,12 +6713,20 @@ type SetLoadBalancerListenerSSLCertificateInput struct {
 	SSLCertificateId *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerListenerSSLCertificateInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerListenerSSLCertificateInput) GoString() string {
 	return s.String()
 }
@@ -6173,12 +6773,20 @@ type SetLoadBalancerListenerSSLCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerListenerSSLCertificateOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerListenerSSLCertificateOutput) GoString() string {
 	return s.String()
 }
@@ -6204,12 +6812,20 @@ type SetLoadBalancerPoliciesForBackendServerInput struct {
 	PolicyNames []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesForBackendServerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesForBackendServerInput) GoString() string {
 	return s.String()
 }
@@ -6256,12 +6872,20 @@ type SetLoadBalancerPoliciesForBackendServerOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesForBackendServerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesForBackendServerOutput) GoString() string {
 	return s.String()
 }
@@ -6288,12 +6912,20 @@ type SetLoadBalancerPoliciesOfListenerInput struct {
 	PolicyNames []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesOfListenerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesOfListenerInput) GoString() string {
 	return s.String()
 }
@@ -6340,12 +6972,20 @@ type SetLoadBalancerPoliciesOfListenerOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesOfListenerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetLoadBalancerPoliciesOfListenerOutput) GoString() string {
 	return s.String()
 }
@@ -6361,12 +7001,20 @@ type SourceSecurityGroup struct {
 	OwnerAlias *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SourceSecurityGroup) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SourceSecurityGroup) GoString() string {
 	return s.String()
 }
@@ -6396,12 +7044,20 @@ type Tag struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }
@@ -6445,12 +7101,20 @@ type TagDescription struct {
 	Tags []*Tag `min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) GoString() string {
 	return s.String()
 }
@@ -6475,12 +7139,20 @@ type TagKeyOnly struct {
 	Key *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagKeyOnly) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagKeyOnly) GoString() string {
 	return s.String()
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elb/service.go
@@ -48,22 +48,23 @@ const (
 //     svc := elb.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ELB {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ELB {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *ELB {
 	svc := &ELB{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2012-06-01",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2012-06-01",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -178,6 +178,12 @@ func (c *ELBV2) AddTagsRequest(input *AddTagsInput) (req *request.Request, outpu
 //   * ErrCodeTargetGroupNotFoundException "TargetGroupNotFound"
 //   The specified target group does not exist.
 //
+//   * ErrCodeListenerNotFoundException "ListenerNotFound"
+//   The specified listener does not exist.
+//
+//   * ErrCodeRuleNotFoundException "RuleNotFound"
+//   The specified rule does not exist.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddTags
 func (c *ELBV2) AddTags(input *AddTagsInput) (*AddTagsOutput, error) {
 	req, out := c.AddTagsRequest(input)
@@ -417,7 +423,8 @@ func (c *ELBV2) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *
 //   A load balancer with the specified name already exists.
 //
 //   * ErrCodeTooManyLoadBalancersException "TooManyLoadBalancers"
-//   You've reached the limit on the number of load balancers for your AWS account.
+//   You've reached the limit on the number of load balancers for your Amazon
+//   Web Services account.
 //
 //   * ErrCodeInvalidConfigurationRequestException "InvalidConfigurationRequest"
 //   The requested configuration is not valid.
@@ -540,7 +547,8 @@ func (c *ELBV2) CreateRuleRequest(input *CreateRuleInput) (req *request.Request,
 //   The specified priority is in use.
 //
 //   * ErrCodeTooManyTargetGroupsException "TooManyTargetGroups"
-//   You've reached the limit on the number of target groups for your AWS account.
+//   You've reached the limit on the number of target groups for your Amazon Web
+//   Services account.
 //
 //   * ErrCodeTooManyRulesException "TooManyRules"
 //   You've reached the limit on the number of rules per load balancer.
@@ -676,7 +684,8 @@ func (c *ELBV2) CreateTargetGroupRequest(input *CreateTargetGroupInput) (req *re
 //   A target group with the specified name already exists.
 //
 //   * ErrCodeTooManyTargetGroupsException "TooManyTargetGroups"
-//   You've reached the limit on the number of target groups for your AWS account.
+//   You've reached the limit on the number of target groups for your Amazon Web
+//   Services account.
 //
 //   * ErrCodeInvalidConfigurationRequestException "InvalidConfigurationRequest"
 //   The requested configuration is not valid.
@@ -766,6 +775,9 @@ func (c *ELBV2) DeleteListenerRequest(input *DeleteListenerInput) (req *request.
 // Returned Error Codes:
 //   * ErrCodeListenerNotFoundException "ListenerNotFound"
 //   The specified listener does not exist.
+//
+//   * ErrCodeResourceInUseException "ResourceInUse"
+//   A specified resource is in use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DeleteListener
 func (c *ELBV2) DeleteListener(input *DeleteListenerInput) (*DeleteListenerOutput, error) {
@@ -1184,8 +1196,8 @@ func (c *ELBV2) DescribeAccountLimitsRequest(input *DescribeAccountLimitsInput) 
 
 // DescribeAccountLimits API operation for Elastic Load Balancing.
 //
-// Describes the current Elastic Load Balancing resource limits for your AWS
-// account.
+// Describes the current Elastic Load Balancing resource limits for your Amazon
+// Web Services account.
 //
 // For more information, see the following:
 //
@@ -3464,12 +3476,20 @@ type Action struct {
 	Type *string `type:"string" required:"true" enum:"ActionTypeEnum"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Action) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Action) GoString() string {
 	return s.String()
 }
@@ -3573,12 +3593,20 @@ type AddListenerCertificatesInput struct {
 	ListenerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddListenerCertificatesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddListenerCertificatesInput) GoString() string {
 	return s.String()
 }
@@ -3618,12 +3646,20 @@ type AddListenerCertificatesOutput struct {
 	Certificates []*Certificate `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddListenerCertificatesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddListenerCertificatesOutput) GoString() string {
 	return s.String()
 }
@@ -3648,12 +3684,20 @@ type AddTagsInput struct {
 	Tags []*Tag `min:"1" type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsInput) GoString() string {
 	return s.String()
 }
@@ -3703,12 +3747,20 @@ type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AddTagsOutput) GoString() string {
 	return s.String()
 }
@@ -3764,12 +3816,20 @@ type AuthenticateCognitoActionConfig struct {
 	UserPoolDomain *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthenticateCognitoActionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthenticateCognitoActionConfig) GoString() string {
 	return s.String()
 }
@@ -3914,12 +3974,20 @@ type AuthenticateOidcActionConfig struct {
 	UserInfoEndpoint *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthenticateOidcActionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AuthenticateOidcActionConfig) GoString() string {
 	return s.String()
 }
@@ -4041,12 +4109,20 @@ type AvailabilityZone struct {
 	ZoneName *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AvailabilityZone) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AvailabilityZone) GoString() string {
 	return s.String()
 }
@@ -4089,12 +4165,20 @@ type Certificate struct {
 	IsDefault *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Certificate) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Certificate) GoString() string {
 	return s.String()
 }
@@ -4122,12 +4206,20 @@ type Cipher struct {
 	Priority *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Cipher) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Cipher) GoString() string {
 	return s.String()
 }
@@ -4202,12 +4294,20 @@ type CreateListenerInput struct {
 	Tags []*Tag `min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateListenerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateListenerInput) GoString() string {
 	return s.String()
 }
@@ -4309,12 +4409,20 @@ type CreateListenerOutput struct {
 	Listeners []*Listener `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateListenerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateListenerOutput) GoString() string {
 	return s.String()
 }
@@ -4334,7 +4442,7 @@ type CreateLoadBalancerInput struct {
 
 	// The type of IP addresses used by the subnets for your load balancer. The
 	// possible values are ipv4 (for IPv4 addresses) and dualstack (for IPv4 and
-	// IPv6 addresses). Internal load balancers must use ipv4.
+	// IPv6 addresses).
 	IpAddressType *string `type:"string" enum:"IpAddressType"`
 
 	// The name of the load balancer.
@@ -4412,12 +4520,20 @@ type CreateLoadBalancerInput struct {
 	Type *string `type:"string" enum:"LoadBalancerTypeEnum"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -4509,12 +4625,20 @@ type CreateLoadBalancerOutput struct {
 	LoadBalancers []*LoadBalancer `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -4552,12 +4676,20 @@ type CreateRuleInput struct {
 	Tags []*Tag `min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRuleInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRuleInput) GoString() string {
 	return s.String()
 }
@@ -4647,12 +4779,20 @@ type CreateRuleOutput struct {
 	Rules []*Rule `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRuleOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateRuleOutput) GoString() string {
 	return s.String()
 }
@@ -4668,7 +4808,7 @@ type CreateTargetGroupInput struct {
 
 	// Indicates whether health checks are enabled. If the target type is lambda,
 	// health checks are disabled by default but can be enabled. If the target type
-	// is instance or ip, health checks are always enabled and cannot be disabled.
+	// is instance, ip, or alb, health checks are always enabled and cannot be disabled.
 	HealthCheckEnabled *bool `type:"boolean"`
 
 	// The approximate amount of time, in seconds, between health checks of an individual
@@ -4683,7 +4823,7 @@ type CreateTargetGroupInput struct {
 	// [HTTP1 or HTTP2 protocol version] The ping path. The default is /.
 	//
 	// [GRPC protocol version] The path of a custom health check method with the
-	// format /package.service/method. The default is /AWS.ALB/healthcheck.
+	// format /package.service/method. The default is /Amazon Web Services.ALB/healthcheck.
 	HealthCheckPath *string `min:"1" type:"string"`
 
 	// The port the load balancer uses when performing health checks on targets.
@@ -4712,6 +4852,11 @@ type CreateTargetGroupInput struct {
 	// HTTPS, the default is 5. For target groups with a protocol of TCP, TLS, or
 	// GENEVE, the default is 3. If the target type is lambda, the default is 5.
 	HealthyThresholdCount *int64 `min:"2" type:"integer"`
+
+	// The type of IP address used for this target group. The possible values are
+	// ipv4 and ipv6. This is an optional parameter. If not specified, the IP address
+	// type defaults to ipv4.
+	IpAddressType *string `type:"string" enum:"TargetGroupIpAddressTypeEnum"`
 
 	// [HTTP/HTTPS health checks] The HTTP or gRPC codes to use when checking for
 	// a successful response from a target.
@@ -4761,6 +4906,8 @@ type CreateTargetGroupInput struct {
 	//    addresses.
 	//
 	//    * lambda - Register a single Lambda function as a target.
+	//
+	//    * alb - Register a single Application Load Balancer as a target.
 	TargetType *string `type:"string" enum:"TargetTypeEnum"`
 
 	// The number of consecutive health check failures required before considering
@@ -4775,12 +4922,20 @@ type CreateTargetGroupInput struct {
 	VpcId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateTargetGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateTargetGroupInput) GoString() string {
 	return s.String()
 }
@@ -4871,6 +5026,12 @@ func (s *CreateTargetGroupInput) SetHealthyThresholdCount(v int64) *CreateTarget
 	return s
 }
 
+// SetIpAddressType sets the IpAddressType field's value.
+func (s *CreateTargetGroupInput) SetIpAddressType(v string) *CreateTargetGroupInput {
+	s.IpAddressType = &v
+	return s
+}
+
 // SetMatcher sets the Matcher field's value.
 func (s *CreateTargetGroupInput) SetMatcher(v *Matcher) *CreateTargetGroupInput {
 	s.Matcher = v
@@ -4932,12 +5093,20 @@ type CreateTargetGroupOutput struct {
 	TargetGroups []*TargetGroup `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateTargetGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateTargetGroupOutput) GoString() string {
 	return s.String()
 }
@@ -4957,12 +5126,20 @@ type DeleteListenerInput struct {
 	ListenerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteListenerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteListenerInput) GoString() string {
 	return s.String()
 }
@@ -4990,12 +5167,20 @@ type DeleteListenerOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteListenerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteListenerOutput) GoString() string {
 	return s.String()
 }
@@ -5009,12 +5194,20 @@ type DeleteLoadBalancerInput struct {
 	LoadBalancerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerInput) GoString() string {
 	return s.String()
 }
@@ -5042,12 +5235,20 @@ type DeleteLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteLoadBalancerOutput) GoString() string {
 	return s.String()
 }
@@ -5061,12 +5262,20 @@ type DeleteRuleInput struct {
 	RuleArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRuleInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRuleInput) GoString() string {
 	return s.String()
 }
@@ -5094,12 +5303,20 @@ type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRuleOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteRuleOutput) GoString() string {
 	return s.String()
 }
@@ -5113,12 +5330,20 @@ type DeleteTargetGroupInput struct {
 	TargetGroupArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTargetGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTargetGroupInput) GoString() string {
 	return s.String()
 }
@@ -5146,12 +5371,20 @@ type DeleteTargetGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTargetGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteTargetGroupOutput) GoString() string {
 	return s.String()
 }
@@ -5171,12 +5404,20 @@ type DeregisterTargetsInput struct {
 	Targets []*TargetDescription `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterTargetsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterTargetsInput) GoString() string {
 	return s.String()
 }
@@ -5223,12 +5464,20 @@ type DeregisterTargetsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterTargetsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeregisterTargetsOutput) GoString() string {
 	return s.String()
 }
@@ -5244,12 +5493,20 @@ type DescribeAccountLimitsInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsInput) GoString() string {
 	return s.String()
 }
@@ -5290,12 +5547,20 @@ type DescribeAccountLimitsOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeAccountLimitsOutput) GoString() string {
 	return s.String()
 }
@@ -5328,12 +5593,20 @@ type DescribeListenerCertificatesInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenerCertificatesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenerCertificatesInput) GoString() string {
 	return s.String()
 }
@@ -5383,12 +5656,20 @@ type DescribeListenerCertificatesOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenerCertificatesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenerCertificatesOutput) GoString() string {
 	return s.String()
 }
@@ -5422,12 +5703,20 @@ type DescribeListenersInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenersInput) GoString() string {
 	return s.String()
 }
@@ -5480,12 +5769,20 @@ type DescribeListenersOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeListenersOutput) GoString() string {
 	return s.String()
 }
@@ -5511,12 +5808,20 @@ type DescribeLoadBalancerAttributesInput struct {
 	LoadBalancerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesInput) GoString() string {
 	return s.String()
 }
@@ -5547,12 +5852,20 @@ type DescribeLoadBalancerAttributesOutput struct {
 	Attributes []*LoadBalancerAttribute `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -5581,12 +5894,20 @@ type DescribeLoadBalancersInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersInput) GoString() string {
 	return s.String()
 }
@@ -5639,12 +5960,20 @@ type DescribeLoadBalancersOutput struct {
 	NextMarker *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
 }
@@ -5678,12 +6007,20 @@ type DescribeRulesInput struct {
 	RuleArns []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRulesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRulesInput) GoString() string {
 	return s.String()
 }
@@ -5736,12 +6073,20 @@ type DescribeRulesOutput struct {
 	Rules []*Rule `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRulesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeRulesOutput) GoString() string {
 	return s.String()
 }
@@ -5761,6 +6106,10 @@ func (s *DescribeRulesOutput) SetRules(v []*Rule) *DescribeRulesOutput {
 type DescribeSSLPoliciesInput struct {
 	_ struct{} `type:"structure"`
 
+	// The type of load balancer. The default lists the SSL policies for all load
+	// balancers.
+	LoadBalancerType *string `type:"string" enum:"LoadBalancerTypeEnum"`
+
 	// The marker for the next set of results. (You received this marker from a
 	// previous call.)
 	Marker *string `type:"string"`
@@ -5772,12 +6121,20 @@ type DescribeSSLPoliciesInput struct {
 	PageSize *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeSSLPoliciesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeSSLPoliciesInput) GoString() string {
 	return s.String()
 }
@@ -5793,6 +6150,12 @@ func (s *DescribeSSLPoliciesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoadBalancerType sets the LoadBalancerType field's value.
+func (s *DescribeSSLPoliciesInput) SetLoadBalancerType(v string) *DescribeSSLPoliciesInput {
+	s.LoadBalancerType = &v
+	return s
 }
 
 // SetMarker sets the Marker field's value.
@@ -5824,12 +6187,20 @@ type DescribeSSLPoliciesOutput struct {
 	SslPolicies []*SslPolicy `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeSSLPoliciesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeSSLPoliciesOutput) GoString() string {
 	return s.String()
 }
@@ -5856,12 +6227,20 @@ type DescribeTagsInput struct {
 	ResourceArns []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
@@ -5892,12 +6271,20 @@ type DescribeTagsOutput struct {
 	TagDescriptions []*TagDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
 }
@@ -5917,12 +6304,20 @@ type DescribeTargetGroupAttributesInput struct {
 	TargetGroupArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupAttributesInput) GoString() string {
 	return s.String()
 }
@@ -5953,12 +6348,20 @@ type DescribeTargetGroupAttributesOutput struct {
 	Attributes []*TargetGroupAttribute `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -5989,12 +6392,20 @@ type DescribeTargetGroupsInput struct {
 	TargetGroupArns []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupsInput) GoString() string {
 	return s.String()
 }
@@ -6053,12 +6464,20 @@ type DescribeTargetGroupsOutput struct {
 	TargetGroups []*TargetGroup `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -6087,12 +6506,20 @@ type DescribeTargetHealthInput struct {
 	Targets []*TargetDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetHealthInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetHealthInput) GoString() string {
 	return s.String()
 }
@@ -6139,12 +6566,20 @@ type DescribeTargetHealthOutput struct {
 	TargetHealthDescriptions []*TargetHealthDescription `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetHealthOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeTargetHealthOutput) GoString() string {
 	return s.String()
 }
@@ -6174,12 +6609,20 @@ type FixedResponseActionConfig struct {
 	StatusCode *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FixedResponseActionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FixedResponseActionConfig) GoString() string {
 	return s.String()
 }
@@ -6227,12 +6670,20 @@ type ForwardActionConfig struct {
 	TargetGroups []*TargetGroupTuple `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ForwardActionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ForwardActionConfig) GoString() string {
 	return s.String()
 }
@@ -6262,12 +6713,20 @@ type HostHeaderConditionConfig struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HostHeaderConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HostHeaderConditionConfig) GoString() string {
 	return s.String()
 }
@@ -6307,12 +6766,20 @@ type HttpHeaderConditionConfig struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HttpHeaderConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HttpHeaderConditionConfig) GoString() string {
 	return s.String()
 }
@@ -6349,12 +6816,20 @@ type HttpRequestMethodConditionConfig struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HttpRequestMethodConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s HttpRequestMethodConditionConfig) GoString() string {
 	return s.String()
 }
@@ -6365,7 +6840,8 @@ func (s *HttpRequestMethodConditionConfig) SetValues(v []*string) *HttpRequestMe
 	return s
 }
 
-// Information about an Elastic Load Balancing resource limit for your AWS account.
+// Information about an Elastic Load Balancing resource limit for your Amazon
+// Web Services account.
 type Limit struct {
 	_ struct{} `type:"structure"`
 
@@ -6412,12 +6888,20 @@ type Limit struct {
 	Name *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Limit) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Limit) GoString() string {
 	return s.String()
 }
@@ -6465,12 +6949,20 @@ type Listener struct {
 	SslPolicy *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Listener) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Listener) GoString() string {
 	return s.String()
 }
@@ -6578,12 +7070,20 @@ type LoadBalancer struct {
 	VpcId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancer) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancer) GoString() string {
 	return s.String()
 }
@@ -6684,12 +7184,20 @@ type LoadBalancerAddress struct {
 	PrivateIPv4Address *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAddress) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAddress) GoString() string {
 	return s.String()
 }
@@ -6743,6 +7251,11 @@ type LoadBalancerAttribute struct {
 	//    * access_logs.s3.prefix - The prefix for the location in the S3 bucket
 	//    for the access logs.
 	//
+	//    * ipv6.deny-all-igw-traffic - Blocks internet gateway (IGW) access to
+	//    the load balancer. It is set to false for internet-facing load balancers
+	//    and true for internal load balancers, preventing unintended access to
+	//    your internal load balancer through an internet gateway.
+	//
 	// The following attributes are supported by only Application Load Balancers:
 	//
 	//    * idle_timeout.timeout_seconds - The idle timeout value, in seconds. The
@@ -6757,31 +7270,57 @@ type LoadBalancerAttribute struct {
 	//    HTTP headers with invalid header fields are removed by the load balancer
 	//    (true) or routed to targets (false). The default is false.
 	//
-	//    * routing.http2.enabled - Indicates whether HTTP/2 is enabled. The value
-	//    is true or false. The default is true. Elastic Load Balancing requires
-	//    that message header names contain only alphanumeric characters and hyphens.
+	//    * routing.http.x_amzn_tls_version_and_cipher_suite.enabled - Indicates
+	//    whether the two headers (x-amzn-tls-version and x-amzn-tls-cipher-suite),
+	//    which contain information about the negotiated TLS version and cipher
+	//    suite, are added to the client request before sending it to the target.
+	//    The x-amzn-tls-version header has information about the TLS protocol version
+	//    negotiated with the client, and the x-amzn-tls-cipher-suite header has
+	//    information about the cipher suite negotiated with the client. Both headers
+	//    are in OpenSSL format. The possible values for the attribute are true
+	//    and false. The default is false.
+	//
+	//    * routing.http.xff_client_port.enabled - Indicates whether the X-Forwarded-For
+	//    header should preserve the source port that the client used to connect
+	//    to the load balancer. The possible values are true and false. The default
+	//    is false.
+	//
+	//    * routing.http2.enabled - Indicates whether HTTP/2 is enabled. The possible
+	//    values are true and false. The default is true. Elastic Load Balancing
+	//    requires that message header names contain only alphanumeric characters
+	//    and hyphens.
 	//
 	//    * waf.fail_open.enabled - Indicates whether to allow a WAF-enabled load
 	//    balancer to route requests to targets if it is unable to forward the request
-	//    to AWS WAF. The value is true or false. The default is false.
+	//    to Amazon Web Services WAF. The possible values are true and false. The
+	//    default is false.
 	//
 	// The following attribute is supported by Network Load Balancers and Gateway
 	// Load Balancers:
 	//
 	//    * load_balancing.cross_zone.enabled - Indicates whether cross-zone load
-	//    balancing is enabled. The value is true or false. The default is false.
+	//    balancing is enabled. The possible values are true and false. The default
+	//    is false.
 	Key *string `type:"string"`
 
 	// The value of the attribute.
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAttribute) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerAttribute) GoString() string {
 	return s.String()
 }
@@ -6813,12 +7352,20 @@ type LoadBalancerState struct {
 	Reason *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerState) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LoadBalancerState) GoString() string {
 	return s.String()
 }
@@ -6851,15 +7398,26 @@ type Matcher struct {
 	// "200,202") or a range of values (for example, "200-299").
 	//
 	// For Network Load Balancers and Gateway Load Balancers, this must be "200–399".
+	//
+	// Note that when using shorthand syntax, some values such as commas need to
+	// be escaped.
 	HttpCode *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Matcher) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Matcher) GoString() string {
 	return s.String()
 }
@@ -6929,12 +7487,20 @@ type ModifyListenerInput struct {
 	SslPolicy *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyListenerInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyListenerInput) GoString() string {
 	return s.String()
 }
@@ -7014,12 +7580,20 @@ type ModifyListenerOutput struct {
 	Listeners []*Listener `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyListenerOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyListenerOutput) GoString() string {
 	return s.String()
 }
@@ -7044,12 +7618,20 @@ type ModifyLoadBalancerAttributesInput struct {
 	LoadBalancerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesInput) GoString() string {
 	return s.String()
 }
@@ -7089,12 +7671,20 @@ type ModifyLoadBalancerAttributesOutput struct {
 	Attributes []*LoadBalancerAttribute `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -7120,12 +7710,20 @@ type ModifyRuleInput struct {
 	RuleArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyRuleInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyRuleInput) GoString() string {
 	return s.String()
 }
@@ -7178,12 +7776,20 @@ type ModifyRuleOutput struct {
 	Rules []*Rule `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyRuleOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyRuleOutput) GoString() string {
 	return s.String()
 }
@@ -7208,12 +7814,20 @@ type ModifyTargetGroupAttributesInput struct {
 	TargetGroupArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupAttributesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupAttributesInput) GoString() string {
 	return s.String()
 }
@@ -7253,12 +7867,20 @@ type ModifyTargetGroupAttributesOutput struct {
 	Attributes []*TargetGroupAttribute `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupAttributesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupAttributesOutput) GoString() string {
 	return s.String()
 }
@@ -7286,16 +7908,19 @@ type ModifyTargetGroupInput struct {
 	// [HTTP1 or HTTP2 protocol version] The ping path. The default is /.
 	//
 	// [GRPC protocol version] The path of a custom health check method with the
-	// format /package.service/method. The default is /AWS.ALB/healthcheck.
+	// format /package.service/method. The default is /Amazon Web Services.ALB/healthcheck.
 	HealthCheckPath *string `min:"1" type:"string"`
 
 	// The port the load balancer uses when performing health checks on targets.
 	HealthCheckPort *string `type:"string"`
 
 	// The protocol the load balancer uses when performing health checks on targets.
-	// The TCP protocol is supported for health checks only if the protocol of the
-	// target group is TCP, TLS, UDP, or TCP_UDP. The GENEVE, TLS, UDP, and TCP_UDP
-	// protocols are not supported for health checks.
+	// For Application Load Balancers, the default is HTTP. For Network Load Balancers
+	// and Gateway Load Balancers, the default is TCP. The TCP protocol is not supported
+	// for health checks if the protocol of the target group is HTTP or HTTPS. It
+	// is supported for health checks only if the protocol of the target group is
+	// TCP, TLS, UDP, or TCP_UDP. The GENEVE, TLS, UDP, and TCP_UDP protocols are
+	// not supported for health checks.
 	//
 	// With Network Load Balancers, you can't modify this setting.
 	HealthCheckProtocol *string `type:"string" enum:"ProtocolEnum"`
@@ -7327,12 +7952,20 @@ type ModifyTargetGroupInput struct {
 	UnhealthyThresholdCount *int64 `min:"2" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupInput) GoString() string {
 	return s.String()
 }
@@ -7432,12 +8065,20 @@ type ModifyTargetGroupOutput struct {
 	TargetGroups []*TargetGroup `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ModifyTargetGroupOutput) GoString() string {
 	return s.String()
 }
@@ -7464,12 +8105,20 @@ type PathPatternConditionConfig struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PathPatternConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PathPatternConditionConfig) GoString() string {
 	return s.String()
 }
@@ -7501,12 +8150,20 @@ type QueryStringConditionConfig struct {
 	Values []*QueryStringKeyValuePair `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s QueryStringConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s QueryStringConditionConfig) GoString() string {
 	return s.String()
 }
@@ -7528,12 +8185,20 @@ type QueryStringKeyValuePair struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s QueryStringKeyValuePair) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s QueryStringKeyValuePair) GoString() string {
 	return s.String()
 }
@@ -7602,12 +8267,20 @@ type RedirectActionConfig struct {
 	StatusCode *string `type:"string" required:"true" enum:"RedirectActionStatusCodeEnum"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RedirectActionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RedirectActionConfig) GoString() string {
 	return s.String()
 }
@@ -7681,12 +8354,20 @@ type RegisterTargetsInput struct {
 	Targets []*TargetDescription `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterTargetsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterTargetsInput) GoString() string {
 	return s.String()
 }
@@ -7733,12 +8414,20 @@ type RegisterTargetsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterTargetsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RegisterTargetsOutput) GoString() string {
 	return s.String()
 }
@@ -7758,12 +8447,20 @@ type RemoveListenerCertificatesInput struct {
 	ListenerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveListenerCertificatesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveListenerCertificatesInput) GoString() string {
 	return s.String()
 }
@@ -7800,12 +8497,20 @@ type RemoveListenerCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveListenerCertificatesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveListenerCertificatesOutput) GoString() string {
 	return s.String()
 }
@@ -7824,12 +8529,20 @@ type RemoveTagsInput struct {
 	TagKeys []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsInput) GoString() string {
 	return s.String()
 }
@@ -7866,12 +8579,20 @@ type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RemoveTagsOutput) GoString() string {
 	return s.String()
 }
@@ -7900,12 +8621,20 @@ type Rule struct {
 	RuleArn *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Rule) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Rule) GoString() string {
 	return s.String()
 }
@@ -8016,12 +8745,20 @@ type RuleCondition struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RuleCondition) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RuleCondition) GoString() string {
 	return s.String()
 }
@@ -8085,12 +8822,20 @@ type RulePriorityPair struct {
 	RuleArn *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RulePriorityPair) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RulePriorityPair) GoString() string {
 	return s.String()
 }
@@ -8124,9 +8869,8 @@ type SetIpAddressTypeInput struct {
 	_ struct{} `type:"structure"`
 
 	// The IP address type. The possible values are ipv4 (for IPv4 addresses) and
-	// dualstack (for IPv4 and IPv6 addresses). Internal load balancers must use
-	// ipv4. You can’t specify dualstack for a load balancer with a UDP or TCP_UDP
-	// listener.
+	// dualstack (for IPv4 and IPv6 addresses). You can’t specify dualstack for
+	// a load balancer with a UDP or TCP_UDP listener.
 	//
 	// IpAddressType is a required field
 	IpAddressType *string `type:"string" required:"true" enum:"IpAddressType"`
@@ -8137,12 +8881,20 @@ type SetIpAddressTypeInput struct {
 	LoadBalancerArn *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetIpAddressTypeInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetIpAddressTypeInput) GoString() string {
 	return s.String()
 }
@@ -8182,12 +8934,20 @@ type SetIpAddressTypeOutput struct {
 	IpAddressType *string `type:"string" enum:"IpAddressType"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetIpAddressTypeOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetIpAddressTypeOutput) GoString() string {
 	return s.String()
 }
@@ -8207,12 +8967,20 @@ type SetRulePrioritiesInput struct {
 	RulePriorities []*RulePriorityPair `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRulePrioritiesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRulePrioritiesInput) GoString() string {
 	return s.String()
 }
@@ -8253,12 +9021,20 @@ type SetRulePrioritiesOutput struct {
 	Rules []*Rule `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRulePrioritiesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetRulePrioritiesOutput) GoString() string {
 	return s.String()
 }
@@ -8283,12 +9059,20 @@ type SetSecurityGroupsInput struct {
 	SecurityGroups []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSecurityGroupsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSecurityGroupsInput) GoString() string {
 	return s.String()
 }
@@ -8328,12 +9112,20 @@ type SetSecurityGroupsOutput struct {
 	SecurityGroupIds []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSecurityGroupsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSecurityGroupsOutput) GoString() string {
 	return s.String()
 }
@@ -8350,8 +9142,7 @@ type SetSubnetsInput struct {
 	// [Network Load Balancers] The type of IP addresses used by the subnets for
 	// your load balancer. The possible values are ipv4 (for IPv4 addresses) and
 	// dualstack (for IPv4 and IPv6 addresses). You can’t specify dualstack for
-	// a load balancer with a UDP or TCP_UDP listener. Internal load balancers must
-	// use ipv4.
+	// a load balancer with a UDP or TCP_UDP listener. .
 	IpAddressType *string `type:"string" enum:"IpAddressType"`
 
 	// The Amazon Resource Name (ARN) of the load balancer.
@@ -8394,12 +9185,20 @@ type SetSubnetsInput struct {
 	Subnets []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSubnetsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSubnetsInput) GoString() string {
 	return s.String()
 }
@@ -8451,12 +9250,20 @@ type SetSubnetsOutput struct {
 	IpAddressType *string `type:"string" enum:"IpAddressType"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSubnetsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SetSubnetsOutput) GoString() string {
 	return s.String()
 }
@@ -8491,12 +9298,20 @@ type SourceIpConditionConfig struct {
 	Values []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SourceIpConditionConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SourceIpConditionConfig) GoString() string {
 	return s.String()
 }
@@ -8519,14 +9334,25 @@ type SslPolicy struct {
 
 	// The protocols.
 	SslProtocols []*string `type:"list"`
+
+	// The supported load balancers.
+	SupportedLoadBalancerTypes []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SslPolicy) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SslPolicy) GoString() string {
 	return s.String()
 }
@@ -8549,6 +9375,12 @@ func (s *SslPolicy) SetSslProtocols(v []*string) *SslPolicy {
 	return s
 }
 
+// SetSupportedLoadBalancerTypes sets the SupportedLoadBalancerTypes field's value.
+func (s *SslPolicy) SetSupportedLoadBalancerTypes(v []*string) *SslPolicy {
+	s.SupportedLoadBalancerTypes = v
+	return s
+}
+
 // Information about a subnet mapping.
 type SubnetMapping struct {
 	_ struct{} `type:"structure"`
@@ -8567,12 +9399,20 @@ type SubnetMapping struct {
 	SubnetId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SubnetMapping) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SubnetMapping) GoString() string {
 	return s.String()
 }
@@ -8614,12 +9454,20 @@ type Tag struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }
@@ -8663,12 +9511,20 @@ type TagDescription struct {
 	Tags []*Tag `min:"1" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagDescription) GoString() string {
 	return s.String()
 }
@@ -8694,7 +9550,7 @@ type TargetDescription struct {
 	// from all enabled Availability Zones for the load balancer.
 	//
 	// This parameter is not supported if the target type of the target group is
-	// instance.
+	// instance or alb.
 	//
 	// If the target type is ip and the IP address is in a subnet of the VPC for
 	// the target group, the Availability Zone is automatically detected and this
@@ -8710,22 +9566,34 @@ type TargetDescription struct {
 
 	// The ID of the target. If the target type of the target group is instance,
 	// specify an instance ID. If the target type is ip, specify an IP address.
-	// If the target type is lambda, specify the ARN of the Lambda function.
+	// If the target type is lambda, specify the ARN of the Lambda function. If
+	// the target type is alb, specify the ARN of the Application Load Balancer
+	// target.
 	//
 	// Id is a required field
 	Id *string `type:"string" required:"true"`
 
 	// The port on which the target is listening. If the target group protocol is
-	// GENEVE, the supported port is 6081. Not used if the target is a Lambda function.
+	// GENEVE, the supported port is 6081. If the target type is alb, the targeted
+	// Application Load Balancer must have at least one listener whose port matches
+	// the target group port. Not used if the target is a Lambda function.
 	Port *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetDescription) GoString() string {
 	return s.String()
 }
@@ -8793,6 +9661,11 @@ type TargetGroup struct {
 	// an unhealthy target healthy.
 	HealthyThresholdCount *int64 `min:"2" type:"integer"`
 
+	// The type of IP address used for this target group. The possible values are
+	// ipv4 and ipv6. This is an optional parameter. If not specified, the IP address
+	// type defaults to ipv4.
+	IpAddressType *string `type:"string" enum:"TargetGroupIpAddressTypeEnum"`
+
 	// The Amazon Resource Names (ARN) of the load balancers that route traffic
 	// to this target group.
 	LoadBalancerArns []*string `type:"list"`
@@ -8820,8 +9693,9 @@ type TargetGroup struct {
 
 	// The type of target that you must specify when registering targets with this
 	// target group. The possible values are instance (register targets by instance
-	// ID), ip (register targets by IP address), or lambda (register a single Lambda
-	// function as a target).
+	// ID), ip (register targets by IP address), lambda (register a single Lambda
+	// function as a target), or alb (register a single Application Load Balancer
+	// as a target).
 	TargetType *string `type:"string" enum:"TargetTypeEnum"`
 
 	// The number of consecutive health check failures required before considering
@@ -8832,12 +9706,20 @@ type TargetGroup struct {
 	VpcId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroup) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroup) GoString() string {
 	return s.String()
 }
@@ -8881,6 +9763,12 @@ func (s *TargetGroup) SetHealthCheckTimeoutSeconds(v int64) *TargetGroup {
 // SetHealthyThresholdCount sets the HealthyThresholdCount field's value.
 func (s *TargetGroup) SetHealthyThresholdCount(v int64) *TargetGroup {
 	s.HealthyThresholdCount = &v
+	return s
+}
+
+// SetIpAddressType sets the IpAddressType field's value.
+func (s *TargetGroup) SetIpAddressType(v string) *TargetGroup {
+	s.IpAddressType = &v
 	return s
 }
 
@@ -8982,8 +9870,9 @@ type TargetGroupAttribute struct {
 	//    default is 0 seconds (disabled).
 	//
 	//    * stickiness.app_cookie.cookie_name - Indicates the name of the application-based
-	//    cookie. Names that start with the following names are not allowed: AWSALB,
-	//    AWSALBAPP, and AWSALBTG. They're reserved for use by the load balancer.
+	//    cookie. Names that start with the following prefixes are not allowed:
+	//    AWSALB, AWSALBAPP, and AWSALBTG; they're reserved for use by the load
+	//    balancer.
 	//
 	//    * stickiness.app_cookie.duration_seconds - The time period, in seconds,
 	//    during which requests from a client should be routed to the same target.
@@ -9027,12 +9916,20 @@ type TargetGroupAttribute struct {
 	Value *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupAttribute) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupAttribute) GoString() string {
 	return s.String()
 }
@@ -9061,12 +9958,20 @@ type TargetGroupStickinessConfig struct {
 	Enabled *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupStickinessConfig) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupStickinessConfig) GoString() string {
 	return s.String()
 }
@@ -9095,12 +10000,20 @@ type TargetGroupTuple struct {
 	Weight *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupTuple) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetGroupTuple) GoString() string {
 	return s.String()
 }
@@ -9188,12 +10101,20 @@ type TargetHealth struct {
 	State *string `type:"string" enum:"TargetHealthStateEnum"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetHealth) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetHealth) GoString() string {
 	return s.String()
 }
@@ -9230,12 +10151,20 @@ type TargetHealthDescription struct {
 	TargetHealth *TargetHealth `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetHealthDescription) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TargetHealthDescription) GoString() string {
 	return s.String()
 }
@@ -9455,6 +10384,22 @@ func RedirectActionStatusCodeEnum_Values() []string {
 }
 
 const (
+	// TargetGroupIpAddressTypeEnumIpv4 is a TargetGroupIpAddressTypeEnum enum value
+	TargetGroupIpAddressTypeEnumIpv4 = "ipv4"
+
+	// TargetGroupIpAddressTypeEnumIpv6 is a TargetGroupIpAddressTypeEnum enum value
+	TargetGroupIpAddressTypeEnumIpv6 = "ipv6"
+)
+
+// TargetGroupIpAddressTypeEnum_Values returns all elements of the TargetGroupIpAddressTypeEnum enum
+func TargetGroupIpAddressTypeEnum_Values() []string {
+	return []string{
+		TargetGroupIpAddressTypeEnumIpv4,
+		TargetGroupIpAddressTypeEnumIpv6,
+	}
+}
+
+const (
 	// TargetHealthReasonEnumElbRegistrationInProgress is a TargetHealthReasonEnum enum value
 	TargetHealthReasonEnumElbRegistrationInProgress = "Elb.RegistrationInProgress"
 
@@ -9551,6 +10496,9 @@ const (
 
 	// TargetTypeEnumLambda is a TargetTypeEnum enum value
 	TargetTypeEnumLambda = "lambda"
+
+	// TargetTypeEnumAlb is a TargetTypeEnum enum value
+	TargetTypeEnumAlb = "alb"
 )
 
 // TargetTypeEnum_Values returns all elements of the TargetTypeEnum enum
@@ -9559,5 +10507,6 @@ func TargetTypeEnum_Values() []string {
 		TargetTypeEnumInstance,
 		TargetTypeEnumIp,
 		TargetTypeEnumLambda,
+		TargetTypeEnumAlb,
 	}
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
@@ -183,7 +183,8 @@ const (
 	// ErrCodeTooManyLoadBalancersException for service response error code
 	// "TooManyLoadBalancers".
 	//
-	// You've reached the limit on the number of load balancers for your AWS account.
+	// You've reached the limit on the number of load balancers for your Amazon
+	// Web Services account.
 	ErrCodeTooManyLoadBalancersException = "TooManyLoadBalancers"
 
 	// ErrCodeTooManyRegistrationsForTargetIdException for service response error code
@@ -208,7 +209,8 @@ const (
 	// ErrCodeTooManyTargetGroupsException for service response error code
 	// "TooManyTargetGroups".
 	//
-	// You've reached the limit on the number of target groups for your AWS account.
+	// You've reached the limit on the number of target groups for your Amazon Web
+	// Services account.
 	ErrCodeTooManyTargetGroupsException = "TooManyTargetGroups"
 
 	// ErrCodeTooManyTargetsException for service response error code

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/elbv2/service.go
@@ -48,22 +48,23 @@ const (
 //     svc := elbv2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ELBV2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ELBV2 {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *ELBV2 {
 	svc := &ELBV2{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2015-12-01",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2015-12-01",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -57,19 +57,19 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 
 // CancelKeyDeletion API operation for AWS Key Management Service.
 //
-// Cancels the deletion of a customer master key (CMK). When this operation
-// succeeds, the key state of the CMK is Disabled. To enable the CMK, use EnableKey.
+// Cancels the deletion of a KMS key. When this operation succeeds, the key
+// state of the KMS key is Disabled. To enable the KMS key, use EnableKey.
 //
-// For more information about scheduling and canceling deletion of a CMK, see
-// Deleting Customer Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// For more information about scheduling and canceling deletion of a KMS key,
+// see Deleting KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:CancelKeyDeletion (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -104,9 +104,9 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CancelKeyDeletion
 func (c *KMS) CancelKeyDeletion(input *CancelKeyDeletionInput) (*CancelKeyDeletionOutput, error) {
@@ -176,19 +176,19 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 // ConnectCustomKeyStore API operation for AWS Key Management Service.
 //
 // Connects or reconnects a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// to its associated AWS CloudHSM cluster.
+// to its associated CloudHSM cluster.
 //
-// The custom key store must be connected before you can create customer master
-// keys (CMKs) in the key store or use the CMKs it contains. You can disconnect
-// and reconnect a custom key store at any time.
+// The custom key store must be connected before you can create KMS keys in
+// the key store or use the KMS keys it contains. You can disconnect and reconnect
+// a custom key store at any time.
 //
-// To connect a custom key store, its associated AWS CloudHSM cluster must have
+// To connect a custom key store, its associated CloudHSM cluster must have
 // at least one active HSM. To get the number of active HSMs in a cluster, use
 // the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 // operation. To add HSMs to the cluster, use the CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 // operation. Also, the kmsuser crypto user (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-// (CU) must not be logged into the cluster. This prevents AWS KMS from using
-// this account to log in.
+// (CU) must not be logged into the cluster. This prevents KMS from using this
+// account to log in.
 //
 // The connection process can take an extended amount of time to complete; up
 // to 20 minutes. This operation starts the connection process, but it does
@@ -198,10 +198,10 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 // the connection state of the custom key store, use the DescribeCustomKeyStores
 // operation.
 //
-// During the connection process, AWS KMS finds the AWS CloudHSM cluster that
-// is associated with the custom key store, creates the connection infrastructure,
-// connects to the cluster, logs into the AWS CloudHSM client as the kmsuser
-// CU, and rotates its password.
+// During the connection process, KMS finds the CloudHSM cluster that is associated
+// with the custom key store, creates the connection infrastructure, connects
+// to the cluster, logs into the CloudHSM client as the kmsuser CU, and rotates
+// its password.
 //
 // The ConnectCustomKeyStore operation might fail for various reasons. To find
 // the reason, use the DescribeCustomKeyStores operation and see the ConnectionErrorCode
@@ -213,10 +213,10 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //
 // If you are having trouble connecting or disconnecting a custom key store,
 // see Troubleshooting a Custom Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:ConnectCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -242,11 +242,11 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //
 // Returned Error Types:
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * CustomKeyStoreInvalidStateException
 //   The request was rejected because of the ConnectionState of the custom key
@@ -268,7 +268,7 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -276,8 +276,8 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //   can be retried.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -292,20 +292,19 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ConnectCustomKeyStore
 func (c *KMS) ConnectCustomKeyStore(input *ConnectCustomKeyStoreInput) (*ConnectCustomKeyStoreOutput, error) {
@@ -374,34 +373,37 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 
 // CreateAlias API operation for AWS Key Management Service.
 //
-// Creates a friendly name for a customer master key (CMK). You can use an alias
-// to identify a CMK in the AWS KMS console, in the DescribeKey operation and
-// in cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations),
-// such as Encrypt and GenerateDataKey.
+// Creates a friendly name for a KMS key.
 //
-// You can also change the CMK that's associated with the alias (UpdateAlias)
-// or delete the alias (DeleteAlias) at any time. These operations don't affect
-// the underlying CMK.
+// Adding, deleting, or updating an alias can allow or deny permission to the
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
-// You can associate the alias with any customer managed CMK in the same AWS
-// Region. Each alias is associated with only on CMK at a time, but a CMK can
-// have multiple aliases. A valid CMK is required. You can't create an alias
-// without a CMK.
+// You can use an alias to identify a KMS key in the KMS console, in the DescribeKey
+// operation and in cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations),
+// such as Encrypt and GenerateDataKey. You can also change the KMS key that's
+// associated with the alias (UpdateAlias) or delete the alias (DeleteAlias)
+// at any time. These operations don't affect the underlying KMS key.
+//
+// You can associate the alias with any customer managed key in the same Amazon
+// Web Services Region. Each alias is associated with only one KMS key at a
+// time, but a KMS key can have multiple aliases. A valid KMS key is required.
+// You can't create an alias without a KMS key.
 //
 // The alias must be unique in the account and Region, but you can have aliases
 // with the same name in different Regions. For detailed information about aliases,
 // see Using aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // This operation does not return a response. To get the alias that you created,
 // use the ListAliases operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on an alias in a
-// different AWS account.
+// different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -409,10 +411,10 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:CreateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the CMK (key policy).
+//    on the KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -452,15 +454,15 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateAlias
 func (c *KMS) CreateAlias(input *CreateAliasInput) (*CreateAliasOutput, error) {
@@ -529,31 +531,31 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 // CreateCustomKeyStore API operation for AWS Key Management Service.
 //
 // Creates a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// that is associated with an AWS CloudHSM cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html)
+// that is associated with an CloudHSM cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html)
 // that you own and manage.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Before you create the custom key store, you must assemble the required elements,
-// including an AWS CloudHSM cluster that fulfills the requirements for a custom
+// including an CloudHSM cluster that fulfills the requirements for a custom
 // key store. For details about the required elements, see Assemble the Prerequisites
 // (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // When the operation completes successfully, it returns the ID of the new custom
 // key store. Before you can use your new custom key store, you need to use
-// the ConnectCustomKeyStore operation to connect the new key store to its AWS
-// CloudHSM cluster. Even if you are not going to use your custom key store
-// immediately, you might want to connect it to verify that all settings are
-// correct and then disconnect it until you are ready to use it.
+// the ConnectCustomKeyStore operation to connect the new key store to its CloudHSM
+// cluster. Even if you are not going to use your custom key store immediately,
+// you might want to connect it to verify that all settings are correct and
+// then disconnect it until you are ready to use it.
 //
 // For help with failures, see Troubleshooting a Custom Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:CreateCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy).
@@ -579,10 +581,10 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CloudHsmClusterInUseException
-//   The request was rejected because the specified AWS CloudHSM cluster is already
+//   The request was rejected because the specified CloudHSM cluster is already
 //   associated with a custom key store or it shares a backup history with a cluster
 //   that is associated with a custom key store. Each custom key store must be
-//   associated with a different AWS CloudHSM cluster.
+//   associated with a different CloudHSM cluster.
 //
 //   Clusters that share a backup history have the same cluster certificate. To
 //   view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -594,32 +596,31 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //   key store name that is unique in the account.
 //
 //   * CloudHsmClusterNotFoundException
-//   The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-//   with the specified cluster ID. Retry the request with a different cluster
-//   ID.
+//   The request was rejected because KMS cannot find the CloudHSM cluster with
+//   the specified cluster ID. Retry the request with a different cluster ID.
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
 //   can be retried.
 //
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * IncorrectTrustAnchorException
 //   The request was rejected because the trust anchor certificate in the request
-//   is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+//   is not the trust anchor certificate for the specified CloudHSM cluster.
 //
 //   When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 //   you create the trust anchor certificate and save it in the customerCA.crt
 //   file.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -634,20 +635,19 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateCustomKeyStore
 func (c *KMS) CreateCustomKeyStore(input *CreateCustomKeyStoreInput) (*CreateCustomKeyStoreOutput, error) {
@@ -715,49 +715,44 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 
 // CreateGrant API operation for AWS Key Management Service.
 //
-// Adds a grant to a customer master key (CMK). The grant allows the grantee
-// principal to use the CMK when the conditions specified in the grant are met.
-// When setting permissions, grants are an alternative to key policies.
+// Adds a grant to a KMS key.
 //
-// To create a grant that allows a cryptographic operation (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-// only when the request includes a particular encryption context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context),
-// use the Constraints parameter. For details, see GrantConstraints.
+// A grant is a policy instrument that allows Amazon Web Services principals
+// to use KMS keys in cryptographic operations. It also can allow them to view
+// a KMS key (DescribeKey) and create and manage grants. When authorizing access
+// to a KMS key, grants are considered along with key policies and IAM policies.
+// Grants are often used for temporary permissions because you can create one,
+// use its permissions, and delete it without changing your key policies or
+// IAM policies.
 //
-// You can create grants on symmetric and asymmetric CMKs. However, if the grant
-// allows an operation that the CMK does not support, CreateGrant fails with
-// a ValidationException.
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
-//    * Grants for symmetric CMKs cannot allow operations that are not supported
-//    for symmetric CMKs, including Sign, Verify, and GetPublicKey. (There are
-//    limited exceptions to this rule for legacy operations, but you should
-//    not create a grant for an operation that AWS KMS does not support.)
+// The CreateGrant operation returns a GrantToken and a GrantId.
 //
-//    * Grants for asymmetric CMKs cannot allow operations that are not supported
-//    for asymmetric CMKs, including operations that generate data keys (https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKey)
-//    or data key pairs (https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyPair),
-//    or operations related to automatic key rotation (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html),
-//    imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-//    or CMKs in custom key stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+//    * When you create, retire, or revoke a grant, there might be a brief delay,
+//    usually less than five minutes, until the grant is available throughout
+//    KMS. This state is known as eventual consistency. Once the grant has achieved
+//    eventual consistency, the grantee principal can use the permissions in
+//    the grant without identifying the grant. However, to use the permissions
+//    in the grant immediately, use the GrantToken that CreateGrant returns.
+//    For details, see Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+//    in the Key Management Service Developer Guide .
 //
-//    * Grants for asymmetric CMKs with a KeyUsage of ENCRYPT_DECRYPT cannot
-//    allow the Sign or Verify operations. Grants for asymmetric CMKs with a
-//    KeyUsage of SIGN_VERIFY cannot allow the Encrypt or Decrypt operations.
+//    * The CreateGrant operation also returns a GrantId. You can use the GrantId
+//    and a key identifier to identify the grant in the RetireGrant and RevokeGrant
+//    operations. To find the grant ID, use the ListGrants or ListRetirableGrants
+//    operations.
 //
-//    * Grants for asymmetric CMKs cannot include an encryption context grant
-//    constraint. An encryption context is not supported on asymmetric CMKs.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide. For more information about
-// grants, see Grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide .
-//
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
-//
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:CreateGrant (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -785,7 +780,7 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -805,15 +800,15 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateGrant
 func (c *KMS) CreateGrant(input *CreateGrantInput) (*CreateGrantOutput, error) {
@@ -881,76 +876,111 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 
 // CreateKey API operation for AWS Key Management Service.
 //
-// Creates a unique customer managed customer master key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master-keys)
-// (CMK) in your AWS account and Region.
+// Creates a unique customer managed KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms-keys)
+// in your Amazon Web Services account and Region.
 //
-// You can use the CreateKey operation to create symmetric or asymmetric CMKs.
+// KMS is replacing the term customer master key (CMK) with KMS key and KMS
+// key. The concept has not changed. To prevent breaking changes, KMS is keeping
+// some variations of this term.
 //
-//    * Symmetric CMKs contain a 256-bit symmetric key that never leaves AWS
-//    KMS unencrypted. To use the CMK, you must call AWS KMS. You can use a
-//    symmetric CMK to encrypt and decrypt small amounts of data, but they are
-//    typically used to generate data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
+// You can use the CreateKey operation to create symmetric or asymmetric KMS
+// keys.
+//
+//    * Symmetric KMS keys contain a 256-bit symmetric key that never leaves
+//    KMS unencrypted. To use the KMS key, you must call KMS. You can use a
+//    symmetric KMS key to encrypt and decrypt small amounts of data, but they
+//    are typically used to generate data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
 //    and data keys pairs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-key-pairs).
 //    For details, see GenerateDataKey and GenerateDataKeyPair.
 //
-//    * Asymmetric CMKs can contain an RSA key pair or an Elliptic Curve (ECC)
-//    key pair. The private key in an asymmetric CMK never leaves AWS KMS unencrypted.
-//    However, you can use the GetPublicKey operation to download the public
-//    key so it can be used outside of AWS KMS. CMKs with RSA key pairs can
-//    be used to encrypt or decrypt data or sign and verify messages (but not
-//    both). CMKs with ECC key pairs can be used only to sign and verify messages.
+//    * Asymmetric KMS keys can contain an RSA key pair or an Elliptic Curve
+//    (ECC) key pair. The private key in an asymmetric KMS key never leaves
+//    KMS unencrypted. However, you can use the GetPublicKey operation to download
+//    the public key so it can be used outside of KMS. KMS keys with RSA key
+//    pairs can be used to encrypt or decrypt data or sign and verify messages
+//    (but not both). KMS keys with ECC key pairs can be used only to sign and
+//    verify messages.
 //
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// For information about symmetric and asymmetric KMS keys, see Using Symmetric
+// and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
-// To create different types of CMKs, use the following guidance:
+// To create different types of KMS keys, use the following guidance:
 //
-// Asymmetric CMKs
+// Asymmetric KMS keys
 //
-// To create an asymmetric CMK, use the CustomerMasterKeySpec parameter to specify
-// the type of key material in the CMK. Then, use the KeyUsage parameter to
-// determine whether the CMK will be used to encrypt and decrypt or sign and
-// verify. You can't change these properties after the CMK is created.
+// To create an asymmetric KMS key, use the KeySpec parameter to specify the
+// type of key material in the KMS key. Then, use the KeyUsage parameter to
+// determine whether the KMS key will be used to encrypt and decrypt or sign
+// and verify. You can't change these properties after the KMS key is created.
 //
-// Symmetric CMKs
+// Symmetric KMS keys
 //
-// When creating a symmetric CMK, you don't need to specify the CustomerMasterKeySpec
-// or KeyUsage parameters. The default value for CustomerMasterKeySpec, SYMMETRIC_DEFAULT,
+// When creating a symmetric KMS key, you don't need to specify the KeySpec
+// or KeyUsage parameters. The default value for KeySpec, SYMMETRIC_DEFAULT,
 // and the default value for KeyUsage, ENCRYPT_DECRYPT, are the only valid values
-// for symmetric CMKs.
+// for symmetric KMS keys.
 //
-// Imported Key Material
+// Multi-Region primary keys
 //
-// To import your own key material, begin by creating a symmetric CMK with no
-// key material. To do this, use the Origin parameter of CreateKey with a value
-// of EXTERNAL. Next, use GetParametersForImport operation to get a public key
-// and import token, and use the public key to encrypt your key material. Then,
-// use ImportKeyMaterial with your import token to import the key material.
+// Imported key material
+//
+// To create a multi-Region primary key in the local Amazon Web Services Region,
+// use the MultiRegion parameter with a value of True. To create a multi-Region
+// replica key, that is, a KMS key with the same key ID and key material as
+// a primary key, but in a different Amazon Web Services Region, use the ReplicateKey
+// operation. To change a replica key to a primary key, and its primary key
+// to a replica key, use the UpdatePrimaryRegion operation.
+//
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
+//
+// You can create symmetric and asymmetric multi-Region keys and multi-Region
+// keys with imported key material. You cannot create multi-Region keys in a
+// custom key store.
+//
+// To import your own key material, begin by creating a symmetric KMS key with
+// no key material. To do this, use the Origin parameter of CreateKey with a
+// value of EXTERNAL. Next, use GetParametersForImport operation to get a public
+// key and import token, and use the public key to encrypt your key material.
+// Then, use ImportKeyMaterial with your import token to import the key material.
 // For step-by-step instructions, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide . You cannot import the
-// key material into an asymmetric CMK.
+// in the Key Management Service Developer Guide . You cannot import the key
+// material into an asymmetric KMS key.
 //
-// Custom Key Stores
+// To create a multi-Region primary key with imported key material, use the
+// Origin parameter of CreateKey with a value of EXTERNAL and the MultiRegion
+// parameter with a value of True. To create replicas of the multi-Region primary
+// key, use the ReplicateKey operation. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
 //
-// To create a symmetric CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// Custom key store
+//
+// To create a symmetric KMS key in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
 // use the CustomKeyStoreId parameter to specify the custom key store. You must
-// also use the Origin parameter with a value of AWS_CLOUDHSM. The AWS CloudHSM
+// also use the Origin parameter with a value of AWS_CLOUDHSM. The CloudHSM
 // cluster that is associated with the custom key store must have at least two
-// active HSMs in different Availability Zones in the AWS Region.
+// active HSMs in different Availability Zones in the Amazon Web Services Region.
 //
-// You cannot create an asymmetric CMK in a custom key store. For information
-// about custom key stores in AWS KMS see Using Custom Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// in the AWS Key Management Service Developer Guide .
+// You cannot create an asymmetric KMS key in a custom key store. For information
+// about custom key stores in KMS see Using Custom Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+// in the Key Management Service Developer Guide .
 //
-// Cross-account use: No. You cannot use this operation to create a CMK in a
-// different AWS account.
+// Cross-account use: No. You cannot use this operation to create a KMS key
+// in a different Amazon Web Services account.
 //
 // Required permissions: kms:CreateKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy). To use the Tags parameter, kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy). For examples and information about related permissions, see
-// Allow a user to create CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key)
-// in the AWS Key Management Service Developer Guide.
+// Allow a user to create KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key)
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -991,13 +1021,13 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreInvalidStateException
@@ -1020,8 +1050,8 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //      for all other ConnectionState values.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -1036,20 +1066,19 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateKey
 func (c *KMS) CreateKey(input *CreateKeyInput) (*CreateKeyOutput, error) {
@@ -1117,8 +1146,8 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 
 // Decrypt API operation for AWS Key Management Service.
 //
-// Decrypts ciphertext that was encrypted by a AWS KMS customer master key (CMK)
-// using any of the following operations:
+// Decrypts ciphertext that was encrypted by a KMS key using any of the following
+// operations:
 //
 //    * Encrypt
 //
@@ -1131,46 +1160,52 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //    * GenerateDataKeyPairWithoutPlaintext
 //
 // You can use this operation to decrypt ciphertext that was encrypted under
-// a symmetric or asymmetric CMK. When the CMK is asymmetric, you must specify
-// the CMK and the encryption algorithm that was used to encrypt the ciphertext.
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// a symmetric or asymmetric KMS key. When the KMS key is asymmetric, you must
+// specify the KMS key and the encryption algorithm that was used to encrypt
+// the ciphertext. For information about symmetric and asymmetric KMS keys,
+// see Using Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // The Decrypt operation also decrypts ciphertext that was encrypted outside
-// of AWS KMS by the public key in an AWS KMS asymmetric CMK. However, it cannot
-// decrypt ciphertext produced by other libraries, such as the AWS Encryption
-// SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// of KMS by the public key in an KMS asymmetric KMS key. However, it cannot
+// decrypt ciphertext produced by other libraries, such as the Amazon Web Services
+// Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
-// These libraries return a ciphertext format that is incompatible with AWS
-// KMS.
+// These libraries return a ciphertext format that is incompatible with KMS.
 //
-// If the ciphertext was encrypted under a symmetric CMK, the KeyId parameter
-// is optional. AWS KMS can get this information from metadata that it adds
-// to the symmetric ciphertext blob. This feature adds durability to your implementation
+// If the ciphertext was encrypted under a symmetric KMS key, the KeyId parameter
+// is optional. KMS can get this information from metadata that it adds to the
+// symmetric ciphertext blob. This feature adds durability to your implementation
 // by ensuring that authorized users can decrypt ciphertext decades after it
-// was encrypted, even if they've lost track of the CMK ID. However, specifying
-// the CMK is always recommended as a best practice. When you use the KeyId
-// parameter to specify a CMK, AWS KMS only uses the CMK you specify. If the
-// ciphertext was encrypted under a different CMK, the Decrypt operation fails.
-// This practice ensures that you use the CMK that you intend.
+// was encrypted, even if they've lost track of the key ID. However, specifying
+// the KMS key is always recommended as a best practice. When you use the KeyId
+// parameter to specify a KMS key, KMS only uses the KMS key you specify. If
+// the ciphertext was encrypted under a different KMS key, the Decrypt operation
+// fails. This practice ensures that you use the KMS key that you intend.
 //
 // Whenever possible, use key policies to give users permission to call the
-// Decrypt operation on a particular CMK, instead of using IAM policies. Otherwise,
-// you might create an IAM user policy that gives the user Decrypt permission
-// on all CMKs. This user could decrypt ciphertext that was encrypted by CMKs
-// in other accounts if the key policy for the cross-account CMK permits it.
-// If you must use an IAM policy for Decrypt permissions, limit the user to
-// particular CMKs or particular trusted accounts. For details, see Best practices
-// for IAM policies (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices)
-// in the AWS Key Management Service Developer Guide.
+// Decrypt operation on a particular KMS key, instead of using IAM policies.
+// Otherwise, you might create an IAM user policy that gives the user Decrypt
+// permission on all KMS keys. This user could decrypt ciphertext that was encrypted
+// by KMS keys in other accounts if the key policy for the cross-account KMS
+// key permits it. If you must use an IAM policy for Decrypt permissions, limit
+// the user to particular KMS keys or particular trusted accounts. For details,
+// see Best practices for IAM policies (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. You can decrypt a ciphertext using a CMK in a different
-// AWS account.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
+//
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Decrypt (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -1198,7 +1233,7 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -1206,32 +1241,33 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * IncorrectKeyException
-//   The request was rejected because the specified CMK cannot decrypt the data.
-//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-//   must identify the same CMK that was used to encrypt the ciphertext.
+//   The request was rejected because the specified KMS key cannot decrypt the
+//   data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same KMS key that was used to encrypt the ciphertext.
 //
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -1248,9 +1284,9 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Decrypt
 func (c *KMS) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
@@ -1321,17 +1357,21 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //
 // Deletes the specified alias.
 //
-// Because an alias is not a property of a CMK, you can delete and change the
-// aliases of a CMK without affecting the CMK. Also, aliases do not appear in
-// the response from the DescribeKey operation. To get the aliases of all CMKs,
-// use the ListAliases operation.
+// Adding, deleting, or updating an alias can allow or deny permission to the
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
-// Each CMK can have multiple aliases. To change the alias of a CMK, use DeleteAlias
-// to delete the current alias and CreateAlias to create a new alias. To associate
-// an existing alias with a different customer master key (CMK), call UpdateAlias.
+// Because an alias is not a property of a KMS key, you can delete and change
+// the aliases of a KMS key without affecting the KMS key. Also, aliases do
+// not appear in the response from the DescribeKey operation. To get the aliases
+// of all KMS keys, use the ListAliases operation.
+//
+// Each KMS key can have multiple aliases. To change the alias of a KMS key,
+// use DeleteAlias to delete the current alias and CreateAlias to create a new
+// alias. To associate an existing alias with a different KMS key, call UpdateAlias.
 //
 // Cross-account use: No. You cannot perform this operation on an alias in a
-// different AWS account.
+// different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -1339,10 +1379,10 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:DeleteAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the CMK (key policy).
+//    on the KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -1376,9 +1416,9 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteAlias
 func (c *KMS) DeleteAlias(input *DeleteAliasInput) (*DeleteAliasOutput, error) {
@@ -1448,37 +1488,35 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 // DeleteCustomKeyStore API operation for AWS Key Management Service.
 //
 // Deletes a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
-// This operation does not delete the AWS CloudHSM cluster that is associated
-// with the custom key store, or affect any users or keys in the cluster.
+// This operation does not delete the CloudHSM cluster that is associated with
+// the custom key store, or affect any users or keys in the cluster.
 //
-// The custom key store that you delete cannot contain any AWS KMS customer
-// master keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
+// The custom key store that you delete cannot contain any KMS KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys).
 // Before deleting the key store, verify that you will never need to use any
-// of the CMKs in the key store for any cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
-// Then, use ScheduleKeyDeletion to delete the AWS KMS customer master keys
-// (CMKs) from the key store. When the scheduled waiting period expires, the
-// ScheduleKeyDeletion operation deletes the CMKs. Then it makes a best effort
-// to delete the key material from the associated cluster. However, you might
-// need to manually delete the orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
+// of the KMS keys in the key store for any cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Then, use ScheduleKeyDeletion to delete the KMS keys from the key store.
+// When the scheduled waiting period expires, the ScheduleKeyDeletion operation
+// deletes the KMS keys. Then it makes a best effort to delete the key material
+// from the associated cluster. However, you might need to manually delete the
+// orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
 // from the cluster and its backups.
 //
-// After all CMKs are deleted from AWS KMS, use DisconnectCustomKeyStore to
-// disconnect the key store from AWS KMS. Then, you can delete the custom key
-// store.
+// After all KMS keys are deleted from KMS, use DisconnectCustomKeyStore to
+// disconnect the key store from KMS. Then, you can delete the custom key store.
 //
 // Instead of deleting the custom key store, consider using DisconnectCustomKeyStore
-// to disconnect it from AWS KMS. While the key store is disconnected, you cannot
-// create or use the CMKs in the key store. But, you do not need to delete CMKs
-// and you can reconnect a disconnected custom key store at any time.
+// to disconnect it from KMS. While the key store is disconnected, you cannot
+// create or use the KMS keys in the key store. But, you do not need to delete
+// KMS keys and you can reconnect a disconnected custom key store at any time.
 //
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DeleteCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -1504,10 +1542,10 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CustomKeyStoreHasCMKsException
-//   The request was rejected because the custom key store contains AWS KMS customer
-//   master keys (CMKs). After verifying that you do not need to use the CMKs,
-//   use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-//   deleted, you can delete the custom key store.
+//   The request was rejected because the custom key store contains KMS keys.
+//   After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+//   operation to delete the KMS keys. After they are deleted, you can delete
+//   the custom key store.
 //
 //   * CustomKeyStoreInvalidStateException
 //   The request was rejected because of the ConnectionState of the custom key
@@ -1529,7 +1567,7 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -1604,22 +1642,23 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 // DeleteImportedKeyMaterial API operation for AWS Key Management Service.
 //
 // Deletes key material that you previously imported. This operation makes the
-// specified customer master key (CMK) unusable. For more information about
-// importing key material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// specified KMS key unusable. For more information about importing key material
+// into KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// When the specified CMK is in the PendingDeletion state, this operation does
-// not change the CMK's state. Otherwise, it changes the CMK's state to PendingImport.
+// When the specified KMS key is in the PendingDeletion state, this operation
+// does not change the KMS key's state. Otherwise, it changes the KMS key's
+// state to PendingImport.
 //
 // After you delete key material, you can use ImportKeyMaterial to reimport
-// the same key material into the CMK.
+// the same key material into the KMS key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DeleteImportedKeyMaterial (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -1662,9 +1701,9 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteImportedKeyMaterial
 func (c *KMS) DeleteImportedKeyMaterial(input *DeleteImportedKeyMaterialInput) (*DeleteImportedKeyMaterialOutput, error) {
@@ -1733,35 +1772,35 @@ func (c *KMS) DescribeCustomKeyStoresRequest(input *DescribeCustomKeyStoresInput
 // DescribeCustomKeyStores API operation for AWS Key Management Service.
 //
 // Gets information about custom key stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// in the account and region.
+// in the account and Region.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // By default, this operation returns information about all custom key stores
-// in the account and region. To get only information about a particular custom
+// in the account and Region. To get only information about a particular custom
 // key store, use either the CustomKeyStoreName or CustomKeyStoreId parameter
 // (but not both).
 //
-// To determine whether the custom key store is connected to its AWS CloudHSM
-// cluster, use the ConnectionState element in the response. If an attempt to
-// connect the custom key store failed, the ConnectionState value is FAILED
-// and the ConnectionErrorCode element in the response indicates the cause of
-// the failure. For help interpreting the ConnectionErrorCode, see CustomKeyStoresListEntry.
+// To determine whether the custom key store is connected to its CloudHSM cluster,
+// use the ConnectionState element in the response. If an attempt to connect
+// the custom key store failed, the ConnectionState value is FAILED and the
+// ConnectionErrorCode element in the response indicates the cause of the failure.
+// For help interpreting the ConnectionErrorCode, see CustomKeyStoresListEntry.
 //
 // Custom key stores have a DISCONNECTED connection state if the key store has
 // never been connected or you use the DisconnectCustomKeyStore operation to
 // disconnect it. If your custom key store state is CONNECTED but you are having
-// trouble using it, make sure that its associated AWS CloudHSM cluster is active
+// trouble using it, make sure that its associated CloudHSM cluster is active
 // and contains the minimum number of HSMs required for the operation, if any.
 //
 // For help repairing your custom key store, see the Troubleshooting Custom
 // Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// topic in the AWS Key Management Service Developer Guide.
+// topic in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DescribeCustomKeyStores (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -1787,8 +1826,12 @@ func (c *KMS) DescribeCustomKeyStoresRequest(input *DescribeCustomKeyStoresInput
 //
 // Returned Error Types:
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
+//
+//   * InvalidMarkerException
+//   The request was rejected because the marker that specifies where pagination
+//   should next begin is not valid.
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
@@ -1860,41 +1903,45 @@ func (c *KMS) DescribeKeyRequest(input *DescribeKeyInput) (req *request.Request,
 
 // DescribeKey API operation for AWS Key Management Service.
 //
-// Provides detailed information about a customer master key (CMK). You can
-// run DescribeKey on a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
-// or an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+// Provides detailed information about a KMS key. You can run DescribeKey on
+// a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+// or an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 //
 // This detailed information includes the key ARN, creation date (and deletion
 // date, if applicable), the key state, and the origin and expiration date (if
-// any) of the key material. For CMKs in custom key stores, it includes information
-// about the custom key store, such as the key store ID and the AWS CloudHSM
-// cluster ID. It includes fields, like KeySpec, that help you distinguish symmetric
-// from asymmetric CMKs. It also provides information that is particularly important
-// to asymmetric CMKs, such as the key usage (encryption or signing) and the
-// encryption algorithms or signing algorithms that the CMK supports.
+// any) of the key material. It includes fields, like KeySpec, that help you
+// distinguish symmetric from asymmetric KMS keys. It also provides information
+// that is particularly important to asymmetric keys, such as the key usage
+// (encryption or signing) and the encryption algorithms or signing algorithms
+// that the KMS key supports. For KMS keys in custom key stores, it includes
+// information about the custom key store, such as the key store ID and the
+// CloudHSM cluster ID. For multi-Region keys, it displays the primary key and
+// all related replica keys.
 //
 // DescribeKey does not return the following information:
 //
-//    * Aliases associated with the CMK. To get this information, use ListAliases.
+//    * Aliases associated with the KMS key. To get this information, use ListAliases.
 //
-//    * Whether automatic key rotation is enabled on the CMK. To get this information,
-//    use GetKeyRotationStatus. Also, some key states prevent a CMK from being
-//    automatically rotated. For details, see How Automatic Key Rotation Works
-//    (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works)
-//    in AWS Key Management Service Developer Guide.
+//    * Whether automatic key rotation is enabled on the KMS key. To get this
+//    information, use GetKeyRotationStatus. Also, some key states prevent a
+//    KMS key from being automatically rotated. For details, see How Automatic
+//    Key Rotation Works (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works)
+//    in Key Management Service Developer Guide.
 //
-//    * Tags on the CMK. To get this information, use ListResourceTags.
+//    * Tags on the KMS key. To get this information, use ListResourceTags.
 //
-//    * Key policies and grants on the CMK. To get this information, use GetKeyPolicy
-//    and ListGrants.
+//    * Key policies and grants on the KMS key. To get this information, use
+//    GetKeyPolicy and ListGrants.
 //
-// If you call the DescribeKey operation on a predefined AWS alias, that is,
-// an AWS alias with no key ID, AWS KMS creates an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
-// Then, it associates the alias with the new CMK, and returns the KeyId and
-// Arn of the new CMK in the response.
+// If you call the DescribeKey operation on a predefined Amazon Web Services
+// alias, that is, an Amazon Web Services alias with no key ID, KMS creates
+// an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+// Then, it associates the alias with the new KMS key, and returns the KeyId
+// and Arn of the new KMS key in the response.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:DescribeKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2006,19 +2053,19 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 
 // DisableKey API operation for AWS Key Management Service.
 //
-// Sets the state of a customer master key (CMK) to disabled. This change temporarily
-// prevents use of the CMK for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Sets the state of a KMS key to disabled. This change temporarily prevents
+// use of the KMS key for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
 //
-// For more information about how key state affects the use of a CMK, see How
-// Key State Affects the Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide .
+// For more information about how key state affects the use of a KMS key, see
+// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide .
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DisableKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2053,9 +2100,9 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DisableKey
 func (c *KMS) DisableKey(input *DisableKeyInput) (*DisableKeyOutput, error) {
@@ -2125,17 +2172,21 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 // DisableKeyRotation API operation for AWS Key Management Service.
 //
 // Disables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified symmetric customer master key (CMK).
+// for the specified symmetric KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
-// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// To enable or disable automatic rotation of a set of related multi-Region
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
+// set the property on the primary key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DisableKeyRotation (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2159,7 +2210,7 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -2177,9 +2228,9 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -2253,14 +2304,14 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 // DisconnectCustomKeyStore API operation for AWS Key Management Service.
 //
 // Disconnects the custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// from its associated AWS CloudHSM cluster. While a custom key store is disconnected,
-// you can manage the custom key store and its customer master keys (CMKs),
-// but you cannot create or use CMKs in the custom key store. You can reconnect
-// the custom key store at any time.
+// from its associated CloudHSM cluster. While a custom key store is disconnected,
+// you can manage the custom key store and its KMS keys, but you cannot create
+// or use KMS keys in the custom key store. You can reconnect the custom key
+// store at any time.
 //
-// While a custom key store is disconnected, all attempts to create customer
-// master keys (CMKs) in the custom key store or to use existing CMKs in cryptographic
-// operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
+// While a custom key store is disconnected, all attempts to create KMS keys
+// in the custom key store or to use existing KMS keys in cryptographic operations
+// (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
 // will fail. This action can prevent users from storing and accessing sensitive
 // data.
 //
@@ -2271,11 +2322,11 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DisconnectCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -2320,7 +2371,7 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -2394,15 +2445,15 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 
 // EnableKey API operation for AWS Key Management Service.
 //
-// Sets the key state of a customer master key (CMK) to enabled. This allows
-// you to use the CMK for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Sets the key state of a KMS key to enabled. This allows you to use the KMS
+// key for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:EnableKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2436,15 +2487,15 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/EnableKey
 func (c *KMS) EnableKey(input *EnableKeyInput) (*EnableKeyOutput, error) {
@@ -2514,17 +2565,21 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 // EnableKeyRotation API operation for AWS Key Management Service.
 //
 // Enables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified symmetric customer master key (CMK).
+// for the specified symmetric KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
-// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// To enable or disable automatic rotation of a set of related multi-Region
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
+// set the property on the primary key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:EnableKeyRotation (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2548,7 +2603,7 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -2566,9 +2621,9 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -2640,55 +2695,56 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 
 // Encrypt API operation for AWS Key Management Service.
 //
-// Encrypts plaintext into ciphertext by using a customer master key (CMK).
-// The Encrypt operation has two primary use cases:
+// Encrypts plaintext into ciphertext by using a KMS key. The Encrypt operation
+// has two primary use cases:
 //
 //    * You can encrypt small amounts of arbitrary data, such as a personal
 //    identifier or database password, or other sensitive information.
 //
-//    * You can use the Encrypt operation to move encrypted data from one AWS
-//    Region to another. For example, in Region A, generate a data key and use
-//    the plaintext key to encrypt your data. Then, in Region A, use the Encrypt
-//    operation to encrypt the plaintext data key under a CMK in Region B. Now,
-//    you can move the encrypted data and the encrypted data key to Region B.
-//    When necessary, you can decrypt the encrypted data key and the encrypted
-//    data entirely within in Region B.
+//    * You can use the Encrypt operation to move encrypted data from one Amazon
+//    Web Services Region to another. For example, in Region A, generate a data
+//    key and use the plaintext key to encrypt your data. Then, in Region A,
+//    use the Encrypt operation to encrypt the plaintext data key under a KMS
+//    key in Region B. Now, you can move the encrypted data and the encrypted
+//    data key to Region B. When necessary, you can decrypt the encrypted data
+//    key and the encrypted data entirely within in Region B.
 //
 // You don't need to use the Encrypt operation to encrypt a data key. The GenerateDataKey
 // and GenerateDataKeyPair operations return a plaintext data key and an encrypted
 // copy of that data key.
 //
-// When you encrypt data, you must specify a symmetric or asymmetric CMK to
-// use in the encryption operation. The CMK must have a KeyUsage value of ENCRYPT_DECRYPT.
-// To find the KeyUsage of a CMK, use the DescribeKey operation.
+// When you encrypt data, you must specify a symmetric or asymmetric KMS key
+// to use in the encryption operation. The KMS key must have a KeyUsage value
+// of ENCRYPT_DECRYPT. To find the KeyUsage of a KMS key, use the DescribeKey
+// operation.
 //
-// If you use a symmetric CMK, you can use an encryption context to add additional
-// security to your encryption operation. If you specify an EncryptionContext
+// If you use a symmetric KMS key, you can use an encryption context to add
+// additional security to your encryption operation. If you specify an EncryptionContext
 // when encrypting data, you must specify the same encryption context (a case-sensitive
 // exact match) when decrypting the data. Otherwise, the request to decrypt
 // fails with an InvalidCiphertextException. For more information, see Encryption
 // Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// If you specify an asymmetric CMK, you must also specify the encryption algorithm.
-// The algorithm must be compatible with the CMK type.
+// If you specify an asymmetric KMS key, you must also specify the encryption
+// algorithm. The algorithm must be compatible with the KMS key type.
 //
-// When you use an asymmetric CMK to encrypt or reencrypt data, be sure to record
-// the CMK and encryption algorithm that you choose. You will be required to
-// provide the same CMK and encryption algorithm when you decrypt the data.
-// If the CMK and algorithm do not match the values used to encrypt the data,
-// the decrypt operation fails.
+// When you use an asymmetric KMS key to encrypt or reencrypt data, be sure
+// to record the KMS key and encryption algorithm that you choose. You will
+// be required to provide the same KMS key and encryption algorithm when you
+// decrypt the data. If the KMS key and algorithm do not match the values used
+// to encrypt the data, the decrypt operation fails.
 //
-// You are not required to supply the CMK ID and encryption algorithm when you
-// decrypt with symmetric CMKs because AWS KMS stores this information in the
-// ciphertext blob. AWS KMS cannot store metadata in ciphertext generated with
-// asymmetric keys. The standard format for asymmetric key ciphertext does not
-// include configurable fields.
+// You are not required to supply the key ID and encryption algorithm when you
+// decrypt with symmetric KMS keys because KMS stores this information in the
+// ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric
+// keys. The standard format for asymmetric key ciphertext does not include
+// configurable fields.
 //
 // The maximum size of the data that you can encrypt varies with the type of
-// CMK and the encryption algorithm that you choose.
+// KMS key and the encryption algorithm that you choose.
 //
-//    * Symmetric CMKs SYMMETRIC_DEFAULT: 4096 bytes
+//    * Symmetric KMS keys SYMMETRIC_DEFAULT: 4096 bytes
 //
 //    * RSA_2048 RSAES_OAEP_SHA_1: 214 bytes RSAES_OAEP_SHA_256: 190 bytes
 //
@@ -2696,12 +2752,13 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //
 //    * RSA_4096 RSAES_OAEP_SHA_1: 470 bytes RSAES_OAEP_SHA_256: 446 bytes
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Encrypt (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2727,11 +2784,11 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -2740,17 +2797,18 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -2763,9 +2821,9 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Encrypt
 func (c *KMS) Encrypt(input *EncryptInput) (*EncryptOutput, error) {
@@ -2835,18 +2893,18 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //
 // Generates a unique symmetric data key for client-side encryption. This operation
 // returns a plaintext copy of the data key and a copy that is encrypted under
-// a customer master key (CMK) that you specify. You can use the plaintext key
-// to encrypt your data outside of AWS KMS and store the encrypted data key
-// with the encrypted data.
+// a KMS key that you specify. You can use the plaintext key to encrypt your
+// data outside of KMS and store the encrypted data key with the encrypted data.
 //
 // GenerateDataKey returns a unique data key for each request. The bytes in
-// the plaintext key are not related to the caller or the CMK.
+// the plaintext key are not related to the caller or the KMS key.
 //
-// To generate a data key, specify the symmetric CMK that will be used to encrypt
-// the data key. You cannot use an asymmetric CMK to generate data keys. To
-// get the type of your CMK, use the DescribeKey operation. You must also specify
-// the length of the data key. Use either the KeySpec or NumberOfBytes parameters
-// (but not both). For 128-bit and 256-bit data keys, use the KeySpec parameter.
+// To generate a data key, specify the symmetric KMS key that will be used to
+// encrypt the data key. You cannot use an asymmetric KMS key to generate data
+// keys. To get the type of your KMS key, use the DescribeKey operation. You
+// must also specify the length of the data key. Use either the KeySpec or NumberOfBytes
+// parameters (but not both). For 128-bit and 256-bit data keys, use the KeySpec
+// parameter.
 //
 // To get only an encrypted copy of the data key, use GenerateDataKeyWithoutPlaintext.
 // To generate an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
@@ -2857,41 +2915,48 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
+//
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 // How to use your data key
 //
 // We recommend that you use the following pattern to encrypt data locally in
 // your application. You can write your own code or use a client-side encryption
-// library, such as the AWS Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/),
+// library, such as the Amazon Web Services Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/),
 // the Amazon DynamoDB Encryption Client (https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/),
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html)
 // to do these tasks for you.
 //
-// To encrypt data outside of AWS KMS:
+// To encrypt data outside of KMS:
 //
 // Use the GenerateDataKey operation to get a data key.
 //
 // Use the plaintext data key (in the Plaintext field of the response) to encrypt
-// your data outside of AWS KMS. Then erase the plaintext data key from memory.
+// your data outside of KMS. Then erase the plaintext data key from memory.
 //
 // Store the encrypted data key (in the CiphertextBlob field of the response)
 // with the encrypted data.
 //
-// To decrypt data outside of AWS KMS:
+// To decrypt data outside of KMS:
 //
 // Use the Decrypt operation to decrypt the encrypted data key. The operation
 // returns a plaintext copy of the data key.
 //
-// Use the plaintext data key to decrypt data outside of AWS KMS, then erase
-// the plaintext data key from memory.
+// Use the plaintext data key to decrypt data outside of KMS, then erase the
+// plaintext data key from memory.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2921,11 +2986,11 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -2934,17 +2999,18 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -2957,9 +3023,9 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKey
 func (c *KMS) GenerateDataKey(input *GenerateDataKeyInput) (*GenerateDataKeyOutput, error) {
@@ -3029,22 +3095,24 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //
 // Generates a unique asymmetric data key pair. The GenerateDataKeyPair operation
 // returns a plaintext public key, a plaintext private key, and a copy of the
-// private key that is encrypted under the symmetric CMK you specify. You can
-// use the data key pair to perform asymmetric cryptography outside of AWS KMS.
-//
-// GenerateDataKeyPair returns a unique data key pair for each request. The
-// bytes in the keys are not related to the caller or the CMK that is used to
-// encrypt the private key.
+// private key that is encrypted under the symmetric KMS key you specify. You
+// can use the data key pair to perform asymmetric cryptography and implement
+// digital signatures outside of KMS.
 //
 // You can use the public key that GenerateDataKeyPair returns to encrypt data
-// or verify a signature outside of AWS KMS. Then, store the encrypted private
-// key with the data. When you are ready to decrypt data or sign a message,
-// you can use the Decrypt operation to decrypt the encrypted private key.
+// or verify a signature outside of KMS. Then, store the encrypted private key
+// with the data. When you are ready to decrypt data or sign a message, you
+// can use the Decrypt operation to decrypt the encrypted private key.
 //
-// To generate a data key pair, you must specify a symmetric customer master
-// key (CMK) to encrypt the private key in a data key pair. You cannot use an
-// asymmetric CMK or a CMK in a custom key store. To get the type and origin
-// of your CMK, use the DescribeKey operation.
+// To generate a data key pair, you must specify a symmetric KMS key to encrypt
+// the private key in a data key pair. You cannot use an asymmetric KMS key
+// or a KMS key in a custom key store. To get the type and origin of your KMS
+// key, use the DescribeKey operation.
+//
+// Use the KeyPairSpec parameter to choose an RSA or Elliptic Curve (ECC) data
+// key pair. KMS recommends that your use ECC key pairs for signing, and use
+// RSA key pairs for either encryption or signing, but not both. However, KMS
+// cannot enforce any restrictions on the use of data key pairs outside of KMS.
 //
 // If you are using the data key pair to encrypt data, or for any operation
 // where you don't immediately need a private key, consider using the GenerateDataKeyPairWithoutPlaintext
@@ -3054,19 +3122,26 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 // to decrypt the data or sign a message, use the Decrypt operation to decrypt
 // the encrypted private key in the data key pair.
 //
+// GenerateDataKeyPair returns a unique data key pair for each request. The
+// bytes in the keys are not related to the caller or the KMS key that is used
+// to encrypt the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo,
+// as specified in RFC 5280 (https://tools.ietf.org/html/rfc5280). The private
+// key is a DER-encoded PKCS8 PrivateKeyInfo, as specified in RFC 5958 (https://tools.ietf.org/html/rfc5958).
+//
 // You can use the optional encryption context to add additional security to
 // the encryption operation. If you specify an EncryptionContext, you must specify
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyPair (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3096,11 +3171,11 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3109,17 +3184,18 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3132,9 +3208,9 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3208,37 +3284,43 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //
 // Generates a unique asymmetric data key pair. The GenerateDataKeyPairWithoutPlaintext
 // operation returns a plaintext public key and a copy of the private key that
-// is encrypted under the symmetric CMK you specify. Unlike GenerateDataKeyPair,
+// is encrypted under the symmetric KMS key you specify. Unlike GenerateDataKeyPair,
 // this operation does not return a plaintext private key.
 //
-// To generate a data key pair, you must specify a symmetric customer master
-// key (CMK) to encrypt the private key in the data key pair. You cannot use
-// an asymmetric CMK or a CMK in a custom key store. To get the type and origin
-// of your CMK, use the KeySpec field in the DescribeKey response.
-//
 // You can use the public key that GenerateDataKeyPairWithoutPlaintext returns
-// to encrypt data or verify a signature outside of AWS KMS. Then, store the
-// encrypted private key with the data. When you are ready to decrypt data or
-// sign a message, you can use the Decrypt operation to decrypt the encrypted
-// private key.
+// to encrypt data or verify a signature outside of KMS. Then, store the encrypted
+// private key with the data. When you are ready to decrypt data or sign a message,
+// you can use the Decrypt operation to decrypt the encrypted private key.
+//
+// To generate a data key pair, you must specify a symmetric KMS key to encrypt
+// the private key in a data key pair. You cannot use an asymmetric KMS key
+// or a KMS key in a custom key store. To get the type and origin of your KMS
+// key, use the DescribeKey operation.
+//
+// Use the KeyPairSpec parameter to choose an RSA or Elliptic Curve (ECC) data
+// key pair. KMS recommends that your use ECC key pairs for signing, and use
+// RSA key pairs for either encryption or signing, but not both. However, KMS
+// cannot enforce any restrictions on the use of data key pairs outside of KMS.
 //
 // GenerateDataKeyPairWithoutPlaintext returns a unique data key pair for each
-// request. The bytes in the key are not related to the caller or CMK that is
-// used to encrypt the private key.
+// request. The bytes in the key are not related to the caller or KMS key that
+// is used to encrypt the private key. The public key is a DER-encoded X.509
+// SubjectPublicKeyInfo, as specified in RFC 5280 (https://tools.ietf.org/html/rfc5280).
 //
 // You can use the optional encryption context to add additional security to
 // the encryption operation. If you specify an EncryptionContext, you must specify
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyPairWithoutPlaintext (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3268,11 +3350,11 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3281,17 +3363,18 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3304,9 +3387,9 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3379,8 +3462,8 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // GenerateDataKeyWithoutPlaintext API operation for AWS Key Management Service.
 //
 // Generates a unique symmetric data key. This operation returns a data key
-// that is encrypted under a customer master key (CMK) that you specify. To
-// request an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
+// that is encrypted under a KMS key that you specify. To request an asymmetric
+// data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
 // operations.
 //
 // GenerateDataKeyWithoutPlaintext is identical to the GenerateDataKey operation
@@ -3399,13 +3482,12 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // never sees the plaintext data key.
 //
 // GenerateDataKeyWithoutPlaintext returns a unique data key for each request.
-// The bytes in the keys are not related to the caller or CMK that is used to
-// encrypt the private key.
+// The bytes in the keys are not related to the caller or KMS key that is used
+// to encrypt the private key.
 //
-// To generate a data key, you must specify the symmetric customer master key
-// (CMK) that is used to encrypt the data key. You cannot use an asymmetric
-// CMK to generate a data key. To get the type of your CMK, use the DescribeKey
-// operation.
+// To generate a data key, you must specify the symmetric KMS key that is used
+// to encrypt the data key. You cannot use an asymmetric KMS key to generate
+// a data key. To get the type of your KMS key, use the DescribeKey operation.
 //
 // If the operation succeeds, you will find the encrypted copy of the data key
 // in the CiphertextBlob field.
@@ -3415,14 +3497,15 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyWithoutPlaintext (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3452,11 +3535,11 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3465,17 +3548,18 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3488,9 +3572,9 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyWithoutPlaintext
 func (c *KMS) GenerateDataKeyWithoutPlaintext(input *GenerateDataKeyWithoutPlaintextInput) (*GenerateDataKeyWithoutPlaintextOutput, error) {
@@ -3560,14 +3644,19 @@ func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *request.Re
 //
 // Returns a random byte string that is cryptographically secure.
 //
-// By default, the random byte string is generated in AWS KMS. To generate the
-// byte string in the AWS CloudHSM cluster that is associated with a custom
-// key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// By default, the random byte string is generated in KMS. To generate the byte
+// string in the CloudHSM cluster that is associated with a custom key store
+// (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
 // specify the custom key store ID.
 //
-// For more information about entropy and random number generation, see the
-// AWS Key Management Service Cryptographic Details (https://d0.awsstatic.com/whitepapers/KMS-Cryptographic-Details.pdf)
-// whitepaper.
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
+//
+// For more information about entropy and random number generation, see Key
+// Management Service Cryptographic Details (https://docs.aws.amazon.com/kms/latest/cryptographic-details/).
 //
 // Required permissions: kms:GenerateRandom (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -3589,7 +3678,7 @@ func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *request.Re
 //   can be retried.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreInvalidStateException
@@ -3677,10 +3766,10 @@ func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Reques
 
 // GetKeyPolicy API operation for AWS Key Management Service.
 //
-// Gets a key policy attached to the specified customer master key (CMK).
+// Gets a key policy attached to the specified KMS key.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:GetKeyPolicy (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3715,9 +3804,9 @@ func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Reques
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetKeyPolicy
 func (c *KMS) GetKeyPolicy(input *GetKeyPolicyInput) (*GetKeyPolicyOutput, error) {
@@ -3787,26 +3876,31 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 //
 // Gets a Boolean value that indicates whether automatic rotation of the key
 // material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// is enabled for the specified customer master key (CMK).
+// is enabled for the specified KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs, CMKs with imported
-// key material, or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
-// The key rotation status for these CMKs is always false.
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// To enable or disable automatic rotation of a set of related multi-Region
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
+// set the property on the primary key. The key rotation status for these KMS
+// keys is always false.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 //    * Disabled: The key rotation status does not change when you disable a
-//    CMK. However, while the CMK is disabled, AWS KMS does not rotate the backing
-//    key.
+//    KMS key. However, while the KMS key is disabled, KMS does not rotate the
+//    key material.
 //
-//    * Pending deletion: While a CMK is pending deletion, its key rotation
-//    status is false and AWS KMS does not rotate the backing key. If you cancel
+//    * Pending deletion: While a KMS key is pending deletion, its key rotation
+//    status is false and KMS does not rotate the key material. If you cancel
 //    the deletion, the original key rotation status is restored.
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:GetKeyRotationStatus (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3845,9 +3939,9 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3920,19 +4014,20 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 // GetParametersForImport API operation for AWS Key Management Service.
 //
 // Returns the items you need to import key material into a symmetric, customer
-// managed customer master key (CMK). For more information about importing key
-// material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// managed KMS key. For more information about importing key material into KMS,
+// see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
 // This operation returns a public key and an import token. Use the public key
 // to encrypt the symmetric key material. Store the import token to send with
 // a subsequent ImportKeyMaterial request.
 //
-// You must specify the key ID of the symmetric CMK into which you will import
-// key material. This CMK's Origin must be EXTERNAL. You must also specify the
-// wrapping algorithm and type of wrapping key (public key) that you will use
-// to encrypt the key material. You cannot perform this operation on an asymmetric
-// CMK or on any CMK in a different AWS account.
+// You must specify the key ID of the symmetric KMS key into which you will
+// import key material. This KMS key's Origin must be EXTERNAL. You must also
+// specify the wrapping algorithm and type of wrapping key (public key) that
+// you will use to encrypt the key material. You cannot perform this operation
+// on an asymmetric KMS key or on any KMS key in a different Amazon Web Services
+// account.
 //
 // To import key material, you must use the public key and import token from
 // the same response. These items are valid for 24 hours. The expiration date
@@ -3940,12 +4035,12 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 // expired token in an ImportKeyMaterial request. If your key and token expire,
 // send another GetParametersForImport request.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:GetParametersForImport (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3988,9 +4083,9 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetParametersForImport
 func (c *KMS) GetParametersForImport(input *GetParametersForImportInput) (*GetParametersForImportOutput, error) {
@@ -4058,27 +4153,26 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 
 // GetPublicKey API operation for AWS Key Management Service.
 //
-// Returns the public key of an asymmetric CMK. Unlike the private key of a
-// asymmetric CMK, which never leaves AWS KMS unencrypted, callers with kms:GetPublicKey
-// permission can download the public key of an asymmetric CMK. You can share
-// the public key to allow others to encrypt messages and verify signatures
-// outside of AWS KMS. For information about symmetric and asymmetric CMKs,
-// see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// Returns the public key of an asymmetric KMS key. Unlike the private key of
+// a asymmetric KMS key, which never leaves KMS unencrypted, callers with kms:GetPublicKey
+// permission can download the public key of an asymmetric KMS key. You can
+// share the public key to allow others to encrypt messages and verify signatures
+// outside of KMS. For information about symmetric and asymmetric KMS keys,
+// see Using Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // You do not need to download the public key. Instead, you can use the public
-// key within AWS KMS by calling the Encrypt, ReEncrypt, or Verify operations
-// with the identifier of an asymmetric CMK. When you use the public key within
-// AWS KMS, you benefit from the authentication, authorization, and logging
-// that are part of every AWS KMS operation. You also reduce of risk of encrypting
-// data that cannot be decrypted. These features are not effective outside of
-// AWS KMS. For details, see Special Considerations for Downloading Public Keys
-// (https://docs.aws.amazon.com/kms/latest/developerguide/download-public-key.html#download-public-key-considerations).
+// key within KMS by calling the Encrypt, ReEncrypt, or Verify operations with
+// the identifier of an asymmetric KMS key. When you use the public key within
+// KMS, you benefit from the authentication, authorization, and logging that
+// are part of every KMS operation. You also reduce of risk of encrypting data
+// that cannot be decrypted. These features are not effective outside of KMS.
+// For details, see Special Considerations for Downloading Public Keys (https://docs.aws.amazon.com/kms/latest/developerguide/download-public-key.html#download-public-key-considerations).
 //
-// To help you use the public key safely outside of AWS KMS, GetPublicKey returns
+// To help you use the public key safely outside of KMS, GetPublicKey returns
 // important information about the public key in the response, including:
 //
-//    * CustomerMasterKeySpec (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-CustomerMasterKeySpec):
+//    * KeySpec (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeySpec):
 //    The type of key material in the public key, such as RSA_4096 or ECC_NIST_P521.
 //
 //    * KeyUsage (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeyUsage):
@@ -4089,19 +4183,20 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //    A list of the encryption algorithms or the signing algorithms for the
 //    key.
 //
-// Although AWS KMS cannot enforce these restrictions on external operations,
-// it is crucial that you use this information to prevent the public key from
-// being used improperly. For example, you can prevent a public signing key
-// from being used encrypt data, or prevent a public key from being used with
-// an encryption algorithm that is not supported by AWS KMS. You can also avoid
-// errors, such as using the wrong signing algorithm in a verification operation.
+// Although KMS cannot enforce these restrictions on external operations, it
+// is crucial that you use this information to prevent the public key from being
+// used improperly. For example, you can prevent a public signing key from being
+// used encrypt data, or prevent a public key from being used with an encryption
+// algorithm that is not supported by KMS. You can also avoid errors, such as
+// using the wrong signing algorithm in a verification operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GetPublicKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4121,11 +4216,11 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -4145,17 +4240,18 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
@@ -4165,9 +4261,9 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetPublicKey
 func (c *KMS) GetPublicKey(input *GetPublicKeyInput) (*GetPublicKeyOutput, error) {
@@ -4236,15 +4332,16 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 
 // ImportKeyMaterial API operation for AWS Key Management Service.
 //
-// Imports key material into an existing symmetric AWS KMS customer master key
-// (CMK) that was created without key material. After you successfully import
-// key material into a CMK, you can reimport the same key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material)
-// into that CMK, but you cannot import different key material.
+// Imports key material into an existing symmetric KMS KMS key that was created
+// without key material. After you successfully import key material into a KMS
+// key, you can reimport the same key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material)
+// into that KMS key, but you cannot import different key material.
 //
-// You cannot perform this operation on an asymmetric CMK or on any CMK in a
-// different AWS account. For more information about creating CMKs with no key
-// material and then importing key material, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// You cannot perform this operation on an asymmetric KMS key or on any KMS
+// key in a different Amazon Web Services account. For more information about
+// creating KMS keys with no key material and then importing key material, see
+// Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
 // Before using this operation, call GetParametersForImport. Its response includes
 // a public key and an import token. Use the public key to encrypt the key material.
@@ -4252,10 +4349,10 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //
 // When calling this operation, you must specify the following values:
 //
-//    * The key ID or key ARN of a CMK with no key material. Its Origin must
-//    be EXTERNAL. To create a CMK with no key material, call CreateKey and
-//    set the value of its Origin parameter to EXTERNAL. To get the Origin of
-//    a CMK, call DescribeKey.)
+//    * The key ID or key ARN of a KMS key with no key material. Its Origin
+//    must be EXTERNAL. To create a KMS key with no key material, call CreateKey
+//    and set the value of its Origin parameter to EXTERNAL. To get the Origin
+//    of a KMS key, call DescribeKey.)
 //
 //    * The encrypted key material. To get the public key to encrypt the key
 //    material, call GetParametersForImport.
@@ -4264,27 +4361,27 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //    a public key and token from the same GetParametersForImport response.
 //
 //    * Whether the key material expires and if so, when. If you set an expiration
-//    date, AWS KMS deletes the key material from the CMK on the specified date,
-//    and the CMK becomes unusable. To use the CMK again, you must reimport
+//    date, KMS deletes the key material from the KMS key on the specified date,
+//    and the KMS key becomes unusable. To use the KMS key again, you must reimport
 //    the same key material. The only way to change an expiration date is by
 //    reimporting the same key material and specifying a new expiration date.
 //
-// When this operation is successful, the key state of the CMK changes from
-// PendingImport to Enabled, and you can use the CMK.
+// When this operation is successful, the key state of the KMS key changes from
+// PendingImport to Enabled, and you can use the KMS key.
 //
 // If this operation fails, use the exception to help determine the problem.
 // If the error is related to the key material, the import token, or wrapping
 // key, use GetParametersForImport to get a new public key and import token
-// for the CMK and repeat the import procedure. For help, see How To Import
+// for the KMS key and repeat the import procedure. For help, see How To Import
 // Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#importing-keys-overview)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ImportKeyMaterial (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4327,9 +4424,9 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -4337,13 +4434,13 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * IncorrectKeyMaterialException
 //   The request was rejected because the key material in the request is, expired,
 //   invalid, or is not the same key material that was previously imported into
-//   this customer master key (CMK).
+//   this KMS key.
 //
 //   * ExpiredImportTokenException
 //   The request was rejected because the specified import token is expired. Use
@@ -4352,7 +4449,7 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //
 //   * InvalidImportTokenException
 //   The request was rejected because the provided import token is invalid or
-//   is associated with a different customer master key (CMK).
+//   is associated with a different KMS key.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ImportKeyMaterial
 func (c *KMS) ImportKeyMaterial(input *ImportKeyMaterialInput) (*ImportKeyMaterialOutput, error) {
@@ -4426,30 +4523,33 @@ func (c *KMS) ListAliasesRequest(input *ListAliasesInput) (req *request.Request,
 
 // ListAliases API operation for AWS Key Management Service.
 //
-// Gets a list of aliases in the caller's AWS account and region. For more information
-// about aliases, see CreateAlias.
+// Gets a list of aliases in the caller's Amazon Web Services account and region.
+// For more information about aliases, see CreateAlias.
 //
 // By default, the ListAliases operation returns all aliases in the account
-// and region. To get only the aliases associated with a particular customer
-// master key (CMK), use the KeyId parameter.
+// and region. To get only the aliases associated with a particular KMS key,
+// use the KeyId parameter.
 //
 // The ListAliases response can include aliases that you created and associated
-// with your customer managed CMKs, and aliases that AWS created and associated
-// with AWS managed CMKs in your account. You can recognize AWS aliases because
-// their names have the format aws/<service-name>, such as aws/dynamodb.
+// with your customer managed keys, and aliases that Amazon Web Services created
+// and associated with Amazon Web Services managed keys in your account. You
+// can recognize Amazon Web Services aliases because their names have the format
+// aws/<service-name>, such as aws/dynamodb.
 //
 // The response might also include aliases that have no TargetKeyId field. These
-// are predefined aliases that AWS has created but has not yet associated with
-// a CMK. Aliases that AWS creates in your account, including predefined aliases,
-// do not count against your AWS KMS aliases quota (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit).
+// are predefined aliases that Amazon Web Services has created but has not yet
+// associated with a KMS key. Aliases that Amazon Web Services creates in your
+// account, including predefined aliases, do not count against your KMS aliases
+// quota (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit).
 //
-// Cross-account use: No. ListAliases does not return aliases in other AWS accounts.
+// Cross-account use: No. ListAliases does not return aliases in other Amazon
+// Web Services accounts.
 //
 // Required permissions: kms:ListAliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -4611,19 +4711,25 @@ func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, o
 
 // ListGrants API operation for AWS Key Management Service.
 //
-// Gets a list of all grants for the specified customer master key (CMK).
+// Gets a list of all grants for the specified KMS key.
 //
-// You must specify the CMK in all requests. You can filter the grant list by
-// grant ID or grantee principal.
+// You must specify the KMS key in all requests. You can filter the grant list
+// by grant ID or grantee principal.
+//
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
 // The GranteePrincipal field in the ListGrants response usually contains the
 // user or role designated as the grantee principal in the grant. However, when
-// the grantee principal in the grant is an AWS service, the GranteePrincipal
-// field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
+// the grantee principal in the grant is an Amazon Web Services service, the
+// GranteePrincipal field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
 // which might represent several different grantee principals.
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:ListGrants (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4673,9 +4779,9 @@ func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, o
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListGrants
 func (c *KMS) ListGrants(input *ListGrantsInput) (*ListGrantsResponse, error) {
@@ -4801,12 +4907,12 @@ func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.
 
 // ListKeyPolicies API operation for AWS Key Management Service.
 //
-// Gets the names of the key policies that are attached to a customer master
-// key (CMK). This operation is designed to get policy names that you can use
-// in a GetKeyPolicy operation. However, the only valid policy name is default.
+// Gets the names of the key policies that are attached to a KMS key. This operation
+// is designed to get policy names that you can use in a GetKeyPolicy operation.
+// However, the only valid policy name is default.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListKeyPolicies (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4845,9 +4951,9 @@ func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListKeyPolicies
 func (c *KMS) ListKeyPolicies(input *ListKeyPoliciesInput) (*ListKeyPoliciesOutput, error) {
@@ -4973,11 +5079,11 @@ func (c *KMS) ListKeysRequest(input *ListKeysInput) (req *request.Request, outpu
 
 // ListKeys API operation for AWS Key Management Service.
 //
-// Gets a list of all customer master keys (CMKs) in the caller's AWS account
-// and Region.
+// Gets a list of all KMS keys in the caller's Amazon Web Services account and
+// Region.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListKeys (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -5130,20 +5236,24 @@ func (c *KMS) ListResourceTagsRequest(input *ListResourceTagsInput) (req *reques
 
 // ListResourceTags API operation for AWS Key Management Service.
 //
-// Returns all tags on the specified customer master key (CMK).
+// Returns all tags on the specified KMS key.
 //
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
 // in the Amazon Web Services General Reference. For information about using
-// tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListResourceTags (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
 //
 // Related operations:
+//
+//    * CreateKey
+//
+//    * ReplicateKey
 //
 //    * TagResource
 //
@@ -5239,22 +5349,28 @@ func (c *KMS) ListRetirableGrantsRequest(input *ListRetirableGrantsInput) (req *
 
 // ListRetirableGrants API operation for AWS Key Management Service.
 //
-// Returns all grants in which the specified principal is the RetiringPrincipal
-// in the grant.
+// Returns information about all grants in the Amazon Web Services account and
+// Region that have the specified retiring principal.
 //
-// You can specify any principal in your AWS account. The grants that are returned
-// include grants for CMKs in your AWS account and other AWS accounts.
+// You can specify any principal in your Amazon Web Services account. The grants
+// that are returned include grants for KMS keys in your Amazon Web Services
+// account and other Amazon Web Services accounts. You might use this operation
+// to determine which grants you may retire. To retire a grant, use the RetireGrant
+// operation.
 //
-// You might use this operation to determine which grants you may retire. To
-// retire a grant, use the RetireGrant operation.
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
-// Cross-account use: You must specify a principal in your AWS account. However,
-// this operation can return grants in any AWS account. You do not need kms:ListRetirableGrants
-// permission (or any other additional permission) in any AWS account other
-// than your own.
+// Cross-account use: You must specify a principal in your Amazon Web Services
+// account. However, this operation can return grants in any Amazon Web Services
+// account. You do not need kms:ListRetirableGrants permission (or any other
+// additional permission) in any Amazon Web Services account other than your
+// own.
 //
 // Required permissions: kms:ListRetirableGrants (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-// (IAM policy) in your AWS account.
+// (IAM policy) in your Amazon Web Services account.
 //
 // Related operations:
 //
@@ -5361,17 +5477,18 @@ func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Reques
 
 // PutKeyPolicy API operation for AWS Key Management Service.
 //
-// Attaches a key policy to the specified customer master key (CMK).
+// Attaches a key policy to the specified KMS key.
 //
 // For more information about key policies, see Key Policies (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
-// in the AWS Key Management Service Developer Guide. For help writing and formatting
+// in the Key Management Service Developer Guide. For help writing and formatting
 // a JSON policy document, see the IAM JSON Policy Reference (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
-// in the IAM User Guide . For examples of adding a key policy in multiple programming
-// languages, see Setting a key policy (https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy)
-// in the AWS Key Management Service Developer Guide.
+// in the Identity and Access Management User Guide . For examples of adding
+// a key policy in multiple programming languages, see Setting a key policy
+// (https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:PutKeyPolicy (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -5413,15 +5530,15 @@ func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Reques
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/PutKeyPolicy
 func (c *KMS) PutKeyPolicy(input *PutKeyPolicyInput) (*PutKeyPolicyOutput, error) {
@@ -5489,80 +5606,80 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 
 // ReEncrypt API operation for AWS Key Management Service.
 //
-// Decrypts ciphertext and then reencrypts it entirely within AWS KMS. You can
-// use this operation to change the customer master key (CMK) under which data
-// is encrypted, such as when you manually rotate (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
-// a CMK or change the CMK that protects a ciphertext. You can also use it to
-// reencrypt ciphertext under the same CMK, such as to change the encryption
-// context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// Decrypts ciphertext and then reencrypts it entirely within KMS. You can use
+// this operation to change the KMS key under which data is encrypted, such
+// as when you manually rotate (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
+// a KMS key or change the KMS key that protects a ciphertext. You can also
+// use it to reencrypt ciphertext under the same KMS key, such as to change
+// the encryption context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
 // of a ciphertext.
 //
 // The ReEncrypt operation can decrypt ciphertext that was encrypted by using
-// an AWS KMS CMK in an AWS KMS operation, such as Encrypt or GenerateDataKey.
-// It can also decrypt ciphertext that was encrypted by using the public key
-// of an asymmetric CMK (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks)
-// outside of AWS KMS. However, it cannot decrypt ciphertext produced by other
-// libraries, such as the AWS Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// an KMS KMS key in an KMS operation, such as Encrypt or GenerateDataKey. It
+// can also decrypt ciphertext that was encrypted by using the public key of
+// an asymmetric KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks)
+// outside of KMS. However, it cannot decrypt ciphertext produced by other libraries,
+// such as the Amazon Web Services Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
-// These libraries return a ciphertext format that is incompatible with AWS
-// KMS.
+// These libraries return a ciphertext format that is incompatible with KMS.
 //
 // When you use the ReEncrypt operation, you need to provide information for
 // the decrypt operation and the subsequent encrypt operation.
 //
-//    * If your ciphertext was encrypted under an asymmetric CMK, you must use
-//    the SourceKeyId parameter to identify the CMK that encrypted the ciphertext.
-//    You must also supply the encryption algorithm that was used. This information
-//    is required to decrypt the data.
+//    * If your ciphertext was encrypted under an asymmetric KMS key, you must
+//    use the SourceKeyId parameter to identify the KMS key that encrypted the
+//    ciphertext. You must also supply the encryption algorithm that was used.
+//    This information is required to decrypt the data.
 //
-//    * If your ciphertext was encrypted under a symmetric CMK, the SourceKeyId
-//    parameter is optional. AWS KMS can get this information from metadata
-//    that it adds to the symmetric ciphertext blob. This feature adds durability
+//    * If your ciphertext was encrypted under a symmetric KMS key, the SourceKeyId
+//    parameter is optional. KMS can get this information from metadata that
+//    it adds to the symmetric ciphertext blob. This feature adds durability
 //    to your implementation by ensuring that authorized users can decrypt ciphertext
-//    decades after it was encrypted, even if they've lost track of the CMK
-//    ID. However, specifying the source CMK is always recommended as a best
-//    practice. When you use the SourceKeyId parameter to specify a CMK, AWS
-//    KMS uses only the CMK you specify. If the ciphertext was encrypted under
-//    a different CMK, the ReEncrypt operation fails. This practice ensures
-//    that you use the CMK that you intend.
+//    decades after it was encrypted, even if they've lost track of the key
+//    ID. However, specifying the source KMS key is always recommended as a
+//    best practice. When you use the SourceKeyId parameter to specify a KMS
+//    key, KMS uses only the KMS key you specify. If the ciphertext was encrypted
+//    under a different KMS key, the ReEncrypt operation fails. This practice
+//    ensures that you use the KMS key that you intend.
 //
 //    * To reencrypt the data, you must use the DestinationKeyId parameter specify
-//    the CMK that re-encrypts the data after it is decrypted. You can select
-//    a symmetric or asymmetric CMK. If the destination CMK is an asymmetric
-//    CMK, you must also provide the encryption algorithm. The algorithm that
-//    you choose must be compatible with the CMK. When you use an asymmetric
-//    CMK to encrypt or reencrypt data, be sure to record the CMK and encryption
-//    algorithm that you choose. You will be required to provide the same CMK
-//    and encryption algorithm when you decrypt the data. If the CMK and algorithm
-//    do not match the values used to encrypt the data, the decrypt operation
-//    fails. You are not required to supply the CMK ID and encryption algorithm
-//    when you decrypt with symmetric CMKs because AWS KMS stores this information
-//    in the ciphertext blob. AWS KMS cannot store metadata in ciphertext generated
-//    with asymmetric keys. The standard format for asymmetric key ciphertext
-//    does not include configurable fields.
+//    the KMS key that re-encrypts the data after it is decrypted. You can select
+//    a symmetric or asymmetric KMS key. If the destination KMS key is an asymmetric
+//    KMS key, you must also provide the encryption algorithm. The algorithm
+//    that you choose must be compatible with the KMS key. When you use an asymmetric
+//    KMS key to encrypt or reencrypt data, be sure to record the KMS key and
+//    encryption algorithm that you choose. You will be required to provide
+//    the same KMS key and encryption algorithm when you decrypt the data. If
+//    the KMS key and algorithm do not match the values used to encrypt the
+//    data, the decrypt operation fails. You are not required to supply the
+//    key ID and encryption algorithm when you decrypt with symmetric KMS keys
+//    because KMS stores this information in the ciphertext blob. KMS cannot
+//    store metadata in ciphertext generated with asymmetric keys. The standard
+//    format for asymmetric key ciphertext does not include configurable fields.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. The source CMK and destination CMK can be in different
-// AWS accounts. Either or both CMKs can be in a different account than the
-// caller.
+// Cross-account use: Yes. The source KMS key and destination KMS key can be
+// in different Amazon Web Services accounts. Either or both KMS keys can be
+// in a different account than the caller. To specify a KMS key in a different
+// account, you must use its key ARN or alias ARN.
 //
 // Required permissions:
 //
 //    * kms:ReEncryptFrom (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    permission on the source CMK (key policy)
+//    permission on the source KMS key (key policy)
 //
 //    * kms:ReEncryptTo (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    permission on the destination CMK (key policy)
+//    permission on the destination KMS key (key policy)
 //
-// To permit reencryption from or to a CMK, include the "kms:ReEncrypt*" permission
-// in your key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html).
+// To permit reencryption from or to a KMS key, include the "kms:ReEncrypt*"
+// permission in your key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html).
 // This permission is automatically included in the key policy when you use
-// the console to create a CMK. But you must include it manually when you create
-// a CMK programmatically or when you use the PutKeyPolicy operation to set
-// a key policy.
+// the console to create a KMS key. But you must include it manually when you
+// create a KMS key programmatically or when you use the PutKeyPolicy operation
+// to set a key policy.
 //
 // Related operations:
 //
@@ -5587,7 +5704,7 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -5595,17 +5712,17 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * IncorrectKeyException
-//   The request was rejected because the specified CMK cannot decrypt the data.
-//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-//   must identify the same CMK that was used to encrypt the ciphertext.
+//   The request was rejected because the specified KMS key cannot decrypt the
+//   data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same KMS key that was used to encrypt the ciphertext.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -5614,17 +5731,18 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -5637,9 +5755,9 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ReEncrypt
 func (c *KMS) ReEncrypt(input *ReEncryptInput) (*ReEncryptOutput, error) {
@@ -5658,6 +5776,199 @@ func (c *KMS) ReEncrypt(input *ReEncryptInput) (*ReEncryptOutput, error) {
 // for more information on using Contexts.
 func (c *KMS) ReEncryptWithContext(ctx aws.Context, input *ReEncryptInput, opts ...request.Option) (*ReEncryptOutput, error) {
 	req, out := c.ReEncryptRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opReplicateKey = "ReplicateKey"
+
+// ReplicateKeyRequest generates a "aws/request.Request" representing the
+// client's request for the ReplicateKey operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ReplicateKey for more information on using the ReplicateKey
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ReplicateKeyRequest method.
+//    req, resp := client.ReplicateKeyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ReplicateKey
+func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Request, output *ReplicateKeyOutput) {
+	op := &request.Operation{
+		Name:       opReplicateKey,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ReplicateKeyInput{}
+	}
+
+	output = &ReplicateKeyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ReplicateKey API operation for AWS Key Management Service.
+//
+// Replicates a multi-Region key into the specified Region. This operation creates
+// a multi-Region replica key based on a multi-Region primary key in a different
+// Region of the same Amazon Web Services partition. You can create multiple
+// replicas of a primary key, but each must be in a different Region. To create
+// a multi-Region primary key, use the CreateKey operation.
+//
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
+//
+// A replica key is a fully-functional KMS key that can be used independently
+// of its primary and peer replica keys. A primary key and its replica keys
+// share properties that make them interoperable. They have the same key ID
+// (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id)
+// and key material. They also have the same key spec (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-spec),
+// key usage (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-usage),
+// key material origin (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-origin),
+// and automatic key rotation status (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html).
+// KMS automatically synchronizes these shared properties among related multi-Region
+// keys. All other properties of a replica key can differ, including its key
+// policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html),
+// tags (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html),
+// aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html),
+// and key state (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
+// KMS pricing and quotas for KMS keys apply to each primary key and replica
+// key.
+//
+// When this operation completes, the new replica key has a transient key state
+// of Creating. This key state changes to Enabled (or PendingImport) after a
+// few seconds when the process of creating the new replica key is complete.
+// While the key state is Creating, you can manage key, but you cannot yet use
+// it in cryptographic operations. If you are creating and using the replica
+// key programmatically, retry on KMSInvalidStateException or call DescribeKey
+// to check its KeyState value before using it. For details about the Creating
+// key state, see Key state: Effect on your KMS key (kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
+//
+// The CloudTrail log of a ReplicateKey operation records a ReplicateKey operation
+// in the primary key's Region and a CreateKey operation in the replica key's
+// Region.
+//
+// If you replicate a multi-Region primary key with imported key material, the
+// replica key is created with no key material. You must import the same key
+// material that you imported into the primary key. For details, see Importing
+// key material into multi-Region keys (kms/latest/developerguide/multi-region-keys-import.html)
+// in the Key Management Service Developer Guide.
+//
+// To convert a replica key to a primary key, use the UpdatePrimaryRegion operation.
+//
+// ReplicateKey uses different default values for the KeyPolicy and Tags parameters
+// than those used in the KMS console. For details, see the parameter descriptions.
+//
+// Cross-account use: No. You cannot use this operation to create a replica
+// key in a different Amazon Web Services account.
+//
+// Required permissions:
+//
+//    * kms:ReplicateKey on the primary key (in the primary key's Region). Include
+//    this permission in the primary key's key policy.
+//
+//    * kms:CreateKey in an IAM policy in the replica Region.
+//
+//    * To use the Tags parameter, kms:TagResource in an IAM policy in the replica
+//    Region.
+//
+// Related operations
+//
+//    * CreateKey
+//
+//    * UpdatePrimaryRegion
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation ReplicateKey for usage and error information.
+//
+// Returned Error Types:
+//   * AlreadyExistsException
+//   The request was rejected because it attempted to create a resource that already
+//   exists.
+//
+//   * DisabledException
+//   The request was rejected because the specified KMS key is not enabled.
+//
+//   * InvalidArnException
+//   The request was rejected because a specified ARN, or an ARN in a key policy,
+//   is not valid.
+//
+//   * InvalidStateException
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
+//
+//   * InternalException
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * LimitExceededException
+//   The request was rejected because a quota was exceeded. For more information,
+//   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
+//   in the Key Management Service Developer Guide.
+//
+//   * MalformedPolicyDocumentException
+//   The request was rejected because the specified policy is not syntactically
+//   or semantically correct.
+//
+//   * NotFoundException
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * TagException
+//   The request was rejected because one or more tags are not valid.
+//
+//   * UnsupportedOperationException
+//   The request was rejected because a specified parameter is not supported or
+//   a specified resource is not valid for this operation.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ReplicateKey
+func (c *KMS) ReplicateKey(input *ReplicateKeyInput) (*ReplicateKeyOutput, error) {
+	req, out := c.ReplicateKeyRequest(input)
+	return out, req.Send()
+}
+
+// ReplicateKeyWithContext is the same as ReplicateKey with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ReplicateKey for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) ReplicateKeyWithContext(ctx aws.Context, input *ReplicateKeyInput, opts ...request.Option) (*ReplicateKeyOutput, error) {
+	req, out := c.ReplicateKeyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5708,30 +6019,29 @@ func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request,
 
 // RetireGrant API operation for AWS Key Management Service.
 //
-// Retires a grant. To clean up, you can retire a grant when you're done using
-// it. You should revoke a grant when you intend to actively deny operations
-// that depend on it. The following are permitted to call this API:
+// Deletes a grant. Typically, you retire a grant when you no longer need its
+// permissions. To identify the grant to retire, use a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token),
+// or both the grant ID and a key identifier (key ID or key ARN) of the KMS
+// key. The CreateGrant operation returns both values.
 //
-//    * The AWS account (root user) under which the grant was created
+// This operation can be called by the retiring principal for a grant, by the
+// grantee principal if the grant allows the RetireGrant operation, and by the
+// Amazon Web Services account (root user) in which the grant is created. It
+// can also be called by principals to whom permission for retiring a grant
+// is delegated. For details, see Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
+// in the Key Management Service Developer Guide.
 //
-//    * The RetiringPrincipal, if present in the grant
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
-//    * The GranteePrincipal, if RetireGrant is an operation specified in the
-//    grant
+// Cross-account use: Yes. You can retire a grant on a KMS key in a different
+// Amazon Web Services account.
 //
-// You must identify the grant to retire by its grant token or by a combination
-// of the grant ID and the Amazon Resource Name (ARN) of the customer master
-// key (CMK). A grant token is a unique variable-length base64-encoded string.
-// A grant ID is a 64 character unique identifier of a grant. The CreateGrant
-// operation returns both.
-//
-// Cross-account use: Yes. You can retire a grant on a CMK in a different AWS
-// account.
-//
-// Required permissions:: Permission to retire a grant is specified in the grant.
-// You cannot control access to this operation in a policy. For more information,
-// see Using grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide.
+// Required permissions::Permission to retire a grant is determined primarily
+// by the grant. For details, see Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -5777,9 +6087,9 @@ func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RetireGrant
 func (c *KMS) RetireGrant(input *RetireGrantInput) (*RetireGrantOutput, error) {
@@ -5848,14 +6158,28 @@ func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request,
 
 // RevokeGrant API operation for AWS Key Management Service.
 //
-// Revokes the specified grant for the specified customer master key (CMK).
-// You can revoke a grant to actively deny operations that depend on it.
+// Deletes the specified grant. You revoke a grant to terminate the permissions
+// that the grant allows. For more information, see Retiring and revoking grants
+// (https://docs.aws.amazon.com/kms/latest/developerguide/managing-grants.html#grant-delete)
+// in the Key Management Service Developer Guide .
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// When you create, retire, or revoke a grant, there might be a brief delay,
+// usually less than five minutes, until the grant is available throughout KMS.
+// This state is known as eventual consistency. For details, see Eventual consistency
+// (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-eventual-consistency)
+// in the Key Management Service Developer Guide .
+//
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
+//
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:RevokeGrant (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-// (key policy)
+// (key policy).
 //
 // Related operations:
 //
@@ -5898,9 +6222,9 @@ func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RevokeGrant
 func (c *KMS) RevokeGrant(input *RevokeGrantInput) (*RevokeGrantOutput, error) {
@@ -5968,39 +6292,51 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 
 // ScheduleKeyDeletion API operation for AWS Key Management Service.
 //
-// Schedules the deletion of a customer master key (CMK). You may provide a
-// waiting period, specified in days, before deletion occurs. If you do not
-// provide a waiting period, the default period of 30 days is used. When this
-// operation is successful, the key state of the CMK changes to PendingDeletion.
-// Before the waiting period ends, you can use CancelKeyDeletion to cancel the
-// deletion of the CMK. After the waiting period ends, AWS KMS deletes the CMK
-// and all AWS KMS data associated with it, including all aliases that refer
-// to it.
+// Schedules the deletion of a KMS key. By default, KMS applies a waiting period
+// of 30 days, but you can specify a waiting period of 7-30 days. When this
+// operation is successful, the key state of the KMS key changes to PendingDeletion
+// and the key can't be used in any cryptographic operations. It remains in
+// this state for the duration of the waiting period. Before the waiting period
+// ends, you can use CancelKeyDeletion to cancel the deletion of the KMS key.
+// After the waiting period ends, KMS deletes the KMS key, its key material,
+// and all KMS data associated with it, including all aliases that refer to
+// it.
 //
-// Deleting a CMK is a destructive and potentially dangerous operation. When
-// a CMK is deleted, all data that was encrypted under the CMK is unrecoverable.
-// To prevent the use of a CMK without deleting it, use DisableKey.
+// Deleting a KMS key is a destructive and potentially dangerous operation.
+// When a KMS key is deleted, all data that was encrypted under the KMS key
+// is unrecoverable. (The only exception is a multi-Region replica key.) To
+// prevent the use of a KMS key without deleting it, use DisableKey.
 //
-// If you schedule deletion of a CMK from a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-// when the waiting period expires, ScheduleKeyDeletion deletes the CMK from
-// AWS KMS. Then AWS KMS makes a best effort to delete the key material from
-// the associated AWS CloudHSM cluster. However, you might need to manually
-// delete the orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
+// If you schedule deletion of a KMS key from a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// when the waiting period expires, ScheduleKeyDeletion deletes the KMS key
+// from KMS. Then KMS makes a best effort to delete the key material from the
+// associated CloudHSM cluster. However, you might need to manually delete the
+// orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
 // from the cluster and its backups.
 //
-// For more information about scheduling a CMK for deletion, see Deleting Customer
-// Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// You can schedule the deletion of a multi-Region primary key and its replica
+// keys at any time. However, KMS will not delete a multi-Region primary key
+// with existing replica keys. If you schedule the deletion of a primary key
+// with replicas, its key state changes to PendingReplicaDeletion and it cannot
+// be replicated or used in cryptographic operations. This status can continue
+// indefinitely. When the last of its replicas keys is deleted (not just scheduled),
+// the key state of the primary key changes to PendingDeletion and its waiting
+// period (PendingWindowInDays) begins. For details, see Deleting multi-Region
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// For more information about scheduling a KMS key for deletion, see Deleting
+// KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Required permissions: kms:ScheduleKeyDeletion (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-// (key policy)
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
+//
+// Required permissions: kms:ScheduleKeyDeletion (key policy)
 //
 // Related operations
 //
@@ -6036,9 +6372,9 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ScheduleKeyDeletion
 func (c *KMS) ScheduleKeyDeletion(input *ScheduleKeyDeletionInput) (*ScheduleKeyDeletionOutput, error) {
@@ -6108,23 +6444,24 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //
 // Creates a digital signature (https://en.wikipedia.org/wiki/Digital_signature)
 // for a message or message digest by using the private key in an asymmetric
-// CMK. To verify the signature, use the Verify operation, or use the public
-// key in the same asymmetric CMK outside of AWS KMS. For information about
-// symmetric and asymmetric CMKs, see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. To verify the signature, use the Verify operation, or use the public
+// key in the same asymmetric KMS key outside of KMS. For information about
+// symmetric and asymmetric KMS keys, see Using Symmetric and Asymmetric KMS
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // Digital signatures are generated and verified by using asymmetric key pair,
-// such as an RSA or ECC pair that is represented by an asymmetric customer
-// master key (CMK). The key owner (or an authorized user) uses their private
-// key to sign a message. Anyone with the public key can verify that the message
-// was signed with that particular private key and that the message hasn't changed
-// since it was signed.
+// such as an RSA or ECC pair that is represented by an asymmetric KMS key.
+// The key owner (or an authorized user) uses their private key to sign a message.
+// Anyone with the public key can verify that the message was signed with that
+// particular private key and that the message hasn't changed since it was signed.
 //
 // To use the Sign operation, provide the following information:
 //
-//    * Use the KeyId parameter to identify an asymmetric CMK with a KeyUsage
-//    value of SIGN_VERIFY. To get the KeyUsage value of a CMK, use the DescribeKey
-//    operation. The caller must have kms:Sign permission on the CMK.
+//    * Use the KeyId parameter to identify an asymmetric KMS key with a KeyUsage
+//    value of SIGN_VERIFY. To get the KeyUsage value of a KMS key, use the
+//    DescribeKey operation. The caller must have kms:Sign permission on the
+//    KMS key.
 //
 //    * Use the Message parameter to specify the message or message digest to
 //    sign. You can submit messages of up to 4096 bytes. To sign a larger message,
@@ -6132,21 +6469,22 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //    in the Message parameter. To indicate whether the message is a full message
 //    or a digest, use the MessageType parameter.
 //
-//    * Choose a signing algorithm that is compatible with the CMK.
+//    * Choose a signing algorithm that is compatible with the KMS key.
 //
-// When signing a message, be sure to record the CMK and the signing algorithm.
+// When signing a message, be sure to record the KMS key and the signing algorithm.
 // This information is required to verify the signature.
 //
 // To verify the signature that this operation generates, use the Verify operation.
 // Or use the GetPublicKey operation to download the public key and then use
-// the public key to verify the signature outside of AWS KMS.
+// the public key to verify the signature outside of KMS.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Sign (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -6166,11 +6504,11 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -6179,17 +6517,18 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -6202,9 +6541,9 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Sign
 func (c *KMS) Sign(input *SignInput) (*SignOutput, error) {
@@ -6273,39 +6612,50 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 
 // TagResource API operation for AWS Key Management Service.
 //
-// Adds or edits tags on a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+// Adds or edits tags on a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+//
+// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
 // Each tag consists of a tag key and a tag value, both of which are case-sensitive
-// strings. The tag value can be an empty (null) string.
+// strings. The tag value can be an empty (null) string. To add a tag, specify
+// a new tag key and a tag value. To edit a tag, specify an existing tag key
+// and a new tag value.
 //
-// To add a tag, specify a new tag key and a tag value. To edit a tag, specify
-// an existing tag key and a new tag value.
+// You can use this operation to tag a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk),
+// but you cannot tag an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk),
+// an Amazon Web Services owned key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk),
+// a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#keystore-concept),
+// or an alias (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#alias-concept).
 //
-// You can use this operation to tag a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk),
-// but you cannot tag an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk),
-// an AWS owned CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk),
-// or an alias.
+// You can also add tags to a KMS key while creating it (CreateKey) or replicating
+// it (ReplicateKey).
 //
+// For information about using tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
-// in the Amazon Web Services General Reference. For information about using
-// tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// in the Amazon Web Services General Reference.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
 //
 // Related operations
 //
-//    * UntagResource
+//    * CreateKey
 //
 //    * ListResourceTags
+//
+//    * ReplicateKey
+//
+//    * UntagResource
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6331,14 +6681,14 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
@@ -6410,34 +6760,42 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 
 // UntagResource API operation for AWS Key Management Service.
 //
-// Deletes tags from a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
-// To delete a tag, specify the tag key and the CMK.
+// Deletes tags from a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+// To delete a tag, specify the tag key and the KMS key.
+//
+// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
 // When it succeeds, the UntagResource operation doesn't return any output.
-// Also, if the specified tag key isn't found on the CMK, it doesn't throw an
-// exception or return a response. To confirm that the operation worked, use
-// the ListResourceTags operation.
+// Also, if the specified tag key isn't found on the KMS key, it doesn't throw
+// an exception or return a response. To confirm that the operation worked,
+// use the ListResourceTags operation.
 //
+// For information about using tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
-// in the Amazon Web Services General Reference. For information about using
-// tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// in the Amazon Web Services General Reference.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:UntagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
 //
 // Related operations
 //
-//    * TagResource
+//    * CreateKey
 //
 //    * ListResourceTags
+//
+//    * ReplicateKey
+//
+//    * TagResource
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6463,9 +6821,9 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
@@ -6537,31 +6895,35 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 
 // UpdateAlias API operation for AWS Key Management Service.
 //
-// Associates an existing AWS KMS alias with a different customer master key
-// (CMK). Each alias is associated with only one CMK at a time, although a CMK
-// can have multiple aliases. The alias and the CMK must be in the same AWS
-// account and region.
+// Associates an existing KMS alias with a different KMS key. Each alias is
+// associated with only one KMS key at a time, although a KMS key can have multiple
+// aliases. The alias and the KMS key must be in the same Amazon Web Services
+// account and Region.
 //
-// The current and new CMK must be the same type (both symmetric or both asymmetric),
-// and they must have the same key usage (ENCRYPT_DECRYPT or SIGN_VERIFY). This
-// restriction prevents errors in code that uses aliases. If you must assign
-// an alias to a different type of CMK, use DeleteAlias to delete the old alias
-// and CreateAlias to create a new alias.
+// Adding, deleting, or updating an alias can allow or deny permission to the
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
+//
+// The current and new KMS key must be the same type (both symmetric or both
+// asymmetric), and they must have the same key usage (ENCRYPT_DECRYPT or SIGN_VERIFY).
+// This restriction prevents errors in code that uses aliases. If you must assign
+// an alias to a different type of KMS key, use DeleteAlias to delete the old
+// alias and CreateAlias to create a new alias.
 //
 // You cannot use UpdateAlias to change an alias name. To change an alias name,
 // use DeleteAlias to delete the old alias and CreateAlias to create a new alias.
 //
-// Because an alias is not a property of a CMK, you can create, update, and
-// delete the aliases of a CMK without affecting the CMK. Also, aliases do not
-// appear in the response from the DescribeKey operation. To get the aliases
-// of all CMKs in the account, use the ListAliases operation.
+// Because an alias is not a property of a KMS key, you can create, update,
+// and delete the aliases of a KMS key without affecting the KMS key. Also,
+// aliases do not appear in the response from the DescribeKey operation. To
+// get the aliases of all KMS keys in the account, use the ListAliases operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -6569,13 +6931,13 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:UpdateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the current CMK (key policy).
+//    on the current KMS key (key policy).
 //
 //    * kms:UpdateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the new CMK (key policy).
+//    on the new KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -6608,15 +6970,15 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateAlias
 func (c *KMS) UpdateAlias(input *UpdateAliasInput) (*UpdateAliasOutput, error) {
@@ -6695,33 +7057,34 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 // the connection state of a custom key store, use the DescribeCustomKeyStores
 // operation.
 //
-// Use the parameters of UpdateCustomKeyStore to edit your keystore settings.
+// The CustomKeyStoreId parameter is required in all commands. Use the other
+// parameters of UpdateCustomKeyStore to edit your key store settings.
 //
 //    * Use the NewCustomKeyStoreName parameter to change the friendly name
 //    of the custom key store to the value that you specify.
 //
-//    * Use the KeyStorePassword parameter tell AWS KMS the current password
-//    of the kmsuser crypto user (CU) (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-//    in the associated AWS CloudHSM cluster. You can use this parameter to
-//    fix connection failures (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-password)
-//    that occur when AWS KMS cannot log into the associated cluster because
-//    the kmsuser password has changed. This value does not change the password
-//    in the AWS CloudHSM cluster.
+//    * Use the KeyStorePassword parameter tell KMS the current password of
+//    the kmsuser crypto user (CU) (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
+//    in the associated CloudHSM cluster. You can use this parameter to fix
+//    connection failures (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-password)
+//    that occur when KMS cannot log into the associated cluster because the
+//    kmsuser password has changed. This value does not change the password
+//    in the CloudHSM cluster.
 //
 //    * Use the CloudHsmClusterId parameter to associate the custom key store
-//    with a different, but related, AWS CloudHSM cluster. You can use this
-//    parameter to repair a custom key store if its AWS CloudHSM cluster becomes
-//    corrupted or is deleted, or when you need to create or restore a cluster
-//    from a backup.
+//    with a different, but related, CloudHSM cluster. You can use this parameter
+//    to repair a custom key store if its CloudHSM cluster becomes corrupted
+//    or is deleted, or when you need to create or restore a cluster from a
+//    backup.
 //
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:UpdateCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -6747,7 +7110,7 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreNameInUseException
@@ -6756,14 +7119,13 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //   key store name that is unique in the account.
 //
 //   * CloudHsmClusterNotFoundException
-//   The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-//   with the specified cluster ID. Retry the request with a different cluster
-//   ID.
+//   The request was rejected because KMS cannot find the CloudHSM cluster with
+//   the specified cluster ID. Retry the request with a different cluster ID.
 //
 //   * CloudHsmClusterNotRelatedException
-//   The request was rejected because the specified AWS CloudHSM cluster has a
-//   different cluster certificate than the original cluster. You cannot use the
-//   operation to specify an unrelated cluster.
+//   The request was rejected because the specified CloudHSM cluster has a different
+//   cluster certificate than the original cluster. You cannot use the operation
+//   to specify an unrelated cluster.
 //
 //   Specify a cluster that shares a backup history with the original cluster.
 //   This includes clusters that were created from a backup of the current cluster,
@@ -6798,15 +7160,15 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //   can be retried.
 //
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -6821,20 +7183,19 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateCustomKeyStore
 func (c *KMS) UpdateCustomKeyStore(input *UpdateCustomKeyStoreInput) (*UpdateCustomKeyStoreOutput, error) {
@@ -6903,15 +7264,15 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 
 // UpdateKeyDescription API operation for AWS Key Management Service.
 //
-// Updates the description of a customer master key (CMK). To see the description
-// of a CMK, use DescribeKey.
+// Updates the description of a KMS key. To see the description of a KMS key,
+// use DescribeKey.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:UpdateKeyDescription (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -6950,9 +7311,9 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateKeyDescription
 func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKeyDescriptionOutput, error) {
@@ -6971,6 +7332,179 @@ func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKey
 // for more information on using Contexts.
 func (c *KMS) UpdateKeyDescriptionWithContext(ctx aws.Context, input *UpdateKeyDescriptionInput, opts ...request.Option) (*UpdateKeyDescriptionOutput, error) {
 	req, out := c.UpdateKeyDescriptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdatePrimaryRegion = "UpdatePrimaryRegion"
+
+// UpdatePrimaryRegionRequest generates a "aws/request.Request" representing the
+// client's request for the UpdatePrimaryRegion operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdatePrimaryRegion for more information on using the UpdatePrimaryRegion
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdatePrimaryRegionRequest method.
+//    req, resp := client.UpdatePrimaryRegionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdatePrimaryRegion
+func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *request.Request, output *UpdatePrimaryRegionOutput) {
+	op := &request.Operation{
+		Name:       opUpdatePrimaryRegion,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdatePrimaryRegionInput{}
+	}
+
+	output = &UpdatePrimaryRegionOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UpdatePrimaryRegion API operation for AWS Key Management Service.
+//
+// Changes the primary key of a multi-Region key.
+//
+// This operation changes the replica key in the specified Region to a primary
+// key and changes the former primary key to a replica key. For example, suppose
+// you have a primary key in us-east-1 and a replica key in eu-west-2. If you
+// run UpdatePrimaryRegion with a PrimaryRegion value of eu-west-2, the primary
+// key is now the key in eu-west-2, and the key in us-east-1 becomes a replica
+// key. For details, see Updating the primary Region (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-update)
+// in the Key Management Service Developer Guide.
+//
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
+//
+// The primary key of a multi-Region key is the source for properties that are
+// always shared by primary and replica keys, including the key material, key
+// ID (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id),
+// key spec (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-spec),
+// key usage (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-usage),
+// key material origin (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-origin),
+// and automatic key rotation (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html).
+// It's the only key that can be replicated. You cannot delete the primary key
+// (https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html)
+// until all replica keys are deleted.
+//
+// The key ID and primary Region that you specify uniquely identify the replica
+// key that will become the primary key. The primary Region must already have
+// a replica key. This operation does not create a KMS key in the specified
+// Region. To find the replica keys, use the DescribeKey operation on the primary
+// key or any replica key. To create a replica key, use the ReplicateKey operation.
+//
+// You can run this operation while using the affected multi-Region keys in
+// cryptographic operations. This operation should not delay, interrupt, or
+// cause failures in cryptographic operations.
+//
+// Even after this operation completes, the process of updating the primary
+// Region might still be in progress for a few more seconds. Operations such
+// as DescribeKey might display both the old and new primary keys as replicas.
+// The old and new primary keys have a transient key state of Updating. The
+// original key state is restored when the update is complete. While the key
+// state is Updating, you can use the keys in cryptographic operations, but
+// you cannot replicate the new primary key or perform certain management operations,
+// such as enabling or disabling these keys. For details about the Updating
+// key state, see Key state: Effect on your KMS key (kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
+//
+// This operation does not return any output. To verify that primary key is
+// changed, use the DescribeKey operation.
+//
+// Cross-account use: No. You cannot use this operation in a different Amazon
+// Web Services account.
+//
+// Required permissions:
+//
+//    * kms:UpdatePrimaryRegion on the current primary key (in the primary key's
+//    Region). Include this permission primary key's key policy.
+//
+//    * kms:UpdatePrimaryRegion on the current replica key (in the replica key's
+//    Region). Include this permission in the replica key's key policy.
+//
+// Related operations
+//
+//    * CreateKey
+//
+//    * ReplicateKey
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation UpdatePrimaryRegion for usage and error information.
+//
+// Returned Error Types:
+//   * DisabledException
+//   The request was rejected because the specified KMS key is not enabled.
+//
+//   * InvalidArnException
+//   The request was rejected because a specified ARN, or an ARN in a key policy,
+//   is not valid.
+//
+//   * InvalidStateException
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
+//
+//   * InternalException
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * NotFoundException
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * UnsupportedOperationException
+//   The request was rejected because a specified parameter is not supported or
+//   a specified resource is not valid for this operation.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdatePrimaryRegion
+func (c *KMS) UpdatePrimaryRegion(input *UpdatePrimaryRegionInput) (*UpdatePrimaryRegionOutput, error) {
+	req, out := c.UpdatePrimaryRegionRequest(input)
+	return out, req.Send()
+}
+
+// UpdatePrimaryRegionWithContext is the same as UpdatePrimaryRegion with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdatePrimaryRegion for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KMS) UpdatePrimaryRegionWithContext(ctx aws.Context, input *UpdatePrimaryRegionInput, opts ...request.Option) (*UpdatePrimaryRegionOutput, error) {
+	req, out := c.UpdatePrimaryRegionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7023,36 +7557,37 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 // Verifies a digital signature that was generated by the Sign operation.
 //
 // Verification confirms that an authorized user signed the message with the
-// specified CMK and signing algorithm, and the message hasn't changed since
+// specified KMS key and signing algorithm, and the message hasn't changed since
 // it was signed. If the signature is verified, the value of the SignatureValid
 // field in the response is True. If the signature verification fails, the Verify
 // operation fails with an KMSInvalidSignatureException exception.
 //
 // A digital signature is generated by using the private key in an asymmetric
-// CMK. The signature is verified by using the public key in the same asymmetric
-// CMK. For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. The signature is verified by using the public key in the same asymmetric
+// KMS key. For information about symmetric and asymmetric KMS keys, see Using
+// Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // To verify a digital signature, you can use the Verify operation. Specify
-// the same asymmetric CMK, message, and signing algorithm that were used to
-// produce the signature.
+// the same asymmetric KMS key, message, and signing algorithm that were used
+// to produce the signature.
 //
 // You can also verify the digital signature by using the public key of the
-// CMK outside of AWS KMS. Use the GetPublicKey operation to download the public
-// key in the asymmetric CMK and then use the public key to verify the signature
-// outside of AWS KMS. The advantage of using the Verify operation is that it
-// is performed within AWS KMS. As a result, it's easy to call, the operation
-// is performed within the FIPS boundary, it is logged in AWS CloudTrail, and
-// you can use key policy and IAM policy to determine who is authorized to use
-// the CMK to verify signatures.
+// KMS key outside of KMS. Use the GetPublicKey operation to download the public
+// key in the asymmetric KMS key and then use the public key to verify the signature
+// outside of KMS. The advantage of using the Verify operation is that it is
+// performed within KMS. As a result, it's easy to call, the operation is performed
+// within the FIPS boundary, it is logged in CloudTrail, and you can use key
+// policy and IAM policy to determine who is authorized to use the KMS key to
+// verify signatures.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see How Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Verify (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -7072,11 +7607,11 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -7085,17 +7620,18 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -7108,14 +7644,14 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * KMSInvalidSignatureException
 //   The request was rejected because the signature verification failed. Signature
 //   verification fails when it cannot confirm that signature was produced by
-//   signing the specified message with the specified CMK and signing algorithm.
+//   signing the specified message with the specified KMS key and signing algorithm.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Verify
 func (c *KMS) Verify(input *VerifyInput) (*VerifyOutput, error) {
@@ -7149,20 +7685,33 @@ type AliasListEntry struct {
 	// String that contains the alias. This value begins with alias/.
 	AliasName *string `min:"1" type:"string"`
 
+	// Date and time that the alias was most recently created in the account and
+	// Region. Formatted as Unix time.
 	CreationDate *time.Time `type:"timestamp"`
 
+	// Date and time that the alias was most recently associated with a KMS key
+	// in the account and Region. Formatted as Unix time.
 	LastUpdatedDate *time.Time `type:"timestamp"`
 
-	// String that contains the key identifier referred to by the alias.
+	// String that contains the key identifier of the KMS key associated with the
+	// alias.
 	TargetKeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AliasListEntry) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AliasListEntry) GoString() string {
 	return s.String()
 }
@@ -7206,12 +7755,20 @@ type AlreadyExistsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AlreadyExistsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AlreadyExistsException) GoString() string {
 	return s.String()
 }
@@ -7257,10 +7814,9 @@ func (s *AlreadyExistsException) RequestID() string {
 type CancelKeyDeletionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The unique identifier for the customer master key (CMK) for which to cancel
-	// deletion.
+	// Identifies the KMS key whose deletion is being canceled.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -7268,18 +7824,26 @@ type CancelKeyDeletionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelKeyDeletionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelKeyDeletionInput) GoString() string {
 	return s.String()
 }
@@ -7310,16 +7874,24 @@ type CancelKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK whose deletion is canceled.
+	// of the KMS key whose deletion is canceled.
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelKeyDeletionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CancelKeyDeletionOutput) GoString() string {
 	return s.String()
 }
@@ -7330,10 +7902,10 @@ func (s *CancelKeyDeletionOutput) SetKeyId(v string) *CancelKeyDeletionOutput {
 	return s
 }
 
-// The request was rejected because the specified AWS CloudHSM cluster is already
+// The request was rejected because the specified CloudHSM cluster is already
 // associated with a custom key store or it shares a backup history with a cluster
 // that is associated with a custom key store. Each custom key store must be
-// associated with a different AWS CloudHSM cluster.
+// associated with a different CloudHSM cluster.
 //
 // Clusters that share a backup history have the same cluster certificate. To
 // view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -7345,12 +7917,20 @@ type CloudHsmClusterInUseException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterInUseException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterInUseException) GoString() string {
 	return s.String()
 }
@@ -7393,8 +7973,8 @@ func (s *CloudHsmClusterInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the associated AWS CloudHSM cluster did
-// not meet the configuration requirements for a custom key store.
+// The request was rejected because the associated CloudHSM cluster did not
+// meet the configuration requirements for a custom key store.
 //
 //    * The cluster must be configured with private subnets in at least two
 //    different Availability Zones in the Region.
@@ -7409,20 +7989,19 @@ func (s *CloudHsmClusterInUseException) RequestID() string {
 //    operation.
 //
 //    * The cluster must contain at least as many HSMs as the operation requires.
-//    To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//    To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //    operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//    operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//    each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//    the AWS CloudHSM must contain at least one active HSM.
+//    operations, the CloudHSM cluster must have at least two active HSMs, each
+//    in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//    the CloudHSM must contain at least one active HSM.
 //
-// For information about the requirements for an AWS CloudHSM cluster that is
-// associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-// in the AWS Key Management Service Developer Guide. For information about
-// creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-// Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-// in the AWS CloudHSM User Guide. For information about cluster security groups,
+// For information about the requirements for an CloudHSM cluster that is associated
+// with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+// in the Key Management Service Developer Guide. For information about creating
+// a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+// in the CloudHSM User Guide. For information about cluster security groups,
 // see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-// in the AWS CloudHSM User Guide .
+// in the CloudHSM User Guide .
 type CloudHsmClusterInvalidConfigurationException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -7430,12 +8009,20 @@ type CloudHsmClusterInvalidConfigurationException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterInvalidConfigurationException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterInvalidConfigurationException) GoString() string {
 	return s.String()
 }
@@ -7478,11 +8065,11 @@ func (s *CloudHsmClusterInvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the AWS CloudHSM cluster that is associated
+// The request was rejected because the CloudHSM cluster that is associated
 // with the custom key store is not active. Initialize and activate the cluster
 // and try the command again. For detailed instructions, see Getting Started
 // (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-// in the AWS CloudHSM User Guide.
+// in the CloudHSM User Guide.
 type CloudHsmClusterNotActiveException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -7490,12 +8077,20 @@ type CloudHsmClusterNotActiveException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotActiveException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotActiveException) GoString() string {
 	return s.String()
 }
@@ -7538,9 +8133,8 @@ func (s *CloudHsmClusterNotActiveException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-// with the specified cluster ID. Retry the request with a different cluster
-// ID.
+// The request was rejected because KMS cannot find the CloudHSM cluster with
+// the specified cluster ID. Retry the request with a different cluster ID.
 type CloudHsmClusterNotFoundException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -7548,12 +8142,20 @@ type CloudHsmClusterNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotFoundException) GoString() string {
 	return s.String()
 }
@@ -7596,9 +8198,9 @@ func (s *CloudHsmClusterNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the specified AWS CloudHSM cluster has a
-// different cluster certificate than the original cluster. You cannot use the
-// operation to specify an unrelated cluster.
+// The request was rejected because the specified CloudHSM cluster has a different
+// cluster certificate than the original cluster. You cannot use the operation
+// to specify an unrelated cluster.
 //
 // Specify a cluster that shares a backup history with the original cluster.
 // This includes clusters that were created from a backup of the current cluster,
@@ -7615,12 +8217,20 @@ type CloudHsmClusterNotRelatedException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotRelatedException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CloudHsmClusterNotRelatedException) GoString() string {
 	return s.String()
 }
@@ -7673,12 +8283,20 @@ type ConnectCustomKeyStoreInput struct {
 	CustomKeyStoreId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectCustomKeyStoreInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectCustomKeyStoreInput) GoString() string {
 	return s.String()
 }
@@ -7709,12 +8327,20 @@ type ConnectCustomKeyStoreOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectCustomKeyStoreOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ConnectCustomKeyStoreOutput) GoString() string {
 	return s.String()
 }
@@ -7728,21 +8354,21 @@ type CreateAliasInput struct {
 	// The AliasName value must be string of 1-256 characters. It can contain only
 	// alphanumeric characters, forward slashes (/), underscores (_), and dashes
 	// (-). The alias name cannot begin with alias/aws/. The alias/aws/ prefix is
-	// reserved for AWS managed CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+	// reserved for Amazon Web Services managed keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 	//
 	// AliasName is a required field
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	// Associates the alias with the specified customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
-	// The CMK must be in the same AWS Region.
+	// Associates the alias with the specified customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+	// The KMS key must be in the same Amazon Web Services Region.
 	//
-	// A valid CMK ID is required. If you supply a null or empty string value, this
+	// A valid key ID is required. If you supply a null or empty string value, this
 	// operation returns an error.
 	//
 	// For help finding the key ID and ARN, see Finding the Key ID and ARN (https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide .
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -7750,18 +8376,26 @@ type CreateAliasInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// TargetKeyId is a required field
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAliasInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAliasInput) GoString() string {
 	return s.String()
 }
@@ -7804,12 +8438,20 @@ type CreateAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAliasOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateAliasOutput) GoString() string {
 	return s.String()
 }
@@ -7817,28 +8459,32 @@ func (s CreateAliasOutput) GoString() string {
 type CreateCustomKeyStoreInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the AWS CloudHSM cluster for the custom key store. Enter the cluster
-	// ID of any active AWS CloudHSM cluster that is not already associated with
-	// a custom key store. To find the cluster ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
+	// Identifies the CloudHSM cluster for the custom key store. Enter the cluster
+	// ID of any active CloudHSM cluster that is not already associated with a custom
+	// key store. To find the cluster ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 	// operation.
 	//
 	// CloudHsmClusterId is a required field
 	CloudHsmClusterId *string `min:"19" type:"string" required:"true"`
 
 	// Specifies a friendly name for the custom key store. The name must be unique
-	// in your AWS account.
+	// in your Amazon Web Services account.
 	//
 	// CustomKeyStoreName is a required field
 	CustomKeyStoreName *string `min:"1" type:"string" required:"true"`
 
 	// Enter the password of the kmsuser crypto user (CU) account (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-	// in the specified AWS CloudHSM cluster. AWS KMS logs into the cluster as this
-	// user to manage key material on your behalf.
+	// in the specified CloudHSM cluster. KMS logs into the cluster as this user
+	// to manage key material on your behalf.
 	//
 	// The password must be a string of 7 to 32 characters. Its value is case sensitive.
 	//
-	// This parameter tells AWS KMS the kmsuser account password; it does not change
-	// the password in the AWS CloudHSM cluster.
+	// This parameter tells KMS the kmsuser account password; it does not change
+	// the password in the CloudHSM cluster.
+	//
+	// KeyStorePassword is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by CreateCustomKeyStoreInput's
+	// String and GoString methods.
 	//
 	// KeyStorePassword is a required field
 	KeyStorePassword *string `min:"7" type:"string" required:"true" sensitive:"true"`
@@ -7851,12 +8497,20 @@ type CreateCustomKeyStoreInput struct {
 	TrustAnchorCertificate *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateCustomKeyStoreInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateCustomKeyStoreInput) GoString() string {
 	return s.String()
 }
@@ -7926,12 +8580,20 @@ type CreateCustomKeyStoreOutput struct {
 	CustomKeyStoreId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateCustomKeyStoreOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateCustomKeyStoreOutput) GoString() string {
 	return s.String()
 }
@@ -7945,41 +8607,54 @@ func (s *CreateCustomKeyStoreOutput) SetCustomKeyStoreId(v string) *CreateCustom
 type CreateGrantInput struct {
 	_ struct{} `type:"structure"`
 
-	// Allows a cryptographic operation (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// only when the encryption context matches or includes the encryption context
-	// specified in this structure. For more information about encryption context,
-	// see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide .
+	// Specifies a grant constraint.
 	//
-	// Grant constraints are not applied to operations that do not support an encryption
-	// context, such as cryptographic operations with asymmetric CMKs and management
-	// operations, such as DescribeKey or RetireGrant.
+	// KMS supports the EncryptionContextEquals and EncryptionContextSubset grant
+	// constraints. Each constraint value can include up to 8 encryption context
+	// pairs. The encryption context value in each constraint cannot exceed 384
+	// characters.
+	//
+	// These grant constraints allow the permissions in the grant only when the
+	// encryption context in the request matches (EncryptionContextEquals) or includes
+	// (EncryptionContextSubset) the encryption context specified in this structure.
+	// For information about grant constraints, see Using grant constraints (https://docs.aws.amazon.com/kms/latest/developerguide/create-grant-overview.html#grant-constraints)
+	// in the Key Management Service Developer Guide. For more information about
+	// encryption context, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the Key Management Service Developer Guide .
+	//
+	// The encryption context grant constraints are supported only on operations
+	// that include an encryption context. You cannot use an encryption context
+	// grant constraint for cryptographic operations with asymmetric KMS keys or
+	// for management operations, such as DescribeKey or RetireGrant.
 	Constraints *GrantConstraints `type:"structure"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// The principal that is given permission to perform the operations that the
-	// grant permits.
+	// The identity that gets the permissions specified in the grant.
 	//
 	// To specify the principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, IAM roles, federated users, and assumed role users. For examples of
-	// the ARN syntax to use for specifying a principal, see AWS Identity and Access
-	// Management (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
-	// in the Example ARNs section of the AWS General Reference.
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, IAM roles, federated
+	// users, and assumed role users. For examples of the ARN syntax to use for
+	// specifying a principal, see Amazon Web Services Identity and Access Management
+	// (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
 	//
 	// GranteePrincipal is a required field
 	GranteePrincipal *string `min:"1" type:"string" required:"true"`
 
-	// The unique identifier for the customer master key (CMK) that the grant applies
-	// to.
+	// Identifies the KMS key for the grant. The grant gives principals permission
+	// to use this KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify
-	// a CMK in a different AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -7987,7 +8662,7 @@ type CreateGrantInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -8008,27 +8683,48 @@ type CreateGrantInput struct {
 
 	// A list of operations that the grant permits.
 	//
+	// The operation must be supported on the KMS key. For example, you cannot create
+	// a grant for a symmetric KMS key that allows the Sign operation, or a grant
+	// for an asymmetric KMS key that allows the GenerateDataKey operation. If you
+	// try, KMS returns a ValidationError exception. For details, see Grant operations
+	// (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations)
+	// in the Key Management Service Developer Guide.
+	//
 	// Operations is a required field
 	Operations []*string `type:"list" required:"true"`
 
-	// The principal that is given permission to retire the grant by using RetireGrant
-	// operation.
+	// The principal that has permission to use the RetireGrant operation to retire
+	// the grant.
 	//
 	// To specify the principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, federated users, and assumed role users. For examples of the ARN syntax
-	// to use for specifying a principal, see AWS Identity and Access Management
-	// (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
-	// in the Example ARNs section of the AWS General Reference.
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, federated users,
+	// and assumed role users. For examples of the ARN syntax to use for specifying
+	// a principal, see Amazon Web Services Identity and Access Management (IAM)
+	// (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
+	//
+	// The grant determines the retiring principal. Other principals might have
+	// permission to retire the grant or revoke the grant. For details, see RevokeGrant
+	// and Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
+	// in the Key Management Service Developer Guide.
 	RetiringPrincipal *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateGrantInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateGrantInput) GoString() string {
 	return s.String()
 }
@@ -8116,17 +8812,28 @@ type CreateGrantOutput struct {
 
 	// The grant token.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateGrantOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateGrantOutput) GoString() string {
 	return s.String()
 }
@@ -8148,61 +8855,79 @@ type CreateKeyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
 	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	// section in the AWS Key Management Service Developer Guide .
+	// section in the Key Management Service Developer Guide .
 	//
 	// Use this parameter only when you include a policy in the request and you
 	// intend to prevent the principal that is making the request from making a
-	// subsequent PutKeyPolicy request on the CMK.
+	// subsequent PutKeyPolicy request on the KMS key.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
 
-	// Creates the CMK in the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// and the key material in its associated AWS CloudHSM cluster. To create a
-	// CMK in a custom key store, you must also specify the Origin parameter with
-	// a value of AWS_CLOUDHSM. The AWS CloudHSM cluster that is associated with
-	// the custom key store must have at least two active HSMs, each in a different
+	// Creates the KMS key in the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+	// and the key material in its associated CloudHSM cluster. To create a KMS
+	// key in a custom key store, you must also specify the Origin parameter with
+	// a value of AWS_CLOUDHSM. The CloudHSM cluster that is associated with the
+	// custom key store must have at least two active HSMs, each in a different
 	// Availability Zone in the Region.
 	//
-	// This parameter is valid only for symmetric CMKs. You cannot create an asymmetric
-	// CMK in a custom key store.
+	// This parameter is valid only for symmetric KMS keys and regional KMS keys.
+	// You cannot create an asymmetric KMS key or a multi-Region key in a custom
+	// key store.
 	//
 	// To find the ID of a custom key store, use the DescribeCustomKeyStores operation.
 	//
-	// The response includes the custom key store ID and the ID of the AWS CloudHSM
+	// The response includes the custom key store ID and the ID of the CloudHSM
 	// cluster.
 	//
 	// This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// feature in AWS KMS, which combines the convenience and extensive integration
-	// of AWS KMS with the isolation and control of a single-tenant key store.
+	// feature in KMS, which combines the convenience and extensive integration
+	// of KMS with the isolation and control of a single-tenant key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
-	// Specifies the type of CMK to create. The default value, SYMMETRIC_DEFAULT,
-	// creates a CMK with a 256-bit symmetric key for encryption and decryption.
-	// For help choosing a key spec for your CMK, see How to Choose Your CMK Configuration
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Instead, use the KeySpec parameter.
 	//
-	// The CustomerMasterKeySpec determines whether the CMK contains a symmetric
-	// key or an asymmetric key pair. It also determines the encryption algorithms
-	// or signing algorithms that the CMK supports. You can't change the CustomerMasterKeySpec
-	// after the CMK is created. To further restrict the algorithms that can be
-	// used with the CMK, use a condition key in its key policy or IAM policy. For
+	// The KeySpec and CustomerMasterKeySpec parameters work the same way. Only
+	// the names differ. We recommend that you use KeySpec parameter in your code.
+	// However, to avoid breaking changes, KMS will support both parameters.
+	//
+	// Deprecated: This parameter has been deprecated. Instead, use the KeySpec parameter.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
+
+	// A description of the KMS key.
+	//
+	// Use a description that helps you decide whether the KMS key is appropriate
+	// for a task. The default value is an empty string (no description).
+	//
+	// To set or change the description after the key is created, use UpdateKeyDescription.
+	Description *string `type:"string"`
+
+	// Specifies the type of KMS key to create. The default value, SYMMETRIC_DEFAULT,
+	// creates a KMS key with a 256-bit symmetric key for encryption and decryption.
+	// For help choosing a key spec for your KMS key, see How to Choose Your KMS
+	// key Configuration (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html)
+	// in the Key Management Service Developer Guide .
+	//
+	// The KeySpec determines whether the KMS key contains a symmetric key or an
+	// asymmetric key pair. It also determines the encryption algorithms or signing
+	// algorithms that the KMS key supports. You can't change the KeySpec after
+	// the KMS key is created. To further restrict the algorithms that can be used
+	// with the KMS key, use a condition key in its key policy or IAM policy. For
 	// more information, see kms:EncryptionAlgorithm (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-algorithm)
 	// or kms:Signing Algorithm (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-signing-algorithm)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide .
 	//
-	// AWS services that are integrated with AWS KMS (http://aws.amazon.com/kms/features/#AWS_Service_Integration)
-	// use symmetric CMKs to protect your data. These services do not support asymmetric
-	// CMKs. For help determining whether a CMK is symmetric or asymmetric, see
-	// Identifying Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Amazon Web Services services that are integrated with KMS (http://aws.amazon.com/kms/features/#AWS_Service_Integration)
+	// use symmetric KMS keys to protect your data. These services do not support
+	// asymmetric KMS keys. For help determining whether a KMS key is symmetric
+	// or asymmetric, see Identifying Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html)
+	// in the Key Management Service Developer Guide.
 	//
-	// AWS KMS supports the following key specs for CMKs:
+	// KMS supports the following key specs for KMS keys:
 	//
 	//    * Symmetric key (default) SYMMETRIC_DEFAULT (AES-256-GCM)
 	//
@@ -8213,100 +8938,132 @@ type CreateKeyInput struct {
 	//
 	//    * Other asymmetric elliptic curve key pairs ECC_SECG_P256K1 (secp256k1),
 	//    commonly used for cryptocurrencies.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
-
-	// A description of the CMK.
-	//
-	// Use a description that helps you decide whether the CMK is appropriate for
-	// a task.
-	Description *string `type:"string"`
+	KeySpec *string `type:"string" enum:"KeySpec"`
 
 	// Determines the cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// for which you can use the CMK. The default value is ENCRYPT_DECRYPT. This
-	// parameter is required only for asymmetric CMKs. You can't change the KeyUsage
-	// value after the CMK is created.
+	// for which you can use the KMS key. The default value is ENCRYPT_DECRYPT.
+	// This parameter is required only for asymmetric KMS keys. You can't change
+	// the KeyUsage value after the KMS key is created.
 	//
 	// Select only one valid value.
 	//
-	//    * For symmetric CMKs, omit the parameter or specify ENCRYPT_DECRYPT.
+	//    * For symmetric KMS keys, omit the parameter or specify ENCRYPT_DECRYPT.
 	//
-	//    * For asymmetric CMKs with RSA key material, specify ENCRYPT_DECRYPT or
-	//    SIGN_VERIFY.
+	//    * For asymmetric KMS keys with RSA key material, specify ENCRYPT_DECRYPT
+	//    or SIGN_VERIFY.
 	//
-	//    * For asymmetric CMKs with ECC key material, specify SIGN_VERIFY.
+	//    * For asymmetric KMS keys with ECC key material, specify SIGN_VERIFY.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
-	// The source of the key material for the CMK. You cannot change the origin
-	// after you create the CMK. The default is AWS_KMS, which means AWS KMS creates
-	// the key material.
+	// Creates a multi-Region primary key that you can replicate into other Amazon
+	// Web Services Regions. You cannot change this value after you create the KMS
+	// key.
 	//
-	// When the parameter value is EXTERNAL, AWS KMS creates a CMK without key material
-	// so that you can import key material from your existing key management infrastructure.
-	// For more information about importing key material into AWS KMS, see Importing
-	// Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-	// in the AWS Key Management Service Developer Guide. This value is valid only
-	// for symmetric CMKs.
+	// For a multi-Region key, set this parameter to True. For a single-Region KMS
+	// key, omit this parameter or set it to False. The default value is False.
 	//
-	// When the parameter value is AWS_CLOUDHSM, AWS KMS creates the CMK in an AWS
-	// KMS custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// and creates its key material in the associated AWS CloudHSM cluster. You
-	// must also use the CustomKeyStoreId parameter to identify the custom key store.
-	// This value is valid only for symmetric CMKs.
+	// This operation supports multi-Region keys, an KMS feature that lets you create
+	// multiple interoperable KMS keys in different Amazon Web Services Regions.
+	// Because these KMS keys have the same key ID, key material, and other metadata,
+	// you can use them interchangeably to encrypt data in one Amazon Web Services
+	// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+	// the data or making a cross-Region call. For more information about multi-Region
+	// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+	// in the Key Management Service Developer Guide.
+	//
+	// This value creates a primary key, not a replica. To create a replica key,
+	// use the ReplicateKey operation.
+	//
+	// You can create a symmetric or asymmetric multi-Region key, and you can create
+	// a multi-Region key with imported key material. However, you cannot create
+	// a multi-Region key in a custom key store.
+	MultiRegion *bool `type:"boolean"`
+
+	// The source of the key material for the KMS key. You cannot change the origin
+	// after you create the KMS key. The default is AWS_KMS, which means that KMS
+	// creates the key material.
+	//
+	// To create a KMS key with no key material (for imported key material), set
+	// the value to EXTERNAL. For more information about importing key material
+	// into KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+	// in the Key Management Service Developer Guide. This value is valid only for
+	// symmetric KMS keys.
+	//
+	// To create a KMS key in an KMS custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+	// and create its key material in the associated CloudHSM cluster, set this
+	// value to AWS_CLOUDHSM. You must also use the CustomKeyStoreId parameter to
+	// identify the custom key store. This value is valid only for symmetric KMS
+	// keys.
 	Origin *string `type:"string" enum:"OriginType"`
 
-	// The key policy to attach to the CMK.
+	// The key policy to attach to the KMS key.
 	//
 	// If you provide a key policy, it must meet the following criteria:
 	//
 	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
 	//    must allow the principal that is making the CreateKey request to make
-	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
-	//    the CMK becomes unmanageable. For more information, refer to the scenario
-	//    in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section of the AWS Key Management Service Developer Guide .
+	//    a subsequent PutKeyPolicy request on the KMS key. This reduces the risk
+	//    that the KMS key becomes unmanageable. For more information, refer to
+	//    the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the Key Management Service Developer Guide .
 	//
 	//    * Each statement in the key policy must contain one or more principals.
-	//    The principals in the key policy must exist and be visible to AWS KMS.
-	//    When you create a new AWS principal (for example, an IAM user or role),
-	//    you might need to enforce a delay before including the new principal in
-	//    a key policy because the new principal might not be immediately visible
-	//    to AWS KMS. For more information, see Changes that I make are not always
-	//    immediately visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the AWS Identity and Access Management User Guide.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Amazon Web Services Identity and Access Management User Guide.
 	//
-	// If you do not provide a key policy, AWS KMS attaches a default key policy
-	// to the CMK. For more information, see Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
-	// in the AWS Key Management Service Developer Guide.
+	// If you do not provide a key policy, KMS attaches a default key policy to
+	// the KMS key. For more information, see Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
+	// in the Key Management Service Developer Guide.
 	//
 	// The key policy size quota is 32 kilobytes (32768 bytes).
 	//
 	// For help writing and formatting a JSON policy document, see the IAM JSON
 	// Policy Reference (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
-	// in the IAM User Guide .
+	// in the Identity and Access Management User Guide .
 	Policy *string `min:"1" type:"string"`
 
-	// One or more tags. Each tag consists of a tag key and a tag value. Both the
-	// tag key and the tag value are required, but the tag value can be an empty
-	// (null) string.
+	// Assigns one or more tags to the KMS key. Use this parameter to tag the KMS
+	// key when it is created. To tag an existing KMS key, use the TagResource operation.
 	//
-	// When you add tags to an AWS resource, AWS generates a cost allocation report
-	// with usage and costs aggregated by tags. For information about adding, changing,
-	// deleting and listing tags for CMKs, see Tagging Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
-	//
-	// Use this parameter to tag the CMK when it is created. To add tags to an existing
-	// CMK, use the TagResource operation.
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
 	//
 	// To use this parameter, you must have kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 	// permission in an IAM policy.
+	//
+	// Each tag consists of a tag key and a tag value. Both the tag key and the
+	// tag value are required, but the tag value can be an empty (null) string.
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
+	// the current tag value with the specified one.
+	//
+	// When you add tags to an Amazon Web Services resource, Amazon Web Services
+	// generates a cost allocation report with usage and costs aggregated by tags.
+	// Tags can also be used to control access to a KMS key. For details, see Tagging
+	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 	Tags []*Tag `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateKeyInput) GoString() string {
 	return s.String()
 }
@@ -8361,9 +9118,21 @@ func (s *CreateKeyInput) SetDescription(v string) *CreateKeyInput {
 	return s
 }
 
+// SetKeySpec sets the KeySpec field's value.
+func (s *CreateKeyInput) SetKeySpec(v string) *CreateKeyInput {
+	s.KeySpec = &v
+	return s
+}
+
 // SetKeyUsage sets the KeyUsage field's value.
 func (s *CreateKeyInput) SetKeyUsage(v string) *CreateKeyInput {
 	s.KeyUsage = &v
+	return s
+}
+
+// SetMultiRegion sets the MultiRegion field's value.
+func (s *CreateKeyInput) SetMultiRegion(v bool) *CreateKeyInput {
+	s.MultiRegion = &v
 	return s
 }
 
@@ -8388,16 +9157,24 @@ func (s *CreateKeyInput) SetTags(v []*Tag) *CreateKeyInput {
 type CreateKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Metadata associated with the CMK.
+	// Metadata associated with the KMS key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CreateKeyOutput) GoString() string {
 	return s.String()
 }
@@ -8408,10 +9185,10 @@ func (s *CreateKeyOutput) SetKeyMetadata(v *KeyMetadata) *CreateKeyOutput {
 	return s
 }
 
-// The request was rejected because the custom key store contains AWS KMS customer
-// master keys (CMKs). After verifying that you do not need to use the CMKs,
-// use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-// deleted, you can delete the custom key store.
+// The request was rejected because the custom key store contains KMS keys.
+// After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+// operation to delete the KMS keys. After they are deleted, you can delete
+// the custom key store.
 type CustomKeyStoreHasCMKsException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -8419,12 +9196,20 @@ type CustomKeyStoreHasCMKsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreHasCMKsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreHasCMKsException) GoString() string {
 	return s.String()
 }
@@ -8491,12 +9276,20 @@ type CustomKeyStoreInvalidStateException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreInvalidStateException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreInvalidStateException) GoString() string {
 	return s.String()
 }
@@ -8549,12 +9342,20 @@ type CustomKeyStoreNameInUseException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreNameInUseException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreNameInUseException) GoString() string {
 	return s.String()
 }
@@ -8597,7 +9398,7 @@ func (s *CustomKeyStoreNameInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because AWS KMS cannot find a custom key store with
+// The request was rejected because KMS cannot find a custom key store with
 // the specified key store name or ID.
 type CustomKeyStoreNotFoundException struct {
 	_            struct{}                  `type:"structure"`
@@ -8606,12 +9407,20 @@ type CustomKeyStoreNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoreNotFoundException) GoString() string {
 	return s.String()
 }
@@ -8659,84 +9468,83 @@ func (s *CustomKeyStoreNotFoundException) RequestID() string {
 type CustomKeyStoresListEntry struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the AWS CloudHSM cluster that is associated with
-	// the custom key store.
+	// A unique identifier for the CloudHSM cluster that is associated with the
+	// custom key store.
 	CloudHsmClusterId *string `min:"19" type:"string"`
 
 	// Describes the connection error. This field appears in the response only when
 	// the ConnectionState is FAILED. For help resolving these errors, see How to
 	// Fix a Connection Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
-	// in AWS Key Management Service Developer Guide.
+	// in Key Management Service Developer Guide.
 	//
 	// Valid values are:
 	//
-	//    * CLUSTER_NOT_FOUND - AWS KMS cannot find the AWS CloudHSM cluster with
-	//    the specified cluster ID.
+	//    * CLUSTER_NOT_FOUND - KMS cannot find the CloudHSM cluster with the specified
+	//    cluster ID.
 	//
-	//    * INSUFFICIENT_CLOUDHSM_HSMS - The associated AWS CloudHSM cluster does
-	//    not contain any active HSMs. To connect a custom key store to its AWS
-	//    CloudHSM cluster, the cluster must contain at least one active HSM.
+	//    * INSUFFICIENT_CLOUDHSM_HSMS - The associated CloudHSM cluster does not
+	//    contain any active HSMs. To connect a custom key store to its CloudHSM
+	//    cluster, the cluster must contain at least one active HSM.
 	//
-	//    * INTERNAL_ERROR - AWS KMS could not complete the request due to an internal
+	//    * INTERNAL_ERROR - KMS could not complete the request due to an internal
 	//    error. Retry the request. For ConnectCustomKeyStore requests, disconnect
 	//    the custom key store before trying to connect again.
 	//
-	//    * INVALID_CREDENTIALS - AWS KMS does not have the correct password for
-	//    the kmsuser crypto user in the AWS CloudHSM cluster. Before you can connect
-	//    your custom key store to its AWS CloudHSM cluster, you must change the
-	//    kmsuser account password and update the key store password value for the
-	//    custom key store.
+	//    * INVALID_CREDENTIALS - KMS does not have the correct password for the
+	//    kmsuser crypto user in the CloudHSM cluster. Before you can connect your
+	//    custom key store to its CloudHSM cluster, you must change the kmsuser
+	//    account password and update the key store password value for the custom
+	//    key store.
 	//
-	//    * NETWORK_ERRORS - Network errors are preventing AWS KMS from connecting
-	//    to the custom key store.
+	//    * NETWORK_ERRORS - Network errors are preventing KMS from connecting to
+	//    the custom key store.
 	//
-	//    * SUBNET_NOT_FOUND - A subnet in the AWS CloudHSM cluster configuration
-	//    was deleted. If AWS KMS cannot find all of the subnets in the cluster
-	//    configuration, attempts to connect the custom key store to the AWS CloudHSM
-	//    cluster fail. To fix this error, create a cluster from a recent backup
-	//    and associate it with your custom key store. (This process creates a new
-	//    cluster configuration with a VPC and private subnets.) For details, see
-	//    How to Fix a Connection Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
-	//    in the AWS Key Management Service Developer Guide.
+	//    * SUBNET_NOT_FOUND - A subnet in the CloudHSM cluster configuration was
+	//    deleted. If KMS cannot find all of the subnets in the cluster configuration,
+	//    attempts to connect the custom key store to the CloudHSM cluster fail.
+	//    To fix this error, create a cluster from a recent backup and associate
+	//    it with your custom key store. (This process creates a new cluster configuration
+	//    with a VPC and private subnets.) For details, see How to Fix a Connection
+	//    Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
+	//    in the Key Management Service Developer Guide.
 	//
 	//    * USER_LOCKED_OUT - The kmsuser CU account is locked out of the associated
-	//    AWS CloudHSM cluster due to too many failed password attempts. Before
-	//    you can connect your custom key store to its AWS CloudHSM cluster, you
-	//    must change the kmsuser account password and update the key store password
-	//    value for the custom key store.
+	//    CloudHSM cluster due to too many failed password attempts. Before you
+	//    can connect your custom key store to its CloudHSM cluster, you must change
+	//    the kmsuser account password and update the key store password value for
+	//    the custom key store.
 	//
 	//    * USER_LOGGED_IN - The kmsuser CU account is logged into the the associated
-	//    AWS CloudHSM cluster. This prevents AWS KMS from rotating the kmsuser
-	//    account password and logging into the cluster. Before you can connect
-	//    your custom key store to its AWS CloudHSM cluster, you must log the kmsuser
-	//    CU out of the cluster. If you changed the kmsuser password to log into
-	//    the cluster, you must also and update the key store password value for
-	//    the custom key store. For help, see How to Log Out and Reconnect (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2)
-	//    in the AWS Key Management Service Developer Guide.
+	//    CloudHSM cluster. This prevents KMS from rotating the kmsuser account
+	//    password and logging into the cluster. Before you can connect your custom
+	//    key store to its CloudHSM cluster, you must log the kmsuser CU out of
+	//    the cluster. If you changed the kmsuser password to log into the cluster,
+	//    you must also and update the key store password value for the custom key
+	//    store. For help, see How to Log Out and Reconnect (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2)
+	//    in the Key Management Service Developer Guide.
 	//
-	//    * USER_NOT_FOUND - AWS KMS cannot find a kmsuser CU account in the associated
-	//    AWS CloudHSM cluster. Before you can connect your custom key store to
-	//    its AWS CloudHSM cluster, you must create a kmsuser CU account in the
-	//    cluster, and then update the key store password value for the custom key
-	//    store.
+	//    * USER_NOT_FOUND - KMS cannot find a kmsuser CU account in the associated
+	//    CloudHSM cluster. Before you can connect your custom key store to its
+	//    CloudHSM cluster, you must create a kmsuser CU account in the cluster,
+	//    and then update the key store password value for the custom key store.
 	ConnectionErrorCode *string `type:"string" enum:"ConnectionErrorCodeType"`
 
-	// Indicates whether the custom key store is connected to its AWS CloudHSM cluster.
+	// Indicates whether the custom key store is connected to its CloudHSM cluster.
 	//
-	// You can create and use CMKs in your custom key stores only when its connection
+	// You can create and use KMS keys in your custom key stores only when its connection
 	// state is CONNECTED.
 	//
 	// The value is DISCONNECTED if the key store has never been connected or you
 	// use the DisconnectCustomKeyStore operation to disconnect it. If the value
 	// is CONNECTED but you are having trouble using the custom key store, make
-	// sure that its associated AWS CloudHSM cluster is active and contains at least
+	// sure that its associated CloudHSM cluster is active and contains at least
 	// one active HSM.
 	//
 	// A value of FAILED indicates that an attempt to connect was unsuccessful.
 	// The ConnectionErrorCode field in the response indicates the cause of the
 	// failure. For help resolving a connection failure, see Troubleshooting a Custom
 	// Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	ConnectionState *string `type:"string" enum:"ConnectionStateType"`
 
 	// The date and time when the custom key store was created.
@@ -8748,18 +9556,26 @@ type CustomKeyStoresListEntry struct {
 	// The user-specified friendly name for the custom key store.
 	CustomKeyStoreName *string `min:"1" type:"string"`
 
-	// The trust anchor certificate of the associated AWS CloudHSM cluster. When
-	// you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
+	// The trust anchor certificate of the associated CloudHSM cluster. When you
+	// initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 	// you create this certificate and save it in the customerCA.crt file.
 	TrustAnchorCertificate *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoresListEntry) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s CustomKeyStoresListEntry) GoString() string {
 	return s.String()
 }
@@ -8810,7 +9626,6 @@ type DecryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext to be decrypted. The blob includes metadata.
-	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	//
 	// CiphertextBlob is a required field
@@ -8821,43 +9636,47 @@ type DecryptInput struct {
 	// a different algorithm, the Decrypt operation fails.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. The default value, SYMMETRIC_DEFAULT, represents the only
-	// supported algorithm that is valid for symmetric CMKs.
+	// asymmetric KMS key. The default value, SYMMETRIC_DEFAULT, represents the
+	// only supported algorithm that is valid for symmetric KMS keys.
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context to use when decrypting the data. An encryption
 	// context is valid only for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// with a symmetric CMK. The standard asymmetric encryption algorithms that
-	// AWS KMS uses do not support an encryption context.
+	// with a symmetric KMS key. The standard asymmetric encryption algorithms that
+	// KMS uses do not support an encryption context.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the customer master key (CMK) that AWS KMS uses to decrypt the
-	// ciphertext. Enter a key ID of the CMK that was used to encrypt the ciphertext.
+	// Specifies the KMS key that KMS uses to decrypt the ciphertext. Enter a key
+	// ID of the KMS key that was used to encrypt the ciphertext.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. If you used a symmetric CMK, AWS KMS can get the CMK from
-	// metadata that it adds to the symmetric ciphertext blob. However, it is always
-	// recommended as a best practice. This practice ensures that you use the CMK
-	// that you intend.
+	// asymmetric KMS key. If you used a symmetric KMS key, KMS can get the KMS
+	// key from metadata that it adds to the symmetric ciphertext blob. However,
+	// it is always recommended as a best practice. This practice ensures that you
+	// use the KMS key that you intend.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -8869,17 +9688,25 @@ type DecryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecryptInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecryptInput) GoString() string {
 	return s.String()
 }
@@ -8940,22 +9767,34 @@ type DecryptOutput struct {
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to decrypt the ciphertext.
+	// of the KMS key that was used to decrypt the ciphertext.
 	KeyId *string `min:"1" type:"string"`
 
-	// Decrypted plaintext data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// Decrypted plaintext data. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// Plaintext is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by DecryptOutput's
+	// String and GoString methods.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecryptOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecryptOutput) GoString() string {
 	return s.String()
 }
@@ -8988,12 +9827,20 @@ type DeleteAliasInput struct {
 	AliasName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAliasInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAliasInput) GoString() string {
 	return s.String()
 }
@@ -9024,12 +9871,20 @@ type DeleteAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAliasOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteAliasOutput) GoString() string {
 	return s.String()
 }
@@ -9044,12 +9899,20 @@ type DeleteCustomKeyStoreInput struct {
 	CustomKeyStoreId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteCustomKeyStoreInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteCustomKeyStoreInput) GoString() string {
 	return s.String()
 }
@@ -9080,12 +9943,20 @@ type DeleteCustomKeyStoreOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteCustomKeyStoreOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteCustomKeyStoreOutput) GoString() string {
 	return s.String()
 }
@@ -9093,10 +9964,10 @@ func (s DeleteCustomKeyStoreOutput) GoString() string {
 type DeleteImportedKeyMaterialInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the CMK from which you are deleting imported key material. The
-	// Origin of the CMK must be EXTERNAL.
+	// Identifies the KMS key from which you are deleting imported key material.
+	// The Origin of the KMS key must be EXTERNAL.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9104,18 +9975,26 @@ type DeleteImportedKeyMaterialInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteImportedKeyMaterialInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteImportedKeyMaterialInput) GoString() string {
 	return s.String()
 }
@@ -9146,12 +10025,20 @@ type DeleteImportedKeyMaterialOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteImportedKeyMaterialOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DeleteImportedKeyMaterialOutput) GoString() string {
 	return s.String()
 }
@@ -9165,12 +10052,20 @@ type DependencyTimeoutException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DependencyTimeoutException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DependencyTimeoutException) GoString() string {
 	return s.String()
 }
@@ -9220,7 +10115,7 @@ type DescribeCustomKeyStoresInput struct {
 	// store ID.
 	//
 	// By default, this operation gets information about all custom key stores in
-	// the account and region. To limit the output to a particular custom key store,
+	// the account and Region. To limit the output to a particular custom key store,
 	// you can use either the CustomKeyStoreId or CustomKeyStoreName parameter,
 	// but not both.
 	CustomKeyStoreId *string `min:"1" type:"string"`
@@ -9229,13 +10124,13 @@ type DescribeCustomKeyStoresInput struct {
 	// name of the custom key store.
 	//
 	// By default, this operation gets information about all custom key stores in
-	// the account and region. To limit the output to a particular custom key store,
+	// the account and Region. To limit the output to a particular custom key store,
 	// you can use either the CustomKeyStoreId or CustomKeyStoreName parameter,
 	// but not both.
 	CustomKeyStoreName *string `min:"1" type:"string"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	Limit *int64 `min:"1" type:"integer"`
 
@@ -9245,12 +10140,20 @@ type DescribeCustomKeyStoresInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeCustomKeyStoresInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeCustomKeyStoresInput) GoString() string {
 	return s.String()
 }
@@ -9318,12 +10221,20 @@ type DescribeCustomKeyStoresOutput struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeCustomKeyStoresOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeCustomKeyStoresOutput) GoString() string {
 	return s.String()
 }
@@ -9351,19 +10262,24 @@ type DescribeKeyInput struct {
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Describes the specified customer master key (CMK).
+	// Describes the specified KMS key.
 	//
-	// If you specify a predefined AWS alias (an AWS alias with no key ID), KMS
-	// associates the alias with an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
+	// If you specify a predefined Amazon Web Services alias (an Amazon Web Services
+	// alias with no key ID), KMS associates the alias with an Amazon Web Services
+	// managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html##aws-managed-cmk)
 	// and returns its KeyId and Arn in the response.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -9375,19 +10291,27 @@ type DescribeKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeKeyInput) GoString() string {
 	return s.String()
 }
@@ -9427,12 +10351,20 @@ type DescribeKeyOutput struct {
 	KeyMetadata *KeyMetadata `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DescribeKeyOutput) GoString() string {
 	return s.String()
 }
@@ -9446,9 +10378,9 @@ func (s *DescribeKeyOutput) SetKeyMetadata(v *KeyMetadata) *DescribeKeyOutput {
 type DisableKeyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Identifies the KMS key to disable.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9456,18 +10388,26 @@ type DisableKeyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyInput) GoString() string {
 	return s.String()
 }
@@ -9498,12 +10438,20 @@ type DisableKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyOutput) GoString() string {
 	return s.String()
 }
@@ -9511,12 +10459,12 @@ func (s DisableKeyOutput) GoString() string {
 type DisableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a symmetric customer master key (CMK). You cannot enable or disable
-	// automatic rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks),
-	// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-	// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+	// Identifies a symmetric KMS key. You cannot enable or disable automatic rotation
+	// of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks),
+	// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+	// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9524,18 +10472,26 @@ type DisableKeyRotationInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyRotationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyRotationInput) GoString() string {
 	return s.String()
 }
@@ -9566,17 +10522,25 @@ type DisableKeyRotationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyRotationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisableKeyRotationOutput) GoString() string {
 	return s.String()
 }
 
-// The request was rejected because the specified CMK is not enabled.
+// The request was rejected because the specified KMS key is not enabled.
 type DisabledException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -9584,12 +10548,20 @@ type DisabledException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisabledException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisabledException) GoString() string {
 	return s.String()
 }
@@ -9642,12 +10614,20 @@ type DisconnectCustomKeyStoreInput struct {
 	CustomKeyStoreId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisconnectCustomKeyStoreInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisconnectCustomKeyStoreInput) GoString() string {
 	return s.String()
 }
@@ -9678,12 +10658,20 @@ type DisconnectCustomKeyStoreOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisconnectCustomKeyStoreOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DisconnectCustomKeyStoreOutput) GoString() string {
 	return s.String()
 }
@@ -9691,9 +10679,9 @@ func (s DisconnectCustomKeyStoreOutput) GoString() string {
 type EnableKeyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Identifies the KMS key to enable.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9701,18 +10689,26 @@ type EnableKeyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyInput) GoString() string {
 	return s.String()
 }
@@ -9743,12 +10739,20 @@ type EnableKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyOutput) GoString() string {
 	return s.String()
 }
@@ -9756,11 +10760,15 @@ func (s EnableKeyOutput) GoString() string {
 type EnableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a symmetric customer master key (CMK). You cannot enable automatic
-	// rotation of asymmetric CMKs, CMKs with imported key material, or CMKs in
-	// a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+	// Identifies a symmetric KMS key. You cannot enable automatic rotation of asymmetric
+	// KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+	// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+	// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+	// To enable or disable automatic rotation of a set of related multi-Region
+	// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
+	// set the property on the primary key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9768,18 +10776,26 @@ type EnableKeyRotationInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyRotationInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyRotationInput) GoString() string {
 	return s.String()
 }
@@ -9810,12 +10826,20 @@ type EnableKeyRotationOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyRotationOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EnableKeyRotationOutput) GoString() string {
 	return s.String()
 }
@@ -9823,40 +10847,44 @@ func (s EnableKeyRotationOutput) GoString() string {
 type EncryptInput struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to encrypt the plaintext
-	// message. The algorithm must be compatible with the CMK that you specify.
+	// Specifies the encryption algorithm that KMS will use to encrypt the plaintext
+	// message. The algorithm must be compatible with the KMS key that you specify.
 	//
-	// This parameter is required only for asymmetric CMKs. The default value, SYMMETRIC_DEFAULT,
-	// is the algorithm used for symmetric CMKs. If you are using an asymmetric
-	// CMK, we recommend RSAES_OAEP_SHA_256.
+	// This parameter is required only for asymmetric KMS keys. The default value,
+	// SYMMETRIC_DEFAULT, is the algorithm used for symmetric KMS keys. If you are
+	// using an asymmetric KMS key, we recommend RSAES_OAEP_SHA_256.
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context that will be used to encrypt the data. An
 	// encryption context is valid only for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// with a symmetric CMK. The standard asymmetric encryption algorithms that
-	// AWS KMS uses do not support an encryption context.
+	// with a symmetric KMS key. The standard asymmetric encryption algorithms that
+	// KMS uses do not support an encryption context.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Identifies the KMS key to use in the encryption operation.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -9868,13 +10896,17 @@ type EncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Data to be encrypted.
+	//
+	// Plaintext is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by EncryptInput's
+	// String and GoString methods.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	//
@@ -9882,12 +10914,20 @@ type EncryptInput struct {
 	Plaintext []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptInput) GoString() string {
 	return s.String()
 }
@@ -9947,9 +10987,8 @@ func (s *EncryptInput) SetPlaintext(v []byte) *EncryptInput {
 type EncryptOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The encrypted plaintext. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
@@ -9957,16 +10996,24 @@ type EncryptOutput struct {
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to encrypt the plaintext.
+	// of the KMS key that was used to encrypt the plaintext.
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s EncryptOutput) GoString() string {
 	return s.String()
 }
@@ -9999,12 +11046,20 @@ type ExpiredImportTokenException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExpiredImportTokenException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ExpiredImportTokenException) GoString() string {
 	return s.String()
 }
@@ -10057,23 +11112,27 @@ type GenerateDataKeyInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the symmetric CMK that encrypts the data key.
+	// Identifies the symmetric KMS key that encrypts the data key.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10085,8 +11144,8 @@ type GenerateDataKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10107,12 +11166,20 @@ type GenerateDataKeyInput struct {
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyInput) GoString() string {
 	return s.String()
 }
@@ -10169,31 +11236,42 @@ func (s *GenerateDataKeyInput) SetNumberOfBytes(v int64) *GenerateDataKeyInput {
 type GenerateDataKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted copy of the data key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The encrypted copy of the data key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the data key.
+	// of the KMS key that encrypted the data key.
 	KeyId *string `min:"1" type:"string"`
 
-	// The plaintext data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded. Use this data key
-	// to encrypt your data outside of KMS. Then, remove it from memory as soon
-	// as possible.
+	// The plaintext data key. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded. Use
+	// this data key to encrypt your data outside of KMS. Then, remove it from memory
+	// as soon as possible.
+	//
+	// Plaintext is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by GenerateDataKeyOutput's
+	// String and GoString methods.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyOutput) GoString() string {
 	return s.String()
 }
@@ -10226,25 +11304,30 @@ type GenerateDataKeyPairInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the symmetric CMK that encrypts the private key in the data key
-	// pair. You cannot specify an asymmetric CMK or a CMK in a custom key store.
-	// To get the type and origin of your CMK, use the DescribeKey operation.
+	// Specifies the symmetric KMS key that encrypts the private key in the data
+	// key pair. You cannot specify an asymmetric KMS key or a KMS key in a custom
+	// key store. To get the type and origin of your KMS key, use the DescribeKey
+	// operation.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10256,29 +11339,37 @@ type GenerateDataKeyPairInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Determines the type of data key pair that is generated.
 	//
-	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// The KMS rule that restricts the use of asymmetric RSA KMS keys to encrypt
 	// and decrypt or to sign and verify (but not both), and the rule that permits
-	// you to use ECC CMKs only to sign and verify, are not effective outside of
-	// AWS KMS.
+	// you to use ECC KMS keys only to sign and verify, are not effective on data
+	// key pairs, which are used outside of KMS.
 	//
 	// KeyPairSpec is a required field
 	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairInput) GoString() string {
 	return s.String()
 }
@@ -10330,36 +11421,46 @@ type GenerateDataKeyPairOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the private key.
+	// of the KMS key that encrypted the private key.
 	KeyId *string `min:"1" type:"string"`
 
 	// The type of data key pair that was generated.
 	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
 
-	// The encrypted copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The encrypted copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
 
-	// The plaintext copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The plaintext copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// PrivateKeyPlaintext is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by GenerateDataKeyPairOutput's
+	// String and GoString methods.
 	//
 	// PrivateKeyPlaintext is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyPlaintext []byte `min:"1" type:"blob" sensitive:"true"`
 
 	// The public key (in plaintext).
-	//
 	// PublicKey is automatically base64 encoded/decoded by the SDK.
 	PublicKey []byte `min:"1" type:"blob"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairOutput) GoString() string {
 	return s.String()
 }
@@ -10404,26 +11505,30 @@ type GenerateDataKeyPairWithoutPlaintextInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the CMK that encrypts the private key in the data key pair. You
-	// must specify a symmetric CMK. You cannot use an asymmetric CMK or a CMK in
-	// a custom key store. To get the type and origin of your CMK, use the DescribeKey
-	// operation.
+	// Specifies the KMS key that encrypts the private key in the data key pair.
+	// You must specify a symmetric KMS key. You cannot use an asymmetric KMS key
+	// or a KMS key in a custom key store. To get the type and origin of your KMS
+	// key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10435,29 +11540,37 @@ type GenerateDataKeyPairWithoutPlaintextInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Determines the type of data key pair that is generated.
 	//
-	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// The KMS rule that restricts the use of asymmetric RSA KMS keys to encrypt
 	// and decrypt or to sign and verify (but not both), and the rule that permits
-	// you to use ECC CMKs only to sign and verify, are not effective outside of
-	// AWS KMS.
+	// you to use ECC KMS keys only to sign and verify, are not effective on data
+	// key pairs, which are used outside of KMS.
 	//
 	// KeyPairSpec is a required field
 	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairWithoutPlaintextInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairWithoutPlaintextInput) GoString() string {
 	return s.String()
 }
@@ -10509,30 +11622,36 @@ type GenerateDataKeyPairWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the private key.
+	// of the KMS key that encrypted the private key.
 	KeyId *string `min:"1" type:"string"`
 
 	// The type of data key pair that was generated.
 	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
 
-	// The encrypted copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The encrypted copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The public key (in plaintext).
-	//
 	// PublicKey is automatically base64 encoded/decoded by the SDK.
 	PublicKey []byte `min:"1" type:"blob"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairWithoutPlaintextOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyPairWithoutPlaintextOutput) GoString() string {
 	return s.String()
 }
@@ -10571,24 +11690,27 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// The identifier of the symmetric customer master key (CMK) that encrypts the
-	// data key.
+	// The identifier of the symmetric KMS key that encrypts the data key.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10600,8 +11722,8 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10617,12 +11739,20 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyWithoutPlaintextInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyWithoutPlaintextInput) GoString() string {
 	return s.String()
 }
@@ -10679,23 +11809,30 @@ func (s *GenerateDataKeyWithoutPlaintextInput) SetNumberOfBytes(v int64) *Genera
 type GenerateDataKeyWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The encrypted data key. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the data key.
+	// of the KMS key that encrypted the data key.
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyWithoutPlaintextOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateDataKeyWithoutPlaintextOutput) GoString() string {
 	return s.String()
 }
@@ -10715,7 +11852,7 @@ func (s *GenerateDataKeyWithoutPlaintextOutput) SetKeyId(v string) *GenerateData
 type GenerateRandomInput struct {
 	_ struct{} `type:"structure"`
 
-	// Generates the random byte string in the AWS CloudHSM cluster that is associated
+	// Generates the random byte string in the CloudHSM cluster that is associated
 	// with the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	// To find the ID of a custom key store, use the DescribeCustomKeyStores operation.
 	CustomKeyStoreId *string `min:"1" type:"string"`
@@ -10724,12 +11861,20 @@ type GenerateRandomInput struct {
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateRandomInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateRandomInput) GoString() string {
 	return s.String()
 }
@@ -10765,19 +11910,31 @@ func (s *GenerateRandomInput) SetNumberOfBytes(v int64) *GenerateRandomInput {
 type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The random byte string. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The random byte string. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	//
+	// Plaintext is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by GenerateRandomOutput's
+	// String and GoString methods.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateRandomOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GenerateRandomOutput) GoString() string {
 	return s.String()
 }
@@ -10791,9 +11948,9 @@ func (s *GenerateRandomOutput) SetPlaintext(v []byte) *GenerateRandomOutput {
 type GetKeyPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Gets the key policy for the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -10801,7 +11958,7 @@ type GetKeyPolicyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10813,12 +11970,20 @@ type GetKeyPolicyInput struct {
 	PolicyName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyPolicyInput) GoString() string {
 	return s.String()
 }
@@ -10864,12 +12029,20 @@ type GetKeyPolicyOutput struct {
 	Policy *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -10883,10 +12056,10 @@ func (s *GetKeyPolicyOutput) SetPolicy(v string) *GetKeyPolicyOutput {
 type GetKeyRotationStatusInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Gets the rotation status for the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify
-	// a CMK in a different AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -10894,18 +12067,26 @@ type GetKeyRotationStatusInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyRotationStatusInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyRotationStatusInput) GoString() string {
 	return s.String()
 }
@@ -10939,12 +12120,20 @@ type GetKeyRotationStatusOutput struct {
 	KeyRotationEnabled *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyRotationStatusOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetKeyRotationStatusOutput) GoString() string {
 	return s.String()
 }
@@ -10958,10 +12147,10 @@ func (s *GetKeyRotationStatusOutput) SetKeyRotationEnabled(v bool) *GetKeyRotati
 type GetParametersForImportInput struct {
 	_ struct{} `type:"structure"`
 
-	// The identifier of the symmetric CMK into which you will import key material.
-	// The Origin of the CMK must be EXTERNAL.
+	// The identifier of the symmetric KMS key into which you will import key material.
+	// The Origin of the KMS key must be EXTERNAL.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -10969,7 +12158,7 @@ type GetParametersForImportInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10977,7 +12166,7 @@ type GetParametersForImportInput struct {
 	// The algorithm you will use to encrypt the key material before importing it
 	// with ImportKeyMaterial. For more information, see Encrypt the Key Material
 	// (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-encrypt-key-material.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	//
 	// WrappingAlgorithm is a required field
 	WrappingAlgorithm *string `type:"string" required:"true" enum:"AlgorithmSpec"`
@@ -10989,12 +12178,20 @@ type GetParametersForImportInput struct {
 	WrappingKeySpec *string `type:"string" required:"true" enum:"WrappingKeySpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetParametersForImportInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetParametersForImportInput) GoString() string {
 	return s.String()
 }
@@ -11043,13 +12240,12 @@ type GetParametersForImportOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The import token to send in a subsequent ImportKeyMaterial request.
-	//
 	// ImportToken is automatically base64 encoded/decoded by the SDK.
 	ImportToken []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK to use in a subsequent ImportKeyMaterial request. This is the
-	// same CMK specified in the GetParametersForImport request.
+	// of the KMS key to use in a subsequent ImportKeyMaterial request. This is
+	// the same KMS key specified in the GetParametersForImport request.
 	KeyId *string `min:"1" type:"string"`
 
 	// The time at which the import token and public key are no longer valid. After
@@ -11060,16 +12256,28 @@ type GetParametersForImportOutput struct {
 	// The public key to use to encrypt the key material before importing it with
 	// ImportKeyMaterial.
 	//
+	// PublicKey is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by GetParametersForImportOutput's
+	// String and GoString methods.
+	//
 	// PublicKey is automatically base64 encoded/decoded by the SDK.
 	PublicKey []byte `min:"1" type:"blob" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetParametersForImportOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetParametersForImportOutput) GoString() string {
 	return s.String()
 }
@@ -11103,15 +12311,19 @@ type GetPublicKeyInput struct {
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the asymmetric CMK that includes the public key.
+	// Identifies the asymmetric KMS key that includes the public key.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -11123,19 +12335,27 @@ type GetPublicKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPublicKeyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPublicKeyInput) GoString() string {
 	return s.String()
 }
@@ -11171,53 +12391,68 @@ func (s *GetPublicKeyInput) SetKeyId(v string) *GetPublicKeyInput {
 type GetPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The type of the of the public key that was downloaded.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
-
-	// The encryption algorithms that AWS KMS supports for this key.
+	// Instead, use the KeySpec field in the GetPublicKey response.
 	//
-	// This information is critical. If a public key encrypts data outside of AWS
-	// KMS by using an unsupported encryption algorithm, the ciphertext cannot be
-	// decrypted.
+	// The KeySpec and CustomerMasterKeySpec fields have the same value. We recommend
+	// that you use the KeySpec field in your code. However, to avoid breaking changes,
+	// KMS will support both fields.
+	//
+	// Deprecated: This field has been deprecated. Instead, use the KeySpec field.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
+
+	// The encryption algorithms that KMS supports for this key.
+	//
+	// This information is critical. If a public key encrypts data outside of KMS
+	// by using an unsupported encryption algorithm, the ciphertext cannot be decrypted.
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is ENCRYPT_DECRYPT.
 	EncryptionAlgorithms []*string `type:"list"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK from which the public key was downloaded.
+	// of the asymmetric KMS key from which the public key was downloaded.
 	KeyId *string `min:"1" type:"string"`
+
+	// The type of the of the public key that was downloaded.
+	KeySpec *string `type:"string" enum:"KeySpec"`
 
 	// The permitted use of the public key. Valid values are ENCRYPT_DECRYPT or
 	// SIGN_VERIFY.
 	//
 	// This information is critical. If a public key with SIGN_VERIFY key usage
-	// encrypts data outside of AWS KMS, the ciphertext cannot be decrypted.
+	// encrypts data outside of KMS, the ciphertext cannot be decrypted.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
 	// The exported public key.
 	//
 	// The value is a DER-encoded X.509 public key, also known as SubjectPublicKeyInfo
 	// (SPKI), as defined in RFC 5280 (https://tools.ietf.org/html/rfc5280). When
-	// you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise,
-	// it is not Base64-encoded.
-	//
+	// you use the HTTP API or the Amazon Web Services CLI, the value is Base64-encoded.
+	// Otherwise, it is not Base64-encoded.
 	// PublicKey is automatically base64 encoded/decoded by the SDK.
 	PublicKey []byte `min:"1" type:"blob"`
 
-	// The signing algorithms that AWS KMS supports for this key.
+	// The signing algorithms that KMS supports for this key.
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is SIGN_VERIFY.
 	SigningAlgorithms []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPublicKeyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetPublicKeyOutput) GoString() string {
 	return s.String()
 }
@@ -11237,6 +12472,12 @@ func (s *GetPublicKeyOutput) SetEncryptionAlgorithms(v []*string) *GetPublicKeyO
 // SetKeyId sets the KeyId field's value.
 func (s *GetPublicKeyOutput) SetKeyId(v string) *GetPublicKeyOutput {
 	s.KeyId = &v
+	return s
+}
+
+// SetKeySpec sets the KeySpec field's value.
+func (s *GetPublicKeyOutput) SetKeySpec(v string) *GetPublicKeyOutput {
+	s.KeySpec = &v
 	return s
 }
 
@@ -11262,11 +12503,11 @@ func (s *GetPublicKeyOutput) SetSigningAlgorithms(v []*string) *GetPublicKeyOutp
 // in the grant only when the operation request includes the specified encryption
 // context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context).
 //
-// AWS KMS applies the grant constraints only to cryptographic operations that
-// support an encryption context, that is, all cryptographic operations with
-// a symmetric CMK (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#symmetric-cmks).
+// KMS applies the grant constraints only to cryptographic operations that support
+// an encryption context, that is, all cryptographic operations with a symmetric
+// KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#symmetric-cmks).
 // Grant constraints are not applied to operations that do not support an encryption
-// context, such as cryptographic operations with asymmetric CMKs and management
+// context, such as cryptographic operations with asymmetric KMS keys and management
 // operations, such as DescribeKey or RetireGrant.
 //
 // In a cryptographic operation, the encryption context in the decryption operation
@@ -11280,7 +12521,7 @@ func (s *GetPublicKeyOutput) SetSigningAlgorithms(v []*string) *GetPublicKeyOutp
 // only by case. To require a fully case-sensitive encryption context, use the
 // kms:EncryptionContext: and kms:EncryptionContextKeys conditions in an IAM
 // or key policy. For details, see kms:EncryptionContext: (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-context)
-// in the AWS Key Management Service Developer Guide .
+// in the Key Management Service Developer Guide .
 type GrantConstraints struct {
 	_ struct{} `type:"structure"`
 
@@ -11298,12 +12539,20 @@ type GrantConstraints struct {
 	EncryptionContextSubset map[string]*string `type:"map"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GrantConstraints) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GrantConstraints) GoString() string {
 	return s.String()
 }
@@ -11338,16 +12587,15 @@ type GrantListEntry struct {
 	//
 	// The GranteePrincipal field in the ListGrants response usually contains the
 	// user or role designated as the grantee principal in the grant. However, when
-	// the grantee principal in the grant is an AWS service, the GranteePrincipal
-	// field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
+	// the grantee principal in the grant is an Amazon Web Services service, the
+	// GranteePrincipal field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
 	// which might represent several different grantee principals.
 	GranteePrincipal *string `min:"1" type:"string"`
 
-	// The AWS account under which the grant was issued.
+	// The Amazon Web Services account under which the grant was issued.
 	IssuingAccount *string `min:"1" type:"string"`
 
-	// The unique identifier for the customer master key (CMK) to which the grant
-	// applies.
+	// The unique identifier for the KMS key to which the grant applies.
 	KeyId *string `min:"1" type:"string"`
 
 	// The friendly name that identifies the grant. If a name was provided in the
@@ -11361,12 +12609,20 @@ type GrantListEntry struct {
 	RetiringPrincipal *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GrantListEntry) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GrantListEntry) GoString() string {
 	return s.String()
 }
@@ -11432,7 +12688,6 @@ type ImportKeyMaterialInput struct {
 	// with the public wrapping key that GetParametersForImport returned, using
 	// the wrapping algorithm that you specified in the same GetParametersForImport
 	// request.
-	//
 	// EncryptedKeyMaterial is automatically base64 encoded/decoded by the SDK.
 	//
 	// EncryptedKeyMaterial is a required field
@@ -11446,17 +12701,16 @@ type ImportKeyMaterialInput struct {
 	// The import token that you received in the response to a previous GetParametersForImport
 	// request. It must be from the same response that contained the public key
 	// that you used to encrypt the key material.
-	//
 	// ImportToken is automatically base64 encoded/decoded by the SDK.
 	//
 	// ImportToken is a required field
 	ImportToken []byte `min:"1" type:"blob" required:"true"`
 
-	// The identifier of the symmetric CMK that receives the imported key material.
-	// The CMK's Origin must be EXTERNAL. This must be the same CMK specified in
-	// the KeyID parameter of the corresponding GetParametersForImport request.
+	// The identifier of the symmetric KMS key that receives the imported key material.
+	// The KMS key's Origin must be EXTERNAL. This must be the same KMS key specified
+	// in the KeyID parameter of the corresponding GetParametersForImport request.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -11464,24 +12718,32 @@ type ImportKeyMaterialInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// The time at which the imported key material expires. When the key material
-	// expires, AWS KMS deletes the key material and the CMK becomes unusable. You
+	// expires, KMS deletes the key material and the KMS key becomes unusable. You
 	// must omit this parameter when the ExpirationModel parameter is set to KEY_MATERIAL_DOES_NOT_EXPIRE.
 	// Otherwise it is required.
 	ValidTo *time.Time `type:"timestamp"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImportKeyMaterialInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImportKeyMaterialInput) GoString() string {
 	return s.String()
 }
@@ -11548,19 +12810,27 @@ type ImportKeyMaterialOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImportKeyMaterialOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ImportKeyMaterialOutput) GoString() string {
 	return s.String()
 }
 
-// The request was rejected because the specified CMK cannot decrypt the data.
-// The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-// must identify the same CMK that was used to encrypt the ciphertext.
+// The request was rejected because the specified KMS key cannot decrypt the
+// data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+// must identify the same KMS key that was used to encrypt the ciphertext.
 type IncorrectKeyException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -11568,12 +12838,20 @@ type IncorrectKeyException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectKeyException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectKeyException) GoString() string {
 	return s.String()
 }
@@ -11618,7 +12896,7 @@ func (s *IncorrectKeyException) RequestID() string {
 
 // The request was rejected because the key material in the request is, expired,
 // invalid, or is not the same key material that was previously imported into
-// this customer master key (CMK).
+// this KMS key.
 type IncorrectKeyMaterialException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -11626,12 +12904,20 @@ type IncorrectKeyMaterialException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectKeyMaterialException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectKeyMaterialException) GoString() string {
 	return s.String()
 }
@@ -11675,7 +12961,7 @@ func (s *IncorrectKeyMaterialException) RequestID() string {
 }
 
 // The request was rejected because the trust anchor certificate in the request
-// is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+// is not the trust anchor certificate for the specified CloudHSM cluster.
 //
 // When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 // you create the trust anchor certificate and save it in the customerCA.crt
@@ -11687,12 +12973,20 @@ type IncorrectTrustAnchorException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectTrustAnchorException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s IncorrectTrustAnchorException) GoString() string {
 	return s.String()
 }
@@ -11744,12 +13038,20 @@ type InternalException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InternalException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InternalException) GoString() string {
 	return s.String()
 }
@@ -11800,12 +13102,20 @@ type InvalidAliasNameException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidAliasNameException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidAliasNameException) GoString() string {
 	return s.String()
 }
@@ -11857,12 +13167,20 @@ type InvalidArnException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidArnException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidArnException) GoString() string {
 	return s.String()
 }
@@ -11910,8 +13228,8 @@ func (s *InvalidArnException) RequestID() string {
 // the ciphertext, such as the encryption context, is corrupted, missing, or
 // otherwise invalid.
 //
-// From the ImportKeyMaterial operation, the request was rejected because AWS
-// KMS could not decrypt the encrypted (wrapped) key material.
+// From the ImportKeyMaterial operation, the request was rejected because KMS
+// could not decrypt the encrypted (wrapped) key material.
 type InvalidCiphertextException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -11919,12 +13237,20 @@ type InvalidCiphertextException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidCiphertextException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidCiphertextException) GoString() string {
 	return s.String()
 }
@@ -11975,12 +13301,20 @@ type InvalidGrantIdException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidGrantIdException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidGrantIdException) GoString() string {
 	return s.String()
 }
@@ -12031,12 +13365,20 @@ type InvalidGrantTokenException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidGrantTokenException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidGrantTokenException) GoString() string {
 	return s.String()
 }
@@ -12080,7 +13422,7 @@ func (s *InvalidGrantTokenException) RequestID() string {
 }
 
 // The request was rejected because the provided import token is invalid or
-// is associated with a different customer master key (CMK).
+// is associated with a different KMS key.
 type InvalidImportTokenException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12088,12 +13430,20 @@ type InvalidImportTokenException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidImportTokenException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidImportTokenException) GoString() string {
 	return s.String()
 }
@@ -12138,17 +13488,18 @@ func (s *InvalidImportTokenException) RequestID() string {
 
 // The request was rejected for one of the following reasons:
 //
-//    * The KeyUsage value of the CMK is incompatible with the API operation.
+//    * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //    * The encryption algorithm or signing algorithm specified for the operation
-//    is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//    is incompatible with the type of key material in the KMS key (KeySpec).
 //
 // For encrypting, decrypting, re-encrypting, and generating data keys, the
 // KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-// must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+// must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+// operation.
 //
-// To find the encryption or signing algorithms supported for a particular CMK,
-// use the DescribeKey operation.
+// To find the encryption or signing algorithms supported for a particular KMS
+// key, use the DescribeKey operation.
 type InvalidKeyUsageException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12156,12 +13507,20 @@ type InvalidKeyUsageException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidKeyUsageException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidKeyUsageException) GoString() string {
 	return s.String()
 }
@@ -12213,12 +13572,20 @@ type InvalidMarkerException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidMarkerException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidMarkerException) GoString() string {
 	return s.String()
 }
@@ -12264,9 +13631,9 @@ func (s *InvalidMarkerException) RequestID() string {
 // The request was rejected because the state of the specified resource is not
 // valid for this request.
 //
-// For more information about how key state affects the use of a CMK, see How
-// Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide .
+// For more information about how key state affects the use of a KMS key, see
+// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide .
 type InvalidStateException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12274,12 +13641,20 @@ type InvalidStateException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidStateException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidStateException) GoString() string {
 	return s.String()
 }
@@ -12324,7 +13699,7 @@ func (s *InvalidStateException) RequestID() string {
 
 // The request was rejected because the signature verification failed. Signature
 // verification fails when it cannot confirm that signature was produced by
-// signing the specified message with the specified CMK and signing algorithm.
+// signing the specified message with the specified KMS key and signing algorithm.
 type KMSInvalidSignatureException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12332,12 +13707,20 @@ type KMSInvalidSignatureException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KMSInvalidSignatureException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KMSInvalidSignatureException) GoString() string {
 	return s.String()
 }
@@ -12391,12 +13774,20 @@ type KeyListEntry struct {
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyListEntry) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyListEntry) GoString() string {
 	return s.String()
 }
@@ -12413,108 +13804,169 @@ func (s *KeyListEntry) SetKeyId(v string) *KeyListEntry {
 	return s
 }
 
-// Contains metadata about a customer master key (CMK).
+// Contains metadata about a KMS key.
 //
 // This data type is used as a response element for the CreateKey and DescribeKey
 // operations.
 type KeyMetadata struct {
 	_ struct{} `type:"structure"`
 
-	// The twelve-digit account ID of the AWS account that owns the CMK.
+	// The twelve-digit account ID of the Amazon Web Services account that owns
+	// the KMS key.
 	AWSAccountId *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the CMK. For examples, see AWS Key Management
-	// Service (AWS KMS) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms)
-	// in the Example ARNs section of the AWS General Reference.
+	// The Amazon Resource Name (ARN) of the KMS key. For examples, see Key Management
+	// Service (KMS) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
 	Arn *string `min:"20" type:"string"`
 
-	// The cluster ID of the AWS CloudHSM cluster that contains the key material
-	// for the CMK. When you create a CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-	// AWS KMS creates the key material for the CMK in the associated AWS CloudHSM
-	// cluster. This value is present only when the CMK is created in a custom key
-	// store.
+	// The cluster ID of the CloudHSM cluster that contains the key material for
+	// the KMS key. When you create a KMS key in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+	// KMS creates the key material for the KMS key in the associated CloudHSM cluster.
+	// This value is present only when the KMS key is created in a custom key store.
 	CloudHsmClusterId *string `min:"19" type:"string"`
 
-	// The date and time when the CMK was created.
+	// The date and time when the KMS key was created.
 	CreationDate *time.Time `type:"timestamp"`
 
 	// A unique identifier for the custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// that contains the CMK. This value is present only when the CMK is created
-	// in a custom key store.
+	// that contains the KMS key. This value is present only when the KMS key is
+	// created in a custom key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
-	// Describes the type of key material in the CMK.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
+	// Instead, use the KeySpec field.
+	//
+	// The KeySpec and CustomerMasterKeySpec fields have the same value. We recommend
+	// that you use the KeySpec field in your code. However, to avoid breaking changes,
+	// KMS will support both fields.
+	//
+	// Deprecated: This field has been deprecated. Instead, use the KeySpec field.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
 
-	// The date and time after which AWS KMS deletes the CMK. This value is present
-	// only when KeyState is PendingDeletion.
+	// The date and time after which KMS deletes this KMS key. This value is present
+	// only when the KMS key is scheduled for deletion, that is, when its KeyState
+	// is PendingDeletion.
+	//
+	// When the primary key in a multi-Region key is scheduled for deletion but
+	// still has replica keys, its key state is PendingReplicaDeletion and the length
+	// of its waiting period is displayed in the PendingDeletionWindowInDays field.
 	DeletionDate *time.Time `type:"timestamp"`
 
-	// The description of the CMK.
+	// The description of the KMS key.
 	Description *string `type:"string"`
 
-	// Specifies whether the CMK is enabled. When KeyState is Enabled this value
+	// Specifies whether the KMS key is enabled. When KeyState is Enabled this value
 	// is true, otherwise it is false.
 	Enabled *bool `type:"boolean"`
 
-	// The encryption algorithms that the CMK supports. You cannot use the CMK with
-	// other encryption algorithms within AWS KMS.
+	// The encryption algorithms that the KMS key supports. You cannot use the KMS
+	// key with other encryption algorithms within KMS.
 	//
-	// This field appears only when the KeyUsage of the CMK is ENCRYPT_DECRYPT.
+	// This value is present only when the KeyUsage of the KMS key is ENCRYPT_DECRYPT.
 	EncryptionAlgorithms []*string `type:"list"`
 
-	// Specifies whether the CMK's key material expires. This value is present only
-	// when Origin is EXTERNAL, otherwise this value is omitted.
+	// Specifies whether the KMS key's key material expires. This value is present
+	// only when Origin is EXTERNAL, otherwise this value is omitted.
 	ExpirationModel *string `type:"string" enum:"ExpirationModelType"`
 
-	// The globally unique identifier for the CMK.
+	// The globally unique identifier for the KMS key.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The manager of the CMK. CMKs in your AWS account are either customer managed
-	// or AWS managed. For more information about the difference, see Customer Master
-	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
-	// in the AWS Key Management Service Developer Guide.
+	// The manager of the KMS key. KMS keys in your Amazon Web Services account
+	// are either customer managed or Amazon Web Services managed. For more information
+	// about the difference, see KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys)
+	// in the Key Management Service Developer Guide.
 	KeyManager *string `type:"string" enum:"KeyManagerType"`
 
-	// The current status of the CMK.
+	// Describes the type of key material in the KMS key.
+	KeySpec *string `type:"string" enum:"KeySpec"`
+
+	// The current status of the KMS key.
 	//
-	// For more information about how key state affects the use of a CMK, see Key
-	// state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide.
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide.
 	KeyState *string `type:"string" enum:"KeyState"`
 
 	// The cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// for which you can use the CMK.
+	// for which you can use the KMS key.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
-	// The source of the CMK's key material. When this value is AWS_KMS, AWS KMS
-	// created the key material. When this value is EXTERNAL, the key material was
-	// imported from your existing key management infrastructure or the CMK lacks
-	// key material. When this value is AWS_CLOUDHSM, the key material was created
-	// in the AWS CloudHSM cluster associated with a custom key store.
+	// Indicates whether the KMS key is a multi-Region (True) or regional (False)
+	// key. This value is True for multi-Region primary and replica keys and False
+	// for regional KMS keys.
+	//
+	// For more information about multi-Region keys, see Using multi-Region keys
+	// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+	// in the Key Management Service Developer Guide.
+	MultiRegion *bool `type:"boolean"`
+
+	// Lists the primary and replica keys in same multi-Region key. This field is
+	// present only when the value of the MultiRegion field is True.
+	//
+	// For more information about any listed KMS key, use the DescribeKey operation.
+	//
+	//    * MultiRegionKeyType indicates whether the KMS key is a PRIMARY or REPLICA
+	//    key.
+	//
+	//    * PrimaryKey displays the key ARN and Region of the primary key. This
+	//    field displays the current KMS key if it is the primary key.
+	//
+	//    * ReplicaKeys displays the key ARNs and Regions of all replica keys. This
+	//    field includes the current KMS key if it is a replica key.
+	MultiRegionConfiguration *MultiRegionConfiguration `type:"structure"`
+
+	// The source of the key material for the KMS key. When this value is AWS_KMS,
+	// KMS created the key material. When this value is EXTERNAL, the key material
+	// was imported or the KMS key doesn't have any key material. When this value
+	// is AWS_CLOUDHSM, the key material was created in the CloudHSM cluster associated
+	// with a custom key store.
 	Origin *string `type:"string" enum:"OriginType"`
 
-	// The signing algorithms that the CMK supports. You cannot use the CMK with
-	// other signing algorithms within AWS KMS.
+	// The waiting period before the primary key in a multi-Region key is deleted.
+	// This waiting period begins when the last of its replica keys is deleted.
+	// This value is present only when the KeyState of the KMS key is PendingReplicaDeletion.
+	// That indicates that the KMS key is the primary key in a multi-Region key,
+	// it is scheduled for deletion, and it still has existing replica keys.
 	//
-	// This field appears only when the KeyUsage of the CMK is SIGN_VERIFY.
+	// When a single-Region KMS key or a multi-Region replica key is scheduled for
+	// deletion, its deletion date is displayed in the DeletionDate field. However,
+	// when the primary key in a multi-Region key is scheduled for deletion, its
+	// waiting period doesn't begin until all of its replica keys are deleted. This
+	// value displays that waiting period. When the last replica key in the multi-Region
+	// key is deleted, the KeyState of the scheduled primary key changes from PendingReplicaDeletion
+	// to PendingDeletion and the deletion date appears in the DeletionDate field.
+	PendingDeletionWindowInDays *int64 `min:"1" type:"integer"`
+
+	// The signing algorithms that the KMS key supports. You cannot use the KMS
+	// key with other signing algorithms within KMS.
+	//
+	// This field appears only when the KeyUsage of the KMS key is SIGN_VERIFY.
 	SigningAlgorithms []*string `type:"list"`
 
 	// The time at which the imported key material expires. When the key material
-	// expires, AWS KMS deletes the key material and the CMK becomes unusable. This
-	// value is present only for CMKs whose Origin is EXTERNAL and whose ExpirationModel
+	// expires, KMS deletes the key material and the KMS key becomes unusable. This
+	// value is present only for KMS keys whose Origin is EXTERNAL and whose ExpirationModel
 	// is KEY_MATERIAL_EXPIRES, otherwise this value is omitted.
 	ValidTo *time.Time `type:"timestamp"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyMetadata) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyMetadata) GoString() string {
 	return s.String()
 }
@@ -12597,6 +14049,12 @@ func (s *KeyMetadata) SetKeyManager(v string) *KeyMetadata {
 	return s
 }
 
+// SetKeySpec sets the KeySpec field's value.
+func (s *KeyMetadata) SetKeySpec(v string) *KeyMetadata {
+	s.KeySpec = &v
+	return s
+}
+
 // SetKeyState sets the KeyState field's value.
 func (s *KeyMetadata) SetKeyState(v string) *KeyMetadata {
 	s.KeyState = &v
@@ -12609,9 +14067,27 @@ func (s *KeyMetadata) SetKeyUsage(v string) *KeyMetadata {
 	return s
 }
 
+// SetMultiRegion sets the MultiRegion field's value.
+func (s *KeyMetadata) SetMultiRegion(v bool) *KeyMetadata {
+	s.MultiRegion = &v
+	return s
+}
+
+// SetMultiRegionConfiguration sets the MultiRegionConfiguration field's value.
+func (s *KeyMetadata) SetMultiRegionConfiguration(v *MultiRegionConfiguration) *KeyMetadata {
+	s.MultiRegionConfiguration = v
+	return s
+}
+
 // SetOrigin sets the Origin field's value.
 func (s *KeyMetadata) SetOrigin(v string) *KeyMetadata {
 	s.Origin = &v
+	return s
+}
+
+// SetPendingDeletionWindowInDays sets the PendingDeletionWindowInDays field's value.
+func (s *KeyMetadata) SetPendingDeletionWindowInDays(v int64) *KeyMetadata {
+	s.PendingDeletionWindowInDays = &v
 	return s
 }
 
@@ -12627,8 +14103,8 @@ func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
 	return s
 }
 
-// The request was rejected because the specified CMK was not available. You
-// can retry the request.
+// The request was rejected because the specified KMS key was not available.
+// You can retry the request.
 type KeyUnavailableException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12636,12 +14112,20 @@ type KeyUnavailableException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyUnavailableException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s KeyUnavailableException) GoString() string {
 	return s.String()
 }
@@ -12686,7 +14170,7 @@ func (s *KeyUnavailableException) RequestID() string {
 
 // The request was rejected because a quota was exceeded. For more information,
 // see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 type LimitExceededException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12694,12 +14178,20 @@ type LimitExceededException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LimitExceededException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LimitExceededException) GoString() string {
 	return s.String()
 }
@@ -12745,13 +14237,13 @@ func (s *LimitExceededException) RequestID() string {
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
 
-	// Lists only aliases that are associated with the specified CMK. Enter a CMK
-	// in your AWS account.
+	// Lists only aliases that are associated with the specified KMS key. Enter
+	// a KMS key in your Amazon Web Services account.
 	//
 	// This parameter is optional. If you omit it, ListAliases returns all aliases
 	// in the account and Region.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -12759,11 +14251,11 @@ type ListAliasesInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	KeyId *string `min:"1" type:"string"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -12776,12 +14268,20 @@ type ListAliasesInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAliasesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAliasesInput) GoString() string {
 	return s.String()
 }
@@ -12840,12 +14340,20 @@ type ListAliasesOutput struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAliasesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAliasesOutput) GoString() string {
 	return s.String()
 }
@@ -12879,11 +14387,10 @@ type ListGrantsInput struct {
 	// for the grant.
 	GranteePrincipal *string `min:"1" type:"string"`
 
-	// Returns only grants for the specified customer master key (CMK). This parameter
-	// is required.
+	// Returns only grants for the specified KMS key. This parameter is required.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify
-	// a CMK in a different AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -12891,13 +14398,13 @@ type ListGrantsInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -12910,12 +14417,20 @@ type ListGrantsInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListGrantsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListGrantsInput) GoString() string {
 	return s.String()
 }
@@ -12995,12 +14510,20 @@ type ListGrantsResponse struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListGrantsResponse) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListGrantsResponse) GoString() string {
 	return s.String()
 }
@@ -13026,9 +14549,9 @@ func (s *ListGrantsResponse) SetTruncated(v bool) *ListGrantsResponse {
 type ListKeyPoliciesInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Gets the names of key policies for the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13036,13 +14559,13 @@ type ListKeyPoliciesInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13057,12 +14580,20 @@ type ListKeyPoliciesInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeyPoliciesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeyPoliciesInput) GoString() string {
 	return s.String()
 }
@@ -13124,12 +14655,20 @@ type ListKeyPoliciesOutput struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeyPoliciesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeyPoliciesOutput) GoString() string {
 	return s.String()
 }
@@ -13156,7 +14695,7 @@ type ListKeysInput struct {
 	_ struct{} `type:"structure"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13169,12 +14708,20 @@ type ListKeysInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeysInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeysInput) GoString() string {
 	return s.String()
 }
@@ -13210,7 +14757,7 @@ func (s *ListKeysInput) SetMarker(v string) *ListKeysInput {
 type ListKeysOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of customer master keys (CMKs).
+	// A list of KMS keys.
 	Keys []*KeyListEntry `type:"list"`
 
 	// When Truncated is true, this element is present and contains the value to
@@ -13224,12 +14771,20 @@ type ListKeysOutput struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeysOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListKeysOutput) GoString() string {
 	return s.String()
 }
@@ -13255,9 +14810,9 @@ func (s *ListKeysOutput) SetTruncated(v bool) *ListKeysOutput {
 type ListResourceTagsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Gets tags on the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13265,13 +14820,13 @@ type ListResourceTagsInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13287,12 +14842,20 @@ type ListResourceTagsInput struct {
 	Marker *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListResourceTagsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListResourceTagsInput) GoString() string {
 	return s.String()
 }
@@ -13347,6 +14910,10 @@ type ListResourceTagsOutput struct {
 	NextMarker *string `min:"1" type:"string"`
 
 	// A list of tags. Each tag consists of a tag key and a tag value.
+	//
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
 	Tags []*Tag `type:"list"`
 
 	// A flag that indicates whether there are more items in the list. When this
@@ -13356,12 +14923,20 @@ type ListResourceTagsOutput struct {
 	Truncated *bool `type:"boolean"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListResourceTagsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListResourceTagsOutput) GoString() string {
 	return s.String()
 }
@@ -13388,7 +14963,7 @@ type ListRetirableGrantsInput struct {
 	_ struct{} `type:"structure"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13401,25 +14976,33 @@ type ListRetirableGrantsInput struct {
 	Marker *string `min:"1" type:"string"`
 
 	// The retiring principal for which to list grants. Enter a principal in your
-	// AWS account.
+	// Amazon Web Services account.
 	//
 	// To specify the retiring principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, federated users, and assumed role users. For examples of the ARN syntax
-	// for specifying a principal, see AWS Identity and Access Management (IAM)
-	// (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, federated users,
+	// and assumed role users. For examples of the ARN syntax for specifying a principal,
+	// see Amazon Web Services Identity and Access Management (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
 	// in the Example ARNs section of the Amazon Web Services General Reference.
 	//
 	// RetiringPrincipal is a required field
 	RetiringPrincipal *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListRetirableGrantsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListRetirableGrantsInput) GoString() string {
 	return s.String()
 }
@@ -13473,12 +15056,20 @@ type MalformedPolicyDocumentException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MalformedPolicyDocumentException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s MalformedPolicyDocumentException) GoString() string {
 	return s.String()
 }
@@ -13521,6 +15112,103 @@ func (s *MalformedPolicyDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+// Describes the configuration of this multi-Region key. This field appears
+// only when the KMS key is a primary or replica of a multi-Region key.
+//
+// For more information about any listed KMS key, use the DescribeKey operation.
+type MultiRegionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether the KMS key is a PRIMARY or REPLICA key.
+	MultiRegionKeyType *string `type:"string" enum:"MultiRegionKeyType"`
+
+	// Displays the key ARN and Region of the primary key. This field includes the
+	// current KMS key if it is the primary key.
+	PrimaryKey *MultiRegionKey `type:"structure"`
+
+	// displays the key ARNs and Regions of all replica keys. This field includes
+	// the current KMS key if it is a replica key.
+	ReplicaKeys []*MultiRegionKey `type:"list"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MultiRegionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MultiRegionConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetMultiRegionKeyType sets the MultiRegionKeyType field's value.
+func (s *MultiRegionConfiguration) SetMultiRegionKeyType(v string) *MultiRegionConfiguration {
+	s.MultiRegionKeyType = &v
+	return s
+}
+
+// SetPrimaryKey sets the PrimaryKey field's value.
+func (s *MultiRegionConfiguration) SetPrimaryKey(v *MultiRegionKey) *MultiRegionConfiguration {
+	s.PrimaryKey = v
+	return s
+}
+
+// SetReplicaKeys sets the ReplicaKeys field's value.
+func (s *MultiRegionConfiguration) SetReplicaKeys(v []*MultiRegionKey) *MultiRegionConfiguration {
+	s.ReplicaKeys = v
+	return s
+}
+
+// Describes the primary or replica key in a multi-Region key.
+type MultiRegionKey struct {
+	_ struct{} `type:"structure"`
+
+	// Displays the key ARN of a primary or replica key of a multi-Region key.
+	Arn *string `min:"20" type:"string"`
+
+	// Displays the Amazon Web Services Region of a primary or replica key in a
+	// multi-Region key.
+	Region *string `min:"1" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MultiRegionKey) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s MultiRegionKey) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *MultiRegionKey) SetArn(v string) *MultiRegionKey {
+	s.Arn = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *MultiRegionKey) SetRegion(v string) *MultiRegionKey {
+	s.Region = &v
+	return s
+}
+
 // The request was rejected because the specified entity or resource could not
 // be found.
 type NotFoundException struct {
@@ -13530,12 +15218,20 @@ type NotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s NotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s NotFoundException) GoString() string {
 	return s.String()
 }
@@ -13583,21 +15279,22 @@ type PutKeyPolicyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
 	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	// section in the AWS Key Management Service Developer Guide.
+	// section in the Key Management Service Developer Guide.
 	//
 	// Use this parameter only when you intend to prevent the principal that is
-	// making the request from making a subsequent PutKeyPolicy request on the CMK.
+	// making the request from making a subsequent PutKeyPolicy request on the KMS
+	// key.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Sets the key policy on the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13605,34 +15302,34 @@ type PutKeyPolicyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The key policy to attach to the CMK.
+	// The key policy to attach to the KMS key.
 	//
 	// The key policy must meet the following criteria:
 	//
 	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
 	//    must allow the principal that is making the PutKeyPolicy request to make
-	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
-	//    the CMK becomes unmanageable. For more information, refer to the scenario
-	//    in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section of the AWS Key Management Service Developer Guide.
+	//    a subsequent PutKeyPolicy request on the KMS key. This reduces the risk
+	//    that the KMS key becomes unmanageable. For more information, refer to
+	//    the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the Key Management Service Developer Guide.
 	//
 	//    * Each statement in the key policy must contain one or more principals.
-	//    The principals in the key policy must exist and be visible to AWS KMS.
-	//    When you create a new AWS principal (for example, an IAM user or role),
-	//    you might need to enforce a delay before including the new principal in
-	//    a key policy because the new principal might not be immediately visible
-	//    to AWS KMS. For more information, see Changes that I make are not always
-	//    immediately visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the AWS Identity and Access Management User Guide.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Amazon Web Services Identity and Access Management User Guide.
 	//
 	// The key policy cannot exceed 32 kilobytes (32768 bytes). For more information,
 	// see Resource Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/resource-limits.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	//
 	// Policy is a required field
 	Policy *string `min:"1" type:"string" required:"true"`
@@ -13643,12 +15340,20 @@ type PutKeyPolicyInput struct {
 	PolicyName *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutKeyPolicyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutKeyPolicyInput) GoString() string {
 	return s.String()
 }
@@ -13709,12 +15414,20 @@ type PutKeyPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutKeyPolicyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PutKeyPolicyOutput) GoString() string {
 	return s.String()
 }
@@ -13723,43 +15436,43 @@ type ReEncryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext of the data to reencrypt.
-	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	//
 	// CiphertextBlob is a required field
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to reecrypt the
-	// data after it has decrypted it. The default value, SYMMETRIC_DEFAULT, represents
-	// the encryption algorithm used for symmetric CMKs.
+	// Specifies the encryption algorithm that KMS will use to reecrypt the data
+	// after it has decrypted it. The default value, SYMMETRIC_DEFAULT, represents
+	// the encryption algorithm used for symmetric KMS keys.
 	//
-	// This parameter is required only when the destination CMK is an asymmetric
-	// CMK.
+	// This parameter is required only when the destination KMS key is an asymmetric
+	// KMS key.
 	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies that encryption context to use when the reencrypting the data.
 	//
-	// A destination encryption context is valid only when the destination CMK is
-	// a symmetric CMK. The standard ciphertext format for asymmetric CMKs does
-	// not include fields for metadata.
+	// A destination encryption context is valid only when the destination KMS key
+	// is a symmetric KMS key. The standard ciphertext format for asymmetric KMS
+	// keys does not include fields for metadata.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	DestinationEncryptionContext map[string]*string `type:"map"`
 
-	// A unique identifier for the CMK that is used to reencrypt the data. Specify
-	// a symmetric or asymmetric CMK with a KeyUsage value of ENCRYPT_DECRYPT. To
-	// find the KeyUsage value of a CMK, use the DescribeKey operation.
+	// A unique identifier for the KMS key that is used to reencrypt the data. Specify
+	// a symmetric or asymmetric KMS key with a KeyUsage value of ENCRYPT_DECRYPT.
+	// To find the KeyUsage value of a KMS key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -13771,27 +15484,30 @@ type ReEncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// DestinationKeyId is a required field
 	DestinationKeyId *string `min:"1" type:"string" required:"true"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to decrypt the ciphertext
+	// Specifies the encryption algorithm that KMS will use to decrypt the ciphertext
 	// before it is reencrypted. The default value, SYMMETRIC_DEFAULT, represents
-	// the algorithm used for symmetric CMKs.
+	// the algorithm used for symmetric KMS keys.
 	//
 	// Specify the same algorithm that was used to encrypt the ciphertext. If you
 	// specify a different algorithm, the decrypt attempt fails.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK.
+	// asymmetric KMS key.
 	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context to use to decrypt the ciphertext. Enter
@@ -13801,25 +15517,26 @@ type ReEncryptInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	SourceEncryptionContext map[string]*string `type:"map"`
 
-	// Specifies the customer master key (CMK) that AWS KMS will use to decrypt
-	// the ciphertext before it is re-encrypted. Enter a key ID of the CMK that
-	// was used to encrypt the ciphertext.
+	// Specifies the KMS key that KMS will use to decrypt the ciphertext before
+	// it is re-encrypted. Enter a key ID of the KMS key that was used to encrypt
+	// the ciphertext.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. If you used a symmetric CMK, AWS KMS can get the CMK from
-	// metadata that it adds to the symmetric ciphertext blob. However, it is always
-	// recommended as a best practice. This practice ensures that you use the CMK
-	// that you intend.
+	// asymmetric KMS key. If you used a symmetric KMS key, KMS can get the KMS
+	// key from metadata that it adds to the symmetric ciphertext blob. However,
+	// it is always recommended as a best practice. This practice ensures that you
+	// use the KMS key that you intend.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -13831,17 +15548,25 @@ type ReEncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	SourceKeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReEncryptInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReEncryptInput) GoString() string {
 	return s.String()
 }
@@ -13922,9 +15647,8 @@ func (s *ReEncryptInput) SetSourceKeyId(v string) *ReEncryptInput {
 type ReEncryptOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The reencrypted data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
-	//
+	// The reencrypted data. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
@@ -13932,23 +15656,31 @@ type ReEncryptOutput struct {
 	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to reencrypt the data.
+	// of the KMS key that was used to reencrypt the data.
 	KeyId *string `min:"1" type:"string"`
 
 	// The encryption algorithm that was used to decrypt the ciphertext before it
 	// was reencrypted.
 	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
-	// Unique identifier of the CMK used to originally encrypt the data.
+	// Unique identifier of the KMS key used to originally encrypt the data.
 	SourceKeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReEncryptOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ReEncryptOutput) GoString() string {
 	return s.String()
 }
@@ -13983,30 +15715,310 @@ func (s *ReEncryptOutput) SetSourceKeyId(v string) *ReEncryptOutput {
 	return s
 }
 
+type ReplicateKeyInput struct {
+	_ struct{} `type:"structure"`
+
+	// A flag to indicate whether to bypass the key policy lockout safety check.
+	//
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
+	// Do not set this value to true indiscriminately.
+	//
+	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	// section in the Key Management Service Developer Guide.
+	//
+	// Use this parameter only when you intend to prevent the principal that is
+	// making the request from making a subsequent PutKeyPolicy request on the KMS
+	// key.
+	//
+	// The default value is false.
+	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
+
+	// A description of the KMS key. The default value is an empty string (no description).
+	//
+	// The description is not a shared property of multi-Region keys. You can specify
+	// the same description or a different description for each key in a set of
+	// related multi-Region keys. KMS does not synchronize this property.
+	Description *string `type:"string"`
+
+	// Identifies the multi-Region primary key that is being replicated. To determine
+	// whether a KMS key is a multi-Region primary key, use the DescribeKey operation
+	// to check the value of the MultiRegionKeyType property.
+	//
+	// Specify the key ID or key ARN of a multi-Region primary key.
+	//
+	// For example:
+	//
+	//    * Key ID: mrk-1234abcd12ab34cd56ef1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
+	//
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// The key policy to attach to the KMS key. This parameter is optional. If you
+	// do not provide a key policy, KMS attaches the default key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
+	// to the KMS key.
+	//
+	// The key policy is not a shared property of multi-Region keys. You can specify
+	// the same key policy or a different key policy for each key in a set of related
+	// multi-Region keys. KMS does not synchronize this property.
+	//
+	// If you provide a key policy, it must meet the following criteria:
+	//
+	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
+	//    must give the caller kms:PutKeyPolicy permission on the replica key. This
+	//    reduces the risk that the KMS key becomes unmanageable. For more information,
+	//    refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the Key Management Service Developer Guide .
+	//
+	//    * Each statement in the key policy must contain one or more principals.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Identity and Access Management User Guide .
+	//
+	//    * The key policy size quota is 32 kilobytes (32768 bytes).
+	Policy *string `min:"1" type:"string"`
+
+	// The Region ID of the Amazon Web Services Region for this replica key.
+	//
+	// Enter the Region ID, such as us-east-1 or ap-southeast-2. For a list of Amazon
+	// Web Services Regions in which KMS is supported, see KMS service endpoints
+	// (https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region) in the
+	// Amazon Web Services General Reference.
+	//
+	// The replica must be in a different Amazon Web Services Region than its primary
+	// key and other replicas of that primary key, but in the same Amazon Web Services
+	// partition. KMS must be available in the replica Region. If the Region is
+	// not enabled by default, the Amazon Web Services account must be enabled in
+	// the Region.
+	//
+	// For information about Amazon Web Services partitions, see Amazon Resource
+	// Names (ARNs) in the Amazon Web Services General Reference. (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// For information about enabling and disabling Regions, see Enabling a Region
+	// (https://docs.aws.amazon.com/general/latest/gr/rande-manage.html#rande-manage-enable)
+	// and Disabling a Region (https://docs.aws.amazon.com/general/latest/gr/rande-manage.html#rande-manage-disable)
+	// in the Amazon Web Services General Reference.
+	//
+	// ReplicaRegion is a required field
+	ReplicaRegion *string `min:"1" type:"string" required:"true"`
+
+	// Assigns one or more tags to the replica key. Use this parameter to tag the
+	// KMS key when it is created. To tag an existing KMS key, use the TagResource
+	// operation.
+	//
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
+	//
+	// To use this parameter, you must have kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
+	// permission in an IAM policy.
+	//
+	// Tags are not a shared property of multi-Region keys. You can specify the
+	// same tags or different tags for each key in a set of related multi-Region
+	// keys. KMS does not synchronize this property.
+	//
+	// Each tag consists of a tag key and a tag value. Both the tag key and the
+	// tag value are required, but the tag value can be an empty (null) string.
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
+	// the current tag value with the specified one.
+	//
+	// When you add tags to an Amazon Web Services resource, Amazon Web Services
+	// generates a cost allocation report with usage and costs aggregated by tags.
+	// Tags can also be used to control access to a KMS key. For details, see Tagging
+	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+	Tags []*Tag `type:"list"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicateKeyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicateKeyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplicateKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplicateKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.ReplicaRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicaRegion"))
+	}
+	if s.ReplicaRegion != nil && len(*s.ReplicaRegion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ReplicaRegion", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBypassPolicyLockoutSafetyCheck sets the BypassPolicyLockoutSafetyCheck field's value.
+func (s *ReplicateKeyInput) SetBypassPolicyLockoutSafetyCheck(v bool) *ReplicateKeyInput {
+	s.BypassPolicyLockoutSafetyCheck = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ReplicateKeyInput) SetDescription(v string) *ReplicateKeyInput {
+	s.Description = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *ReplicateKeyInput) SetKeyId(v string) *ReplicateKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *ReplicateKeyInput) SetPolicy(v string) *ReplicateKeyInput {
+	s.Policy = &v
+	return s
+}
+
+// SetReplicaRegion sets the ReplicaRegion field's value.
+func (s *ReplicateKeyInput) SetReplicaRegion(v string) *ReplicateKeyInput {
+	s.ReplicaRegion = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ReplicateKeyInput) SetTags(v []*Tag) *ReplicateKeyInput {
+	s.Tags = v
+	return s
+}
+
+type ReplicateKeyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Displays details about the new replica key, including its Amazon Resource
+	// Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
+	// and key state (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
+	// It also includes the ARN and Amazon Web Services Region of its primary key
+	// and other replica keys.
+	ReplicaKeyMetadata *KeyMetadata `type:"structure"`
+
+	// The key policy of the new replica key. The value is a key policy document
+	// in JSON format.
+	ReplicaPolicy *string `min:"1" type:"string"`
+
+	// The tags on the new replica key. The value is a list of tag key and tag value
+	// pairs.
+	ReplicaTags []*Tag `type:"list"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicateKeyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicateKeyOutput) GoString() string {
+	return s.String()
+}
+
+// SetReplicaKeyMetadata sets the ReplicaKeyMetadata field's value.
+func (s *ReplicateKeyOutput) SetReplicaKeyMetadata(v *KeyMetadata) *ReplicateKeyOutput {
+	s.ReplicaKeyMetadata = v
+	return s
+}
+
+// SetReplicaPolicy sets the ReplicaPolicy field's value.
+func (s *ReplicateKeyOutput) SetReplicaPolicy(v string) *ReplicateKeyOutput {
+	s.ReplicaPolicy = &v
+	return s
+}
+
+// SetReplicaTags sets the ReplicaTags field's value.
+func (s *ReplicateKeyOutput) SetReplicaTags(v []*Tag) *ReplicateKeyOutput {
+	s.ReplicaTags = v
+	return s
+}
+
 type RetireGrantInput struct {
 	_ struct{} `type:"structure"`
 
-	// Unique identifier of the grant to retire. The grant ID is returned in the
-	// response to a CreateGrant operation.
+	// Identifies the grant to retire. To get the grant ID, use CreateGrant, ListGrants,
+	// or ListRetirableGrants.
 	//
 	//    * Grant ID Example - 0123456789012345678901234567890123456789012345678901234567890123
 	GrantId *string `min:"1" type:"string"`
 
-	// Token that identifies the grant to be retired.
+	// Identifies the grant to be retired. You can use a grant token to identify
+	// a new grant even before it has achieved eventual consistency.
+	//
+	// Only the CreateGrant operation returns a grant token. For details, see Grant
+	// token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Eventual consistency (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-eventual-consistency)
+	// in the Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the CMK associated with the grant.
+	// The key ARN KMS key associated with the grant. To find the key ARN, use the
+	// ListKeys operation.
 	//
 	// For example: arn:aws:kms:us-east-2:444455556666:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	KeyId *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RetireGrantInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RetireGrantInput) GoString() string {
 	return s.String()
 }
@@ -14052,12 +16064,20 @@ type RetireGrantOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RetireGrantOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RetireGrantOutput) GoString() string {
 	return s.String()
 }
@@ -14065,15 +16085,17 @@ func (s RetireGrantOutput) GoString() string {
 type RevokeGrantInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifier of the grant to be revoked.
+	// Identifies the grant to revoke. To get the grant ID, use CreateGrant, ListGrants,
+	// or ListRetirableGrants.
 	//
 	// GrantId is a required field
 	GrantId *string `min:"1" type:"string" required:"true"`
 
-	// A unique identifier for the customer master key associated with the grant.
+	// A unique identifier for the KMS key associated with the grant. To get the
+	// key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify
-	// a CMK in a different AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -14081,18 +16103,26 @@ type RevokeGrantInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RevokeGrantInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RevokeGrantInput) GoString() string {
 	return s.String()
 }
@@ -14135,12 +16165,20 @@ type RevokeGrantOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RevokeGrantOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RevokeGrantOutput) GoString() string {
 	return s.String()
 }
@@ -14148,9 +16186,9 @@ func (s RevokeGrantOutput) GoString() string {
 type ScheduleKeyDeletionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The unique identifier of the customer master key (CMK) to delete.
+	// The unique identifier of the KMS key to delete.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14158,25 +16196,37 @@ type ScheduleKeyDeletionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// The waiting period, specified in number of days. After the waiting period
-	// ends, AWS KMS deletes the customer master key (CMK).
+	// ends, KMS deletes the KMS key.
+	//
+	// If the KMS key is a multi-Region primary key with replicas, the waiting period
+	// begins when the last of its replica keys is deleted. Otherwise, the waiting
+	// period begins immediately.
 	//
 	// This value is optional. If you include a value, it must be between 7 and
 	// 30, inclusive. If you do not include a value, it defaults to 30.
 	PendingWindowInDays *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduleKeyDeletionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduleKeyDeletionInput) GoString() string {
 	return s.String()
 }
@@ -14215,20 +16265,46 @@ func (s *ScheduleKeyDeletionInput) SetPendingWindowInDays(v int64) *ScheduleKeyD
 type ScheduleKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The date and time after which AWS KMS deletes the customer master key (CMK).
+	// The date and time after which KMS deletes the KMS key.
+	//
+	// If the KMS key is a multi-Region primary key with replica keys, this field
+	// does not appear. The deletion date for the primary key isn't known until
+	// its last replica key is deleted.
 	DeletionDate *time.Time `type:"timestamp"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK whose deletion is scheduled.
+	// of the KMS key whose deletion is scheduled.
 	KeyId *string `min:"1" type:"string"`
+
+	// The current status of the KMS key.
+	//
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide.
+	KeyState *string `type:"string" enum:"KeyState"`
+
+	// The waiting period before the KMS key is deleted.
+	//
+	// If the KMS key is a multi-Region primary key with replicas, the waiting period
+	// begins when the last of its replica keys is deleted. Otherwise, the waiting
+	// period begins immediately.
+	PendingWindowInDays *int64 `min:"1" type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduleKeyDeletionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ScheduleKeyDeletionOutput) GoString() string {
 	return s.String()
 }
@@ -14245,22 +16321,38 @@ func (s *ScheduleKeyDeletionOutput) SetKeyId(v string) *ScheduleKeyDeletionOutpu
 	return s
 }
 
+// SetKeyState sets the KeyState field's value.
+func (s *ScheduleKeyDeletionOutput) SetKeyState(v string) *ScheduleKeyDeletionOutput {
+	s.KeyState = &v
+	return s
+}
+
+// SetPendingWindowInDays sets the PendingWindowInDays field's value.
+func (s *ScheduleKeyDeletionOutput) SetPendingWindowInDays(v int64) *ScheduleKeyDeletionOutput {
+	s.PendingWindowInDays = &v
+	return s
+}
+
 type SignInput struct {
 	_ struct{} `type:"structure"`
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies an asymmetric CMK. AWS KMS uses the private key in the asymmetric
-	// CMK to sign the message. The KeyUsage type of the CMK must be SIGN_VERIFY.
-	// To find the KeyUsage of a CMK, use the DescribeKey operation.
+	// Identifies an asymmetric KMS key. KMS uses the private key in the asymmetric
+	// KMS key to sign the message. The KeyUsage type of the KMS key must be SIGN_VERIFY.
+	// To find the KeyUsage of a KMS key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -14272,8 +16364,8 @@ type SignInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -14281,34 +16373,46 @@ type SignInput struct {
 	// Specifies the message or message digest to sign. Messages can be 0-4096 bytes.
 	// To sign a larger message, provide the message digest.
 	//
-	// If you provide a message, AWS KMS generates a hash digest of the message
-	// and then signs it.
+	// If you provide a message, KMS generates a hash digest of the message and
+	// then signs it.
+	//
+	// Message is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by SignInput's
+	// String and GoString methods.
 	//
 	// Message is automatically base64 encoded/decoded by the SDK.
 	//
 	// Message is a required field
 	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
 
-	// Tells AWS KMS whether the value of the Message parameter is a message or
-	// message digest. The default value, RAW, indicates a message. To indicate
-	// a message digest, enter DIGEST.
+	// Tells KMS whether the value of the Message parameter is a message or message
+	// digest. The default value, RAW, indicates a message. To indicate a message
+	// digest, enter DIGEST.
 	MessageType *string `type:"string" enum:"MessageType"`
 
 	// Specifies the signing algorithm to use when signing the message.
 	//
 	// Choose an algorithm that is compatible with the type and size of the specified
-	// asymmetric CMK.
+	// asymmetric KMS key.
 	//
 	// SigningAlgorithm is a required field
 	SigningAlgorithm *string `type:"string" required:"true" enum:"SigningAlgorithmSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SignInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SignInput) GoString() string {
 	return s.String()
 }
@@ -14372,7 +16476,7 @@ type SignOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK that was used to sign the message.
+	// of the asymmetric KMS key that was used to sign the message.
 	KeyId *string `min:"1" type:"string"`
 
 	// The cryptographic signature that was generated for the message.
@@ -14386,9 +16490,8 @@ type SignOutput struct {
 	//    This is the most commonly used signature format and is appropriate for
 	//    most uses.
 	//
-	// When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise,
-	// it is not Base64-encoded.
-	//
+	// When you use the HTTP API or the Amazon Web Services CLI, the value is Base64-encoded.
+	// Otherwise, it is not Base64-encoded.
 	// Signature is automatically base64 encoded/decoded by the SDK.
 	Signature []byte `min:"1" type:"blob"`
 
@@ -14396,12 +16499,20 @@ type SignOutput struct {
 	SigningAlgorithm *string `type:"string" enum:"SigningAlgorithmSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SignOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s SignOutput) GoString() string {
 	return s.String()
 }
@@ -14429,7 +16540,7 @@ func (s *SignOutput) SetSigningAlgorithm(v string) *SignOutput {
 //
 // For information about the rules that apply to tag keys and tag values, see
 // User-Defined Tag Restrictions (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html)
-// in the AWS Billing and Cost Management User Guide.
+// in the Amazon Web Services Billing and Cost Management User Guide.
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -14444,12 +16555,20 @@ type Tag struct {
 	TagValue *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }
@@ -14493,12 +16612,20 @@ type TagException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagException) GoString() string {
 	return s.String()
 }
@@ -14544,9 +16671,9 @@ func (s *TagException) RequestID() string {
 type TagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a customer managed CMK in the account and Region.
+	// Identifies a customer managed key in the account and Region.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14554,7 +16681,7 @@ type TagResourceInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -14564,20 +16691,28 @@ type TagResourceInput struct {
 	// Each tag consists of a tag key and a tag value. The tag value can be an empty
 	// (null) string.
 	//
-	// You cannot have more than one tag on a CMK with the same tag key. If you
-	// specify an existing tag key with a different tag value, AWS KMS replaces
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
 	// the current tag value with the specified one.
 	//
 	// Tags is a required field
 	Tags []*Tag `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceInput) GoString() string {
 	return s.String()
 }
@@ -14627,12 +16762,20 @@ type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TagResourceOutput) GoString() string {
 	return s.String()
 }
@@ -14646,12 +16789,20 @@ type UnsupportedOperationException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnsupportedOperationException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnsupportedOperationException) GoString() string {
 	return s.String()
 }
@@ -14697,9 +16848,9 @@ func (s *UnsupportedOperationException) RequestID() string {
 type UntagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the CMK from which you are removing tags.
+	// Identifies the KMS key from which you are removing tags.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14707,7 +16858,7 @@ type UntagResourceInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -14718,12 +16869,20 @@ type UntagResourceInput struct {
 	TagKeys []*string `type:"list" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceInput) GoString() string {
 	return s.String()
 }
@@ -14763,12 +16922,20 @@ type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
 }
@@ -14776,22 +16943,23 @@ func (s UntagResourceOutput) GoString() string {
 type UpdateAliasInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the alias that is changing its CMK. This value must begin with
-	// alias/ followed by the alias name, such as alias/ExampleAlias. You cannot
+	// Identifies the alias that is changing its KMS key. This value must begin
+	// with alias/ followed by the alias name, such as alias/ExampleAlias. You cannot
 	// use UpdateAlias to change the alias name.
 	//
 	// AliasName is a required field
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	// Identifies the customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+	// Identifies the customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
 	// to associate with the alias. You don't have permission to associate an alias
-	// with an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+	// with an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 	//
-	// The CMK must be in the same AWS account and Region as the alias. Also, the
-	// new target CMK must be the same type as the current target CMK (both symmetric
-	// or both asymmetric) and they must have the same key usage.
+	// The KMS key must be in the same Amazon Web Services account and Region as
+	// the alias. Also, the new target KMS key must be the same type as the current
+	// target KMS key (both symmetric or both asymmetric) and they must have the
+	// same key usage.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14799,20 +16967,28 @@ type UpdateAliasInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
-	// To verify that the alias is mapped to the correct CMK, use ListAliases.
+	// To verify that the alias is mapped to the correct KMS key, use ListAliases.
 	//
 	// TargetKeyId is a required field
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAliasInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAliasInput) GoString() string {
 	return s.String()
 }
@@ -14855,12 +17031,20 @@ type UpdateAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAliasOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateAliasOutput) GoString() string {
 	return s.String()
 }
@@ -14868,7 +17052,7 @@ func (s UpdateAliasOutput) GoString() string {
 type UpdateCustomKeyStoreInput struct {
 	_ struct{} `type:"structure"`
 
-	// Associates the custom key store with a related AWS CloudHSM cluster.
+	// Associates the custom key store with a related CloudHSM cluster.
 	//
 	// Enter the cluster ID of the cluster that you used to create the custom key
 	// store or a cluster that shares a backup history and has the same cluster
@@ -14887,25 +17071,37 @@ type UpdateCustomKeyStoreInput struct {
 	// CustomKeyStoreId is a required field
 	CustomKeyStoreId *string `min:"1" type:"string" required:"true"`
 
-	// Enter the current password of the kmsuser crypto user (CU) in the AWS CloudHSM
+	// Enter the current password of the kmsuser crypto user (CU) in the CloudHSM
 	// cluster that is associated with the custom key store.
 	//
-	// This parameter tells AWS KMS the current password of the kmsuser crypto user
-	// (CU). It does not set or change the password of any users in the AWS CloudHSM
+	// This parameter tells KMS the current password of the kmsuser crypto user
+	// (CU). It does not set or change the password of any users in the CloudHSM
 	// cluster.
+	//
+	// KeyStorePassword is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by UpdateCustomKeyStoreInput's
+	// String and GoString methods.
 	KeyStorePassword *string `min:"7" type:"string" sensitive:"true"`
 
 	// Changes the friendly name of the custom key store to the value that you specify.
-	// The custom key store name must be unique in the AWS account.
+	// The custom key store name must be unique in the Amazon Web Services account.
 	NewCustomKeyStoreName *string `min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateCustomKeyStoreInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateCustomKeyStoreInput) GoString() string {
 	return s.String()
 }
@@ -14963,12 +17159,20 @@ type UpdateCustomKeyStoreOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateCustomKeyStoreOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateCustomKeyStoreOutput) GoString() string {
 	return s.String()
 }
@@ -14976,14 +17180,14 @@ func (s UpdateCustomKeyStoreOutput) GoString() string {
 type UpdateKeyDescriptionInput struct {
 	_ struct{} `type:"structure"`
 
-	// New description for the CMK.
+	// New description for the KMS key.
 	//
 	// Description is a required field
 	Description *string `type:"string" required:"true"`
 
-	// A unique identifier for the customer master key (CMK).
+	// Updates the description of the specified KMS key.
 	//
-	// Specify the key ID or the Amazon Resource Name (ARN) of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14991,18 +17195,26 @@ type UpdateKeyDescriptionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateKeyDescriptionInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateKeyDescriptionInput) GoString() string {
 	return s.String()
 }
@@ -15042,13 +17254,125 @@ type UpdateKeyDescriptionOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateKeyDescriptionOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UpdateKeyDescriptionOutput) GoString() string {
+	return s.String()
+}
+
+type UpdatePrimaryRegionInput struct {
+	_ struct{} `type:"structure"`
+
+	// Identifies the current primary key. When the operation completes, this KMS
+	// key will be a replica key.
+	//
+	// Specify the key ID or key ARN of a multi-Region primary key.
+	//
+	// For example:
+	//
+	//    * Key ID: mrk-1234abcd12ab34cd56ef1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
+	//
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// The Amazon Web Services Region of the new primary key. Enter the Region ID,
+	// such as us-east-1 or ap-southeast-2. There must be an existing replica key
+	// in this Region.
+	//
+	// When the operation completes, the multi-Region key in this Region will be
+	// the primary key.
+	//
+	// PrimaryRegion is a required field
+	PrimaryRegion *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdatePrimaryRegionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdatePrimaryRegionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePrimaryRegionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePrimaryRegionInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.PrimaryRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrimaryRegion"))
+	}
+	if s.PrimaryRegion != nil && len(*s.PrimaryRegion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PrimaryRegion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *UpdatePrimaryRegionInput) SetKeyId(v string) *UpdatePrimaryRegionInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPrimaryRegion sets the PrimaryRegion field's value.
+func (s *UpdatePrimaryRegionInput) SetPrimaryRegion(v string) *UpdatePrimaryRegionInput {
+	s.PrimaryRegion = &v
+	return s
+}
+
+type UpdatePrimaryRegionOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdatePrimaryRegionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdatePrimaryRegionOutput) GoString() string {
 	return s.String()
 }
 
@@ -15057,17 +17381,21 @@ type VerifyInput struct {
 
 	// A list of grant tokens.
 	//
-	// For more information, see Grant Tokens (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// Use a grant token when your permission to call this operation comes from
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the asymmetric CMK that will be used to verify the signature.
-	// This must be the same CMK that was used to generate the signature. If you
-	// specify a different CMK, the signature verification fails.
+	// Identifies the asymmetric KMS key that will be used to verify the signature.
+	// This must be the same KMS key that was used to generate the signature. If
+	// you specify a different KMS key, the signature verification fails.
 	//
-	// To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name,
-	// or alias ARN. When using an alias name, prefix it with "alias/". To specify
-	// a CMK in a different AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -15079,8 +17407,8 @@ type VerifyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -15093,14 +17421,18 @@ type VerifyInput struct {
 	// the signature verification fails. A message and its hash digest are considered
 	// to be the same message.
 	//
+	// Message is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by VerifyInput's
+	// String and GoString methods.
+	//
 	// Message is automatically base64 encoded/decoded by the SDK.
 	//
 	// Message is a required field
 	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
 
-	// Tells AWS KMS whether the value of the Message parameter is a message or
-	// message digest. The default value, RAW, indicates a message. To indicate
-	// a message digest, enter DIGEST.
+	// Tells KMS whether the value of the Message parameter is a message or message
+	// digest. The default value, RAW, indicates a message. To indicate a message
+	// digest, enter DIGEST.
 	//
 	// Use the DIGEST value only when the value of the Message parameter is a message
 	// digest. If you use the DIGEST value with a raw message, the security of the
@@ -15108,7 +17440,6 @@ type VerifyInput struct {
 	MessageType *string `type:"string" enum:"MessageType"`
 
 	// The signature that the Sign operation generated.
-	//
 	// Signature is automatically base64 encoded/decoded by the SDK.
 	//
 	// Signature is a required field
@@ -15121,12 +17452,20 @@ type VerifyInput struct {
 	SigningAlgorithm *string `type:"string" required:"true" enum:"SigningAlgorithmSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s VerifyInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s VerifyInput) GoString() string {
 	return s.String()
 }
@@ -15202,7 +17541,7 @@ type VerifyOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK that was used to verify the signature.
+	// of the asymmetric KMS key that was used to verify the signature.
 	KeyId *string `min:"1" type:"string"`
 
 	// A Boolean value that indicates whether the signature was verified. A value
@@ -15215,12 +17554,20 @@ type VerifyOutput struct {
 	SigningAlgorithm *string `type:"string" enum:"SigningAlgorithmSpec"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s VerifyOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s VerifyOutput) GoString() string {
 	return s.String()
 }
@@ -15544,6 +17891,49 @@ func KeyManagerType_Values() []string {
 }
 
 const (
+	// KeySpecRsa2048 is a KeySpec enum value
+	KeySpecRsa2048 = "RSA_2048"
+
+	// KeySpecRsa3072 is a KeySpec enum value
+	KeySpecRsa3072 = "RSA_3072"
+
+	// KeySpecRsa4096 is a KeySpec enum value
+	KeySpecRsa4096 = "RSA_4096"
+
+	// KeySpecEccNistP256 is a KeySpec enum value
+	KeySpecEccNistP256 = "ECC_NIST_P256"
+
+	// KeySpecEccNistP384 is a KeySpec enum value
+	KeySpecEccNistP384 = "ECC_NIST_P384"
+
+	// KeySpecEccNistP521 is a KeySpec enum value
+	KeySpecEccNistP521 = "ECC_NIST_P521"
+
+	// KeySpecEccSecgP256k1 is a KeySpec enum value
+	KeySpecEccSecgP256k1 = "ECC_SECG_P256K1"
+
+	// KeySpecSymmetricDefault is a KeySpec enum value
+	KeySpecSymmetricDefault = "SYMMETRIC_DEFAULT"
+)
+
+// KeySpec_Values returns all elements of the KeySpec enum
+func KeySpec_Values() []string {
+	return []string{
+		KeySpecRsa2048,
+		KeySpecRsa3072,
+		KeySpecRsa4096,
+		KeySpecEccNistP256,
+		KeySpecEccNistP384,
+		KeySpecEccNistP521,
+		KeySpecEccSecgP256k1,
+		KeySpecSymmetricDefault,
+	}
+}
+
+const (
+	// KeyStateCreating is a KeyState enum value
+	KeyStateCreating = "Creating"
+
 	// KeyStateEnabled is a KeyState enum value
 	KeyStateEnabled = "Enabled"
 
@@ -15556,18 +17946,27 @@ const (
 	// KeyStatePendingImport is a KeyState enum value
 	KeyStatePendingImport = "PendingImport"
 
+	// KeyStatePendingReplicaDeletion is a KeyState enum value
+	KeyStatePendingReplicaDeletion = "PendingReplicaDeletion"
+
 	// KeyStateUnavailable is a KeyState enum value
 	KeyStateUnavailable = "Unavailable"
+
+	// KeyStateUpdating is a KeyState enum value
+	KeyStateUpdating = "Updating"
 )
 
 // KeyState_Values returns all elements of the KeyState enum
 func KeyState_Values() []string {
 	return []string{
+		KeyStateCreating,
 		KeyStateEnabled,
 		KeyStateDisabled,
 		KeyStatePendingDeletion,
 		KeyStatePendingImport,
+		KeyStatePendingReplicaDeletion,
 		KeyStateUnavailable,
+		KeyStateUpdating,
 	}
 }
 
@@ -15600,6 +17999,22 @@ func MessageType_Values() []string {
 	return []string{
 		MessageTypeRaw,
 		MessageTypeDigest,
+	}
+}
+
+const (
+	// MultiRegionKeyTypePrimary is a MultiRegionKeyType enum value
+	MultiRegionKeyTypePrimary = "PRIMARY"
+
+	// MultiRegionKeyTypeReplica is a MultiRegionKeyType enum value
+	MultiRegionKeyTypeReplica = "REPLICA"
+)
+
+// MultiRegionKeyType_Values returns all elements of the MultiRegionKeyType enum
+func MultiRegionKeyType_Values() []string {
+	return []string{
+		MultiRegionKeyTypePrimary,
+		MultiRegionKeyTypeReplica,
 	}
 }
 

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/doc.go
@@ -3,21 +3,26 @@
 // Package kms provides the client and types for making API
 // requests to AWS Key Management Service.
 //
-// AWS Key Management Service (AWS KMS) is an encryption and key management
-// web service. This guide describes the AWS KMS operations that you can call
-// programmatically. For general information about AWS KMS, see the AWS Key
-// Management Service Developer Guide (https://docs.aws.amazon.com/kms/latest/developerguide/).
+// Key Management Service (KMS) is an encryption and key management web service.
+// This guide describes the KMS operations that you can call programmatically.
+// For general information about KMS, see the Key Management Service Developer
+// Guide (https://docs.aws.amazon.com/kms/latest/developerguide/).
 //
-// AWS provides SDKs that consist of libraries and sample code for various programming
-// languages and platforms (Java, Ruby, .Net, macOS, Android, etc.). The SDKs
-// provide a convenient way to create programmatic access to AWS KMS and other
-// AWS services. For example, the SDKs take care of tasks such as signing requests
-// (see below), managing errors, and retrying requests automatically. For more
-// information about the AWS SDKs, including how to download and install them,
-// see Tools for Amazon Web Services (http://aws.amazon.com/tools/).
+// KMS is replacing the term customer master key (CMK) with KMS key and KMS
+// key. The concept has not changed. To prevent breaking changes, KMS is keeping
+// some variations of this term.
 //
-// We recommend that you use the AWS SDKs to make programmatic API calls to
-// AWS KMS.
+// Amazon Web Services provides SDKs that consist of libraries and sample code
+// for various programming languages and platforms (Java, Ruby, .Net, macOS,
+// Android, etc.). The SDKs provide a convenient way to create programmatic
+// access to KMS and other Amazon Web Services services. For example, the SDKs
+// take care of tasks such as signing requests (see below), managing errors,
+// and retrying requests automatically. For more information about the Amazon
+// Web Services SDKs, including how to download and install them, see Tools
+// for Amazon Web Services (http://aws.amazon.com/tools/).
+//
+// We recommend that you use the Amazon Web Services SDKs to make programmatic
+// API calls to KMS.
 //
 // Clients must support TLS (Transport Layer Security) 1.0. We recommend TLS
 // 1.2. Clients must also support cipher suites with Perfect Forward Secrecy
@@ -28,30 +33,31 @@
 // Signing Requests
 //
 // Requests must be signed by using an access key ID and a secret access key.
-// We strongly recommend that you do not use your AWS account (root) access
-// key ID and secret key for everyday work with AWS KMS. Instead, use the access
-// key ID and secret access key for an IAM user. You can also use the AWS Security
-// Token Service to generate temporary security credentials that you can use
-// to sign requests.
+// We strongly recommend that you do not use your Amazon Web Services account
+// (root) access key ID and secret key for everyday work with KMS. Instead,
+// use the access key ID and secret access key for an IAM user. You can also
+// use the Amazon Web Services Security Token Service to generate temporary
+// security credentials that you can use to sign requests.
 //
-// All AWS KMS operations require Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+// All KMS operations require Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 //
 // Logging API Requests
 //
-// AWS KMS supports AWS CloudTrail, a service that logs AWS API calls and related
-// events for your AWS account and delivers them to an Amazon S3 bucket that
-// you specify. By using the information collected by CloudTrail, you can determine
-// what requests were made to AWS KMS, who made the request, when it was made,
-// and so on. To learn more about CloudTrail, including how to turn it on and
-// find your log files, see the AWS CloudTrail User Guide (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/).
+// KMS supports CloudTrail, a service that logs Amazon Web Services API calls
+// and related events for your Amazon Web Services account and delivers them
+// to an Amazon S3 bucket that you specify. By using the information collected
+// by CloudTrail, you can determine what requests were made to KMS, who made
+// the request, when it was made, and so on. To learn more about CloudTrail,
+// including how to turn it on and find your log files, see the CloudTrail User
+// Guide (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/).
 //
 // Additional Resources
 //
 // For more information about credentials and request signing, see the following:
 //
-//    * AWS Security Credentials (https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
+//    * Amazon Web Services Security Credentials (https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
 //    - This topic provides general information about the types of credentials
-//    used for accessing AWS.
+//    used to access Amazon Web Services.
 //
 //    * Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
 //    - This section of the IAM User Guide describes how to create and use temporary

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
@@ -18,10 +18,10 @@ const (
 	// ErrCodeCloudHsmClusterInUseException for service response error code
 	// "CloudHsmClusterInUseException".
 	//
-	// The request was rejected because the specified AWS CloudHSM cluster is already
+	// The request was rejected because the specified CloudHSM cluster is already
 	// associated with a custom key store or it shares a backup history with a cluster
 	// that is associated with a custom key store. Each custom key store must be
-	// associated with a different AWS CloudHSM cluster.
+	// associated with a different CloudHSM cluster.
 	//
 	// Clusters that share a backup history have the same cluster certificate. To
 	// view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -31,8 +31,8 @@ const (
 	// ErrCodeCloudHsmClusterInvalidConfigurationException for service response error code
 	// "CloudHsmClusterInvalidConfigurationException".
 	//
-	// The request was rejected because the associated AWS CloudHSM cluster did
-	// not meet the configuration requirements for a custom key store.
+	// The request was rejected because the associated CloudHSM cluster did not
+	// meet the configuration requirements for a custom key store.
 	//
 	//    * The cluster must be configured with private subnets in at least two
 	//    different Availability Zones in the Region.
@@ -47,46 +47,44 @@ const (
 	//    operation.
 	//
 	//    * The cluster must contain at least as many HSMs as the operation requires.
-	//    To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+	//    To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 	//    operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-	//    operations, the AWS CloudHSM cluster must have at least two active HSMs,
-	//    each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-	//    the AWS CloudHSM must contain at least one active HSM.
+	//    operations, the CloudHSM cluster must have at least two active HSMs, each
+	//    in a different Availability Zone. For the ConnectCustomKeyStore operation,
+	//    the CloudHSM must contain at least one active HSM.
 	//
-	// For information about the requirements for an AWS CloudHSM cluster that is
-	// associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-	// in the AWS Key Management Service Developer Guide. For information about
-	// creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-	// Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-	// in the AWS CloudHSM User Guide. For information about cluster security groups,
+	// For information about the requirements for an CloudHSM cluster that is associated
+	// with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+	// in the Key Management Service Developer Guide. For information about creating
+	// a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+	// in the CloudHSM User Guide. For information about cluster security groups,
 	// see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-	// in the AWS CloudHSM User Guide .
+	// in the CloudHSM User Guide .
 	ErrCodeCloudHsmClusterInvalidConfigurationException = "CloudHsmClusterInvalidConfigurationException"
 
 	// ErrCodeCloudHsmClusterNotActiveException for service response error code
 	// "CloudHsmClusterNotActiveException".
 	//
-	// The request was rejected because the AWS CloudHSM cluster that is associated
+	// The request was rejected because the CloudHSM cluster that is associated
 	// with the custom key store is not active. Initialize and activate the cluster
 	// and try the command again. For detailed instructions, see Getting Started
 	// (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-	// in the AWS CloudHSM User Guide.
+	// in the CloudHSM User Guide.
 	ErrCodeCloudHsmClusterNotActiveException = "CloudHsmClusterNotActiveException"
 
 	// ErrCodeCloudHsmClusterNotFoundException for service response error code
 	// "CloudHsmClusterNotFoundException".
 	//
-	// The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-	// with the specified cluster ID. Retry the request with a different cluster
-	// ID.
+	// The request was rejected because KMS cannot find the CloudHSM cluster with
+	// the specified cluster ID. Retry the request with a different cluster ID.
 	ErrCodeCloudHsmClusterNotFoundException = "CloudHsmClusterNotFoundException"
 
 	// ErrCodeCloudHsmClusterNotRelatedException for service response error code
 	// "CloudHsmClusterNotRelatedException".
 	//
-	// The request was rejected because the specified AWS CloudHSM cluster has a
-	// different cluster certificate than the original cluster. You cannot use the
-	// operation to specify an unrelated cluster.
+	// The request was rejected because the specified CloudHSM cluster has a different
+	// cluster certificate than the original cluster. You cannot use the operation
+	// to specify an unrelated cluster.
 	//
 	// Specify a cluster that shares a backup history with the original cluster.
 	// This includes clusters that were created from a backup of the current cluster,
@@ -101,10 +99,10 @@ const (
 	// ErrCodeCustomKeyStoreHasCMKsException for service response error code
 	// "CustomKeyStoreHasCMKsException".
 	//
-	// The request was rejected because the custom key store contains AWS KMS customer
-	// master keys (CMKs). After verifying that you do not need to use the CMKs,
-	// use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-	// deleted, you can delete the custom key store.
+	// The request was rejected because the custom key store contains KMS keys.
+	// After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+	// operation to delete the KMS keys. After they are deleted, you can delete
+	// the custom key store.
 	ErrCodeCustomKeyStoreHasCMKsException = "CustomKeyStoreHasCMKsException"
 
 	// ErrCodeCustomKeyStoreInvalidStateException for service response error code
@@ -140,7 +138,7 @@ const (
 	// ErrCodeCustomKeyStoreNotFoundException for service response error code
 	// "CustomKeyStoreNotFoundException".
 	//
-	// The request was rejected because AWS KMS cannot find a custom key store with
+	// The request was rejected because KMS cannot find a custom key store with
 	// the specified key store name or ID.
 	ErrCodeCustomKeyStoreNotFoundException = "CustomKeyStoreNotFoundException"
 
@@ -154,7 +152,7 @@ const (
 	// ErrCodeDisabledException for service response error code
 	// "DisabledException".
 	//
-	// The request was rejected because the specified CMK is not enabled.
+	// The request was rejected because the specified KMS key is not enabled.
 	ErrCodeDisabledException = "DisabledException"
 
 	// ErrCodeExpiredImportTokenException for service response error code
@@ -168,9 +166,9 @@ const (
 	// ErrCodeIncorrectKeyException for service response error code
 	// "IncorrectKeyException".
 	//
-	// The request was rejected because the specified CMK cannot decrypt the data.
-	// The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-	// must identify the same CMK that was used to encrypt the ciphertext.
+	// The request was rejected because the specified KMS key cannot decrypt the
+	// data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+	// must identify the same KMS key that was used to encrypt the ciphertext.
 	ErrCodeIncorrectKeyException = "IncorrectKeyException"
 
 	// ErrCodeIncorrectKeyMaterialException for service response error code
@@ -178,14 +176,14 @@ const (
 	//
 	// The request was rejected because the key material in the request is, expired,
 	// invalid, or is not the same key material that was previously imported into
-	// this customer master key (CMK).
+	// this KMS key.
 	ErrCodeIncorrectKeyMaterialException = "IncorrectKeyMaterialException"
 
 	// ErrCodeIncorrectTrustAnchorException for service response error code
 	// "IncorrectTrustAnchorException".
 	//
 	// The request was rejected because the trust anchor certificate in the request
-	// is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+	// is not the trust anchor certificate for the specified CloudHSM cluster.
 	//
 	// When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 	// you create the trust anchor certificate and save it in the customerCA.crt
@@ -220,8 +218,8 @@ const (
 	// the ciphertext, such as the encryption context, is corrupted, missing, or
 	// otherwise invalid.
 	//
-	// From the ImportKeyMaterial operation, the request was rejected because AWS
-	// KMS could not decrypt the encrypted (wrapped) key material.
+	// From the ImportKeyMaterial operation, the request was rejected because KMS
+	// could not decrypt the encrypted (wrapped) key material.
 	ErrCodeInvalidCiphertextException = "InvalidCiphertextException"
 
 	// ErrCodeInvalidGrantIdException for service response error code
@@ -240,7 +238,7 @@ const (
 	// "InvalidImportTokenException".
 	//
 	// The request was rejected because the provided import token is invalid or
-	// is associated with a different customer master key (CMK).
+	// is associated with a different KMS key.
 	ErrCodeInvalidImportTokenException = "InvalidImportTokenException"
 
 	// ErrCodeInvalidKeyUsageException for service response error code
@@ -248,17 +246,18 @@ const (
 	//
 	// The request was rejected for one of the following reasons:
 	//
-	//    * The KeyUsage value of the CMK is incompatible with the API operation.
+	//    * The KeyUsage value of the KMS key is incompatible with the API operation.
 	//
 	//    * The encryption algorithm or signing algorithm specified for the operation
-	//    is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+	//    is incompatible with the type of key material in the KMS key (KeySpec).
 	//
 	// For encrypting, decrypting, re-encrypting, and generating data keys, the
 	// KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-	// must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+	// must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+	// operation.
 	//
-	// To find the encryption or signing algorithms supported for a particular CMK,
-	// use the DescribeKey operation.
+	// To find the encryption or signing algorithms supported for a particular KMS
+	// key, use the DescribeKey operation.
 	ErrCodeInvalidKeyUsageException = "InvalidKeyUsageException"
 
 	// ErrCodeInvalidMarkerException for service response error code
@@ -274,9 +273,9 @@ const (
 	// The request was rejected because the state of the specified resource is not
 	// valid for this request.
 	//
-	// For more information about how key state affects the use of a CMK, see How
-	// Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide .
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide .
 	ErrCodeInvalidStateException = "KMSInvalidStateException"
 
 	// ErrCodeKMSInvalidSignatureException for service response error code
@@ -284,14 +283,14 @@ const (
 	//
 	// The request was rejected because the signature verification failed. Signature
 	// verification fails when it cannot confirm that signature was produced by
-	// signing the specified message with the specified CMK and signing algorithm.
+	// signing the specified message with the specified KMS key and signing algorithm.
 	ErrCodeKMSInvalidSignatureException = "KMSInvalidSignatureException"
 
 	// ErrCodeKeyUnavailableException for service response error code
 	// "KeyUnavailableException".
 	//
-	// The request was rejected because the specified CMK was not available. You
-	// can retry the request.
+	// The request was rejected because the specified KMS key was not available.
+	// You can retry the request.
 	ErrCodeKeyUnavailableException = "KeyUnavailableException"
 
 	// ErrCodeLimitExceededException for service response error code
@@ -299,7 +298,7 @@ const (
 	//
 	// The request was rejected because a quota was exceeded. For more information,
 	// see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
 	// ErrCodeMalformedPolicyDocumentException for service response error code

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/kms/service.go
@@ -49,24 +49,25 @@ const (
 //     svc := kms.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *KMS {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *KMS {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *KMS {
 	svc := &KMS{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2014-11-01",
-				JSONVersion:   "1.1",
-				TargetPrefix:  "TrentService",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2014-11-01",
+				ResolvedRegion: resolvedRegion,
+				JSONVersion:    "1.1",
+				TargetPrefix:   "TrentService",
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sso/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sso/api.go
@@ -513,12 +513,20 @@ type AccountInfo struct {
 	EmailAddress *string `locationName:"emailAddress" min:"1" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AccountInfo) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AccountInfo) GoString() string {
 	return s.String()
 }
@@ -542,11 +550,15 @@ func (s *AccountInfo) SetEmailAddress(v string) *AccountInfo {
 }
 
 type GetRoleCredentialsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" nopayload:"true"`
 
 	// The token issued by the CreateToken API call. For more information, see CreateToken
 	// (https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html)
 	// in the AWS SSO OIDC API Reference Guide.
+	//
+	// AccessToken is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by GetRoleCredentialsInput's
+	// String and GoString methods.
 	//
 	// AccessToken is a required field
 	AccessToken *string `location:"header" locationName:"x-amz-sso_bearer_token" type:"string" required:"true" sensitive:"true"`
@@ -562,12 +574,20 @@ type GetRoleCredentialsInput struct {
 	RoleName *string `location:"querystring" locationName:"role_name" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRoleCredentialsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRoleCredentialsInput) GoString() string {
 	return s.String()
 }
@@ -616,12 +636,20 @@ type GetRoleCredentialsOutput struct {
 	RoleCredentials *RoleCredentials `locationName:"roleCredentials" type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRoleCredentialsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetRoleCredentialsOutput) GoString() string {
 	return s.String()
 }
@@ -641,12 +669,20 @@ type InvalidRequestException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidRequestException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s InvalidRequestException) GoString() string {
 	return s.String()
 }
@@ -690,11 +726,15 @@ func (s *InvalidRequestException) RequestID() string {
 }
 
 type ListAccountRolesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" nopayload:"true"`
 
 	// The token issued by the CreateToken API call. For more information, see CreateToken
 	// (https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html)
 	// in the AWS SSO OIDC API Reference Guide.
+	//
+	// AccessToken is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by ListAccountRolesInput's
+	// String and GoString methods.
 	//
 	// AccessToken is a required field
 	AccessToken *string `location:"header" locationName:"x-amz-sso_bearer_token" type:"string" required:"true" sensitive:"true"`
@@ -712,12 +752,20 @@ type ListAccountRolesInput struct {
 	NextToken *string `location:"querystring" locationName:"next_token" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountRolesInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountRolesInput) GoString() string {
 	return s.String()
 }
@@ -776,12 +824,20 @@ type ListAccountRolesOutput struct {
 	RoleList []*RoleInfo `locationName:"roleList" type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountRolesOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountRolesOutput) GoString() string {
 	return s.String()
 }
@@ -799,11 +855,15 @@ func (s *ListAccountRolesOutput) SetRoleList(v []*RoleInfo) *ListAccountRolesOut
 }
 
 type ListAccountsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" nopayload:"true"`
 
 	// The token issued by the CreateToken API call. For more information, see CreateToken
 	// (https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html)
 	// in the AWS SSO OIDC API Reference Guide.
+	//
+	// AccessToken is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by ListAccountsInput's
+	// String and GoString methods.
 	//
 	// AccessToken is a required field
 	AccessToken *string `location:"header" locationName:"x-amz-sso_bearer_token" type:"string" required:"true" sensitive:"true"`
@@ -816,12 +876,20 @@ type ListAccountsInput struct {
 	NextToken *string `location:"querystring" locationName:"next_token" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountsInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountsInput) GoString() string {
 	return s.String()
 }
@@ -871,12 +939,20 @@ type ListAccountsOutput struct {
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountsOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ListAccountsOutput) GoString() string {
 	return s.String()
 }
@@ -894,22 +970,34 @@ func (s *ListAccountsOutput) SetNextToken(v string) *ListAccountsOutput {
 }
 
 type LogoutInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" nopayload:"true"`
 
 	// The token issued by the CreateToken API call. For more information, see CreateToken
 	// (https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html)
 	// in the AWS SSO OIDC API Reference Guide.
 	//
+	// AccessToken is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by LogoutInput's
+	// String and GoString methods.
+	//
 	// AccessToken is a required field
 	AccessToken *string `location:"header" locationName:"x-amz-sso_bearer_token" type:"string" required:"true" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LogoutInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LogoutInput) GoString() string {
 	return s.String()
 }
@@ -937,12 +1025,20 @@ type LogoutOutput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LogoutOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s LogoutOutput) GoString() string {
 	return s.String()
 }
@@ -955,12 +1051,20 @@ type ResourceNotFoundException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ResourceNotFoundException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s ResourceNotFoundException) GoString() string {
 	return s.String()
 }
@@ -1020,20 +1124,36 @@ type RoleCredentials struct {
 	// The key that is used to sign the request. For more information, see Using
 	// Temporary Security Credentials to Request Access to AWS Resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)
 	// in the AWS IAM User Guide.
+	//
+	// SecretAccessKey is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by RoleCredentials's
+	// String and GoString methods.
 	SecretAccessKey *string `locationName:"secretAccessKey" type:"string" sensitive:"true"`
 
 	// The token used for temporary credentials. For more information, see Using
 	// Temporary Security Credentials to Request Access to AWS Resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)
 	// in the AWS IAM User Guide.
+	//
+	// SessionToken is a sensitive parameter and its value will be
+	// replaced with "sensitive" in string returned by RoleCredentials's
+	// String and GoString methods.
 	SessionToken *string `locationName:"sessionToken" type:"string" sensitive:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RoleCredentials) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RoleCredentials) GoString() string {
 	return s.String()
 }
@@ -1073,12 +1193,20 @@ type RoleInfo struct {
 	RoleName *string `locationName:"roleName" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RoleInfo) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s RoleInfo) GoString() string {
 	return s.String()
 }
@@ -1104,12 +1232,20 @@ type TooManyRequestsException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TooManyRequestsException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s TooManyRequestsException) GoString() string {
 	return s.String()
 }
@@ -1161,12 +1297,20 @@ type UnauthorizedException struct {
 	Message_ *string `locationName:"message" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnauthorizedException) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s UnauthorizedException) GoString() string {
 	return s.String()
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sso/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sso/service.go
@@ -52,22 +52,23 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *SSO {
 	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "awsssoportal"
 	}
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *SSO {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *SSO {
 	svc := &SSO{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2019-06-10",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2019-06-10",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -57,19 +57,21 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // AssumeRole API operation for AWS Security Token Service.
 //
 // Returns a set of temporary security credentials that you can use to access
-// AWS resources that you might not normally have access to. These temporary
-// credentials consist of an access key ID, a secret access key, and a security
-// token. Typically, you use AssumeRole within your account or for cross-account
-// access. For a comparison of AssumeRole with other API operations that produce
-// temporary credentials, see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-// and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+// Amazon Web Services resources that you might not normally have access to.
+// These temporary credentials consist of an access key ID, a secret access
+// key, and a security token. Typically, you use AssumeRole within your account
+// or for cross-account access. For a comparison of AssumeRole with other API
+// operations that produce temporary credentials, see Requesting Temporary Security
+// Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
 // Permissions
 //
 // The temporary security credentials created by AssumeRole can be used to make
-// API calls to any AWS service with the following exception: You cannot call
-// the AWS STS GetFederationToken or GetSessionToken API operations.
+// API calls to any Amazon Web Services service with the following exception:
+// You cannot call the Amazon Web Services STS GetFederationToken or GetSessionToken
+// API operations.
 //
 // (Optional) You can pass inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // to this operation. You can pass a single JSON policy document to use as an
@@ -79,32 +81,39 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
-// AWS API calls to access resources in the account that owns the role. You
-// cannot use session policies to grant more permissions than those allowed
-// by the identity-based policy of the role that is being assumed. For more
-// information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+// Amazon Web Services API calls to access resources in the account that owns
+// the role. You cannot use session policies to grant more permissions than
+// those allowed by the identity-based policy of the role that is being assumed.
+// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide.
 //
-// To assume a role from a different account, your AWS account must be trusted
-// by the role. The trust relationship is defined in the role's trust policy
-// when the role is created. That trust policy states which accounts are allowed
-// to delegate that access to users in the account.
+// When you create a role, you create two policies: A role trust policy that
+// specifies who can assume the role and a permissions policy that specifies
+// what can be done with the role. You specify the trusted principal who is
+// allowed to assume the role in the role trust policy.
+//
+// To assume a role from a different account, your Amazon Web Services account
+// must be trusted by the role. The trust relationship is defined in the role's
+// trust policy when the role is created. That trust policy states which accounts
+// are allowed to delegate that access to users in the account.
 //
 // A user who wants to access a role in a different account must also have permissions
 // that are delegated from the user account administrator. The administrator
 // must attach a policy that allows the user to call AssumeRole for the ARN
-// of the role in the other account. If the user is in the same account as the
-// role, then you can do either of the following:
+// of the role in the other account.
 //
-//    * Attach a policy to the user (identical to the previous user in a different
-//    account).
+// To allow a user to assume a role in the same account, you can do either of
+// the following:
+//
+//    * Attach a policy to the user that allows the user to call AssumeRole
+//    (as long as the role's trust policy trusts the account).
 //
 //    * Add the user as a principal directly in the role's trust policy.
 //
-// In this case, the trust policy acts as an IAM resource-based policy. Users
-// in the same account as the role do not need explicit permission to assume
-// the role. For more information about trust policies and resource-based policies,
-// see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
+// You can do either because the role’s trust policy acts as an IAM resource-based
+// policy. When a resource-based policy grants access to a principal in the
+// same account, no additional identity-based policy is required. For more information
+// about trust policies and resource-based policies, see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
 // in the IAM User Guide.
 //
 // Tags
@@ -129,12 +138,12 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 //
 // (Optional) You can include multi-factor authentication (MFA) information
 // when you call AssumeRole. This is useful for cross-account scenarios to ensure
-// that the user that assumes the role has been authenticated with an AWS MFA
-// device. In that scenario, the trust policy of the role being assumed includes
-// a condition that tests for MFA authentication. If the caller does not include
-// valid MFA information, the request to assume the role is denied. The condition
-// in a trust policy that tests for MFA authentication might look like the following
-// example.
+// that the user that assumes the role has been authenticated with an Amazon
+// Web Services MFA device. In that scenario, the trust policy of the role being
+// assumed includes a condition that tests for MFA authentication. If the caller
+// does not include valid MFA information, the request to assume the role is
+// denied. The condition in a trust policy that tests for MFA authentication
+// might look like the following example.
 //
 // "Condition": {"Bool": {"aws:MultiFactorAuthPresent": true}}
 //
@@ -160,23 +169,24 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
 //   The request was rejected because the total packed size of the session policies
-//   and session tags combined was too large. An AWS conversion compresses the
-//   session policy document, session policy ARNs, and session tags into a packed
-//   binary format that has a separate limit. The error message indicates by percentage
-//   how close the policies and tags are to the upper size limit. For more information,
-//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   and session tags combined was too large. An Amazon Web Services conversion
+//   compresses the session policy document, session policy ARNs, and session
+//   tags into a packed binary format that has a separate limit. The error message
+//   indicates by percentage how close the policies and tags are to the upper
+//   size limit. For more information, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 //   in the IAM User Guide.
 //
 //   You could receive this error even though you meet other defined session policy
 //   and session tag limits. For more information, see IAM and STS Entity Character
-//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length)
 //   in the IAM User Guide.
 //
 //   * ErrCodeRegionDisabledException "RegionDisabledException"
 //   STS is not activated in the requested region for the account that is being
 //   asked to generate credentials. The account administrator must use the IAM
 //   console to activate STS in that region. For more information, see Activating
-//   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+//   (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
 //   * ErrCodeExpiredTokenException "ExpiredTokenException"
@@ -252,16 +262,17 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 //
 // Returns a set of temporary security credentials for users who have been authenticated
 // via a SAML authentication response. This operation provides a mechanism for
-// tying an enterprise identity store or directory to role-based AWS access
-// without user-specific credentials or configuration. For a comparison of AssumeRoleWithSAML
-// with the other API operations that produce temporary credentials, see Requesting
-// Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-// and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+// tying an enterprise identity store or directory to role-based Amazon Web
+// Services access without user-specific credentials or configuration. For a
+// comparison of AssumeRoleWithSAML with the other API operations that produce
+// temporary credentials, see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
 // The temporary security credentials returned by this operation consist of
 // an access key ID, a secret access key, and a security token. Applications
-// can use these temporary security credentials to sign calls to AWS services.
+// can use these temporary security credentials to sign calls to Amazon Web
+// Services services.
 //
 // Session Duration
 //
@@ -281,19 +292,19 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // in the IAM User Guide.
 //
 // Role chaining (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining)
-// limits your AWS CLI or AWS API role session to a maximum of one hour. When
-// you use the AssumeRole API operation to assume a role, you can specify the
-// duration of your role session with the DurationSeconds parameter. You can
-// specify a parameter value of up to 43200 seconds (12 hours), depending on
-// the maximum session duration setting for your role. However, if you assume
+// limits your CLI or Amazon Web Services API role session to a maximum of one
+// hour. When you use the AssumeRole API operation to assume a role, you can
+// specify the duration of your role session with the DurationSeconds parameter.
+// You can specify a parameter value of up to 43200 seconds (12 hours), depending
+// on the maximum session duration setting for your role. However, if you assume
 // a role using role chaining and provide a DurationSeconds parameter value
 // greater than one hour, the operation fails.
 //
 // Permissions
 //
 // The temporary security credentials created by AssumeRoleWithSAML can be used
-// to make API calls to any AWS service with the following exception: you cannot
-// call the STS GetFederationToken or GetSessionToken API operations.
+// to make API calls to any Amazon Web Services service with the following exception:
+// you cannot call the STS GetFederationToken or GetSessionToken API operations.
 //
 // (Optional) You can pass inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // to this operation. You can pass a single JSON policy document to use as an
@@ -303,18 +314,19 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
-// AWS API calls to access resources in the account that owns the role. You
-// cannot use session policies to grant more permissions than those allowed
-// by the identity-based policy of the role that is being assumed. For more
-// information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+// Amazon Web Services API calls to access resources in the account that owns
+// the role. You cannot use session policies to grant more permissions than
+// those allowed by the identity-based policy of the role that is being assumed.
+// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide.
 //
-// Calling AssumeRoleWithSAML does not require the use of AWS security credentials.
-// The identity of the caller is validated by using keys in the metadata document
-// that is uploaded for the SAML provider entity for your identity provider.
+// Calling AssumeRoleWithSAML does not require the use of Amazon Web Services
+// security credentials. The identity of the caller is validated by using keys
+// in the metadata document that is uploaded for the SAML provider entity for
+// your identity provider.
 //
-// Calling AssumeRoleWithSAML can result in an entry in your AWS CloudTrail
-// logs. The entry includes the value in the NameID element of the SAML assertion.
+// Calling AssumeRoleWithSAML can result in an entry in your CloudTrail logs.
+// The entry includes the value in the NameID element of the SAML assertion.
 // We recommend that you use a NameIDType that is not associated with any personally
 // identifiable information (PII). For example, you could instead use the persistent
 // identifier (urn:oasis:names:tc:SAML:2.0:nameid-format:persistent).
@@ -332,11 +344,11 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 // in the IAM User Guide.
 //
-// An AWS conversion compresses the passed session policies and session tags
-// into a packed binary format that has a separate limit. Your request can fail
-// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-// response element indicates by percentage how close the policies and tags
-// for your request are to the upper size limit.
+// An Amazon Web Services conversion compresses the passed session policies
+// and session tags into a packed binary format that has a separate limit. Your
+// request can fail for this limit even if your plaintext meets the other requirements.
+// The PackedPolicySize response element indicates by percentage how close the
+// policies and tags for your request are to the upper size limit.
 //
 // You can pass a session tag with the same key as a tag that is attached to
 // the role. When you do, session tags override the role's tags with the same
@@ -356,10 +368,11 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // SAML Configuration
 //
 // Before your application can call AssumeRoleWithSAML, you must configure your
-// SAML identity provider (IdP) to issue the claims required by AWS. Additionally,
-// you must use AWS Identity and Access Management (IAM) to create a SAML provider
-// entity in your AWS account that represents your identity provider. You must
-// also create an IAM role that specifies this SAML provider in its trust policy.
+// SAML identity provider (IdP) to issue the claims required by Amazon Web Services.
+// Additionally, you must use Identity and Access Management (IAM) to create
+// a SAML provider entity in your Amazon Web Services account that represents
+// your identity provider. You must also create an IAM role that specifies this
+// SAML provider in its trust policy.
 //
 // For more information, see the following resources:
 //
@@ -389,16 +402,16 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
 //   The request was rejected because the total packed size of the session policies
-//   and session tags combined was too large. An AWS conversion compresses the
-//   session policy document, session policy ARNs, and session tags into a packed
-//   binary format that has a separate limit. The error message indicates by percentage
-//   how close the policies and tags are to the upper size limit. For more information,
-//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   and session tags combined was too large. An Amazon Web Services conversion
+//   compresses the session policy document, session policy ARNs, and session
+//   tags into a packed binary format that has a separate limit. The error message
+//   indicates by percentage how close the policies and tags are to the upper
+//   size limit. For more information, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 //   in the IAM User Guide.
 //
 //   You could receive this error even though you meet other defined session policy
 //   and session tag limits. For more information, see IAM and STS Entity Character
-//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length)
 //   in the IAM User Guide.
 //
 //   * ErrCodeIDPRejectedClaimException "IDPRejectedClaim"
@@ -409,8 +422,9 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 //   can also mean that the claim has expired or has been explicitly revoked.
 //
 //   * ErrCodeInvalidIdentityTokenException "InvalidIdentityToken"
-//   The web identity token that was passed could not be validated by AWS. Get
-//   a new identity token from the identity provider and then retry the request.
+//   The web identity token that was passed could not be validated by Amazon Web
+//   Services. Get a new identity token from the identity provider and then retry
+//   the request.
 //
 //   * ErrCodeExpiredTokenException "ExpiredTokenException"
 //   The web identity token that was passed is expired or is not valid. Get a
@@ -420,7 +434,8 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 //   STS is not activated in the requested region for the account that is being
 //   asked to generate credentials. The account administrator must use the IAM
 //   console to activate STS in that region. For more information, see Activating
-//   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+//   (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15/AssumeRoleWithSAML
@@ -496,30 +511,33 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // Connect-compatible identity provider.
 //
 // For mobile applications, we recommend that you use Amazon Cognito. You can
-// use Amazon Cognito with the AWS SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/)
-// and the AWS SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/)
-// to uniquely identify a user. You can also supply the user with a consistent
-// identity throughout the lifetime of an application.
+// use Amazon Cognito with the Amazon Web Services SDK for iOS Developer Guide
+// (http://aws.amazon.com/sdkforios/) and the Amazon Web Services SDK for Android
+// Developer Guide (http://aws.amazon.com/sdkforandroid/) to uniquely identify
+// a user. You can also supply the user with a consistent identity throughout
+// the lifetime of an application.
 //
 // To learn more about Amazon Cognito, see Amazon Cognito Overview (https://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/cognito-auth.html#d0e840)
-// in AWS SDK for Android Developer Guide and Amazon Cognito Overview (https://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth.html#d0e664)
-// in the AWS SDK for iOS Developer Guide.
+// in Amazon Web Services SDK for Android Developer Guide and Amazon Cognito
+// Overview (https://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth.html#d0e664)
+// in the Amazon Web Services SDK for iOS Developer Guide.
 //
-// Calling AssumeRoleWithWebIdentity does not require the use of AWS security
-// credentials. Therefore, you can distribute an application (for example, on
-// mobile devices) that requests temporary security credentials without including
-// long-term AWS credentials in the application. You also don't need to deploy
-// server-based proxy services that use long-term AWS credentials. Instead,
-// the identity of the caller is validated by using a token from the web identity
-// provider. For a comparison of AssumeRoleWithWebIdentity with the other API
-// operations that produce temporary credentials, see Requesting Temporary Security
-// Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-// and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+// Calling AssumeRoleWithWebIdentity does not require the use of Amazon Web
+// Services security credentials. Therefore, you can distribute an application
+// (for example, on mobile devices) that requests temporary security credentials
+// without including long-term Amazon Web Services credentials in the application.
+// You also don't need to deploy server-based proxy services that use long-term
+// Amazon Web Services credentials. Instead, the identity of the caller is validated
+// by using a token from the web identity provider. For a comparison of AssumeRoleWithWebIdentity
+// with the other API operations that produce temporary credentials, see Requesting
+// Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
 // The temporary security credentials returned by this API consist of an access
 // key ID, a secret access key, and a security token. Applications can use these
-// temporary security credentials to sign calls to AWS service API operations.
+// temporary security credentials to sign calls to Amazon Web Services service
+// API operations.
 //
 // Session Duration
 //
@@ -539,8 +557,9 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // Permissions
 //
 // The temporary security credentials created by AssumeRoleWithWebIdentity can
-// be used to make API calls to any AWS service with the following exception:
-// you cannot call the STS GetFederationToken or GetSessionToken API operations.
+// be used to make API calls to any Amazon Web Services service with the following
+// exception: you cannot call the STS GetFederationToken or GetSessionToken
+// API operations.
 //
 // (Optional) You can pass inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // to this operation. You can pass a single JSON policy document to use as an
@@ -550,10 +569,10 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // to this operation returns new temporary credentials. The resulting session's
 // permissions are the intersection of the role's identity-based policy and
 // the session policies. You can use the role's temporary credentials in subsequent
-// AWS API calls to access resources in the account that owns the role. You
-// cannot use session policies to grant more permissions than those allowed
-// by the identity-based policy of the role that is being assumed. For more
-// information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+// Amazon Web Services API calls to access resources in the account that owns
+// the role. You cannot use session policies to grant more permissions than
+// those allowed by the identity-based policy of the role that is being assumed.
+// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 // in the IAM User Guide.
 //
 // Tags
@@ -569,11 +588,11 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 // in the IAM User Guide.
 //
-// An AWS conversion compresses the passed session policies and session tags
-// into a packed binary format that has a separate limit. Your request can fail
-// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-// response element indicates by percentage how close the policies and tags
-// for your request are to the upper size limit.
+// An Amazon Web Services conversion compresses the passed session policies
+// and session tags into a packed binary format that has a separate limit. Your
+// request can fail for this limit even if your plaintext meets the other requirements.
+// The PackedPolicySize response element indicates by percentage how close the
+// policies and tags for your request are to the upper size limit.
 //
 // You can pass a session tag with the same key as a tag that is attached to
 // the role. When you do, the session tag overrides the role tag with the same
@@ -598,7 +617,7 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // the identity provider that is associated with the identity token. In other
 // words, the identity provider must be specified in the role's trust policy.
 //
-// Calling AssumeRoleWithWebIdentity can result in an entry in your AWS CloudTrail
+// Calling AssumeRoleWithWebIdentity can result in an entry in your CloudTrail
 // logs. The entry includes the Subject (http://openid.net/specs/openid-connect-core-1_0.html#Claims)
 // of the provided web identity token. We recommend that you avoid using any
 // personally identifiable information (PII) in this field. For example, you
@@ -614,10 +633,10 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //    * Web Identity Federation Playground (https://aws.amazon.com/blogs/aws/the-aws-web-identity-federation-playground/).
 //    Walk through the process of authenticating through Login with Amazon,
 //    Facebook, or Google, getting temporary security credentials, and then
-//    using those credentials to make a request to AWS.
+//    using those credentials to make a request to Amazon Web Services.
 //
-//    * AWS SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/) and
-//    AWS SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/).
+//    * Amazon Web Services SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/)
+//    and Amazon Web Services SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/).
 //    These toolkits contain sample apps that show how to invoke the identity
 //    providers. The toolkits then show how to use the information from these
 //    providers to get and use temporary security credentials.
@@ -641,16 +660,16 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
 //   The request was rejected because the total packed size of the session policies
-//   and session tags combined was too large. An AWS conversion compresses the
-//   session policy document, session policy ARNs, and session tags into a packed
-//   binary format that has a separate limit. The error message indicates by percentage
-//   how close the policies and tags are to the upper size limit. For more information,
-//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   and session tags combined was too large. An Amazon Web Services conversion
+//   compresses the session policy document, session policy ARNs, and session
+//   tags into a packed binary format that has a separate limit. The error message
+//   indicates by percentage how close the policies and tags are to the upper
+//   size limit. For more information, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 //   in the IAM User Guide.
 //
 //   You could receive this error even though you meet other defined session policy
 //   and session tag limits. For more information, see IAM and STS Entity Character
-//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length)
 //   in the IAM User Guide.
 //
 //   * ErrCodeIDPRejectedClaimException "IDPRejectedClaim"
@@ -668,8 +687,9 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //   error persists, the identity provider might be down or not responding.
 //
 //   * ErrCodeInvalidIdentityTokenException "InvalidIdentityToken"
-//   The web identity token that was passed could not be validated by AWS. Get
-//   a new identity token from the identity provider and then retry the request.
+//   The web identity token that was passed could not be validated by Amazon Web
+//   Services. Get a new identity token from the identity provider and then retry
+//   the request.
 //
 //   * ErrCodeExpiredTokenException "ExpiredTokenException"
 //   The web identity token that was passed is expired or is not valid. Get a
@@ -679,7 +699,8 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //   STS is not activated in the requested region for the account that is being
 //   asked to generate credentials. The account administrator must use the IAM
 //   console to activate STS in that region. For more information, see Activating
-//   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+//   (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15/AssumeRoleWithWebIdentity
@@ -749,22 +770,25 @@ func (c *STS) DecodeAuthorizationMessageRequest(input *DecodeAuthorizationMessag
 // DecodeAuthorizationMessage API operation for AWS Security Token Service.
 //
 // Decodes additional information about the authorization status of a request
-// from an encoded message returned in response to an AWS request.
+// from an encoded message returned in response to an Amazon Web Services request.
 //
 // For example, if a user is not authorized to perform an operation that he
 // or she has requested, the request returns a Client.UnauthorizedOperation
-// response (an HTTP 403 response). Some AWS operations additionally return
-// an encoded message that can provide details about this authorization failure.
+// response (an HTTP 403 response). Some Amazon Web Services operations additionally
+// return an encoded message that can provide details about this authorization
+// failure.
 //
-// Only certain AWS operations return an encoded authorization message. The
-// documentation for an individual operation indicates whether that operation
-// returns an encoded message in addition to returning an HTTP code.
+// Only certain Amazon Web Services operations return an encoded authorization
+// message. The documentation for an individual operation indicates whether
+// that operation returns an encoded message in addition to returning an HTTP
+// code.
 //
 // The message is encoded because the details of the authorization status can
-// constitute privileged information that the user who requested the operation
+// contain privileged information that the user who requested the operation
 // should not see. To decode an authorization status message, a user must be
-// granted permissions via an IAM policy to request the DecodeAuthorizationMessage
-// (sts:DecodeAuthorizationMessage) action.
+// granted permissions through an IAM policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
+// to request the DecodeAuthorizationMessage (sts:DecodeAuthorizationMessage)
+// action.
 //
 // The decoded message includes the following type of information:
 //
@@ -869,12 +893,12 @@ func (c *STS) GetAccessKeyInfoRequest(input *GetAccessKeyInfoInput) (req *reques
 // in the IAM User Guide.
 //
 // When you pass an access key ID to this operation, it returns the ID of the
-// AWS account to which the keys belong. Access key IDs beginning with AKIA
-// are long-term credentials for an IAM user or the AWS account root user. Access
-// key IDs beginning with ASIA are temporary credentials that are created using
-// STS operations. If the account in the response belongs to you, you can sign
-// in as the root user and review your root user access keys. Then, you can
-// pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
+// Amazon Web Services account to which the keys belong. Access key IDs beginning
+// with AKIA are long-term credentials for an IAM user or the Amazon Web Services
+// account root user. Access key IDs beginning with ASIA are temporary credentials
+// that are created using STS operations. If the account in the response belongs
+// to you, you can sign in as the root user and review your root user access
+// keys. Then, you can pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
 // to learn which IAM user owns the keys. To learn who requested the temporary
 // credentials for an ASIA access key, view the STS events in your CloudTrail
 // logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
@@ -1050,7 +1074,7 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 // For a comparison of GetFederationToken with the other API operations that
 // produce temporary credentials, see Requesting Temporary Security Credentials
 // (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-// and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
 // You can create a mobile-based or browser-based app that can authenticate
@@ -1062,27 +1086,28 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 // in the IAM User Guide.
 //
 // You can also call GetFederationToken using the security credentials of an
-// AWS account root user, but we do not recommend it. Instead, we recommend
-// that you create an IAM user for the purpose of the proxy application. Then
-// attach a policy to the IAM user that limits federated users to only the actions
-// and resources that they need to access. For more information, see IAM Best
-// Practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+// Amazon Web Services account root user, but we do not recommend it. Instead,
+// we recommend that you create an IAM user for the purpose of the proxy application.
+// Then attach a policy to the IAM user that limits federated users to only
+// the actions and resources that they need to access. For more information,
+// see IAM Best Practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
 // in the IAM User Guide.
 //
 // Session duration
 //
 // The temporary credentials are valid for the specified duration, from 900
 // seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The default
-// session duration is 43,200 seconds (12 hours). Temporary credentials that
-// are obtained by using AWS account root user credentials have a maximum duration
-// of 3,600 seconds (1 hour).
+// session duration is 43,200 seconds (12 hours). Temporary credentials obtained
+// by using the Amazon Web Services account root user credentials have a maximum
+// duration of 3,600 seconds (1 hour).
 //
 // Permissions
 //
 // You can use the temporary credentials created by GetFederationToken in any
-// AWS service except the following:
+// Amazon Web Services service except the following:
 //
-//    * You cannot call any IAM operations using the AWS CLI or the AWS API.
+//    * You cannot call any IAM operations using the CLI or the Amazon Web Services
+//    API.
 //
 //    * You cannot call any STS operations except GetCallerIdentity.
 //
@@ -1125,62 +1150,6 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 // (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
 // in the IAM User Guide.
 //
-// You can also call GetFederationToken using the security credentials of an
-// AWS account root user, but we do not recommend it. Instead, we recommend
-// that you create an IAM user for the purpose of the proxy application. Then
-// attach a policy to the IAM user that limits federated users to only the actions
-// and resources that they need to access. For more information, see IAM Best
-// Practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
-// in the IAM User Guide.
-//
-// Session duration
-//
-// The temporary credentials are valid for the specified duration, from 900
-// seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The default
-// session duration is 43,200 seconds (12 hours). Temporary credentials that
-// are obtained by using AWS account root user credentials have a maximum duration
-// of 3,600 seconds (1 hour).
-//
-// Permissions
-//
-// You can use the temporary credentials created by GetFederationToken in any
-// AWS service except the following:
-//
-//    * You cannot call any IAM operations using the AWS CLI or the AWS API.
-//
-//    * You cannot call any STS operations except GetCallerIdentity.
-//
-// You must pass an inline or managed session policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
-// to this operation. You can pass a single JSON policy document to use as an
-// inline session policy. You can also specify up to 10 managed policies to
-// use as managed session policies. The plain text that you use for both inline
-// and managed session policies can't exceed 2,048 characters.
-//
-// Though the session policy parameters are optional, if you do not pass a policy,
-// then the resulting federated user session has no permissions. When you pass
-// session policies, the session permissions are the intersection of the IAM
-// user policies and the session policies that you pass. This gives you a way
-// to further restrict the permissions for a federated user. You cannot use
-// session policies to grant more permissions than those that are defined in
-// the permissions policy of the IAM user. For more information, see Session
-// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
-// in the IAM User Guide. For information about using GetFederationToken to
-// create temporary security credentials, see GetFederationToken—Federation
-// Through a Custom Identity Broker (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getfederationtoken).
-//
-// You can use the credentials to access a resource that has a resource-based
-// policy. If that policy specifically references the federated user session
-// in the Principal element of the policy, the session has the permissions allowed
-// by the policy. These permissions are granted in addition to the permissions
-// granted by the session policies.
-//
-// Tags
-//
-// (Optional) You can pass tag key-value pairs to your session. These are called
-// session tags. For more information about session tags, see Passing Session
-// Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
-// in the IAM User Guide.
-//
 // An administrator must grant you the permissions necessary to pass session
 // tags. The administrator can also create granular permissions to allow you
 // to pass only specific session tags. For more information, see Tutorial: Using
@@ -1208,23 +1177,24 @@ func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *re
 //
 //   * ErrCodePackedPolicyTooLargeException "PackedPolicyTooLarge"
 //   The request was rejected because the total packed size of the session policies
-//   and session tags combined was too large. An AWS conversion compresses the
-//   session policy document, session policy ARNs, and session tags into a packed
-//   binary format that has a separate limit. The error message indicates by percentage
-//   how close the policies and tags are to the upper size limit. For more information,
-//   see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+//   and session tags combined was too large. An Amazon Web Services conversion
+//   compresses the session policy document, session policy ARNs, and session
+//   tags into a packed binary format that has a separate limit. The error message
+//   indicates by percentage how close the policies and tags are to the upper
+//   size limit. For more information, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 //   in the IAM User Guide.
 //
 //   You could receive this error even though you meet other defined session policy
 //   and session tag limits. For more information, see IAM and STS Entity Character
-//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length)
 //   in the IAM User Guide.
 //
 //   * ErrCodeRegionDisabledException "RegionDisabledException"
 //   STS is not activated in the requested region for the account that is being
 //   asked to generate credentials. The account administrator must use the IAM
 //   console to activate STS in that region. For more information, see Activating
-//   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+//   (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15/GetFederationToken
@@ -1293,51 +1263,53 @@ func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *request.
 
 // GetSessionToken API operation for AWS Security Token Service.
 //
-// Returns a set of temporary credentials for an AWS account or IAM user. The
-// credentials consist of an access key ID, a secret access key, and a security
-// token. Typically, you use GetSessionToken if you want to use MFA to protect
-// programmatic calls to specific AWS API operations like Amazon EC2 StopInstances.
-// MFA-enabled IAM users would need to call GetSessionToken and submit an MFA
-// code that is associated with their MFA device. Using the temporary security
-// credentials that are returned from the call, IAM users can then make programmatic
-// calls to API operations that require MFA authentication. If you do not supply
-// a correct MFA code, then the API returns an access denied error. For a comparison
-// of GetSessionToken with the other API operations that produce temporary credentials,
-// see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-// and Comparing the AWS STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+// Returns a set of temporary credentials for an Amazon Web Services account
+// or IAM user. The credentials consist of an access key ID, a secret access
+// key, and a security token. Typically, you use GetSessionToken if you want
+// to use MFA to protect programmatic calls to specific Amazon Web Services
+// API operations like Amazon EC2 StopInstances. MFA-enabled IAM users would
+// need to call GetSessionToken and submit an MFA code that is associated with
+// their MFA device. Using the temporary security credentials that are returned
+// from the call, IAM users can then make programmatic calls to API operations
+// that require MFA authentication. If you do not supply a correct MFA code,
+// then the API returns an access denied error. For a comparison of GetSessionToken
+// with the other API operations that produce temporary credentials, see Requesting
+// Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 // in the IAM User Guide.
 //
 // Session Duration
 //
-// The GetSessionToken operation must be called by using the long-term AWS security
-// credentials of the AWS account root user or an IAM user. Credentials that
-// are created by IAM users are valid for the duration that you specify. This
-// duration can range from 900 seconds (15 minutes) up to a maximum of 129,600
-// seconds (36 hours), with a default of 43,200 seconds (12 hours). Credentials
-// based on account credentials can range from 900 seconds (15 minutes) up to
-// 3,600 seconds (1 hour), with a default of 1 hour.
+// The GetSessionToken operation must be called by using the long-term Amazon
+// Web Services security credentials of the Amazon Web Services account root
+// user or an IAM user. Credentials that are created by IAM users are valid
+// for the duration that you specify. This duration can range from 900 seconds
+// (15 minutes) up to a maximum of 129,600 seconds (36 hours), with a default
+// of 43,200 seconds (12 hours). Credentials based on account credentials can
+// range from 900 seconds (15 minutes) up to 3,600 seconds (1 hour), with a
+// default of 1 hour.
 //
 // Permissions
 //
 // The temporary security credentials created by GetSessionToken can be used
-// to make API calls to any AWS service with the following exceptions:
+// to make API calls to any Amazon Web Services service with the following exceptions:
 //
 //    * You cannot call any IAM API operations unless MFA authentication information
 //    is included in the request.
 //
 //    * You cannot call any STS API except AssumeRole or GetCallerIdentity.
 //
-// We recommend that you do not call GetSessionToken with AWS account root user
-// credentials. Instead, follow our best practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users)
+// We recommend that you do not call GetSessionToken with Amazon Web Services
+// account root user credentials. Instead, follow our best practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users)
 // by creating one or more IAM users, giving them the necessary permissions,
-// and using IAM users for everyday interaction with AWS.
+// and using IAM users for everyday interaction with Amazon Web Services.
 //
 // The credentials that are returned by GetSessionToken are based on permissions
 // associated with the user whose credentials were used to call the operation.
-// If GetSessionToken is called using AWS account root user credentials, the
-// temporary credentials have root user permissions. Similarly, if GetSessionToken
-// is called using the credentials of an IAM user, the temporary credentials
-// have the same permissions as the IAM user.
+// If GetSessionToken is called using Amazon Web Services account root user
+// credentials, the temporary credentials have root user permissions. Similarly,
+// if GetSessionToken is called using the credentials of an IAM user, the temporary
+// credentials have the same permissions as the IAM user.
 //
 // For more information about using GetSessionToken to create temporary credentials,
 // go to Temporary Credentials for Users in Untrusted Environments (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken)
@@ -1355,7 +1327,8 @@ func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *request.
 //   STS is not activated in the requested region for the account that is being
 //   asked to generate credentials. The account administrator must use the IAM
 //   console to activate STS in that region. For more information, see Activating
-//   and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+//   and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+//   (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 //   in the IAM User Guide.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15/GetSessionToken
@@ -1383,15 +1356,23 @@ func (c *STS) GetSessionTokenWithContext(ctx aws.Context, input *GetSessionToken
 type AssumeRoleInput struct {
 	_ struct{} `type:"structure"`
 
-	// The duration, in seconds, of the role session. The value specified can can
-	// range from 900 seconds (15 minutes) up to the maximum session duration that
-	// is set for the role. The maximum session duration setting can have a value
-	// from 1 hour to 12 hours. If you specify a value higher than this setting
-	// or the administrator setting (whichever is lower), the operation fails. For
-	// example, if you specify a session duration of 12 hours, but your administrator
-	// set the maximum session duration to 6 hours, your operation fails. To learn
-	// how to view the maximum value for your role, see View the Maximum Session
-	// Duration Setting for a Role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// The duration, in seconds, of the role session. The value specified can range
+	// from 900 seconds (15 minutes) up to the maximum session duration set for
+	// the role. The maximum session duration setting can have a value from 1 hour
+	// to 12 hours. If you specify a value higher than this setting or the administrator
+	// setting (whichever is lower), the operation fails. For example, if you specify
+	// a session duration of 12 hours, but your administrator set the maximum session
+	// duration to 6 hours, your operation fails.
+	//
+	// Role chaining limits your Amazon Web Services CLI or Amazon Web Services
+	// API role session to a maximum of one hour. When you use the AssumeRole API
+	// operation to assume a role, you can specify the duration of your role session
+	// with the DurationSeconds parameter. You can specify a parameter value of
+	// up to 43200 seconds (12 hours), depending on the maximum session duration
+	// setting for your role. However, if you assume a role using role chaining
+	// and provide a DurationSeconds parameter value greater than one hour, the
+	// operation fails. To learn how to view the maximum value for your role, see
+	// View the Maximum Session Duration Setting for a Role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
 	// in the IAM User Guide.
 	//
 	// By default, the value is set to 3600 seconds.
@@ -1401,7 +1382,7 @@ type AssumeRoleInput struct {
 	// to the federation endpoint for a console sign-in token takes a SessionDuration
 	// parameter that specifies the maximum length of the console session. For more
 	// information, see Creating a URL that Enables Federated Users to Access the
-	// AWS Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+	// Amazon Web Services Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
@@ -1413,8 +1394,8 @@ type AssumeRoleInput struct {
 	// of the trusting account might send an external ID to the administrator of
 	// the trusted account. That way, only someone with the ID can assume the role,
 	// rather than everyone in the account. For more information about the external
-	// ID, see How to Use an External ID When Granting Access to Your AWS Resources
-	// to a Third Party (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
+	// ID, see How to Use an External ID When Granting Access to Your Amazon Web
+	// Services Resources to a Third Party (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
 	// in the IAM User Guide.
 	//
 	// The regex used to validate this parameter is a string of characters consisting
@@ -1427,10 +1408,11 @@ type AssumeRoleInput struct {
 	// This parameter is optional. Passing policies to this operation returns new
 	// temporary credentials. The resulting session's permissions are the intersection
 	// of the role's identity-based policy and the session policies. You can use
-	// the role's temporary credentials in subsequent AWS API calls to access resources
-	// in the account that owns the role. You cannot use session policies to grant
-	// more permissions than those allowed by the identity-based policy of the role
-	// that is being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// the role's temporary credentials in subsequent Amazon Web Services API calls
+	// to access resources in the account that owns the role. You cannot use session
+	// policies to grant more permissions than those allowed by the identity-based
+	// policy of the role that is being assumed. For more information, see Session
+	// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	//
 	// The plaintext that you use for both inline and managed session policies can't
@@ -1439,11 +1421,11 @@ type AssumeRoleInput struct {
 	// \u00FF). It can also include the tab (\u0009), linefeed (\u000A), and carriage
 	// return (\u000D) characters.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -1453,22 +1435,22 @@ type AssumeRoleInput struct {
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plaintext that you use for both inline and managed session policies
 	// can't exceed 2,048 characters. For more information about ARNs, see Amazon
-	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// in the AWS General Reference.
+	// Resource Names (ARNs) and Amazon Web Services Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// in the Amazon Web Services General Reference.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
 	// policy and the session policies. You can use the role's temporary credentials
-	// in subsequent AWS API calls to access resources in the account that owns
-	// the role. You cannot use session policies to grant more permissions than
-	// those allowed by the identity-based policy of the role that is being assumed.
-	// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// in subsequent Amazon Web Services API calls to access resources in the account
+	// that owns the role. You cannot use session policies to grant more permissions
+	// than those allowed by the identity-based policy of the role that is being
+	// assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
 
@@ -1485,7 +1467,7 @@ type AssumeRoleInput struct {
 	// account that owns the role. The role session name is also used in the ARN
 	// of the assumed role principal. This means that subsequent cross-account API
 	// requests that use the temporary security credentials will expose the role
-	// session name to the external account in their AWS CloudTrail logs.
+	// session name to the external account in their CloudTrail logs.
 	//
 	// The regex used to validate this parameter is a string of characters consisting
 	// of upper- and lower-case alphanumeric characters with no spaces. You can
@@ -1510,23 +1492,23 @@ type AssumeRoleInput struct {
 	//
 	// You can require users to specify a source identity when they assume a role.
 	// You do this by using the sts:SourceIdentity condition key in a role trust
-	// policy. You can use source identity information in AWS CloudTrail logs to
-	// determine who took actions with a role. You can use the aws:SourceIdentity
-	// condition key to further control access to AWS resources based on the value
-	// of source identity. For more information about using source identity, see
-	// Monitor and control actions taken with assumed roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html)
+	// policy. You can use source identity information in CloudTrail logs to determine
+	// who took actions with a role. You can use the aws:SourceIdentity condition
+	// key to further control access to Amazon Web Services resources based on the
+	// value of source identity. For more information about using source identity,
+	// see Monitor and control actions taken with assumed roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html)
 	// in the IAM User Guide.
 	//
 	// The regex used to validate this parameter is a string of characters consisting
 	// of upper- and lower-case alphanumeric characters with no spaces. You can
 	// also include underscores or any of the following characters: =,.@-. You cannot
-	// use a value that begins with the text aws:. This prefix is reserved for AWS
-	// internal use.
+	// use a value that begins with the text aws:. This prefix is reserved for Amazon
+	// Web Services internal use.
 	SourceIdentity *string `min:"2" type:"string"`
 
 	// A list of session tags that you want to pass. Each session tag consists of
 	// a key name and an associated value. For more information about session tags,
-	// see Tagging AWS STS Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// see Tagging Amazon Web Services STS Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 	// in the IAM User Guide.
 	//
 	// This parameter is optional. You can pass up to 50 session tags. The plaintext
@@ -1535,11 +1517,11 @@ type AssumeRoleInput struct {
 	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 	// in the IAM User Guide.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	//
 	// You can pass a session tag with the same key as a tag that is already attached
 	// to the role. When you do, session tags override a role tag with the same
@@ -1554,7 +1536,7 @@ type AssumeRoleInput struct {
 	// Additionally, if you used temporary credentials to perform this operation,
 	// the new session inherits any transitive session tags from the calling session.
 	// If you pass a session tag with the same key as an inherited tag, the operation
-	// fails. To view the inherited tags for a session, see the AWS CloudTrail logs.
+	// fails. To view the inherited tags for a session, see the CloudTrail logs.
 	// For more information, see Viewing Session Tags in CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/session-tags.html#id_session-tags_ctlogs)
 	// in the IAM User Guide.
 	Tags []*Tag `type:"list"`
@@ -1583,12 +1565,20 @@ type AssumeRoleInput struct {
 	TransitiveTagKeys []*string `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleInput) GoString() string {
 	return s.String()
 }
@@ -1720,7 +1710,8 @@ func (s *AssumeRoleInput) SetTransitiveTagKeys(v []*string) *AssumeRoleInput {
 }
 
 // Contains the response to a successful AssumeRole request, including temporary
-// AWS credentials that can be used to make AWS requests.
+// Amazon Web Services credentials that can be used to make Amazon Web Services
+// requests.
 type AssumeRoleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1749,11 +1740,11 @@ type AssumeRoleOutput struct {
 	//
 	// You can require users to specify a source identity when they assume a role.
 	// You do this by using the sts:SourceIdentity condition key in a role trust
-	// policy. You can use source identity information in AWS CloudTrail logs to
-	// determine who took actions with a role. You can use the aws:SourceIdentity
-	// condition key to further control access to AWS resources based on the value
-	// of source identity. For more information about using source identity, see
-	// Monitor and control actions taken with assumed roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html)
+	// policy. You can use source identity information in CloudTrail logs to determine
+	// who took actions with a role. You can use the aws:SourceIdentity condition
+	// key to further control access to Amazon Web Services resources based on the
+	// value of source identity. For more information about using source identity,
+	// see Monitor and control actions taken with assumed roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html)
 	// in the IAM User Guide.
 	//
 	// The regex used to validate this parameter is a string of characters consisting
@@ -1762,12 +1753,20 @@ type AssumeRoleOutput struct {
 	SourceIdentity *string `min:"2" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleOutput) GoString() string {
 	return s.String()
 }
@@ -1819,7 +1818,7 @@ type AssumeRoleWithSAMLInput struct {
 	// to the federation endpoint for a console sign-in token takes a SessionDuration
 	// parameter that specifies the maximum length of the console session. For more
 	// information, see Creating a URL that Enables Federated Users to Access the
-	// AWS Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+	// Amazon Web Services Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
@@ -1828,10 +1827,11 @@ type AssumeRoleWithSAMLInput struct {
 	// This parameter is optional. Passing policies to this operation returns new
 	// temporary credentials. The resulting session's permissions are the intersection
 	// of the role's identity-based policy and the session policies. You can use
-	// the role's temporary credentials in subsequent AWS API calls to access resources
-	// in the account that owns the role. You cannot use session policies to grant
-	// more permissions than those allowed by the identity-based policy of the role
-	// that is being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// the role's temporary credentials in subsequent Amazon Web Services API calls
+	// to access resources in the account that owns the role. You cannot use session
+	// policies to grant more permissions than those allowed by the identity-based
+	// policy of the role that is being assumed. For more information, see Session
+	// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	//
 	// The plaintext that you use for both inline and managed session policies can't
@@ -1840,11 +1840,11 @@ type AssumeRoleWithSAMLInput struct {
 	// \u00FF). It can also include the tab (\u0009), linefeed (\u000A), and carriage
 	// return (\u000D) characters.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -1854,22 +1854,22 @@ type AssumeRoleWithSAMLInput struct {
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plaintext that you use for both inline and managed session policies
 	// can't exceed 2,048 characters. For more information about ARNs, see Amazon
-	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// in the AWS General Reference.
+	// Resource Names (ARNs) and Amazon Web Services Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// in the Amazon Web Services General Reference.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
 	// policy and the session policies. You can use the role's temporary credentials
-	// in subsequent AWS API calls to access resources in the account that owns
-	// the role. You cannot use session policies to grant more permissions than
-	// those allowed by the identity-based policy of the role that is being assumed.
-	// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// in subsequent Amazon Web Services API calls to access resources in the account
+	// that owns the role. You cannot use session policies to grant more permissions
+	// than those allowed by the identity-based policy of the role that is being
+	// assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
 
@@ -1893,12 +1893,20 @@ type AssumeRoleWithSAMLInput struct {
 	SAMLAssertion *string `min:"4" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithSAMLInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithSAMLInput) GoString() string {
 	return s.String()
 }
@@ -1984,7 +1992,8 @@ func (s *AssumeRoleWithSAMLInput) SetSAMLAssertion(v string) *AssumeRoleWithSAML
 }
 
 // Contains the response to a successful AssumeRoleWithSAML request, including
-// temporary AWS credentials that can be used to make AWS requests.
+// temporary Amazon Web Services credentials that can be used to make Amazon
+// Web Services requests.
 type AssumeRoleWithSAMLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2010,7 +2019,7 @@ type AssumeRoleWithSAMLOutput struct {
 	//
 	//    * The Issuer response value.
 	//
-	//    * The AWS account ID.
+	//    * The Amazon Web Services account ID.
 	//
 	//    * The friendly name (the last part of the ARN) of the SAML provider in
 	//    IAM.
@@ -2064,12 +2073,20 @@ type AssumeRoleWithSAMLOutput struct {
 	SubjectType *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithSAMLOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithSAMLOutput) GoString() string {
 	return s.String()
 }
@@ -2148,7 +2165,7 @@ type AssumeRoleWithWebIdentityInput struct {
 	// to the federation endpoint for a console sign-in token takes a SessionDuration
 	// parameter that specifies the maximum length of the console session. For more
 	// information, see Creating a URL that Enables Federated Users to Access the
-	// AWS Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+	// Amazon Web Services Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
@@ -2157,10 +2174,11 @@ type AssumeRoleWithWebIdentityInput struct {
 	// This parameter is optional. Passing policies to this operation returns new
 	// temporary credentials. The resulting session's permissions are the intersection
 	// of the role's identity-based policy and the session policies. You can use
-	// the role's temporary credentials in subsequent AWS API calls to access resources
-	// in the account that owns the role. You cannot use session policies to grant
-	// more permissions than those allowed by the identity-based policy of the role
-	// that is being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// the role's temporary credentials in subsequent Amazon Web Services API calls
+	// to access resources in the account that owns the role. You cannot use session
+	// policies to grant more permissions than those allowed by the identity-based
+	// policy of the role that is being assumed. For more information, see Session
+	// Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	//
 	// The plaintext that you use for both inline and managed session policies can't
@@ -2169,11 +2187,11 @@ type AssumeRoleWithWebIdentityInput struct {
 	// \u00FF). It can also include the tab (\u0009), linefeed (\u000A), and carriage
 	// return (\u000D) characters.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -2183,22 +2201,22 @@ type AssumeRoleWithWebIdentityInput struct {
 	// This parameter is optional. You can provide up to 10 managed policy ARNs.
 	// However, the plaintext that you use for both inline and managed session policies
 	// can't exceed 2,048 characters. For more information about ARNs, see Amazon
-	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// in the AWS General Reference.
+	// Resource Names (ARNs) and Amazon Web Services Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// in the Amazon Web Services General Reference.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	//
 	// Passing policies to this operation returns new temporary credentials. The
 	// resulting session's permissions are the intersection of the role's identity-based
 	// policy and the session policies. You can use the role's temporary credentials
-	// in subsequent AWS API calls to access resources in the account that owns
-	// the role. You cannot use session policies to grant more permissions than
-	// those allowed by the identity-based policy of the role that is being assumed.
-	// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// in subsequent Amazon Web Services API calls to access resources in the account
+	// that owns the role. You cannot use session policies to grant more permissions
+	// than those allowed by the identity-based policy of the role that is being
+	// assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
 
@@ -2238,12 +2256,20 @@ type AssumeRoleWithWebIdentityInput struct {
 	WebIdentityToken *string `min:"4" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithWebIdentityInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithWebIdentityInput) GoString() string {
 	return s.String()
 }
@@ -2338,7 +2364,8 @@ func (s *AssumeRoleWithWebIdentityInput) SetWebIdentityToken(v string) *AssumeRo
 }
 
 // Contains the response to a successful AssumeRoleWithWebIdentity request,
-// including temporary AWS credentials that can be used to make AWS requests.
+// including temporary Amazon Web Services credentials that can be used to make
+// Amazon Web Services requests.
 type AssumeRoleWithWebIdentityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2405,12 +2432,20 @@ type AssumeRoleWithWebIdentityOutput struct {
 	SubjectFromWebIdentityToken *string `min:"6" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithWebIdentityOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumeRoleWithWebIdentityOutput) GoString() string {
 	return s.String()
 }
@@ -2471,19 +2506,27 @@ type AssumedRoleUser struct {
 	Arn *string `min:"20" type:"string" required:"true"`
 
 	// A unique identifier that contains the role ID and the role session name of
-	// the role that is being assumed. The role ID is generated by AWS when the
-	// role is created.
+	// the role that is being assumed. The role ID is generated by Amazon Web Services
+	// when the role is created.
 	//
 	// AssumedRoleId is a required field
 	AssumedRoleId *string `min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumedRoleUser) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s AssumedRoleUser) GoString() string {
 	return s.String()
 }
@@ -2500,7 +2543,7 @@ func (s *AssumedRoleUser) SetAssumedRoleId(v string) *AssumedRoleUser {
 	return s
 }
 
-// AWS credentials for API authentication.
+// Amazon Web Services credentials for API authentication.
 type Credentials struct {
 	_ struct{} `type:"structure"`
 
@@ -2525,12 +2568,20 @@ type Credentials struct {
 	SessionToken *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Credentials) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Credentials) GoString() string {
 	return s.String()
 }
@@ -2568,12 +2619,20 @@ type DecodeAuthorizationMessageInput struct {
 	EncodedMessage *string `min:"1" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecodeAuthorizationMessageInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecodeAuthorizationMessageInput) GoString() string {
 	return s.String()
 }
@@ -2601,21 +2660,29 @@ func (s *DecodeAuthorizationMessageInput) SetEncodedMessage(v string) *DecodeAut
 }
 
 // A document that contains additional information about the authorization status
-// of a request from an encoded message that is returned in response to an AWS
-// request.
+// of a request from an encoded message that is returned in response to an Amazon
+// Web Services request.
 type DecodeAuthorizationMessageOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An XML document that contains the decoded message.
+	// The API returns a response with the decoded message.
 	DecodedMessage *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecodeAuthorizationMessageOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s DecodeAuthorizationMessageOutput) GoString() string {
 	return s.String()
 }
@@ -2645,12 +2712,20 @@ type FederatedUser struct {
 	FederatedUserId *string `min:"2" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FederatedUser) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s FederatedUser) GoString() string {
 	return s.String()
 }
@@ -2679,12 +2754,20 @@ type GetAccessKeyInfoInput struct {
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAccessKeyInfoInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAccessKeyInfoInput) GoString() string {
 	return s.String()
 }
@@ -2714,16 +2797,24 @@ func (s *GetAccessKeyInfoInput) SetAccessKeyId(v string) *GetAccessKeyInfoInput 
 type GetAccessKeyInfoOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The number used to identify the AWS account.
+	// The number used to identify the Amazon Web Services account.
 	Account *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAccessKeyInfoOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetAccessKeyInfoOutput) GoString() string {
 	return s.String()
 }
@@ -2738,12 +2829,20 @@ type GetCallerIdentityInput struct {
 	_ struct{} `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetCallerIdentityInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetCallerIdentityInput) GoString() string {
 	return s.String()
 }
@@ -2753,11 +2852,11 @@ func (s GetCallerIdentityInput) GoString() string {
 type GetCallerIdentityOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID number of the account that owns or contains the calling
-	// entity.
+	// The Amazon Web Services account ID number of the account that owns or contains
+	// the calling entity.
 	Account *string `type:"string"`
 
-	// The AWS ARN associated with the calling entity.
+	// The Amazon Web Services ARN associated with the calling entity.
 	Arn *string `min:"20" type:"string"`
 
 	// The unique identifier of the calling entity. The exact value depends on the
@@ -2767,12 +2866,20 @@ type GetCallerIdentityOutput struct {
 	UserId *string `type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetCallerIdentityOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetCallerIdentityOutput) GoString() string {
 	return s.String()
 }
@@ -2801,9 +2908,10 @@ type GetFederationTokenInput struct {
 	// The duration, in seconds, that the session should last. Acceptable durations
 	// for federation sessions range from 900 seconds (15 minutes) to 129,600 seconds
 	// (36 hours), with 43,200 seconds (12 hours) as the default. Sessions obtained
-	// using AWS account root user credentials are restricted to a maximum of 3,600
-	// seconds (one hour). If the specified duration is longer than one hour, the
-	// session obtained by using root user credentials defaults to one hour.
+	// using Amazon Web Services account root user credentials are restricted to
+	// a maximum of 3,600 seconds (one hour). If the specified duration is longer
+	// than one hour, the session obtained by using root user credentials defaults
+	// to one hour.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
 	// The name of the federated user. The name is used as an identifier for the
@@ -2848,11 +2956,11 @@ type GetFederationTokenInput struct {
 	// \u00FF). It can also include the tab (\u0009), linefeed (\u000A), and carriage
 	// return (\u000D) characters.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	Policy *string `min:"1" type:"string"`
 
 	// The Amazon Resource Names (ARNs) of the IAM managed policies that you want
@@ -2865,8 +2973,8 @@ type GetFederationTokenInput struct {
 	// use as managed session policies. The plaintext that you use for both inline
 	// and managed session policies can't exceed 2,048 characters. You can provide
 	// up to 10 managed policy ARNs. For more information about ARNs, see Amazon
-	// Resource Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// in the AWS General Reference.
+	// Resource Names (ARNs) and Amazon Web Services Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// in the Amazon Web Services General Reference.
 	//
 	// This parameter is optional. However, if you do not pass any session policies,
 	// then the resulting federated user session has no permissions.
@@ -2885,11 +2993,11 @@ type GetFederationTokenInput struct {
 	// by the policy. These permissions are granted in addition to the permissions
 	// that are granted by the session policies.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
 
 	// A list of session tags. Each session tag consists of a key name and an associated
@@ -2903,11 +3011,11 @@ type GetFederationTokenInput struct {
 	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 	// in the IAM User Guide.
 	//
-	// An AWS conversion compresses the passed session policies and session tags
-	// into a packed binary format that has a separate limit. Your request can fail
-	// for this limit even if your plaintext meets the other requirements. The PackedPolicySize
-	// response element indicates by percentage how close the policies and tags
-	// for your request are to the upper size limit.
+	// An Amazon Web Services conversion compresses the passed session policies
+	// and session tags into a packed binary format that has a separate limit. Your
+	// request can fail for this limit even if your plaintext meets the other requirements.
+	// The PackedPolicySize response element indicates by percentage how close the
+	// policies and tags for your request are to the upper size limit.
 	//
 	// You can pass a session tag with the same key as a tag that is already attached
 	// to the user you are federating. When you do, session tags override a user
@@ -2921,12 +3029,20 @@ type GetFederationTokenInput struct {
 	Tags []*Tag `type:"list"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetFederationTokenInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetFederationTokenInput) GoString() string {
 	return s.String()
 }
@@ -3004,7 +3120,8 @@ func (s *GetFederationTokenInput) SetTags(v []*Tag) *GetFederationTokenInput {
 }
 
 // Contains the response to a successful GetFederationToken request, including
-// temporary AWS credentials that can be used to make AWS requests.
+// temporary Amazon Web Services credentials that can be used to make Amazon
+// Web Services requests.
 type GetFederationTokenOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3028,12 +3145,20 @@ type GetFederationTokenOutput struct {
 	PackedPolicySize *int64 `type:"integer"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetFederationTokenOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetFederationTokenOutput) GoString() string {
 	return s.String()
 }
@@ -3062,9 +3187,9 @@ type GetSessionTokenInput struct {
 	// The duration, in seconds, that the credentials should remain valid. Acceptable
 	// durations for IAM user sessions range from 900 seconds (15 minutes) to 129,600
 	// seconds (36 hours), with 43,200 seconds (12 hours) as the default. Sessions
-	// for AWS account owners are restricted to a maximum of 3,600 seconds (one
-	// hour). If the duration is longer than one hour, the session for AWS account
-	// owners defaults to one hour.
+	// for Amazon Web Services account owners are restricted to a maximum of 3,600
+	// seconds (one hour). If the duration is longer than one hour, the session
+	// for Amazon Web Services account owners defaults to one hour.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
 	// The identification number of the MFA device that is associated with the IAM
@@ -3072,8 +3197,8 @@ type GetSessionTokenInput struct {
 	// user has a policy that requires MFA authentication. The value is either the
 	// serial number for a hardware device (such as GAHT12345678) or an Amazon Resource
 	// Name (ARN) for a virtual device (such as arn:aws:iam::123456789012:mfa/user).
-	// You can find the device for an IAM user by going to the AWS Management Console
-	// and viewing the user's security credentials.
+	// You can find the device for an IAM user by going to the Amazon Web Services
+	// Management Console and viewing the user's security credentials.
 	//
 	// The regex used to validate this parameter is a string of characters consisting
 	// of upper- and lower-case alphanumeric characters with no spaces. You can
@@ -3091,12 +3216,20 @@ type GetSessionTokenInput struct {
 	TokenCode *string `min:"6" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetSessionTokenInput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetSessionTokenInput) GoString() string {
 	return s.String()
 }
@@ -3139,7 +3272,8 @@ func (s *GetSessionTokenInput) SetTokenCode(v string) *GetSessionTokenInput {
 }
 
 // Contains the response to a successful GetSessionToken request, including
-// temporary AWS credentials that can be used to make AWS requests.
+// temporary Amazon Web Services credentials that can be used to make Amazon
+// Web Services requests.
 type GetSessionTokenOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3151,12 +3285,20 @@ type GetSessionTokenOutput struct {
 	Credentials *Credentials `type:"structure"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetSessionTokenOutput) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s GetSessionTokenOutput) GoString() string {
 	return s.String()
 }
@@ -3174,17 +3316,25 @@ type PolicyDescriptorType struct {
 
 	// The Amazon Resource Name (ARN) of the IAM managed policy to use as a session
 	// policy for the role. For more information about ARNs, see Amazon Resource
-	// Names (ARNs) and AWS Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// in the AWS General Reference.
+	// Names (ARNs) and Amazon Web Services Service Namespaces (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// in the Amazon Web Services General Reference.
 	Arn *string `locationName:"arn" min:"20" type:"string"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyDescriptorType) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s PolicyDescriptorType) GoString() string {
 	return s.String()
 }
@@ -3210,8 +3360,8 @@ func (s *PolicyDescriptorType) SetArn(v string) *PolicyDescriptorType {
 
 // You can pass custom key-value pair attributes when you assume a role or federate
 // a user. These are called session tags. You can then use the session tags
-// to control access to resources. For more information, see Tagging AWS STS
-// Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+// to control access to resources. For more information, see Tagging Amazon
+// Web Services STS Sessions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 // in the IAM User Guide.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -3237,12 +3387,20 @@ type Tag struct {
 	Value *string `type:"string" required:"true"`
 }
 
-// String returns the string representation
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) String() string {
 	return awsutil.Prettify(s)
 }
 
-// GoString returns the string representation
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
 func (s Tag) GoString() string {
 	return s.String()
 }

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
@@ -3,11 +3,11 @@
 // Package sts provides the client and types for making API
 // requests to AWS Security Token Service.
 //
-// AWS Security Token Service (STS) enables you to request temporary, limited-privilege
-// credentials for AWS Identity and Access Management (IAM) users or for users
-// that you authenticate (federated users). This guide provides descriptions
-// of the STS API. For more information about using this service, see Temporary
-// Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).
+// Security Token Service (STS) enables you to request temporary, limited-privilege
+// credentials for Identity and Access Management (IAM) users or for users that
+// you authenticate (federated users). This guide provides descriptions of the
+// STS API. For more information about using this service, see Temporary Security
+// Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/sts-2011-06-15 for more information on this service.
 //

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/errors.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/errors.go
@@ -42,8 +42,9 @@ const (
 	// ErrCodeInvalidIdentityTokenException for service response error code
 	// "InvalidIdentityToken".
 	//
-	// The web identity token that was passed could not be validated by AWS. Get
-	// a new identity token from the identity provider and then retry the request.
+	// The web identity token that was passed could not be validated by Amazon Web
+	// Services. Get a new identity token from the identity provider and then retry
+	// the request.
 	ErrCodeInvalidIdentityTokenException = "InvalidIdentityToken"
 
 	// ErrCodeMalformedPolicyDocumentException for service response error code
@@ -57,16 +58,16 @@ const (
 	// "PackedPolicyTooLarge".
 	//
 	// The request was rejected because the total packed size of the session policies
-	// and session tags combined was too large. An AWS conversion compresses the
-	// session policy document, session policy ARNs, and session tags into a packed
-	// binary format that has a separate limit. The error message indicates by percentage
-	// how close the policies and tags are to the upper size limit. For more information,
-	// see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// and session tags combined was too large. An Amazon Web Services conversion
+	// compresses the session policy document, session policy ARNs, and session
+	// tags into a packed binary format that has a separate limit. The error message
+	// indicates by percentage how close the policies and tags are to the upper
+	// size limit. For more information, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
 	// in the IAM User Guide.
 	//
 	// You could receive this error even though you meet other defined session policy
 	// and session tag limits. For more information, see IAM and STS Entity Character
-	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+	// Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length)
 	// in the IAM User Guide.
 	ErrCodePackedPolicyTooLargeException = "PackedPolicyTooLarge"
 
@@ -76,7 +77,8 @@ const (
 	// STS is not activated in the requested region for the account that is being
 	// asked to generate credentials. The account administrator must use the IAM
 	// console to activate STS in that region. For more information, see Activating
-	// and Deactivating AWS STS in an AWS Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+	// and Deactivating Amazon Web Services STS in an Amazon Web Services Region
+	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 	// in the IAM User Guide.
 	ErrCodeRegionDisabledException = "RegionDisabledException"
 )

--- a/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/service.go
+++ b/cluster-autoscaler/vendor/github.com/aws/aws-sdk-go/service/sts/service.go
@@ -48,22 +48,23 @@ const (
 //     svc := sts.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *STS {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName, c.ResolvedRegion)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *STS {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName, resolvedRegion string) *STS {
 	svc := &STS{
 		Client: client.New(
 			cfg,
 			metadata.ClientInfo{
-				ServiceName:   ServiceName,
-				ServiceID:     ServiceID,
-				SigningName:   signingName,
-				SigningRegion: signingRegion,
-				PartitionID:   partitionID,
-				Endpoint:      endpoint,
-				APIVersion:    "2011-06-15",
+				ServiceName:    ServiceName,
+				ServiceID:      ServiceID,
+				SigningName:    signingName,
+				SigningRegion:  signingRegion,
+				PartitionID:    partitionID,
+				Endpoint:       endpoint,
+				APIVersion:     "2011-06-15",
+				ResolvedRegion: resolvedRegion,
 			},
 			handlers,
 		),

--- a/cluster-autoscaler/vendor/golang.org/x/net/http2/ascii.go
+++ b/cluster-autoscaler/vendor/golang.org/x/net/http2/ascii.go
@@ -6,6 +6,10 @@ package http2
 
 import "strings"
 
+// The HTTP protocols are defined in terms of ASCII, not Unicode. This file
+// contains helper functions which may use Unicode-aware functions which would
+// otherwise be unsafe and could introduce vulnerabilities if used improperly.
+
 // asciiEqualFold is strings.EqualFold, ASCII only. It reports whether s and t
 // are equal, ASCII-case-insensitively.
 func asciiEqualFold(s, t string) bool {

--- a/cluster-autoscaler/vendor/golang.org/x/net/http2/server.go
+++ b/cluster-autoscaler/vendor/golang.org/x/net/http2/server.go
@@ -259,15 +259,11 @@ func ConfigureServer(s *http.Server, conf *Server) error {
 
 	s.TLSConfig.PreferServerCipherSuites = true
 
-	haveNPN := false
-	for _, p := range s.TLSConfig.NextProtos {
-		if p == NextProtoTLS {
-			haveNPN = true
-			break
-		}
-	}
-	if !haveNPN {
+	if !strSliceContains(s.TLSConfig.NextProtos, NextProtoTLS) {
 		s.TLSConfig.NextProtos = append(s.TLSConfig.NextProtos, NextProtoTLS)
+	}
+	if !strSliceContains(s.TLSConfig.NextProtos, "http/1.1") {
+		s.TLSConfig.NextProtos = append(s.TLSConfig.NextProtos, "http/1.1")
 	}
 
 	if s.TLSNextProto == nil {

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -86,7 +86,7 @@ github.com/PuerkitoBio/urlesc
 github.com/armon/circbuf
 # github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 github.com/asaskevich/govalidator
-# github.com/aws/aws-sdk-go v1.38.49
+# github.com/aws/aws-sdk-go v1.42.11
 ## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
@@ -690,7 +690,7 @@ golang.org/x/crypto/pkcs12
 golang.org/x/crypto/pkcs12/internal/rc2
 golang.org/x/crypto/poly1305
 golang.org/x/crypto/salsa20/salsa
-# golang.org/x/net v0.0.0-20210525063256-abc453219eb5
+# golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp


### PR DESCRIPTION
### **Description:**

This change addresses #4505 by leveraging ASG's new tag filtering support for DescribeAutoScalingGroups API to simplify the ASG discovery logic.

Changes include updating AWS SDK version from v1.38.49 -> v1.42.11.

### **Testing done to prevent behavior regression:**

1. Scaling up to place pending pods works for auto-discovered and named ASGs
2. Decreasing the number of pods resulted in a scale down
3. Testing done to show impact of change, shown below

***Test Scenario 1***
1 explicitly-configured ASG
99 tagged ASGs
1 auto-discovery spec (default)

***Observed behavior for Scenario 1***
Master branch API Call Count: 2
Feature branch API Call Count: 2

***Test Scenario 2***
1 explicitly-configured ASG
100 tagged ASGs
1 auto-discovery spec (default)

***Branch behavior for Scenario 2***
Master branch API Call Count: 3
Feature branch API Call Count: 2

***Test Scenario 3***
1 explicitly-configured ASG
99 tagged ASGs
1 auto-discovery spec (default)
lowered `maxAsgNamesPerDescribe` from 100->10 to simulate increase in ASG batched calls that we'd expect with more ASGs

***Branch behavior for Scenario 3***
Master branch API Call Count: 11
Feature branch API Call Count: 2