### PR TITLE
add TargetCPUPercentile to VerticalPodAutoscalerSpec

### DIFF
--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -103,6 +103,11 @@ type VerticalPodAutoscalerSpec struct {
 	// recommendation) or contain exactly one recommender.
 	// +optional
 	Recommenders []*VerticalPodAutoscalerRecommenderSelector `json:"recommenders,omitempty" protobuf:"bytes,4,opt,name=recommenders"`
+
+	// Specifies the target CPU percentile to consider when computing recommendations.
+	// The default is 0.9
+	// *optional
+	TargetCPUPercentile float64 `json:"targetCPUPercentile,omitempty" protobuf:"bytes,5,rep,name=targetCPUPercentile"`
 }
 
 // PodUpdatePolicy describes the rules on how changes are applied to the pods.

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -95,9 +95,13 @@ func (e *constEstimator) GetResourceEstimation(s *model.AggregateContainerState)
 
 // Returns specific percentiles of CPU and memory peaks distributions.
 func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerState) model.Resources {
+	cpuPercentile := e.cpuPercentile
+	if s.TargetCPUPercentile != nil {
+		cpuPercentile = *s.TargetCPUPercentile
+	}
 	return model.Resources{
 		model.ResourceCPU: model.CPUAmountFromCores(
-			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
+			s.AggregateCPUUsage.Percentile(cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -51,6 +51,7 @@ func TestPercentileEstimator(t *testing.T) {
 	CPUPercentile := 0.2
 	MemoryPercentile := 0.5
 	estimator := NewPercentileEstimator(CPUPercentile, MemoryPercentile)
+	dotNinety := 0.9
 
 	resourceEstimation := estimator.GetResourceEstimation(
 		&model.AggregateContainerState{
@@ -60,6 +61,14 @@ func TestPercentileEstimator(t *testing.T) {
 	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
 	assert.InEpsilon(t, 1.0, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)
 	assert.InEpsilon(t, 2e9, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+	// test overriding CPUPercentile via aggregator
+	resourceEstimation = estimator.GetResourceEstimation(
+		&model.AggregateContainerState{
+			AggregateCPUUsage:    cpuHistogram,
+			AggregateMemoryPeaks: memoryPeaksHistogram,
+			TargetCPUPercentile:  &dotNinety,
+		})
+	assert.InEpsilon(t, 3, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)
 }
 
 // Verifies that the confidenceMultiplier calculates the internal

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -110,6 +110,7 @@ type AggregateContainerState struct {
 	UpdateMode          *vpa_types.UpdateMode
 	ScalingMode         *vpa_types.ContainerScalingMode
 	ControlledResources *[]ResourceName
+	TargetCPUPercentile *float64
 }
 
 // GetLastRecommendation returns last recorded recommendation.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -279,6 +279,7 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	vpa.Recommendation = currentRecommendation
 	vpa.SetUpdateMode(apiObject.Spec.UpdatePolicy)
 	vpa.SetResourcePolicy(apiObject.Spec.ResourcePolicy)
+	vpa.TargetCPUPercentile = apiObject.Spec.TargetCPUPercentile
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -110,6 +110,8 @@ type Vpa struct {
 	TargetRef *autoscaling.CrossVersionObjectReference
 	// PodCount contains number of live Pods matching a given VPA object.
 	PodCount int
+	// TargetCPUPercentile is the CPU percentile to consider when computing recommendations.
+	TargetCPUPercentile float64
 }
 
 // NewVpa returns a new Vpa with a given ID and pod selector. Doesn't set the


### PR DESCRIPTION
#### Which component this PR applies to?
vertical-pod-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4293

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add TargetCPUPercentile to VerticalPodAutoscalerSpec to override default per VPA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
