### PR TITLE
Fix CI script to use GO111MODULE auto as default

### DIFF
--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -45,6 +45,8 @@ for project_name in ${PROJECT_NAMES[*]}; do
   (
     if [[ $project_name == cluster-autoscaler ]];then
       export GO111MODULE=off
+    else
+      export GO111MODULE=auto
     fi
 
     project=${CONTRIB_ROOT}/${project_name}


### PR DESCRIPTION
The cluster-autoscaler use godep, and the  cluster-autoscaler vertical-pod-autoscaler use gomod.

So should we set GO111MODULE=auto as default. and GO111MODULE=off only for the  cluster-autoscaler project.

Signed-off-by: Kay Yan <kay.yan@daocloud.io>

