### PR TITLE
[CA] [HELM] fix templating of secret used for CAPI

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.15.0
+version: 9.15.1

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           securityContext:
             {{ toYaml .Values.containerSecurityContext | nindent 12 | trim }}
           {{- end }}
-          {{- if or (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumeMounts }}
+          {{- if or (eq .Values.cloudProvider "magnum") (eq .Values.cloudProvider "clusterapi") .Values.extraVolumeSecrets .Values.extraVolumeMounts }}
           volumeMounts:
           {{- if eq .Values.cloudProvider "magnum" }}
             - name: cloudconfig
@@ -245,7 +245,7 @@ spec:
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 | trim }}
       {{- end }}
-      {{- if or (eq .Values.cloudProvider "magnum") .Values.extraVolumeSecrets .Values.extraVolumes }}
+      {{- if or (eq .Values.cloudProvider "magnum") (eq .Values.cloudProvider "clusterapi") .Values.extraVolumeSecrets .Values.extraVolumes }}
       volumes:
       {{- if eq .Values.cloudProvider "magnum" }}
         - name: cloudconfig


### PR DESCRIPTION
#### Which component this PR applies to?
cluster-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Fixes the templating of the kubeconfig secret used


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix usage of `clusterAPIKubeconfigSecret``in cluster-autoscaler helm chart
```

