### PR TITLE
Cluster Autoscaler: GCE: check the result of the operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -229,6 +229,10 @@ func (client *autoscalingGceClientV1) waitForOp(operation *gce.Operation, projec
 		if op, err := client.gceService.ZoneOperations.Get(project, zone, operation.Name).Do(); err == nil {
 			klog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
 			if op.Status == "DONE" {
+				if op.Error != nil {
+					return fmt.Errorf("error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
+				}
+
 				return nil
 			}
 		} else {


### PR DESCRIPTION
Suppose the instance group update mode is not `Opportunistic`. In that case, the operation ends without error; the GCP console shows no increase in the number of nodes (but it shows the updating clock image) and tries to repeat the operation multiple times.

If the operation is `DONE` but contains an error, return it.

Note: I am aware this is not an error in the autoscaler but the only place to find the reason why the scale-up operation is not being done is in the console https://console.cloud.google.com/compute/operations (even there, the operation appears as OK)


![Screenshot from 2021-12-08 18-12-23](https://user-images.githubusercontent.com/161571/145285119-a4106322-c631-49f6-b202-8ca7bb66d09e.png)

