### PR TITLE
azure: change a flacky test

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util_test.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -35,10 +34,10 @@ import (
 
 const (
 	testAccountName = "account"
-	// TODO(nilo19): verify the client err message used in DeleteBlob unit test
+	// TODO(nilo19): verify if DeleteBlob unit test needs to check error string, and which message is expected. We saw both:
 	// storageAccountClientErrMsg = "Server failed to authenticate the request. Make sure the value of Authorization " +
 	//	 "header is formed correctly including the signature"
-	storageAccountClientErrMsg = "The specified account is disabled"
+	// storageAccountClientErrMsg = "The specified account is disabled"
 )
 
 func GetTestAzureUtil(t *testing.T) *AzUtil {
@@ -321,7 +320,7 @@ func TestDeleteBlob(t *testing.T) {
 	azUtil.manager.azClient.storageAccountsClient = mockSAClient
 
 	err := azUtil.DeleteBlob(testAccountName, "vhd", "blob")
-	assert.True(t, strings.Contains(err.Error(), storageAccountClientErrMsg))
+	assert.Error(t, err)
 }
 
 func TestNormalizeMasterResourcesForScaling(t *testing.T) {


### PR DESCRIPTION
It seems that test gets varying error messages which prompted
Bartłomiej previous fix, but I'm now seeing the original error
message string back ("Server failed to authenticate [...]"),
so that `TestDeleteBlob` test is failing again (other PRs' tests
failures suggest that's not just my laptop).

Let's assume this was meant to check for an error, until someone
can confirm, that might be better than potentially hidding other
PRs real tests failures.

#### Which component this PR applies to?
Azure cloud provider.

#### What type of PR is this?
/kind flake

#### Special notes for your reviewer:
Please let us know if that was really meant to catch specific error messages, and if so, which message.
