### PR TITLE
[CA Helm] fix RBAC for namespaced mode

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.16.0
+version: 9.16.1

--- a/charts/cluster-autoscaler/templates/role.yaml
+++ b/charts/cluster-autoscaler/templates/role.yaml
@@ -43,7 +43,7 @@ rules:
       - get
       - update
 {{- end }}
-{{- if and ( and ( eq .Values.cloudProvider "clusterapi" ) ( not .Values.rbac.clusterScoped ) ( or ( eq .Values.clusterAPIMode "incluster-incluster" ) ( eq .Values.clusterAPIMode "incluster-kubeconfig" ) ))}}
+{{- if and ( and ( eq .Values.cloudProvider "clusterapi" ) ( not .Values.rbac.clusterScoped ) ( or ( eq .Values.clusterAPIMode "incluster-incluster" ) ( eq .Values.clusterAPIMode "kubeconfig-incluster" ) ))}}
   - apiGroups:
     - cluster.x-k8s.io
     resources:


### PR DESCRIPTION
#### Which component this PR applies to?
Cluster Autoscaler helm chart
Cluster
/kind bug


#### What this PR does / why we need it:
 This fixed the RBAC for namespaced mode of the cluster autoscaler

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
fix RBAC for namespaced mode of cluster autoscaler helm chart
```

