### PR TITLE
feat: use non-root user for base-image

### DIFF
--- a/cluster-autoscaler/Dockerfile.amd64
+++ b/cluster-autoscaler/Dockerfile.amd64
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG BASEIMAGE=gcr.io/distroless/static:latest-amd64
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot-amd64
 FROM $BASEIMAGE
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 COPY cluster-autoscaler-amd64 /cluster-autoscaler
+WORKDIR /
 CMD ["/cluster-autoscaler"]

--- a/cluster-autoscaler/Dockerfile.arm64
+++ b/cluster-autoscaler/Dockerfile.arm64
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG BASEIMAGE=gcr.io/distroless/static:latest-arm64
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot-arm64
 FROM $BASEIMAGE
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 COPY cluster-autoscaler-arm64 /cluster-autoscaler
+WORKDIR /
 CMD ["/cluster-autoscaler"]


### PR DESCRIPTION
There is no need to use the root user. This allows the user to comply with pod security standards.

It turns out that the `nonroot` image has the `cwd` set to `/home/nonroot` whereas `latest` is rooted in `/` :shrug: . 
This is important because the helm chart uses `./cluster-autoscaler` as command. Keeping the same cwd seems like the safest option to me. 

#### Which component this PR applies to?
cluster-autoscaler

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR makes infosec happy :smiley: 

#### Which issue(s) this PR fixes:
Fixes #3705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
