### PR TITLE
vpa: admission-controller: add logs for failure to start webhook server

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -136,5 +136,8 @@ func main() {
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)
 	}()
-	server.ListenAndServeTLS("", "")
+	err = server.ListenAndServeTLS("", "")
+	if err != nil {
+		klog.Fatalf("HTTPS Error: %s", err)
+	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -136,8 +136,8 @@ func main() {
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)
 	}()
-	err = server.ListenAndServeTLS("", "")
-	if err != nil {
+
+	if err = server.ListenAndServeTLS("", ""); err != nil {
 		klog.Fatalf("HTTPS Error: %s", err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: sedflix <sedflix@gmail.com>

#### Which component this PR applies to?

vertical-pod-autoscaler, admission controller 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds feature to log failure of HTTPS Server Startup

#### Which issue(s) this PR fixes:

It will help in debugging #4695 

#### Special notes for your reviewer:
I'm not sure about the best practices to follow here.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
