### PR TITLE
Fix example in values file for topologySpreadConstraint

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.13.0
+version: 9.13.1

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -330,12 +330,12 @@ tolerations: []
 
 # topologySpreadConstraints -- You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19).
 topologySpreadConstraints: []
-#  - labelSelector:
-#      matchLabels:
-#        app.kubernetes.io/name: aws-cluster-autoscaler
-#    maxSkew: 1
-#    topologyKey: topology.kubernetes.io/zone
-#    whenUnsatisfiable: DoNotSchedule
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/instance: cluster-autoscaler
 
 # updateStrategy -- [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
 updateStrategy: {}


### PR DESCRIPTION
Which component this PR applies to?

This PR applies to the helm chart. It modifies the example how to use the topologySpreadConstraints in the helm chart.
Noticed today that the terraform helm provider doesn't accept the code for topologySpreadConstraint if it start with "- labelSelector"

```yaml
topologySpreadConstraints:
  - labelSelector:
       matchLabels:
         app.kubernetes.io/name: aws-cluster-autoscaler
    maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
```
It end's with the following error. 

```sh
Error: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.topologySpreadConstraints[0]): unknown field "matchLabels" in io.k8s.api.core.v1.TopologySpreadConstraint
```

To prevent issues with that, I changed the example Code and It work with helm and also with the terraform helm provider.

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        app.kubernetes.io/instance: cluster-autoscaler
```
The funny things is, if you check the deployment in k8s the yaml code for the topologySpreadConstraints start with "- labelSelector:". Maybe this is a bug in helm , but it's better to change the example to prevent an issue as to ignore it.

I'm so sorry for the new PR after the release today. If you think, it's not necessary to correct it, feel free to close the PR without merging.

What type of PR is this?
/kind feature

What this PR does / why we need it:
The example in the values.yaml for topologySpreadConstraints is not accepted by helm and could cause errors.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/4577

Special notes for your reviewer:
Does this PR introduce a user-facing change?
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Example in the values.yaml changed.