### PR TITLE
Update VPA to go1.16

### DIFF
--- a/vertical-pod-autoscaler/builder/Dockerfile
+++ b/vertical-pod-autoscaler/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14.3
+FROM golang:1.16.6
 LABEL maintainer="Beata Skiba	<bskiba@google.com>"
 
 ENV GOPATH /gopath/

--- a/vertical-pod-autoscaler/go.mod
+++ b/vertical-pod-autoscaler/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/vertical-pod-autoscaler
 
-go 1.14
+go 1.16
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/vertical-pod-autoscaler/go.sum
+++ b/vertical-pod-autoscaler/go.sum
@@ -33,7 +33,6 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
Created with

go mod edit -go=1.16
go mod tidy
vi builder/Dockerfile


/kind cleanup
```release-note
NONE
```