### PR TITLE
Cache Mig instances in GceCache

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -283,11 +283,12 @@ func (m *gceManagerImpl) GetMigForInstance(instance GceRef) (Mig, error) {
 
 // GetMigNodes returns mig nodes.
 func (m *gceManagerImpl) GetMigNodes(mig Mig) ([]cloudprovider.Instance, error) {
-	return m.GceService.FetchMigInstances(mig.GceRef())
+	return m.migInfoProvider.GetMigInstances(mig.GceRef())
 }
 
 // Refresh triggers refresh of cached resources.
 func (m *gceManagerImpl) Refresh() error {
+	m.cache.InvalidateAllMigInstances()
 	m.cache.InvalidateAllMigTargetSizes()
 	m.cache.InvalidateAllMigBasenames()
 	m.cache.InvalidateAllMigInstanceTemplateNames()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -334,6 +334,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 
 	cache := &GceCache{
 		migs:                    make(map[GceRef]Mig),
+		instances:               make(map[GceRef][]cloudprovider.Instance),
 		instancesToMig:          make(map[GceRef]GceRef),
 		instancesFromUnknownMig: make(map[GceRef]bool),
 		autoscalingOptionsCache: map[GceRef]map[string]string{},

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -159,8 +159,9 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			name: "mig from cache fill",
 			cache: &GceCache{
 				migs:             map[GceRef]Mig{mig.GceRef(): mig},
-				migBaseNameCache: map[GceRef]string{mig.GceRef(): "base-instance-name"},
+				instances:        map[GceRef][]cloudprovider.Instance{},
 				instancesToMig:   map[GceRef]GceRef{},
+				migBaseNameCache: map[GceRef]string{mig.GceRef(): "base-instance-name"},
 			},
 			fetchMigInstances:    fetchMigInstancesConst([]cloudprovider.Instance{instance}),
 			expectedMig:          mig,
@@ -171,8 +172,9 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			name: "mig and basename from cache fill",
 			cache: &GceCache{
 				migs:             map[GceRef]Mig{mig.GceRef(): mig},
-				migBaseNameCache: map[GceRef]string{},
+				instances:        map[GceRef][]cloudprovider.Instance{},
 				instancesToMig:   map[GceRef]GceRef{},
+				migBaseNameCache: map[GceRef]string{},
 			},
 			fetchMigInstances:    fetchMigInstancesConst([]cloudprovider.Instance{instance}),
 			fetchMigBasename:     fetchMigBasenameConst("base-instance-name"),
@@ -184,8 +186,9 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			name: "unknown mig from cache fill",
 			cache: &GceCache{
 				migs:                    map[GceRef]Mig{mig.GceRef(): mig},
-				migBaseNameCache:        map[GceRef]string{mig.GceRef(): "base-instance-name"},
+				instances:               map[GceRef][]cloudprovider.Instance{},
 				instancesFromUnknownMig: map[GceRef]bool{},
+				migBaseNameCache:        map[GceRef]string{mig.GceRef(): "base-instance-name"},
 			},
 			fetchMigInstances:        fetchMigInstancesConst([]cloudprovider.Instance{}),
 			expectedCachedMigUnknown: true,
@@ -203,8 +206,8 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			name: "fetch instances error during cache fill",
 			cache: &GceCache{
 				migs:             map[GceRef]Mig{mig.GceRef(): mig},
-				migBaseNameCache: map[GceRef]string{mig.GceRef(): "base-instance-name"},
 				instancesToMig:   map[GceRef]GceRef{},
+				migBaseNameCache: map[GceRef]string{mig.GceRef(): "base-instance-name"},
 			},
 			fetchMigInstances: fetchMigInstancesFail,
 			expectedErr:       errFetchMigInstances,
@@ -213,8 +216,8 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			name: "fetch basename error during cache fill",
 			cache: &GceCache{
 				migs:             map[GceRef]Mig{mig.GceRef(): mig},
-				migBaseNameCache: map[GceRef]string{},
 				instancesToMig:   map[GceRef]GceRef{},
+				migBaseNameCache: map[GceRef]string{},
 			},
 			fetchMigBasename: fetchMigBasenameFail,
 			expectedErr:      nil,
@@ -736,6 +739,7 @@ func TestGetMigInstanceTemplate(t *testing.T) {
 func emptyCache() *GceCache {
 	return &GceCache{
 		migs:                      map[GceRef]Mig{mig.GceRef(): mig},
+		instances:                 make(map[GceRef][]cloudprovider.Instance),
 		migTargetSizeCache:        make(map[GceRef]int64),
 		migBaseNameCache:          make(map[GceRef]string),
 		instanceTemplateNameCache: make(map[GceRef]string),


### PR DESCRIPTION
I've added caching of the Mig instances to the `GceCache` + utilised the existing logic from `MigInfoProvider` to update and refresh this cache. This way we pass all the Mig info-related data from `GceClient` to `GceManager` exclusively via `MigInfoProvider`. This gives us better control over the client and cache, while also improving the separation of these components.

Additionally we may utilise the Mig instance cache in the future. It is refreshed once per loop, so any new functionalities that would require fetching instances will now no longer increase the QPS.

It is worth noting that we do not guarantee that `instances` and `instanceToMig` caches are in sync. They are modified independently and at different times, so it is possible that they get out of sync for a couple loops. This is mostly caused by `InvalidateXYZ` methods, which are used to force the refresh of cache.