### PR TITLE
Add AutoscalingContext to the scale-down post-processor

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -923,7 +923,7 @@ func (sd *ScaleDown) TryToScaleDown(
 	// try to delete not-so-empty nodes, possibly killing some pods and allowing them
 	// to recreate on other nodes.
 	emptyNodesToRemove := sd.getEmptyNodesToRemove(candidateNames, scaleDownResourcesLeft, currentTime)
-	emptyNodesToRemove = sd.processors.ScaleDownSetProcessor.GetNodesToRemove(emptyNodesToRemove, sd.context.MaxEmptyBulkDelete)
+	emptyNodesToRemove = sd.processors.ScaleDownSetProcessor.GetNodesToRemove(sd.context, emptyNodesToRemove, sd.context.MaxEmptyBulkDelete)
 	if len(emptyNodesToRemove) > 0 {
 		nodeDeletionStart := time.Now()
 		deletedNodes, err := sd.scheduleDeleteEmptyNodes(emptyNodesToRemove, sd.context.ClientSet, sd.context.Recorder, readinessMap, candidateNodeGroups)
@@ -965,7 +965,7 @@ func (sd *ScaleDown) TryToScaleDown(
 		scaleDownStatus.Result = status.ScaleDownError
 		return scaleDownStatus, err.AddPrefix("Find node to remove failed: ")
 	}
-	nodesToRemove = sd.processors.ScaleDownSetProcessor.GetNodesToRemove(nodesToRemove, 1)
+	nodesToRemove = sd.processors.ScaleDownSetProcessor.GetNodesToRemove(sd.context, nodesToRemove, 1)
 	if len(nodesToRemove) == 0 {
 		klog.V(1).Infof("No node to remove")
 		scaleDownStatus.Result = status.ScaleDownNoNodeDeleted

--- a/cluster-autoscaler/processors/nodes/post_filtering_processor.go
+++ b/cluster-autoscaler/processors/nodes/post_filtering_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 )
 
@@ -25,7 +26,7 @@ type PostFilteringScaleDownNodeProcessor struct {
 }
 
 // GetNodesToRemove selects up to maxCount nodes for deletion, by selecting a first maxCount candidates
-func (n *PostFilteringScaleDownNodeProcessor) GetNodesToRemove(candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved {
+func (n *PostFilteringScaleDownNodeProcessor) GetNodesToRemove(ctx *context.AutoscalingContext, candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved {
 	end := len(candidates)
 	if len(candidates) > maxCount {
 		end = maxCount

--- a/cluster-autoscaler/processors/nodes/types.go
+++ b/cluster-autoscaler/processors/nodes/types.go
@@ -38,7 +38,7 @@ type ScaleDownNodeProcessor interface {
 // ScaleDownSetProcessor contains a method to select nodes for deletion
 type ScaleDownSetProcessor interface {
 	// GetNodesToRemove selects up to maxCount nodes for deletion
-	GetNodesToRemove(candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved
+	GetNodesToRemove(ctx *context.AutoscalingContext, candidates []simulator.NodeToBeRemoved, maxCount int) []simulator.NodeToBeRemoved
 	// CleanUp is called at CA termination
 	CleanUp()
 }


### PR DESCRIPTION
This is a followup PR to #4519 that extends the `ScaleDownSetProcessor` to include the `context.AutoscalingContext` parameter in the `GetNodesToRemove` function.

Edit: unlike the https://github.com/kubernetes/autoscaler/pull/4519#issuecomment-1012967211 suggested I propose we use the context that is already part of `ScaleDown`