### PR TITLE
Introduce gce image types and remove *_containerd gce os distributions

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_reserved.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_reserved.go
@@ -100,9 +100,9 @@ func (r *GceReserved) CalculateKernelReserved(physicalMemory int64, os Operating
 		// The reason for this value is we detected additional reservation, but we were
 		// unable to find the root cause. Hence, we added a best estimated formula that was
 		// statistically developed.
-		if osDistribution == OperatingSystemDistributionCOS || osDistribution == OperatingSystemDistributionCOSContainerd {
+		if osDistribution == OperatingSystemDistributionCOS {
 			reserved += int64(math.Min(correctionConstant*float64(physicalMemory), maximumCorrectionValue))
-		} else if osDistribution == OperatingSystemDistributionUbuntu || osDistribution == OperatingSystemDistributionUbuntuContainerd {
+		} else if osDistribution == OperatingSystemDistributionUbuntu {
 			reserved += int64(math.Min(correctionConstant*float64(physicalMemory), maximumCorrectionValue))
 			reserved += ubuntuSpecificOffset
 		}
@@ -253,17 +253,7 @@ func EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(diskCount int64, osDist
 		measuredCount = 24 // max attachable
 	}
 
-	// the container runtime doesn't affect filesystem overhead
-	var measuredOS OperatingSystemDistribution
-	if osDistribution == OperatingSystemDistributionCOSContainerd {
-		measuredOS = OperatingSystemDistributionCOS
-	} else if osDistribution == OperatingSystemDistributionUbuntuContainerd {
-		measuredOS = OperatingSystemDistributionUbuntu
-	} else {
-		measuredOS = osDistribution
-	}
-
-	o, ok := ephemeralStorageOnLocalSSDFilesystemOverheadInKiBByOSAndDiskCount[measuredOS]
+	o, ok := ephemeralStorageOnLocalSSDFilesystemOverheadInKiBByOSAndDiskCount[osDistribution]
 	if !ok {
 		klog.Errorf("Ephemeral storage backed by local SSDs is not supported for image family %v", osDistribution)
 		return 0
@@ -274,11 +264,11 @@ func EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(diskCount int64, osDist
 // CalculateOSReservedEphemeralStorage estimates how much ephemeral storage OS will reserve and eviction threshold
 func (r *GceReserved) CalculateOSReservedEphemeralStorage(diskSize int64, os OperatingSystem, osDistribution OperatingSystemDistribution, nodeVersion string) int64 {
 	switch osDistribution {
-	case OperatingSystemDistributionCOS, OperatingSystemDistributionCOSContainerd:
+	case OperatingSystemDistributionCOS:
 		storage := int64(math.Ceil(0.015635*float64(diskSize))) + int64(math.Ceil(4.148*GiB)) // os partition estimation
 		storage += int64(math.Min(100*MiB, math.Ceil(0.001*float64(diskSize))))               // over-provisioning buffer
 		return storage
-	case OperatingSystemDistributionUbuntu, OperatingSystemDistributionUbuntuContainerd:
+	case OperatingSystemDistributionUbuntu:
 		storage := int64(math.Ceil(0.03083*float64(diskSize))) + int64(math.Ceil(0.171*GiB)) // os partition estimation
 		storage += int64(math.Min(100*MiB, math.Ceil(0.001*float64(diskSize))))              // over-provisioning buffer
 		return storage

--- a/cluster-autoscaler/cloudprovider/gce/gce_reserved_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_reserved_test.go
@@ -120,22 +120,10 @@ func TestEphemeralStorageOnLocalSSDFilesystemOverheadInBytes(t *testing.T) {
 			expected:       7289472 * KiB,
 		},
 		{
-			scenario:       "measured disk count but OS with different container runtime (cos_containerd)",
-			diskCount:      1,
-			osDistribution: OperatingSystemDistributionCOSContainerd,
-			expected:       7289472 * KiB, // same as COS
-		},
-		{
 			scenario:       "measured disk count and OS (ubuntu)",
 			diskCount:      1,
 			osDistribution: OperatingSystemDistributionUbuntu,
 			expected:       7219840 * KiB,
-		},
-		{
-			scenario:       "measured disk count but OS with different container runtime (ubuntu_containerd)",
-			diskCount:      1,
-			osDistribution: OperatingSystemDistributionUbuntuContainerd,
-			expected:       7219840 * KiB, // same as Ubuntu
 		},
 		{
 			scenario:       "mapped disk count",

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -470,6 +470,33 @@ func extractOperatingSystemFromKubeEnv(kubeEnv string) OperatingSystem {
 	}
 }
 
+// OperatingSystemImage denotes  image of the operating system used by nodes coming from node group
+type OperatingSystemImage string
+
+const (
+	// OperatingSystemImageUnknown is used if operating distribution system is unknown
+	OperatingSystemImageUnknown OperatingSystemImage = ""
+	// OperatingSystemImageUbuntu is used if operating distribution system is Ubuntu
+	OperatingSystemImageUbuntu OperatingSystemImage = "ubuntu"
+	// OperatingSystemImageWindowsLTSC is used if operating distribution system is Windows LTSC
+	OperatingSystemImageWindowsLTSC OperatingSystemImage = "windows_ltsc"
+	// OperatingSystemImageWindowsSAC is used if operating distribution system is Windows SAC
+	OperatingSystemImageWindowsSAC OperatingSystemImage = "windows_sac"
+	// OperatingSystemImageCOS is used if operating distribution system is COS
+	OperatingSystemImageCOS OperatingSystemImage = "cos"
+	// OperatingSystemImageCOSContainerd is used if operating distribution system is COS Containerd
+	OperatingSystemImageCOSContainerd OperatingSystemImage = "cos_containerd"
+	// OperatingSystemImageUbuntuContainerd is used if operating distribution system is Ubuntu Containerd
+	OperatingSystemImageUbuntuContainerd OperatingSystemImage = "ubuntu_containerd"
+	// OperatingSystemImageWindowsLTSCContainerd is used if operating distribution system is Windows LTSC Containerd
+	OperatingSystemImageWindowsLTSCContainerd OperatingSystemImage = "windows_ltsc_containerd"
+	// OperatingSystemImageWindowsSACContainerd is used if operating distribution system is Windows SAC Containerd
+	OperatingSystemImageWindowsSACContainerd OperatingSystemImage = "windows_sac_containerd"
+
+	// OperatingSystemImageDefault defines which operating system will be assumed as default.
+	OperatingSystemImageDefault = OperatingSystemImageCOSContainerd
+)
+
 // OperatingSystemDistribution denotes  distribution of the operating system used by nodes coming from node group
 type OperatingSystemDistribution string
 
@@ -484,14 +511,25 @@ const (
 	OperatingSystemDistributionWindowsSAC OperatingSystemDistribution = "windows_sac"
 	// OperatingSystemDistributionCOS is used if operating distribution system is COS
 	OperatingSystemDistributionCOS OperatingSystemDistribution = "cos"
-	// OperatingSystemDistributionCOSContainerd is used if operating distribution system is COS Containerd
-	OperatingSystemDistributionCOSContainerd OperatingSystemDistribution = "cos_containerd"
-	// OperatingSystemDistributionUbuntuContainerd is used if operating distribution system is Ubuntu Containerd
-	OperatingSystemDistributionUbuntuContainerd OperatingSystemDistribution = "ubuntu_containerd"
 
 	// OperatingSystemDistributionDefault defines which operating system will be assumed if not explicitly passed via AUTOSCALER_ENV_VARS
 	OperatingSystemDistributionDefault = OperatingSystemDistributionCOS
 )
+
+func extractOperatingSystemDistributionFromImageType(imageType string) OperatingSystemDistribution {
+	switch imageType {
+	case string(OperatingSystemImageUbuntu), string(OperatingSystemImageUbuntuContainerd):
+		return OperatingSystemDistributionUbuntu
+	case string(OperatingSystemImageWindowsLTSC), string(OperatingSystemImageWindowsLTSCContainerd):
+		return OperatingSystemDistributionWindowsLTSC
+	case string(OperatingSystemImageWindowsSAC), string(OperatingSystemImageWindowsSACContainerd):
+		return OperatingSystemDistributionWindowsSAC
+	case string(OperatingSystemImageCOS), string(OperatingSystemImageCOSContainerd):
+		return OperatingSystemDistributionCOS
+	default:
+		return OperatingSystemDistributionUnknown
+	}
+}
 
 func extractOperatingSystemDistributionFromKubeEnv(kubeEnv string) OperatingSystemDistribution {
 	osDistributionValue, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "os_distribution")
@@ -515,10 +553,14 @@ func extractOperatingSystemDistributionFromKubeEnv(kubeEnv string) OperatingSyst
 		return OperatingSystemDistributionWindowsSAC
 	case string(OperatingSystemDistributionCOS):
 		return OperatingSystemDistributionCOS
-	case string(OperatingSystemDistributionCOSContainerd):
-		return OperatingSystemDistributionCOSContainerd
-	case string(OperatingSystemDistributionUbuntuContainerd):
-		return OperatingSystemDistributionUbuntuContainerd
+	// Deprecated
+	case "cos_containerd":
+		klog.Warning("cos_containerd os distribution is deprecated")
+		return OperatingSystemDistributionCOS
+	// Deprecated
+	case "ubuntu_containerd":
+		klog.Warning("ubuntu_containerd os distribution is deprecated")
+		return OperatingSystemDistributionUbuntu
 	default:
 		klog.Errorf("unexpected os-distribution=%v passed via AUTOSCALER_ENV_VARS", osDistributionValue)
 		return OperatingSystemDistributionUnknown

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -1002,7 +1002,7 @@ func TestExtractOperatingSystemDistributionFromKubeEnv(t *testing.T) {
 				"kube_reserved=cpu=1000m,memory=300000Mi;" +
 				"os_distribution=cos_containerd\n" +
 				"KUBELET_TEST_ARGS: --experimental-allocatable-ignore-eviction\n",
-			expectedOperatingSystemDistribution: OperatingSystemDistributionCOSContainerd,
+			expectedOperatingSystemDistribution: OperatingSystemDistributionCOS,
 		},
 		{
 			name: "ubuntu containerd",
@@ -1013,7 +1013,7 @@ func TestExtractOperatingSystemDistributionFromKubeEnv(t *testing.T) {
 				"kube_reserved=cpu=1000m,memory=300000Mi;" +
 				"os_distribution=ubuntu_containerd\n" +
 				"KUBELET_TEST_ARGS: --experimental-allocatable-ignore-eviction\n",
-			expectedOperatingSystemDistribution: OperatingSystemDistributionUbuntuContainerd,
+			expectedOperatingSystemDistribution: OperatingSystemDistributionUbuntu,
 		},
 		{
 			name: "ubuntu",


### PR DESCRIPTION
#### Which component this PR applies to?
cluster-autoscaler


#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
*_containerd os distributions weren't used and made a confusions with image types.

#### Release notes
Gce cos_containerd and ubuntu_containerd os distributions are deprecated. 