### PR TITLE
Limit caching pods per owner reference

### DIFF
--- a/cluster-autoscaler/core/equivalence_groups_test.go
+++ b/cluster-autoscaler/core/equivalence_groups_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -164,4 +165,22 @@ func TestEquivalenceGroupSizeLimiting(t *testing.T) {
 	for i := range podGroups {
 		assert.Equal(t, 1, len(podGroups[i]))
 	}
+}
+
+func TestEquivalenceGroupIgnoresDaemonSets(t *testing.T) {
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds",
+			Namespace: "default",
+			SelfLink:  "api/v1/namespaces/default/daemonsets/ds",
+			UID:       "12345678-1234-1234-1234-123456789012",
+		},
+	}
+	pods := make([]*apiv1.Pod, 2)
+	pods[0] = BuildTestPod("p1", 3000, 200000)
+	pods[0].OwnerReferences = GenerateOwnerReferences(ds.Name, "DaemonSet", "apps/v1", ds.UID)
+	pods[1] = BuildTestPod("p2", 3000, 200000)
+	pods[1].OwnerReferences = GenerateOwnerReferences(ds.Name, "DaemonSet", "apps/v1", ds.UID)
+	podGroups := groupPodsBySchedulingProperties(pods)
+	assert.Equal(t, 2, len(podGroups))
 }

--- a/cluster-autoscaler/core/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filter_out_schedulable.go
@@ -100,7 +100,7 @@ func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(
 	unschedulableCandidates []*apiv1.Pod,
 	clusterSnapshot simulator.ClusterSnapshot,
 	predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {
-	unschedulablePodsCache := make(utils.PodSchedulableMap)
+	unschedulablePodsCache := utils.NewPodSchedulableMap()
 
 	// Sort unschedulable pods by importance
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {
@@ -172,6 +172,7 @@ func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(
 			unschedulablePodsCache.Set(pod, nil)
 		}
 	}
+	metrics.UpdateOverflowingControllers(unschedulablePodsCache.OverflowingControllerCount())
 	klog.V(4).Infof("%v pods were kept as unschedulable based on caching", unschedulePodsCacheHitCounter)
 	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.", len(unschedulableCandidates)-len(unschedulablePods))
 	return unschedulablePods, nil

--- a/cluster-autoscaler/core/utils/pod_schedulable.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+	pod_utils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
 
 // PodSchedulableInfo data structure is used to avoid running predicates #pending_pods * #nodes
@@ -86,7 +87,7 @@ func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, bool)
 // Set sets scheduling info for given pod in PodSchedulableMap
 func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *simulator.PredicateError) {
 	ref := drain.ControllerRef(pod)
-	if ref == nil {
+	if ref == nil || pod_utils.IsDaemonSetPod(pod) {
 		return
 	}
 	uid := string(ref.UID)

--- a/cluster-autoscaler/core/utils/pod_schedulable.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable.go
@@ -45,8 +45,21 @@ type PodSchedulableInfo struct {
 	schedulingError *simulator.PredicateError
 }
 
+const maxPodsPerOwnerRef = 10
+
 // PodSchedulableMap stores mapping from controller ref to PodSchedulableInfo
-type PodSchedulableMap map[string][]PodSchedulableInfo
+type PodSchedulableMap struct {
+	items                  map[string][]PodSchedulableInfo
+	overflowingControllers map[string]bool
+}
+
+// NewPodSchedulableMap creates a new PodSchedulableMap
+func NewPodSchedulableMap() PodSchedulableMap {
+	return PodSchedulableMap{
+		items:                  make(map[string][]PodSchedulableInfo),
+		overflowingControllers: make(map[string]bool),
+	}
+}
 
 // Match tests if given pod matches PodSchedulableInfo
 func (psi *PodSchedulableInfo) Match(pod *apiv1.Pod) bool {
@@ -54,13 +67,13 @@ func (psi *PodSchedulableInfo) Match(pod *apiv1.Pod) bool {
 }
 
 // Get returns scheduling info for given pod if matching one exists in PodSchedulableMap
-func (podMap PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, bool) {
+func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, bool) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
 		return nil, false
 	}
 	uid := string(ref.UID)
-	if infos, found := podMap[uid]; found {
+	if infos, found := p.items[uid]; found {
 		for _, info := range infos {
 			if info.Match(pod) {
 				return info.schedulingError, true
@@ -71,15 +84,29 @@ func (podMap PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, 
 }
 
 // Set sets scheduling info for given pod in PodSchedulableMap
-func (podMap PodSchedulableMap) Set(pod *apiv1.Pod, err *simulator.PredicateError) {
+func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *simulator.PredicateError) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
 		return
 	}
 	uid := string(ref.UID)
-	podMap[uid] = append(podMap[uid], PodSchedulableInfo{
+	pm := p.items[uid]
+	if len(pm) >= maxPodsPerOwnerRef {
+		// Too many different pods per owner reference. Don't cache the
+		// entry to avoid O(N) search in Get(). It would defeat the
+		// benefits from caching anyway.
+		p.overflowingControllers[uid] = true
+		return
+	}
+	p.items[uid] = append(pm, PodSchedulableInfo{
 		spec:            pod.Spec,
 		labels:          pod.Labels,
 		schedulingError: err,
 	})
+}
+
+// OverflowingControllerCount returns the number of controllers that had too
+// many different pods to be effectively cached.
+func (p PodSchedulableMap) OverflowingControllerCount() int {
+	return len(p.overflowingControllers)
 }

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -304,6 +304,14 @@ var (
 		},
 	)
 
+	overflowingControllersCount = k8smetrics.NewGauge(
+		&k8smetrics.GaugeOpts{
+			Namespace: caNamespace,
+			Name:      "overflowing_controllers_count",
+			Help:      "Number of controllers that own a large set of heterogenous pods, preventing CA from treating these pods as equivalent.",
+		},
+	)
+
 	/**** Metrics related to NodeAutoprovisioning ****/
 	napEnabled = k8smetrics.NewGauge(
 		&k8smetrics.GaugeOpts{
@@ -355,6 +363,7 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	legacyregistry.MustRegister(unremovableNodesCount)
 	legacyregistry.MustRegister(scaleDownInCooldown)
 	legacyregistry.MustRegister(oldUnregisteredNodesRemovedCount)
+	legacyregistry.MustRegister(overflowingControllersCount)
 	legacyregistry.MustRegister(napEnabled)
 	legacyregistry.MustRegister(nodeGroupCreationCount)
 	legacyregistry.MustRegister(nodeGroupDeletionCount)
@@ -531,4 +540,10 @@ func UpdateScaleDownInCooldown(inCooldown bool) {
 // nodes that have been removed by the cluster autoscaler
 func RegisterOldUnregisteredNodesRemoved(nodesCount int) {
 	oldUnregisteredNodesRemovedCount.Add(float64(nodesCount))
+}
+
+// UpdateOverflowingControllers sets the number of controllers that could not
+// have their pods cached.
+func UpdateOverflowingControllers(count int) {
+	overflowingControllersCount.Set(float64(count))
 }


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This limits the number of pods that are searched in O(N) time per owner reference to a small fixed constant (10), to avoid future regressions when PodSpec is extended with new fields that differ between pods owned by the same controller. I added a new metric for tracking this, so that we can monitor & fix cases when that happens. This should keep the caching optimization maintainable in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4724

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @MaciekPytel 