### PR TITLE
Charts - CA - Default to system-cluster-critical priority class

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.10.9
+version: 9.11.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -382,7 +382,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | podAnnotations | object | `{}` | Annotations to add to each pod. |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Pod disruption budget. |
 | podLabels | object | `{}` | Labels to add to each pod. |
-| priorityClassName | string | `""` | priorityClassName |
+| priorityClassName | string | `"system-cluster-critical"` | priorityClassName |
 | priorityConfigMapAnnotations | object | `{}` | Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap. |
 | prometheusRule.additionalLabels | object | `{}` | Additional labels to be set in metadata. |
 | prometheusRule.enabled | bool | `false` | If true, creates a Prometheus Operator PrometheusRule. |

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -239,7 +239,7 @@ podLabels: {}
 additionalLabels: {}
 
 # priorityClassName -- priorityClassName
-priorityClassName: ""
+priorityClassName: "system-cluster-critical"
 
 rbac:
   # rbac.create -- If `true`, create and use RBAC resources.


### PR DESCRIPTION
Sets the default priority class of the CA to `system-cluster-critical`. We should default to safe behaviour, and risking the CA being deployed by default without a priority class risks users having their CAs be evicted and not being able to be rescheduled, thus losing scaling in their clusters is not a safe default.

This matches the examples for a number of cloud providers already in this repo, e.g. [AWS](https://github.com/kubernetes/autoscaler/blob/9e63892f86a389b337dc77558df433921237254c/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml#L140) and [AliCloud](https://github.com/kubernetes/autoscaler/blob/2542e8c884a8e25634d3b8f43243fa8706007f30/cluster-autoscaler/cloudprovider/alicloud/README.md).

