### PR TITLE
Allow colon in AWS ASG autodiscovery tag keys

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -106,9 +106,9 @@ Auto-Discovery Setup is the preferred method to configure Cluster Autoscaler.
 
 To enable this, provide the `--node-group-auto-discovery` flag as an argument
 whose value is a list of tag keys that should be looked for. For example,
-`--node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/<cluster-name>`
-will find the ASGs where those tag keys _exist_. It does not matter what value
-the tags have.
+`--node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/<cluster-name>,my-custom-tag=custom-value`
+will find the ASGs that have the given tags. Optionally, a value can be provided
+for each tag as well.
 
 Example deployment:
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -541,7 +541,7 @@ func parseASGAutoDiscoverySpecs(o cloudprovider.NodeGroupDiscoveryOptions) ([]as
 func parseASGAutoDiscoverySpec(spec string) (asgAutoDiscoveryConfig, error) {
 	cfg := asgAutoDiscoveryConfig{}
 
-	tokens := strings.Split(spec, ":")
+	tokens := strings.SplitN(spec, ":", 2)
 	if len(tokens) != 2 {
 		return cfg, fmt.Errorf("invalid node group auto discovery spec specified via --node-group-auto-discovery: %s", spec)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -880,11 +880,13 @@ func TestParseASGAutoDiscoverySpecs(t *testing.T) {
 				"asg:tag=tag,anothertag",
 				"asg:tag=cooltag,anothertag",
 				"asg:tag=label=value,anothertag",
+				"asg:tag=my:label=value,my:otherlabel=othervalue",
 			},
 			want: []asgAutoDiscoveryConfig{
 				{Tags: map[string]string{"tag": "", "anothertag": ""}},
 				{Tags: map[string]string{"cooltag": "", "anothertag": ""}},
 				{Tags: map[string]string{"label": "value", "anothertag": ""}},
+				{Tags: map[string]string{"my:label": "value", "my:otherlabel": "othervalue"}},
 			},
 		},
 		{


### PR DESCRIPTION
#### Which component this PR applies to?
cluster-autoscaler

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR allows the use of colon (`:`) in AWS ASG autodiscovery tag keys.

Our cluster ASGs are tagged like `<namespace>:cluster = <clustername>` and `<namespace>:nodegroup = <nodegroup>`. 

The existing code for tag-based autodiscovery would attempt to further split the tag, and this has been fixed to limit the amount of splitting that is done.

We have ensured the tests pass and updated the documentation to demonstrate that the ASG tag discovery code supports tag values as well.

#### Does this PR introduce a user-facing change?
```release-note
Added support for colon (`:`) in the AWS ASG discovery tag keys
```
