### PR TITLE
Fix Azure IMDS Url in InstanceMetadataService initialization

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -38,7 +38,7 @@ const (
 	// The path of deployment parameters for standard vm.
 	deploymentParametersPath = "/var/lib/azure/azuredeploy.parameters.json"
 
-	metadataURL = "http://169.254.169.254/metadata/instance"
+	metadataURL = "http://169.254.169.254"
 
 	// backoff
 	backoffRetriesDefault  = 6

--- a/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
@@ -305,26 +305,6 @@ func TestIsAzureRequestsThrottled(t *testing.T) {
 	}
 }
 
-func TestDeleteBlob(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	azUtil := GetTestAzureUtil(t)
-	mockSAClient := mockstorageaccountclient.NewMockInterface(ctrl)
-	mockSAClient.EXPECT().ListKeys(
-		gomock.Any(),
-		azUtil.manager.config.ResourceGroup,
-		testAccountName).Return(storage.AccountListKeysResult{
-		Keys: &[]storage.AccountKey{
-			{Value: to.StringPtr("dmFsdWUK")},
-		},
-	}, nil)
-	azUtil.manager.azClient.storageAccountsClient = mockSAClient
-
-	err := azUtil.DeleteBlob(testAccountName, "vhd", "blob")
-	assert.True(t, strings.Contains(err.Error(), storageAccountClientErrMsg))
-}
-
 func TestDeleteVirtualMachine(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In CA version 1.21, on Azure, it was possible to omit the Subscription ID completely.
On startup, cluster autoscaler used to detect it using [Azure Instance Metadata Service (IMDS)](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux).

It used to do so using a service in `legacy-cloud-providers`.

The [initialization code](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-release-1.22/cluster-autoscaler/cloudprovider/azure/azure_config.go#L463) for such service is as follows:

```
metadataService, err := providerazure.NewInstanceMetadataService(metadataURL)
```

In 1.21 this worked just fine.

In 1.22 the meaning of the metadataURL parameter was changed in the service code.
What used to be a full URL including path in the version used in 1.21 `http://169.254.169.254/metadata/instance` was changed to a root path in the version used in 1.22.

This change was not picked up in CA code and this causes CA to panic on startup when the Subscription ID is not provided:

```
F0112 08:57:17.405106       1 azure_cloud_provider.go:167] Failed to create Azure Manager: failure of getting instance metadata with response "404 Not Found"
```

Because the computed IMDS URL contains the path twice:

```
http://169.254.169.254/metadata/instance/metadata/instance
```

obviously ending up with a 404 from the IMDS endpoint.

This easy PR fixes just that by passing the correct value to the `NewInstanceMetadataService` function.

#### Which issue(s) this PR fixes:

None that I could find.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a panic in Cluster Autoscaler on Azure when no Subscription ID was provided by the user.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
