### PR TITLE
Fix lint issues in cluster autoscaller

### DIFF
--- a/cluster-autoscaler/clusterstate/api/utils_test.go
+++ b/cluster-autoscaler/clusterstate/api/utils_test.go
@@ -38,7 +38,7 @@ func prepareConditions() (health, scaleUp ClusterAutoscalerCondition) {
 
 func TestGetStringForEmptyStatus(t *testing.T) {
 	var empty ClusterAutoscalerStatus
-	assert.Regexp(t, regexp.MustCompile("\\s*Health:\\s*<unknown>"), empty.GetReadableString())
+	assert.Regexp(t, regexp.MustCompile(`\s*Health:\s*<unknown>`), empty.GetReadableString())
 }
 
 func TestGetStringNothingGoingOn(t *testing.T) {
@@ -86,6 +86,6 @@ func TestGetStringNodeGroups(t *testing.T) {
 	status.NodeGroupStatuses = append(status.NodeGroupStatuses, ng1)
 	status.NodeGroupStatuses = append(status.NodeGroupStatuses, ng2)
 	result := status.GetReadableString()
-	assert.Regexp(t, regexp.MustCompile("(?ms)NodeGroups:.*Name:\\s*ng1"), result)
-	assert.Regexp(t, regexp.MustCompile("(?ms)NodeGroups:.*Name:\\s*ng2"), result)
+	assert.Regexp(t, regexp.MustCompile(`(?ms)NodeGroups:.*Name:\s*ng1`), result)
+	assert.Regexp(t, regexp.MustCompile(`(?ms)NodeGroups:.*Name:\s*ng2`), result)
 }

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -1100,7 +1100,7 @@ func (csr *ClusterStateRegistry) GetCreatedNodesWithErrors() []*apiv1.Node {
 	csr.Lock()
 	defer csr.Unlock()
 
-	nodesWithCreateErrors := make([]*apiv1.Node, 0, 0)
+	nodesWithCreateErrors := make([]*apiv1.Node, 0)
 	for _, nodeGroupInstances := range csr.cloudProviderNodeInstances {
 		_, _, instancesByErrorCode := csr.buildInstanceToErrorCodeMappings(nodeGroupInstances)
 		for _, instances := range instancesByErrorCode {

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -512,19 +512,22 @@ func TestIncorrectSize(t *testing.T) {
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff())
 	now := time.Now()
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-5*time.Minute))
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-5*time.Minute))
+	assert.NoError(t, err)
 	incorrect := clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 1, incorrect.CurrentSize)
 	assert.Equal(t, now.Add(-5*time.Minute), incorrect.FirstObserved)
 
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-4*time.Minute))
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-4*time.Minute))
+	assert.NoError(t, err)
 	incorrect = clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 1, incorrect.CurrentSize)
 	assert.Equal(t, now.Add(-5*time.Minute), incorrect.FirstObserved)
 
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1}, nil, now.Add(-3*time.Minute))
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1}, nil, now.Add(-3*time.Minute))
+	assert.NoError(t, err)
 	incorrect = clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 2, incorrect.CurrentSize)
@@ -653,7 +656,7 @@ func TestUpdateLastTransitionTimes(t *testing.T) {
 		}
 	}
 
-	expectedNgTimestamps := make(map[string](map[api.ClusterAutoscalerConditionType]metav1.Time), 0)
+	expectedNgTimestamps := make(map[string](map[api.ClusterAutoscalerConditionType]metav1.Time))
 	// Same as cluster-wide
 	expectedNgTimestamps["ng1"] = map[api.ClusterAutoscalerConditionType]metav1.Time{
 		api.ClusterAutoscalerHealth:    now,
@@ -769,20 +772,23 @@ func TestGetClusterSize(t *testing.T) {
 	}, fakeLogRecorder, newBackoff())
 
 	// There are 2 actual nodes in 2 node groups with target sizes of 5 and 1.
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, notAutoscaledNode}, nil, now)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, notAutoscaledNode}, nil, now)
+	assert.NoError(t, err)
 	currentSize, targetSize := clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 2, currentSize)
 	assert.Equal(t, 6, targetSize)
 
 	// Current size should increase after a new node is added.
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(time.Minute))
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(time.Minute))
+	assert.NoError(t, err)
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 6, targetSize)
 
 	// Target size should increase after a new node group is added.
 	provider.AddNodeGroup("ng3", 1, 10, 1)
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(2*time.Minute))
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(2*time.Minute))
+	assert.NoError(t, err)
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 7, targetSize)
@@ -791,7 +797,8 @@ func TestGetClusterSize(t *testing.T) {
 	for _, ng := range provider.NodeGroups() {
 		ng.(*testprovider.TestNodeGroup).SetTargetSize(10)
 	}
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(3*time.Minute))
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, nil, now.Add(3*time.Minute))
+	assert.NoError(t, err)
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 30, targetSize)

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
@@ -165,7 +165,7 @@ func (cache *CloudProviderNodeInstancesCache) Refresh() {
 		}
 		cache.updateCacheEntryLocked(nodeGroup, &cloudProviderNodeInstancesCacheEntry{nodeGroupInstances, time.Now()})
 	}
