### PR TITLE
CA - Exoscale Provider - Add owners file

### DIFF
--- a/cluster-autoscaler/cloudprovider/exoscale/OWNERS
+++ b/cluster-autoscaler/cloudprovider/exoscale/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+# - pierre-emmanuelJ
+# - 7fELF
+# - PhilippeChepy


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

Cluster-autoscaler - Exoscale Cloud Provider

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind documentation

#### What this PR does / why we need it:

Adds an OWNERS file for the Exoscale cloud provider as per discussion here: https://github.com/kubernetes/autoscaler/pull/4247#issuecomment-999456948

#### Special notes for your reviewer:

Note: None of the users being added are currently members of the Kubernetes org, which is [viewed as bad practice](https://www.kubernetes.dev/docs/guide/owners/#maintaining-owners-files), however, none of the maintainers of the wider CA code have experience on Exoscale. We should instead work to enable the owners of this code to gain membership of the Kubernetes org.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
