### PR TITLE
Re-add default expander

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -149,7 +149,7 @@ var (
 	estimatorFlag = flag.String("estimator", estimator.BinpackingEstimatorName,
 		"Type of resource estimator to be used in scale up. Available values: ["+strings.Join(estimator.AvailableEstimators, ",")+"]")
 
-	expanderFlag = flag.String("expander", "", "Type of node group expander to be used in scale up. Available values: ["+strings.Join(expander.AvailableExpanders, ",")+"]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly.")
+	expanderFlag = flag.String("expander", expander.RandomExpanderName, "Type of node group expander to be used in scale up. Available values: ["+strings.Join(expander.AvailableExpanders, ",")+"]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly.")
 
 	ignoreDaemonSetsUtilization = flag.Bool("ignore-daemonsets-utilization", false,
 		"Should CA ignore DaemonSet pods when calculating resource utilization for scaling down")


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/pull/4233  introduced the possibility to add multiple expanders but removed the default definition so now it must be explicitly defined otherwise a user gets the not user-friendly error:

```
F1209 16:45:32.229497       1 main.go:350] Failed to create autoscaler: Expander  not supported
```

This PR reintroduces a default expander, with value "random" as it was before, so that the `--expander` flag does not need to be explicitly defined if a user does not care about it.


