### PR TITLE
ignore azure csi topology label for similarity checks and populate it for scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -33,6 +33,8 @@ import (
 	"time"
 )
 
+const azureDiskTopologyKey string = "topology.disk.csi.azure.com/zone"
+
 func buildInstanceOS(template compute.VirtualMachineScaleSet) string {
 	instanceOS := cloudprovider.DefaultOS
 	if template.VirtualMachineProfile != nil && template.VirtualMachineProfile.OsProfile != nil && template.VirtualMachineProfile.OsProfile.WindowsConfiguration != nil {
@@ -58,8 +60,10 @@ func buildGenericLabels(template compute.VirtualMachineScaleSet, nodeName string
 		}
 
 		result[apiv1.LabelTopologyZone] = strings.Join(failureDomains[:], cloudvolume.LabelMultiZoneDelimiter)
+		result[azureDiskTopologyKey] = strings.Join(failureDomains[:], cloudvolume.LabelMultiZoneDelimiter)
 	} else {
 		result[apiv1.LabelTopologyZone] = "0"
+		result[azureDiskTopologyKey] = ""
 	}
 
 	result[apiv1.LabelHostname] = nodeName

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
@@ -26,6 +26,9 @@ const AzureNodepoolLegacyLabel = "agentpool"
 // AzureNodepoolLabel is an AKS label specifying which nodepool a particular node belongs to
 const AzureNodepoolLabel = "kubernetes.azure.com/agentpool"
 
+// AzureDiskTopologyKey is the topology key of Azure Disk CSI driver
+const AzureDiskTopologyKey = "topology.disk.csi.azure.com/zone"
+
 func nodesFromSameAzureNodePool(n1, n2 *schedulerframework.NodeInfo) bool {
 	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLabel]
 	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLabel]
@@ -48,6 +51,7 @@ func CreateAzureNodeInfoComparator(extraIgnoredLabels []string) NodeInfoComparat
 	}
 	azureIgnoredLabels[AzureNodepoolLegacyLabel] = true
 	azureIgnoredLabels[AzureNodepoolLabel] = true
+	azureIgnoredLabels[AzureDiskTopologyKey] = true
 	for _, k := range extraIgnoredLabels {
 		azureIgnoredLabels[k] = true
 	}


### PR DESCRIPTION
For balancing similar nodegroups, this label should be ignored when comparing nodegroups that may be in different zones.

This also adds the label to the set of zonal labels predicted by azure template for the scale from zero case.