### PR TITLE
Send UID too in AdmissionReview response

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -67,6 +67,8 @@ func (s *AdmissionServer) admit(data []byte) (*v1beta1.AdmissionResponse, metric
 		return &response, metrics_admission.Error, metrics_admission.Unknown
 	}
 
+	response.UID = ar.Request.UID
+
 	var patches []resource.PatchRecord
 	var err error
 	resource := metrics_admission.Unknown


### PR DESCRIPTION
Based on https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#response, the `AdmissionReview` response stanza must contain, at a minimum, the following fields:
- `uid`, copied from the `request.uid` sent to the webhook
- `allowed`, either set to true or false

This PR populates UID field into the response returned by the VPA admission controller.

By setting `register-webhook=false` and using a  `MutatingWebhookConfiguration` like
```
---
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  name: vpa-webhook-config
webhooks:
  - name: vpa.k8s.io
    rules:
      - apiGroups:
          - ""
        apiVersions:
          - v1
        resources:
          - pods
        operations:
          - CREATE
        scope: '*'
      - apiGroups:
          - autoscaling.k8s.io
        apiVersions:
          - '*'
        operations:
          - CREATE
          - UPDATE
        resources:
          - verticalpodautoscalers
    clientConfig:
      caBundle: "{{SERVER_CERT}}"
      service:
        namespace: kube-system
        name: vpa-webhook
        port: 443
    admissionReviewVersions:
      - v1
      - v1beta1
    failurePolicy: Ignore
    sideEffects: None
    timeoutSeconds: 2
    matchPolicy: Equivalent
```

k8s apiserver is unhappy and drop vpa admission responses with:
```
[kube-apiserver-vmss-master-test-zteye000002] W1218 10:16:08.749302       1 dispatcher.go:170] Failed calling webhook, failing open vpa.k8s.io: failed calling webhook "vpa.k8s.io": expected response.uid="b0cbb31a-cc99-41e7-b5ed-80c1cf4af533", got ""
[kube-apiserver-vmss-master-test-zteye000002] E1218 10:16:08.749352       1 dispatcher.go:171] failed calling webhook "vpa.k8s.io": expected response.uid="b0cbb31a-cc99-41e7-b5ed-80c1cf4af533", got ""
[kube-apiserver-vmss-master-test-zteye000002] W1218 10:16:09.138220       1 dispatcher.go:170] Failed calling webhook, failing open vpa.k8s.io: failed calling webhook "vpa.k8s.io": expected response.uid="fea31e63-ea99-4d2b-9da3-e13b518bd77a", got ""
[kube-apiserver-vmss-master-test-zteye000002] E1218 10:16:09.138274       1 dispatcher.go:171] failed calling webhook "vpa.k8s.io": expected response.uid="fea31e63-ea99-4d2b-9da3-e13b518bd77a", got ""
```

This PR can be closed if https://github.com/kubernetes/autoscaler/pull/4537 will be merged first.
