### PR TITLE
add user configurable cluster api version

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -180,6 +180,23 @@ the machine annotation on nodes will be `test.8s.io/machine`, the machine deleti
 annotation will be `test.k8s.io/delete-machine`, and the cluster name label will be
 `test.k8s.io/cluster-name`.
 
+## Specifying a Custom Resource Version
+
+When determining the group version for the Cluster API types, by default the autoscaler
+will look for the latest version of the group. For example, if `MachineDeployments`
+exist in the `cluster.x-k8s.io` group at versions `v1alpha1` and `v1beta1`, the
+autoscaler will choose `v1beta1`.
+
+In some cases it may be desirable to specify which version of the API the cluster
+autoscaler should use. This can be useful in debugging scenarios, or in situations
+where you have deployed multiple API versions and wish to ensure that the autoscaler
+uses a specific version.
+
+Setting the `CAPI_VERSION` environment variable will instruct the autoscaler to use
+the version specified. This works in a similar fashion as the API group environment
+variable with the exception that there is no default value. When this variable is not
+set, the autoscaler will use the behavior described above.
+
 ## Sample manifest
 
 A sample manifest that will create a deployment running the autoscaler is


### PR DESCRIPTION

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change introduces an environment variable, `CAPI_VERSION`, through
which a user can set the API version for the group they are using. This
change is being added to address situations where a user might have
multiple API versions for the cluster api group and wishes to be
explicit about which version is selected.

Also adds unit tests and documentation for the new behavior. This change
does not break the existing behavior.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now specify the Cluster API group version by setting the `CAPI_VERSION` environment variable to the desired version string.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Updated the README file to include usage documentation