### PR TITLE
Skip pod hostname when comparing PodSpecs

### DIFF
--- a/cluster-autoscaler/utils/utils_test.go
+++ b/cluster-autoscaler/utils/utils_test.go
@@ -73,6 +73,16 @@ func TestPodSpecSemanticallyEqual(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "two pods with different hostnames",
+			p1Spec: apiv1.PodSpec{
+				Hostname: "foo",
+			},
+			p2Spec: apiv1.PodSpec{
+				Hostname: "bar",
+			},
+			result: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,7 +93,7 @@ func TestPodSpecSemanticallyEqual(t *testing.T) {
 	}
 }
 
-func TestSanitizeProjectedVolumesAndMounts(t *testing.T) {
+func TestSanitizePodSpec(t *testing.T) {
 	projectedSAVol := test.BuildServiceTokenProjectedVolumeSource("path")
 
 	tests := []struct {
@@ -170,7 +180,7 @@ func TestSanitizeProjectedVolumesAndMounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeProjectedVolumesAndMounts(tt.inputPodSpec)
+			got := sanitizePodSpec(tt.inputPodSpec)
 			assert.True(t, assert.ObjectsAreEqualValues(tt.outputPodSpec, got), "\ngot: %#v\nwant: %#v", got, tt.outputPodSpec)
 		})
 	}


### PR DESCRIPTION
Hostname doesn't affect scheduling and different hostnames prevent
caching of similar pods in CA.

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This improves CA performance when handling IndexedJobs (see #4724).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4724

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
