### PR TITLE
Update Cluster Autoscaler to go 1.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17.5
 
       - uses: actions/checkout@v2
         with:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16
+FROM golang:1.17.5
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -57,6 +57,7 @@ this document:
   * [My cluster is below minimum / above maximum number of nodes, but CA did not fix that! Why?](#my-cluster-is-below-minimum--above-maximum-number-of-nodes-but-ca-did-not-fix-that-why)
   * [What happens in scale-up when I have no more quota in the cloud provider?](#what-happens-in-scale-up-when-i-have-no-more-quota-in-the-cloud-provider)
 * [Developer](#developer)
+  * [What go version should be used to compile CA?](#what-go-version-should-be-used-to-compile-ca)
   * [How can I run e2e tests?](#how-can-i-run-e2e-tests)
   * [How should I test my code before submitting PR?](#how-should-i-test-my-code-before-submitting-pr)
   * [How can I update CA dependencies (particularly k8s.io/kubernetes)?](#how-can-i-update-ca-dependencies-particularly-k8siokubernetes)
@@ -919,6 +920,21 @@ From version 0.6.2, Cluster Autoscaler backs off from scaling up a node group af
 Depending on how long scale-ups have been failing, it may wait up to 30 minutes before next attempt.
 
 # Developer:
+
+### What go version should be used to compile CA?
+
+Cluster Autoscaler generally tries to use the same go version that is used by embedded Kubernetes code.
+For example CA 1.21 will use the same go version as Kubernetes 1.21. Only the officially used go
+version is supported and CA may not compile using other versions.
+
+The source of truth for the used go version is builder/Dockerfile.
+
+Warning: do NOT rely on go version specified in go.mod file. It is only meant to control go mod
+behavior and is not indicative of the go version actually used by CA. In particular go 1.17 changes go mod
+behavior in a way that is incompatible with existing Kubernetes tooling.
+Following [Kubernetes example](https://github.com/kubernetes/kubernetes/pull/105563#issuecomment-960915506)
+we have decided to pin version specified in go.mod to 1.16 for now (even though both Kubernetes
+and CA no longer compile using go 1.16).
 
 ### How can I run e2e tests?
 

--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types/gen.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types/gen.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 /*

--- a/cluster-autoscaler/cloudprovider/azure/azure_instance_types/gen.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_instance_types/gen.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
@@ -1,3 +1,4 @@
+//go:build alicloud
 // +build alicloud
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -1,3 +1,4 @@
+//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !packet
 // +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!packet
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_aws.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_aws.go
@@ -1,3 +1,4 @@
+//go:build aws
 // +build aws
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_azure.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_azure.go
@@ -1,3 +1,4 @@
+//go:build azure
 // +build azure
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
@@ -1,3 +1,4 @@
+//go:build baiducloud
 // +build baiducloud
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_bizflycloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_bizflycloud.go
@@ -1,3 +1,4 @@
+//go:build bizflycloud
 // +build bizflycloud
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_brightbox.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_brightbox.go
@@ -1,3 +1,4 @@
+//go:build brightbox
 // +build brightbox
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_cloudstack.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_cloudstack.go
@@ -1,3 +1,4 @@
+//go:build cloudstack
 // +build cloudstack
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
@@ -1,3 +1,4 @@
+//go:build clusterapi
 // +build clusterapi
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_digitalocean.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_digitalocean.go
@@ -1,3 +1,4 @@
+//go:build digitalocean
 // +build digitalocean
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_exoscale.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_exoscale.go
@@ -1,3 +1,4 @@
+//go:build exoscale
 // +build exoscale
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_gce.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_gce.go
@@ -1,3 +1,4 @@
+//go:build gce
 // +build gce
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_hetzner.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_hetzner.go
@@ -1,3 +1,4 @@
+//go:build hetzner
 // +build hetzner
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_huaweicloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_huaweicloud.go
@@ -1,3 +1,4 @@
+//go:build huaweicloud
 // +build huaweicloud
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_ionoscloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_ionoscloud.go
@@ -1,3 +1,4 @@
+//go:build ionoscloud
 // +build ionoscloud
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
@@ -1,3 +1,4 @@
+//go:build kubemark
 // +build kubemark
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_linode.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_linode.go
@@ -1,3 +1,4 @@
+//go:build linode
 // +build linode
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
@@ -1,3 +1,4 @@
+//go:build magnum
 // +build magnum
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
@@ -1,3 +1,4 @@
+//go:build exoscale
 // +build exoscale
 
 /*

--- a/cluster-autoscaler/cloudprovider/builder/builder_packet.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_packet.go
@@ -1,3 +1,4 @@
+//go:build packet
 // +build packet
 
 /*

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -215,7 +215,8 @@ def get_regexs():
     # company holder names can be anything
     regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    regexs["go_build_constraints"] = re.compile(
+        r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     # Search for generated files

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -34,6 +34,7 @@ find_files() {
         -o -wholename '*/third_party/*' \
         -o -wholename '*/Godeps/*' \
         -o -wholename '*/vendor/*' \
+        -o -wholename '*/zz_generated.deepcopy.go' \
         -o -wholename './cluster-autoscaler/cloudprovider/magnum/gophercloud/*' \
         -o -wholename './cluster-autoscaler/cloudprovider/digitalocean/godo/*' \
         -o -wholename './cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/*' \


### PR DESCRIPTION
This is a partial cherry-pick of a #4567. 

Kubernetes has moved to go 1.17 and no longer compiles on go 1.16 (currently used by CA). This bumps CA to go1.17 and is a prerequisite to updating deps (which I'll do in a follow-up PR).
Some gotchas:
 * Go version tag in go.mod is purposefully left at go1.16. This is needed, because go1.17 changes how go.mod work and the upstream kubernetes haven't transitioned to the new go.mod yet (they misrepresent go version in go.mod exactly the same way). https://github.com/kubernetes/kubernetes/pull/105563#issuecomment-960915506
 * Added go:build tags matching existing +build tags for all cluster-autoscaler files across different providers. This should have no effect, but it is a part of golang migration to new syntax and both tags is expected by go fmt in go1.17. 