### PR TITLE
Add MigLister interface with default no-op implementation

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -111,6 +111,7 @@ type gceManagerImpl struct {
 
 	GceService      AutoscalingGceClient
 	migInfoProvider MigInfoProvider
+	migLister       MigLister
 
 	location              string
 	projectId             string
@@ -178,10 +179,12 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 		return nil, err
 	}
 	cache := NewGceCache()
+	migLister := NewMigLister(cache)
 	manager := &gceManagerImpl{
 		cache:                  cache,
 		GceService:             gceService,
-		migInfoProvider:        NewCachingMigInfoProvider(cache, gceService, projectId, concurrentGceRefreshes),
+		migLister:              migLister,
+		migInfoProvider:        NewCachingMigInfoProvider(cache, migLister, gceService, projectId, concurrentGceRefreshes),
 		location:               location,
 		regional:               regional,
 		projectId:              projectId,
@@ -273,7 +276,7 @@ func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
 
 // GetMigs returns list of registered MIGs.
 func (m *gceManagerImpl) GetMigs() []Mig {
-	return m.cache.GetMigs()
+	return m.migLister.GetMigs()
 }
 
 // GetMigForInstance returns MIG to which the given instance belongs.
@@ -331,7 +334,7 @@ func (m *gceManagerImpl) forceRefresh() error {
 }
 
 func (m *gceManagerImpl) refreshAutoscalingOptions() {
-	for _, mig := range m.cache.GetMigs() {
+	for _, mig := range m.migLister.GetMigs() {
 		template, err := m.migInfoProvider.GetMigInstanceTemplate(mig.GceRef())
 		if err != nil {
 			klog.Warningf("Not evaluating autoscaling options for %q MIG: failed to find corresponding instance template", mig.GceRef(), err)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -348,9 +348,11 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		instanceTemplatesCache:    map[GceRef]*gce.InstanceTemplate{},
 		migBaseNameCache:          map[GceRef]string{},
 	}
+	migLister := NewMigLister(cache)
 	manager := &gceManagerImpl{
 		cache:                  cache,
-		migInfoProvider:        NewCachingMigInfoProvider(cache, gceService, projectId, 1),
+		migLister:              migLister,
+		migInfoProvider:        NewCachingMigInfoProvider(cache, migLister, gceService, projectId, 1),
 		GceService:             gceService,
 		projectId:              projectId,
 		regional:               regional,

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -231,7 +231,8 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 				fetchMigInstances: tc.fetchMigInstances,
 				fetchMigs:         fetchMigsConst(nil),
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 
 			mig, err := provider.GetMigForInstance(instanceRef)
 
@@ -302,7 +303,8 @@ func TestGetMigInstances(t *testing.T) {
 			client := &mockAutoscalingGceClient{
 				fetchMigInstances: tc.fetchMigInstances,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 			instances, err := provider.GetMigInstances(mig.GceRef())
 			cachedInstances, cached := tc.cache.GetMigInstances(mig.GceRef())
 
@@ -465,7 +467,8 @@ func TestRegenerateMigInstancesCache(t *testing.T) {
 			client := &mockAutoscalingGceClient{
 				fetchMigInstances: tc.fetchMigInstances,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 			err := provider.RegenerateMigInstancesCache()
 
 			assert.Equal(t, tc.expectedErr, err)
@@ -543,7 +546,8 @@ func TestGetMigTargetSize(t *testing.T) {
 				fetchMigs:          tc.fetchMigs,
 				fetchMigTargetSize: tc.fetchMigTargetSize,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 
 			targetSize, err := provider.GetMigTargetSize(mig.GceRef())
 			cachedTargetSize, found := tc.cache.GetMigTargetSize(mig.GceRef())
@@ -624,7 +628,8 @@ func TestGetMigBasename(t *testing.T) {
 				fetchMigs:        tc.fetchMigs,
 				fetchMigBasename: tc.fetchMigBasename,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 
 			basename, err := provider.GetMigBasename(mig.GceRef())
 			cachedBasename, found := tc.cache.GetMigBasename(mig.GceRef())
@@ -705,7 +710,8 @@ func TestGetMigInstanceTemplateName(t *testing.T) {
 				fetchMigs:            tc.fetchMigs,
 				fetchMigTemplateName: tc.fetchMigTemplateName,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 
 			templateName, err := provider.GetMigInstanceTemplateName(mig.GceRef())
 			cachedTemplateName, found := tc.cache.GetMigInstanceTemplateName(mig.GceRef())
@@ -810,7 +816,8 @@ func TestGetMigInstanceTemplate(t *testing.T) {
 				fetchMigTemplateName: tc.fetchMigTemplateName,
 				fetchMigTemplate:     tc.fetchMigTemplate,
 			}
-			provider := NewCachingMigInfoProvider(tc.cache, client, mig.GceRef().Project, 1)
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1)
 
 			template, err := provider.GetMigInstanceTemplate(mig.GceRef())
 			cachedTemplate, found := tc.cache.GetMigInstanceTemplate(mig.GceRef())

--- a/cluster-autoscaler/cloudprovider/gce/mig_lister.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_lister.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+// MigLister is a mig listing interface
+type MigLister interface {
+	// GetMigs returns the list of migs
+	GetMigs() []Mig
+	// HandleMigIssue handles an issue with a given mig
+	HandleMigIssue(migRef GceRef, err error)
+}
+
+type migLister struct {
+	cache *GceCache
+}
+
+// NewMigLister returns an instance of migLister
+func NewMigLister(cache *GceCache) *migLister {
+	return &migLister{
+		cache: cache,
+	}
+}
+
+// GetMigs returns the list of migs
+func (l *migLister) GetMigs() []Mig {
+	return l.cache.GetMigs()
+}
+
+// HandleMigIssue handles an issue with a given mig
+func (l *migLister) HandleMigIssue(_ GceRef, _ error) {
+}


### PR DESCRIPTION
`MigLister` is an interface handling issues with Migs and wrapping the `GetMigs` method of `GceCache`. It can be used to detect problematic Migs which could potentially break the CA behaviour if they were not filtered out from the `GceCloudProvider.NodeGroups()` call result.