### PR TITLE
Introduce the scale down processor that picks the final scale down candidates

### DIFF
--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfos"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -140,6 +141,7 @@ func NewTestProcessors() *processors.AutoscalingProcessors {
 		PodListProcessor:       NewFilterOutSchedulablePodListProcessor(),
 		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{},
 		NodeGroupSetProcessor:  nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}),
+		ScaleDownSetProcessor:  nodes.NewPostFilteringScaleDownNodeProcessor(),
 		// TODO(bskiba): change scale up test so that this can be a NoOpProcessor
 		ScaleUpStatusProcessor:     &status.EventingScaleUpStatusProcessor{},
 		ScaleDownStatusProcessor:   &status.NoOpScaleDownStatusProcessor{},

--- a/cluster-autoscaler/processors/nodes/post_filtering_processor.go
+++ b/cluster-autoscaler/processors/nodes/post_filtering_processor.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+)
+
+// PostFilteringScaleDownNodeProcessor selects first maxCount nodes (if possible) to be removed
+type PostFilteringScaleDownNodeProcessor struct {
+}
+
+// GetNodesToRemove selects up to maxCount nodes for deletion, by selecting a first maxCount candidates
+func (n *PostFilteringScaleDownNodeProcessor) GetNodesToRemove(candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved {
+	end := len(candidates)
+	if len(candidates) > maxCount {
+		end = maxCount
+	}
+	return candidates[:end]
+}
+
+// CleanUp is called at CA termination
+func (n *PostFilteringScaleDownNodeProcessor) CleanUp() {
+}
+
+// NewPostFilteringScaleDownNodeProcessor returns a new PostFilteringScaleDownNodeProcessor
+func NewPostFilteringScaleDownNodeProcessor() *PostFilteringScaleDownNodeProcessor {
+	return &PostFilteringScaleDownNodeProcessor{}
+}

--- a/cluster-autoscaler/processors/nodes/types.go
+++ b/cluster-autoscaler/processors/nodes/types.go
@@ -20,6 +20,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 )
 
@@ -30,6 +31,14 @@ type ScaleDownNodeProcessor interface {
 	GetPodDestinationCandidates(*context.AutoscalingContext, []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError)
 	// GetScaleDownCandidates returns nodes that potentially could be scaled down.
 	GetScaleDownCandidates(*context.AutoscalingContext, []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError)
+	// CleanUp is called at CA termination
+	CleanUp()
+}
+
+// ScaleDownSetProcessor contains a method to select nodes for deletion
+type ScaleDownSetProcessor interface {
+	// GetNodesToRemove selects up to maxCount nodes for deletion
+	GetNodesToRemove(candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved
 	// CleanUp is called at CA termination
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -42,6 +42,8 @@ type AutoscalingProcessors struct {
 	ScaleUpStatusProcessor status.ScaleUpStatusProcessor
 	// ScaleDownNodeProcessor is used to process the nodes of the cluster before scale-down.
 	ScaleDownNodeProcessor nodes.ScaleDownNodeProcessor
+	// ScaleDownSetProcessor is used to make final selection of nodes to scale-down.
+	ScaleDownSetProcessor nodes.ScaleDownSetProcessor
 	// ScaleDownStatusProcessor is used to process the state of the cluster after a scale-down.
 	ScaleDownStatusProcessor status.ScaleDownStatusProcessor
 	// AutoscalingStatusProcessor is used to process the state of the cluster after each autoscaling iteration.
@@ -68,6 +70,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeGroupSetProcessor:      nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}),
 		ScaleUpStatusProcessor:     status.NewDefaultScaleUpStatusProcessor(),
 		ScaleDownNodeProcessor:     nodes.NewPreFilteringScaleDownNodeProcessor(),
+		ScaleDownSetProcessor:      nodes.NewPostFilteringScaleDownNodeProcessor(),
 		ScaleDownStatusProcessor:   status.NewDefaultScaleDownStatusProcessor(),
 		AutoscalingStatusProcessor: status.NewDefaultAutoscalingStatusProcessor(),
 		NodeGroupManager:           nodegroups.NewDefaultNodeGroupManager(),
@@ -85,6 +88,7 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeGroupListProcessor.CleanUp()
 	ap.NodeGroupSetProcessor.CleanUp()
 	ap.ScaleUpStatusProcessor.CleanUp()
+	ap.ScaleDownSetProcessor.CleanUp()
 	ap.ScaleDownStatusProcessor.CleanUp()
 	ap.AutoscalingStatusProcessor.CleanUp()
 	ap.NodeGroupManager.CleanUp()


### PR DESCRIPTION
This PR introduces a new processor (proposed name is: `ScaleDownSetProcessor`), that is used at ScaleDown operations to pick a final set of candidates (after sanity checks size, pods etc.).
This may be useful to implement a variety of features, for example, users can introduce a processor that has a specific priorities for which node group to scale down first.

In this PR I also simplified the `FindNodesToRemove` function to not include the `maxCount` and `fastCheck` parameters.
The latter one is no longer needed due to the Fast and Detailed functions being backed by the same checks.
Rather than return a limited number of candidates the function returns a slice with all possible (so that the processor can pick a best suited one).

The PR also includes a default implementation of the processor that picks first x candidates (current behaviour).