### PR TITLE
Fix label indentation for the service monitor manifest

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.16.1
+version: 9.16.2

--- a/charts/cluster-autoscaler/templates/servicemonitor.yaml
+++ b/charts/cluster-autoscaler/templates/servicemonitor.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- range $key, $value := .Values.serviceMonitor.selector }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler helm chart

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This PR fixes the service monitor manifest in the chat. Labels have wrong indentation that breaks the yaml file

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
