### PR TITLE
Add more buckets to admission_latency_seconds metric

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/metrics/admission/admission.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/admission/admission.go
@@ -74,7 +74,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "admission_latency_seconds",
 			Help:      "Time spent in VPA Admission Controller.",
-			Buckets:   []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0},
+			Buckets:   []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0},
 		}, []string{"status", "resource"},
 	)
 )


### PR DESCRIPTION
I want more resolution in [0.2, 1]s range. [K8s Pod Creation Latency
SLO](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md) has a target of 5s so it makes a difference for the SLO how the
delay we introduce is distributed. Right now I think buckets are too
wide in the [0.1, 1]s range.

/kind feature

```release-note
NONE
```
