### PR TITLE
Refresh instances to mig cache in MigInfoProvider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache_test.go
@@ -82,7 +82,7 @@ func TestMachineCache(t *testing.T) {
 			},
 		},
 	}
-	c := NewGceCache(nil, 1)
+	c := NewGceCache()
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, m := range tc.machines {

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -173,7 +173,7 @@ func TestGetMigTargetSize(t *testing.T) {
 				fetchMigs:          tc.fetchMigs,
 				fetchMigTargetSize: tc.fetchMigTargetSize,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project)
+			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project, 1)
 
 			targetSize, err := provider.GetMigTargetSize(gceRef)
 			cachedTargetSize, found := tc.cache.GetMigTargetSize(gceRef)
@@ -254,7 +254,7 @@ func TestGetMigBasename(t *testing.T) {
 				fetchMigs:        tc.fetchMigs,
 				fetchMigBasename: tc.fetchMigBasename,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project)
+			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project, 1)
 
 			basename, err := provider.GetMigBasename(gceRef)
 			cachedBasename, found := tc.cache.GetMigBasename(gceRef)
@@ -335,7 +335,7 @@ func TestGetMigInstanceTemplateName(t *testing.T) {
 				fetchMigs:            tc.fetchMigs,
 				fetchMigTemplateName: tc.fetchMigTemplateName,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project)
+			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project, 1)
 
 			templateName, err := provider.GetMigInstanceTemplateName(gceRef)
 			cachedTemplateName, found := tc.cache.GetMigInstanceTemplateName(gceRef)
@@ -440,7 +440,7 @@ func TestGetMigInstanceTemplate(t *testing.T) {
 				fetchMigTemplateName: tc.fetchMigTemplateName,
 				fetchMigTemplate:     tc.fetchMigTemplate,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project)
+			provider := NewCachingMigInfoProvider(tc.cache, client, gceRef.Project, 1)
 
 			template, err := provider.GetMigInstanceTemplate(gceRef)
 			cachedTemplate, found := tc.cache.GetMigInstanceTemplate(gceRef)


### PR DESCRIPTION
Refreshing `GceCache` should be done by other components, similarly to how the basenames are refreshed by `MigInfoProvider` or how `Migs` are registered by `GceManager`. This provides additional level of isolation in the code, cleans up dependencies and simplifies reasoning.

Currently instances to `Migs` cache is being refreshed by `GceCache` itself. This introduces unnecessary dependancy on the `GceClient`. This change moves that refreshing logic to `MigInfoProvider`, simplifying the resulting dependency network.

The changes are aimed to maintain the same functionality as the current one. The only significant difference is checking all the Migs in `RefillAllMigInstances` and `fillCandidateMigInstances` functions in `MigInfoProvider`. Thanks to that the CA should be able to handle fetches returning errors better - such cases will no longer block cache updating for other Migs.