-	klog.Infof("Refresh cloud provider node instances cache finished, refresh took %v", time.Now().Sub(refreshStart))
+	klog.Infof("Refresh cloud provider node instances cache finished, refresh took %v", time.Since(refreshStart))
 }
 
 // Start starts components running in background.

--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -69,7 +69,7 @@ func NewStatusMapRecorder(kubeClient kube_client.Interface, namespace string, re
 	if active {
 		mapObj, err = WriteStatusConfigMap(kubeClient, namespace, "Initializing", nil, statusConfigMapName)
 		if err != nil {
-			return nil, errors.New("Failed to init status ConfigMap")
+			return nil, errors.New("failed to init status ConfigMap")
 		}
 	}
 	return &LogEventRecorder{

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -60,7 +60,7 @@ type Autoscaler interface {
 	// RunOnce represents an iteration in the control-loop of CA
 	RunOnce(currentTime time.Time) errors.AutoscalerError
 	// ExitCleanUp is a clean-up performed just before process termination.
-	ExitCleanUp()
+	ExitCleanUp() error
 }
 
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters

--- a/cluster-autoscaler/core/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/filter_out_schedulable_test.go
@@ -101,6 +101,7 @@ func TestFilterOutSchedulableByPacking(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			predicateChecker, err := simulator.NewTestPredicateChecker()
+			assert.NoError(t, err)
 			clusterSnapshot := simulator.NewBasicClusterSnapshot()
 
 			for _, node := range tt.nodes {
@@ -119,9 +120,7 @@ func TestFilterOutSchedulableByPacking(t *testing.T) {
 			assert.NoError(t, err)
 
 			var expectedPodsInSnapshot = tt.scheduledPods
-			for _, pod := range tt.expectedFilteredOutPods {
-				expectedPodsInSnapshot = append(expectedPodsInSnapshot, pod)
-			}
+			expectedPodsInSnapshot = append(expectedPodsInSnapshot, tt.expectedFilteredOutPods...)
 
 			var expectedPendingPods []*apiv1.Pod
 			for _, pod := range tt.pendingPods {
@@ -222,16 +221,16 @@ func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
 	for snapshotName, snapshotFactory := range snapshots {
 		for _, tc := range tests {
 			b.Run(fmt.Sprintf("%s: %d nodes %d scheduled %d pending", snapshotName, tc.nodes, tc.scheduledPods, tc.pendingPods), func(b *testing.B) {
-				pendingPods := make([]*apiv1.Pod, tc.pendingPods, tc.pendingPods)
+				pendingPods := make([]*apiv1.Pod, tc.pendingPods)
 				for i := 0; i < tc.pendingPods; i++ {
 					pendingPods[i] = BuildTestPod(fmt.Sprintf("p-%d", i), 1000, 2000000)
 				}
-				nodes := make([]*apiv1.Node, tc.nodes, tc.nodes)
+				nodes := make([]*apiv1.Node, tc.nodes)
 				for i := 0; i < tc.nodes; i++ {
 					nodes[i] = BuildTestNode(fmt.Sprintf("n-%d", i), 2000, 200000)
 					SetNodeReadyState(nodes[i], true, time.Time{})
 				}
-				scheduledPods := make([]*apiv1.Pod, tc.scheduledPods, tc.scheduledPods)
+				scheduledPods := make([]*apiv1.Pod, tc.scheduledPods)
 				j := 0
 				for i := 0; i < tc.scheduledPods; i++ {
 					scheduledPods[i] = BuildTestPod(fmt.Sprintf("s-%d", i), 1000, 200000)

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
@@ -1809,18 +1808,6 @@ func TestScaleDownNoMove(t *testing.T) {
 	assert.Equal(t, status.ScaleDownNoUnneeded, scaleDownStatus.Result)
 }
 
-func getCountOfChan(c chan string) int {
-	count := 0
-	for {
-		select {
-		case <-c:
-			count++
-		default:
-			return count
-		}
-	}
-}
-
 func TestCalculateCoresAndMemoryTotal(t *testing.T) {
 	nodeConfigs := []nodeConfig{
 		{"n1", 2000, 7500 * utils.MiB, 0, true, "ng1"},
@@ -2129,7 +2116,6 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 	}
 	defer func() {
 		now = time.Now
-		return
 	}()
 
 	fakeClient := fake.NewSimpleClientset()
@@ -2217,11 +2203,10 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 
 func TestWaitForDelayDeletion(t *testing.T) {
 	type testcase struct {
-		name                 string
-		timeout              time.Duration
-		addAnnotation        bool
-		removeAnnotation     bool
-		expectCallingGetNode bool
+		name             string
+		timeout          time.Duration
+		addAnnotation    bool
+		removeAnnotation bool
 	}
 	tests := []testcase{
 		{
@@ -2257,7 +2242,7 @@ func TestWaitForDelayDeletion(t *testing.T) {
 			node := BuildTestNode("n1", 1000, 10)
 			nodeWithAnnotation := BuildTestNode("n1", 1000, 10)
 			nodeWithAnnotation.Annotations = map[string]string{DelayDeletionAnnotationPrefix + "ingress": "true"}
-			allNodeLister := kubernetes.NewTestNodeLister(nil)
+			allNodeLister := kube_util.NewTestNodeLister(nil)
 			if test.addAnnotation {
 				if test.removeAnnotation {
 					allNodeLister.SetNodes([]*apiv1.Node{node})

--- a/cluster-autoscaler/core/scale_test_common.go
+++ b/cluster-autoscaler/core/scale_test_common.go
@@ -97,7 +97,6 @@ type scaleTestResults struct {
 	expansionOptions []groupSizeChange
 	finalOption      groupSizeChange
 	noScaleUpReason  string
-	finalScaleDowns  []string
 	events           []string
 	scaleUpStatus    scaleUpStatusInfo
 }

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -375,7 +375,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 	}
 	klog.V(4).Infof("Upcoming %d nodes", len(upcomingNodes))
 
-	expansionOptions := make(map[string]expander.Option, 0)
+	expansionOptions := make(map[string]expander.Option)
 
 	if processors != nil && processors.NodeGroupListProcessor != nil {
 		var errProc error

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -532,7 +532,8 @@ func runSimpleScaleUpTest(t *testing.T, config *scaleTestConfig) *scaleTestResul
 
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil).Process(&context, nodes, []*appsv1.DaemonSet{}, nil, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
-	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	err = clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	assert.NoError(t, err)
 
 	extraPods := make([]*apiv1.Pod, len(config.extraPods))
 	for i, p := range config.extraPods {
@@ -693,7 +694,8 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	nodes := []*apiv1.Node{n1, n2}
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil).Process(&context, nodes, []*appsv1.DaemonSet{}, nil, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
-	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	err = clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	assert.NoError(t, err)
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	processors := NewTestProcessors()
@@ -734,7 +736,8 @@ func TestScaleUpNoHelp(t *testing.T) {
 	nodes := []*apiv1.Node{n1}
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil).Process(&context, nodes, []*appsv1.DaemonSet{}, nil, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
-	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	err = clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	assert.NoError(t, err)
 	p3 := BuildTestPod("p-new", 500, 0)
 
 	processors := NewTestProcessors()
@@ -801,7 +804,8 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil).Process(&context, nodes, []*appsv1.DaemonSet{}, nil, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, newBackoff())
-	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	err = clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+	assert.NoError(t, err)
 
 	pods := make([]*apiv1.Pod, 0)
 	for i := 0; i < 2; i++ {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	core_utils "k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	kube_record "k8s.io/client-go/tools/record"
@@ -133,8 +132,8 @@ func (m *onNodeGroupDeleteMock) Delete(id string) error {
 }
 
 func TestStaticAutoscalerRunOnce(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -302,8 +301,8 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -456,8 +455,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -528,10 +527,12 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 
 	nodes := []*apiv1.Node{n1}
 	//nodeInfos, _ := getNodeInfosForGroups(nodes, provider, listerRegistry, []*appsv1.DaemonSet{}, context.PredicateChecker)
-	clusterState.UpdateNodes(nodes, nil, now)
+	err = clusterState.UpdateNodes(nodes, nil, now)
+	assert.NoError(t, err)
 
 	// broken node failed to register in time
-	clusterState.UpdateNodes(nodes, nil, later)
+	err = clusterState.UpdateNodes(nodes, nil, later)
+	assert.NoError(t, err)
 
 	processors := NewTestProcessors()
 
@@ -578,8 +579,8 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -732,8 +733,8 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -828,8 +829,8 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 }
 
 func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	readyNodeLister := kube_util.NewTestNodeLister(nil)
+	allNodeLister := kube_util.NewTestNodeLister(nil)
 	scheduledPodMock := &podListerMock{}
 	unschedulablePodMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
@@ -1055,7 +1056,8 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 
 	clusterState.RefreshCloudProviderNodeInstancesCache()
 	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err = clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
 
 	// delete nodes with create errors
 	assert.True(t, autoscaler.deleteCreatedNodesWithErrors())
@@ -1079,7 +1081,8 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 
 	// propagate nodes info in cluster state again
 	// no changes in what provider returns
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err = clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
 
 	// delete nodes with create errors
 	assert.True(t, autoscaler.deleteCreatedNodesWithErrors())
@@ -1142,7 +1145,8 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	clusterState.RefreshCloudProviderNodeInstancesCache()
 
 	// update cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err = clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
 
 	// delete nodes with create errors
 	assert.False(t, autoscaler.deleteCreatedNodesWithErrors())

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -139,23 +139,6 @@ func sanitizeTemplateNode(node *apiv1.Node, nodeGroup string, ignoredTaints tain
 	return newNode, nil
 }
 
-func hasHardInterPodAffinity(affinity *apiv1.Affinity) bool {
-	if affinity == nil {
-		return false
-	}
-	if affinity.PodAffinity != nil {
-		if len(affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) > 0 {
-			return true
-		}
-	}
-	if affinity.PodAntiAffinity != nil {
-		if len(affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // GetNodeCoresAndMemory extracts cpu and memory resources out of Node object
 func GetNodeCoresAndMemory(node *apiv1.Node) (int64, int64) {
 	cores := getNodeResource(node, apiv1.ResourceCPU)

--- a/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
+++ b/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
@@ -118,7 +118,10 @@ func (d *DebuggingSnapshotterImpl) ResponseHandler(w http.ResponseWriter, r *htt
 		defer d.Mutex.Unlock()
 		klog.Errorf("Debugging Snapshot is currently being processed. Another snapshot can't be processed")
 		w.WriteHeader(http.StatusTooManyRequests)
-		w.Write([]byte("Another debugging snapshot request is being processed. Concurrent requests not supported"))
+		_, err := w.Write([]byte("Another debugging snapshot request is being processed. Concurrent requests not supported"))
+		if err != nil {
+			klog.Errorf("Cannot write response body: %v", err)
+		}
 		return
 	}
 
@@ -140,7 +143,10 @@ func (d *DebuggingSnapshotterImpl) ResponseHandler(w http.ResponseWriter, r *htt
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
-		w.Write(body)
+		_, err := w.Write(body)
+		if err != nil {
+			klog.Errorf("Cannot write response body: %v", err)
+		}
 
 		// reset the debugging State to receive a new snapshot request
 		*d.State = LISTENING

--- a/cluster-autoscaler/expander/priority/priority_test.go
+++ b/cluster-autoscaler/expander/priority/priority_test.go
@@ -38,8 +38,6 @@ const (
 	configWarnConfigMapEmpty = "Warning PriorityConfigMapInvalid Wrong configuration for priority expander: " +
 		"priority configuration in cluster-autoscaler-priority-expander configmap is empty; please provide " +
 		"valid configuration. Ignoring update."
-	configWarnEmptyMsg = "priority configuration in cluster-autoscaler-priority-expander configmap is empty; please provide valid configuration"
-	configWarnParseMsg = "Can't parse YAML with priorities in the configmap"
 )
 
 var (
@@ -55,12 +53,6 @@ var (
 	oneEntryConfig = `
 10: 
   - ".*t2\\.large.*"
-`
-	notMatchingConfig = `
-5:
-  - ".*t\\.micro.*"
-10: 
-  - ".*t\\.large.*"
 `
 	wildcardMatchConfig = `
 5:

--- a/cluster-autoscaler/metrics/liveness.go
+++ b/cluster-autoscaler/metrics/liveness.go
@@ -74,11 +74,14 @@ func (hc *HealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hc.mutex.Unlock()
 
 	if timedOut {
-		w.WriteHeader(500)
-		w.Write([]byte(fmt.Sprintf("Error: last activity more %v ago, last success more than %v ago", time.Now().Sub(lastActivity).String(), time.Now().Sub(lastSuccessfulRun).String())))
+		msg := fmt.Sprintf("Error: last activity more %v ago, last success more than %v ago", time.Since(lastActivity).String(), time.Since(lastSuccessfulRun).String())
+		http.Error(w, msg, http.StatusInternalServerError)
 	} else {
 		w.WriteHeader(200)
-		w.Write([]byte("OK"))
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
 	}
 }
 

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -368,7 +368,7 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 // UpdateDurationFromStart records the duration of the step identified by the
 // label using start time
 func UpdateDurationFromStart(label FunctionLabel, start time.Time) {
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	UpdateDuration(label, duration)
 }
 

--- a/cluster-autoscaler/processors/callbacks/test_utils.go
+++ b/cluster-autoscaler/processors/callbacks/test_utils.go
@@ -26,7 +26,6 @@ type TestProcessorCallbacks struct {
 
 // ResetUnneededNodes is test implementation, which takes no action
 func (callbacks *TestProcessorCallbacks) ResetUnneededNodes() {
-	return
 }
 
 // NewTestProcessorCallbacks creates new instance of TestProcessorCallbacks

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
@@ -205,7 +205,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	}
 
 	toMap := func(suiList []ScaleUpInfo) map[string]ScaleUpInfo {
-		result := make(map[string]ScaleUpInfo, 0)
+		result := make(map[string]ScaleUpInfo)
 		for _, sui := range suiList {
 			result[sui.Group.Id()] = sui
 		}

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -77,7 +77,7 @@ func compareLabels(nodes []*schedulerframework.NodeInfo, ignoredLabels map[strin
 	labels := make(map[string][]string)
 	for _, node := range nodes {
 		for label, value := range node.Node().ObjectMeta.Labels {
-			ignore, _ := ignoredLabels[label]
+			ignore := ignoredLabels[label]
 			if !ignore {
 				labels[label] = append(labels[label], value)
 			}

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -195,14 +195,15 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 	cachedInfo, found = niProcessor.nodeInfoCache["ng2"]
 	assert.True(t, found)
 	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
-	cachedInfo, found = niProcessor.nodeInfoCache["ng3"]
+	_, found = niProcessor.nodeInfoCache["ng3"]
 	assert.False(t, found)
-	cachedInfo, found = niProcessor.nodeInfoCache["ng4"]
+	_, found = niProcessor.nodeInfoCache["ng4"]
 	assert.False(t, found)
 
 	// Invalidate part of cache in two different ways
 	provider1.DeleteNodeGroup("ng1")
-	provider1.GetNodeGroup("ng3").Delete()
+	err = provider1.GetNodeGroup("ng3").Delete()
+	assert.NoError(t, err)
 	assert.Equal(t, "ng3", lastDeletedGroup)
 
 	// Check cache with all nodes removed
@@ -221,7 +222,7 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 	cachedInfo, found = niProcessor.nodeInfoCache["ng2"]
 	assert.True(t, found)
 	assertEqualNodeCapacities(t, ready2, cachedInfo.Node())
-	cachedInfo, found = niProcessor.nodeInfoCache["ng4"]
+	_, found = niProcessor.nodeInfoCache["ng4"]
 	assert.False(t, found)
 
 	// Fill cache manually

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -321,7 +321,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 			if err := predicateChecker.CheckPredicates(clusterSnapshot, pod, hintedNode); err == nil {
 				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, hintedNode)
 				if err := clusterSnapshot.AddPod(pod, hintedNode); err != nil {
-					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, hintedNode, err)
+					return fmt.Errorf("simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, hintedNode, err)
 				}
 				newHints[podKey(pod)] = hintedNode
 				foundPlace = true
@@ -336,7 +336,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 			if err == nil {
 				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, newNodeName)
 				if err := clusterSnapshot.AddPod(pod, newNodeName); err != nil {
-					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, newNodeName, err)
+					return fmt.Errorf("simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, newNodeName, err)
 				}
 				newHints[podKey(pod)] = newNodeName
 				targetNode = newNodeName

--- a/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_benchmark_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func createTestNodesWithPrefix(prefix string, n int) []*apiv1.Node {
-	nodes := make([]*apiv1.Node, n, n)
+	nodes := make([]*apiv1.Node, n)
 	for i := 0; i < n; i++ {
 		nodes[i] = BuildTestNode(fmt.Sprintf("%s-%d", prefix, i), 2000, 2000000)
 		SetNodeReadyState(nodes[i], true, time.Time{})
@@ -41,7 +41,7 @@ func createTestNodes(n int) []*apiv1.Node {
 }
 
 func createTestPodsWithPrefix(prefix string, n int) []*apiv1.Pod {
-	pods := make([]*apiv1.Pod, n, n)
+	pods := make([]*apiv1.Pod, n)
 	for i := 0; i < n; i++ {
 		pods[i] = BuildTestPod(fmt.Sprintf("%s-%d", prefix, i), 1000, 2000000)
 	}

--- a/cluster-autoscaler/simulator/cluster_snapshot_test.go
+++ b/cluster-autoscaler/simulator/cluster_snapshot_test.go
@@ -35,14 +35,6 @@ var snapshots = map[string]func() ClusterSnapshot{
 	"delta": func() ClusterSnapshot { return NewDeltaClusterSnapshot() },
 }
 
-func nodeNames(nodes []*apiv1.Node) []string {
-	names := make([]string, len(nodes), len(nodes))
-	for i, node := range nodes {
-		names[i] = node.Name
-	}
-	return names
-}
-
 func extractNodes(nodeInfos []*schedulerframework.NodeInfo) []*apiv1.Node {
 	nodes := []*apiv1.Node{}
 	for _, ni := range nodeInfos {
@@ -253,14 +245,14 @@ func TestClear(t *testing.T) {
 
 	extraNodes := createTestNodesWithPrefix("extra", extraNodeCount)
 
-	allNodes := make([]*apiv1.Node, len(nodes)+len(extraNodes), len(nodes)+len(extraNodes))
+	allNodes := make([]*apiv1.Node, len(nodes)+len(extraNodes))
 	copy(allNodes, nodes)
 	copy(allNodes[len(nodes):], extraNodes)
 
 	extraPods := createTestPodsWithPrefix("extra", extraPodCount)
 	assignPodsToNodes(extraPods, allNodes)
 
-	allPods := make([]*apiv1.Pod, len(pods)+len(extraPods), len(pods)+len(extraPods))
+	allPods := make([]*apiv1.Pod, len(pods)+len(extraPods))
 	copy(allPods, pods)
 	copy(allPods[len(pods):], extraPods)
 

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -105,7 +105,7 @@ func TestUtilization(t *testing.T) {
 	nodeInfo = schedulerframework.NewNodeInfo(pod, pod, gpuPod)
 	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
-	assert.InEpsilon(t, 1/1, utilInfo.Utilization, 0.01)
+	assert.InEpsilon(t, 1, utilInfo.Utilization, 0.01)
 
 	// Node with Unready GPU
 	gpuNode = BuildTestNode("gpu_node", 2000, 2000000)
@@ -114,16 +114,6 @@ func TestUtilization(t *testing.T) {
 	utilInfo, err = CalculateUtilization(gpuNode, nodeInfo, false, false, gpuLabel, testTime)
 	assert.NoError(t, err)
 	assert.Zero(t, utilInfo.Utilization)
-}
-
-func nodeInfos(nodes []*apiv1.Node) []*schedulerframework.NodeInfo {
-	result := make([]*schedulerframework.NodeInfo, len(nodes))
-	for i, node := range nodes {
-		ni := schedulerframework.NewNodeInfo()
-		ni.SetNode(node)
-		result[i] = ni
-	}
-	return result
 }
 
 func TestFindPlaceAllOk(t *testing.T) {

--- a/cluster-autoscaler/simulator/delta_cluster_snapshot.go
+++ b/cluster-autoscaler/simulator/delta_cluster_snapshot.go
@@ -187,10 +187,7 @@ func (data *internalDeltaSnapshotData) removeNode(nodeName string) error {
 		delete(data.addedNodeInfoMap, nodeName)
 	}
 
-	if _, modified := data.modifiedNodeInfoMap[nodeName]; modified {
-		// If node was modified within this delta, delete this change.
-		delete(data.modifiedNodeInfoMap, nodeName)
-	}
+	delete(data.modifiedNodeInfoMap, nodeName)
 
 	if _, deleted := data.deletedNodeInfos[nodeName]; deleted {
 		// If node was deleted within this delta, fail with error.

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -23,7 +23,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
-	v1listers "k8s.io/client-go/listers/core/v1"
 	klog "k8s.io/klog/v2"
 	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -36,8 +35,6 @@ import (
 type SchedulerBasedPredicateChecker struct {
 	framework              schedulerframework.Framework
 	delegatingSharedLister *DelegatingSchedulerSharedLister
-	nodeLister             v1listers.NodeLister
-	podLister              v1listers.PodLister
 	lastIndex              int
 }
 

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker_test.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker_test.go
@@ -76,6 +76,7 @@ func TestCheckPredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			predicateChecker, err := NewTestPredicateChecker()
+			assert.NoError(t, err)
 			clusterSnapshot := NewBasicClusterSnapshot()
 			err = clusterSnapshot.AddNodeWithPods(tt.node, tt.scheduledPods)
 			assert.NoError(t, err)
@@ -120,7 +121,7 @@ func TestFitsAnyNode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "n2000", nodeName)
 
-	nodeName, err = predicateChecker.FitsAnyNode(clusterSnapshot, p2100)
+	_, err = predicateChecker.FitsAnyNode(clusterSnapshot, p2100)
 	assert.Error(t, err)
 }
 

--- a/cluster-autoscaler/utils/deletetaint/delete_test.go
+++ b/cluster-autoscaler/utils/deletetaint/delete_test.go
@@ -97,7 +97,7 @@ func TestQueryNodes(t *testing.T) {
 	val, err := GetToBeDeletedTime(updatedNode)
 	assert.NoError(t, err)
 	assert.NotNil(t, val)
-	assert.True(t, time.Now().Sub(*val) < 10*time.Second)
+	assert.True(t, time.Since(*val) < 10*time.Second)
 }
 
 func TestSoftQueryNodes(t *testing.T) {
@@ -113,7 +113,7 @@ func TestSoftQueryNodes(t *testing.T) {
 	val, err := GetDeletionCandidateTime(updatedNode)
 	assert.NoError(t, err)
 	assert.NotNil(t, val)
-	assert.True(t, time.Now().Sub(*val) < 10*time.Second)
+	assert.True(t, time.Since(*val) < 10*time.Second)
 }
 
 func TestCleanNodes(t *testing.T) {

--- a/cluster-autoscaler/utils/pod/pod.go
+++ b/cluster-autoscaler/utils/pod/pod.go
@@ -54,7 +54,7 @@ func IsMirrorPod(pod *apiv1.Pod) bool {
 // IsStaticPod returns true if the pod is a static pod.
 func IsStaticPod(pod *apiv1.Pod) bool {
 	if pod.Annotations != nil {
-		if source, ok := pod.Annotations[types.ConfigSourceAnnotationKey]; ok == true {
+		if source, ok := pod.Annotations[types.ConfigSourceAnnotationKey]; ok {
 			return source != types.ApiserverSource
 		}
 	}

--- a/cluster-autoscaler/utils/tpu/tpu_test.go
+++ b/cluster-autoscaler/utils/tpu/tpu_test.go
@@ -32,7 +32,6 @@ var (
 )
 
 type requests map[apiv1.ResourceName]int64
-type containerSpecs []requests
 
 func testContainer(requests requests) apiv1.Container {
 	container := apiv1.Container{


### PR DESCRIPTION
#### Which component this PR applies to?

All

Used tools: `gofmt` and `golangci-lint`

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a massive code refactoring aimed to meet current golang code formatting requirements.

#### Special notes for your reviewer:

gofmt updated some autogenerated files (zz_generated.deepcopy.go) by adding a building flag. This is a common k8s practice: https://github.com/kubernetes/client-go/commit/624e6827e688a8171a5c47d41aa14e60e397e2e3
`deepcopy-gen` won't complain about this change.

#### Does this PR introduce a user-facing change?
No

```release-note
None
```

