### PR TITLE
Make charts link in README.md slightly more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ amount of CPU and memory requested by pods running in the Kubernetes Cluster. Cu
 [Addon Resizer](https://github.com/kubernetes/autoscaler/tree/master/addon-resizer) - a simplified version of vertical pod autoscaler that modifies
 resource requests of a deployment based on the number of nodes in the Kubernetes Cluster. Current state - beta.
 
+### Charts
 [Charts](https://github.com/kubernetes/autoscaler/tree/master/charts) - Supported Helm charts for components above.
 
 ## Contact Info


### PR DESCRIPTION
Feel free to disregard this, but I looked at this repo's README.md a couple times specifically to find charts, and didn't notice the charts link until maybe the third or fourth time!  So... thought making it a bit more prominent under an H3 might help others.  

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

The readme for the repo at large. 

#### What type of PR is this?

/kind documentation 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Makes the charts link a bit more visible to those coming looking for helm charts for the components provided in this repo.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Feel free to disregard, maybe no one else ever had an issue finding the charts link until me! 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
