### PR TITLE
Shorten Hetzners node names with hex repr

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -305,7 +305,7 @@ func toInstanceStatus(status hcloud.ServerStatus) *cloudprovider.InstanceStatus 
 }
 
 func newNodeName(n *hetznerNodeGroup) string {
-	return fmt.Sprintf("%s-%d", n.id, rand.Int63())
+	return fmt.Sprintf("%s-%x", n.id, rand.Int63())
 }
 
 func buildNodeGroupLabels(n *hetznerNodeGroup) map[string]string {


### PR DESCRIPTION
This PR doesn't change or adds any functionality, it's a pure visual change.
Node names with the Hetzner Cloud Provider used to have a long name of random numbers. To shorten those names this PR aims to change the random number to a hex representation.