### PR TITLE
use gcr hosted cluster-autoscaler image

### DIFF
--- a/cluster-autoscaler/cloudprovider/packet/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/packet/examples/cluster-autoscaler-deployment.yaml
@@ -147,7 +147,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: mist/packet-autoscaler
+          image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
           imagePullPolicy: Always
           env:
             - name: BOOTSTRAP_TOKEN_ID


### PR DESCRIPTION
Signed-off-by: Chris Privitere <cprivite@users.noreply.github.com>

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates our example yaml to use the normal upstream cluster-autoscaler image instead of an old out of date (was still on version 1.18) packet specific one (mist/packet-autoscaler)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Equinix Metal (aka Packet) example cluster-autoscaler-deployment.yaml file updated to use current latest autoscaler image by default. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
