### PR TITLE
Create a multi-architecture manifest when pushing image to registry

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -39,12 +39,18 @@ all: all-container
 sub-container-%:
 	$(MAKE) ARCH=$* container
 
+sub-manifest-push-%:
+	$(MAKE) ARCH=$* manifest-push
+
 sub-push-%:
 	$(MAKE) ARCH=$* push
 
 all-container: test $(addprefix sub-container-,$(ALL_ARCH))
 
-all-push: $(addprefix sub-push-,$(ALL_ARCH))
+all-manifest-push: $(addprefix sub-manifest-push-,$(ALL_ARCH))
+	docker manifest push -p $(IMAGE):$(TAG)
+
+all-push: $(addprefix sub-push-,$(ALL_ARCH)) all-manifest-push
 
 buildx-setup:
 	docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
@@ -86,6 +92,11 @@ push: .push-$(ARCH)
 ifeq ($(ARCH), amd64)
 	gcloud docker -- push $(IMAGE):$(TAG)
 endif
+
+manifest-push: .manifest-push-$(ARCH)
+.manifest-push-$(ARCH):
+	docker manifest create --amend $(IMAGE):$(TAG) $(MULTI_ARCH_IMG):$(TAG) && \
+	docker manifest annotate --os=linux --arch=$(ARCH) $(IMAGE):$(TAG) $(MULTI_ARCH_IMG):$(TAG)
 
 clean: $(addprefix sub-clean-,$(ALL_ARCH))
 sub-clean-%:


### PR DESCRIPTION
#### Which component this PR applies to?

addon-resizer

#### What type of PR is this?

/feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The docker images published for addon-resizer releases are not multi arch images (docker images that support multiple CPU architectures). Right now, we publish a separate image tag for each architecture. The image `us.gcr.io/k8s-artifacts-prod/addon-resizer:{verison}` is built using the `amd64` format, and in addition, there are image for for each supported CPU architecture using the format `addon-resizer-{arch}` for example `us.gcr.io/k8s-artifacts-prod/addon-resizer-amd64:2.3` and `us.gcr.io/k8s-artifacts-prod/addon-resizer-arm64:2.3`. The target CPU architectures are specified in the [addon-resizer Makefile](https://github.com/kubernetes/autoscaler/blob/addon-resizer-2.3/addon-resizer/Makefile#L20).

The manifest for the [1.8.14 release `us.gcr.io/k8s-artifacts-prod/autoscaling/addon-resizer:1.8.14`](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/autoscaling%2Faddon-resizer@sha256:43f129b81d28f0fdd54de6d8e7eacd5728030782e03db16087fc241ad747d3d6/details?tab=pull)  without multi-arch support looks like this.
```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 1797,
      "digest": "sha256:948469cec2c33f949fd0d7bf195e27efe7df506006f57ea809b00acceba123f4"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 657654,
         "digest": "sha256:5dea5ec2316d4a067b946b15c3c4f140b4f2ad607e73e9bc41b673ee5ebb99a3"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 9493663,
         "digest": "sha256:a726845f8648042707825932e404af77db159ac71f1601c894c3cd2c555075df"
      }
   ]
}
```

If a user wants to run addon-resizer on an arm based device such as a raspberry pi, they will need to use the image `us.gcr.io/k8s-artifacts-prod/addon-resizer-arm:2.3`. If they have a k8s cluster with mixed ARM and AMD64 nodes, they will need to create separate pods for each architecture so that they can specify the correct image.

To avoid having to specify different images for each architecture, Docker supports multi-arch images [using image manifests](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/). With image manifests, the container runtime can use the image `us.gcr.io/k8s-artifacts-prod/addon-resizer:2.3` and still get the correct image for its CPU architecture.

As I mentioned before, addon-resizer already publishes images for the various supported architectures. This PR creates an image manifest linking together the existing images so that they can be pulled from a single image url. 
Other applications in this repo like [cluster-autoscaler are already configured](https://github.com/kubernetes/autoscaler/blob/addon-resizer-2.3/cluster-autoscaler/Makefile#L68) to publish [multi-arch images](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/autoscaling%2Fcluster-autoscaler@sha256:f46687231c2c1bfa139f2b18275b123222c8cf6a288bb9c8145932bd14ac3deb/details?tab=pull).


I created a [test image `gcr.io/k8s-image-staging/addon-resizer:2.3-tstapler-test`](https://console.cloud.google.com/gcr/images/k8s-image-staging/global/addon-resizer@sha256:b2958b73e4df904fe55df4fd2e9612915d71f2706ff765b4117ef2da60ff3302/details?tab=manifest) using this branch. You can see the references to other images and the architectures associated with them. Instead of layers, the manifest has a list of manifests which reference other docker images such as the [`addon-resizer-amd:2.3-tstapler-test` image](https://console.cloud.google.com/gcr/images/k8s-image-staging/global/addon-resizer-amd64@sha256:e4f2efdf7a340041aa33e8c9695d8ac524f78968a97b538f504771575c37d759/details) for the `amd64` architecture:
```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:e4f2efdf7a340041aa33e8c9695d8ac524f78968a97b538f504771575c37d759",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:89cc252aa20144958e889e29ac9f94427b19d02daaa2c1e693f8865f4545a093",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:85c7ecb544ee3112739c5993bfda38765f0a0966d2fe0c07831ec02d01be45bc",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:8a8fb247a180b9bb0d9bcfd4aa9d46621993f6e898bef2c330e07118d326624d",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:57a98bb006908c48dab9cad3ad92235f98e1f8eae93aa3d551aefbf6521a9cfd",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add multi arch container image for addon-resizer
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```