### PR TITLE
Add topology spread constraints to control how Pods are spread

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.12.0
+version: 9.13.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -412,4 +412,5 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | serviceMonitor.path | string | `"/metrics"` | The path to scrape for metrics; autoscaler exposes `/metrics` (this is standard) |
 | serviceMonitor.selector | object | `{"release":"prometheus-operator"}` | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install. |
 | tolerations | list | `[]` | List of node taints to tolerate (requires Kubernetes >= 1.6). |
+| topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |
 | updateStrategy | object | `{}` | [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -218,6 +218,10 @@ spec:
       serviceAccountName: {{ template "cluster-autoscaler.serviceAccountName" . }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+    {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+    {{- end }}
       {{- if .Values.securityContext }}
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 | trim }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -328,6 +328,15 @@ prometheusRule:
 # tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
 tolerations: []
 
+# topologySpreadConstraints -- You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19).
+topologySpreadConstraints: []
+#  - labelSelector:
+#      matchLabels:
+#        app.kubernetes.io/name: aws-cluster-autoscaler
+#    maxSkew: 1
+#    topologyKey: topology.kubernetes.io/zone
+#    whenUnsatisfiable: DoNotSchedule
+
 # updateStrategy -- [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
 updateStrategy: {}
   # rollingUpdate:


### PR DESCRIPTION
#### Which component this PR applies to?

This PR applies to helm chart. It adds the possibility to use topologySpreadConstraints in the helm chart.

Tested one two EKS with k8s 1.21. 

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

topologySpreadConstraints is not supported yet by the helm chart, but we need it to spread pods over Zones.

#### Which issue(s) this PR fixes:

Fixes #4577

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Added a line in README.MD and also an example in the values.yaml.
