### PR TITLE
cluster-autoscaler/cloudstack: Identify node by name and id

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,6 +111,8 @@ func testNodeNotExist(t *testing.T) {
 		},
 	}
 	_, err := provider.NodeGroupForNode(node)
+	fmt.Println(provider.manager.asg.cluster)
+	fmt.Println(err)
 	assert.NotEqual(t, nil, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
@@ -87,12 +88,10 @@ func TestNodeGroups(t *testing.T) {
 	assert.Equal(t, testConfig.minSize, asgs[0].MinSize())
 }
 
-func testNodeExists(t *testing.T) {
+func testNodeExistsWithName(t *testing.T) {
 	node := &v1.Node{
-		Status: v1.NodeStatus{
-			NodeInfo: v1.NodeSystemInfo{
-				SystemUUID: "vm1",
-			},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vm1",
 		},
 	}
 	asg, err := provider.NodeGroupForNode(node)
@@ -102,7 +101,32 @@ func testNodeExists(t *testing.T) {
 	assert.Equal(t, testConfig.minSize, asg.MinSize())
 }
 
-func testNodeNotExist(t *testing.T) {
+func testNodeExistsWithoutName(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vm1",
+		},
+	}
+	asg, err := provider.NodeGroupForNode(node)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, testConfig.clusterID, asg.Id())
+	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
+	assert.Equal(t, testConfig.minSize, asg.MinSize())
+}
+
+func testNodeNotExistWithName(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vm5",
+		},
+	}
+	_, err := provider.NodeGroupForNode(node)
+	fmt.Println(provider.manager.asg.cluster)
+	fmt.Println(err)
+	assert.NotEqual(t, nil, err)
+}
+
+func testNodeNotExistWithoutName(t *testing.T) {
 	node := &v1.Node{
 		Status: v1.NodeStatus{
 			NodeInfo: v1.NodeSystemInfo{
@@ -117,8 +141,10 @@ func testNodeNotExist(t *testing.T) {
 }
 
 func TestNodeGroupForNode(t *testing.T) {
-	t.Run("testNodeExists", testNodeExists)
-	t.Run("testNodeNotExist", testNodeNotExist)
+	t.Run("testNodeExistsWithName", testNodeExistsWithName)
+	t.Run("testNodeExistsWithoutName", testNodeExistsWithoutName)
+	t.Run("testNodeNotExistWithName", testNodeNotExistWithName)
+	t.Run("testNodeNotExistWithoutName", testNodeNotExistWithoutName)
 }
 
 func TestGetAvailableMachineTypes(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager.go
@@ -84,10 +84,6 @@ func (manager *manager) fetchCluster() error {
 	if err != nil {
 		return err
 	}
-	cluster.VirtualMachineMap = make(map[string]*service.VirtualMachine)
-	for _, vm := range cluster.VirtualMachines {
-		cluster.VirtualMachineMap[vm.Name] = vm
-	}
 
 	klog.Info("Got cluster : ", cluster)
 	manager.setMinMaxIfNotPresent(cluster)

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager.go
@@ -84,6 +84,10 @@ func (manager *manager) fetchCluster() error {
 	if err != nil {
 		return err
 	}
+	cluster.VirtualMachineMap = make(map[string]*service.VirtualMachine)
+	for _, vm := range cluster.VirtualMachines {
+		cluster.VirtualMachineMap[vm.Name] = vm
+	}
 
 	klog.Info("Got cluster : ", cluster)
 	manager.setMinMaxIfNotPresent(cluster)

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
@@ -56,6 +56,7 @@ func createClusterDetails() *service.Cluster {
 				ID: "vm3",
 			},
 		},
+		VirtualMachineMap: make(map[string]*service.VirtualMachine),
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	nodeIDs = []string{"vm2", "vm3"}
+	nodeIDs = []string{"m1", "vm2"}
 )
 
 func createClusterDetails() *service.Cluster {
@@ -47,13 +47,16 @@ func createClusterDetails() *service.Cluster {
 				ID: "m1",
 			},
 			{
-				ID: "vm1",
+				ID:   "vm1",
+				Name: "vm1",
 			},
 			{
-				ID: "vm2",
+				ID:   "vm2",
+				Name: "vm2",
 			},
 			{
-				ID: "vm3",
+				ID:   "vm3",
+				Name: "vm3",
 			},
 		},
 		VirtualMachineMap: make(map[string]*service.VirtualMachine),
@@ -72,19 +75,24 @@ func createScaleUpClusterDetails() *service.Cluster {
 				ID: "m1",
 			},
 			{
-				ID: "vm1",
+				ID:   "vm1",
+				Name: "vm1",
 			},
 			{
-				ID: "vm2",
+				ID:   "vm2",
+				Name: "vm2",
 			},
 			{
-				ID: "vm3",
+				ID:   "vm3",
+				Name: "vm3",
 			},
 			{
-				ID: "vm4",
+				ID:   "vm4",
+				Name: "vm4",
 			},
 			{
-				ID: "vm5",
+				ID:   "vm5",
+				Name: "vm5",
 			},
 		},
 	}
@@ -99,10 +107,12 @@ func createScaleDownClusterDetails() *service.Cluster {
 		WorkerCount: 1,
 		VirtualMachines: []*service.VirtualMachine{
 			{
-				ID: "m1",
+				ID:   "vm2",
+				Name: "vm2",
 			},
 			{
-				ID: "vm1",
+				ID:   "vm3",
+				Name: "vm3",
 			},
 		},
 	}
@@ -170,6 +180,7 @@ func TestFetchCluster(t *testing.T) {
 	assert.Equal(t, testConfig.clusterID, asg.Id())
 	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
 	assert.Equal(t, testConfig.minSize, asg.MinSize())
+	assert.Nil(t, asg.cluster.VirtualMachineMap[""])
 	s.AssertExpectations(t)
 }
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -83,7 +83,7 @@ func (asg *asg) DecreaseTargetSize(delta int) error {
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 	for _, vm := range asg.cluster.VirtualMachines {
-		if vm.Name == node.Name {
+		if vm.Name != "" && node.Name != "" && vm.Name == node.Name {
 			return true, nil
 		}
 		if vm.ID == node.Status.NodeInfo.SystemUUID {

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -83,6 +83,9 @@ func (asg *asg) DecreaseTargetSize(delta int) error {
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 	for _, vm := range asg.cluster.VirtualMachines {
+		if vm.Name == node.Name {
+			return true, nil
+		}
 		if vm.ID == node.Status.NodeInfo.SystemUUID {
 			return true, nil
 		}
@@ -98,7 +101,11 @@ func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
 
 	nodeIDs := make([]string, len(nodes))
 	for i, node := range nodes {
-		nodeIDs[i] = node.Status.NodeInfo.SystemUUID
+		if vm, ok := asg.cluster.VirtualMachineMap[node.Name]; ok {
+			nodeIDs[i] = vm.ID
+		} else {
+			nodeIDs[i] = node.Status.NodeInfo.SystemUUID
+		}
 	}
 	if len(nodeIDs) == 0 {
 		return fmt.Errorf("Unable to fetch nodeids from %v", nodes)

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
@@ -144,11 +145,14 @@ func testDeleteNodesError(t *testing.T) {
 		{
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
-					SystemUUID: "vm1",
+					SystemUUID: "m1",
 				},
 			},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vm2",
+			},
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
 					SystemUUID: "vm2",
@@ -178,14 +182,17 @@ func testDeleteNodesSuccess(t *testing.T) {
 		{
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
-					SystemUUID: "vm2",
+					SystemUUID: "m1",
 				},
 			},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vm2",
+			},
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
-					SystemUUID: "vm3",
+					SystemUUID: "vm2",
 				},
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
@@ -55,13 +55,14 @@ type ClusterResponse struct {
 
 // Cluster contains the CKS Cluster details
 type Cluster struct {
-	ID              string            `json:"id"`
-	Name            string            `json:"name"`
-	Minsize         int               `json:"minsize"`
-	Maxsize         int               `json:"maxsize"`
-	WorkerCount     int               `json:"size"`
-	MasterCount     int               `json:"masternodes"`
-	VirtualMachines []*VirtualMachine `json:"virtualmachines"`
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	Minsize           int               `json:"minsize"`
+	Maxsize           int               `json:"maxsize"`
+	WorkerCount       int               `json:"size"`
+	MasterCount       int               `json:"masternodes"`
+	VirtualMachines   []*VirtualMachine `json:"virtualmachines"`
+	VirtualMachineMap map[string]*VirtualMachine
 }
 
 // VirtualMachine represents a node in a CKS cluster

--- a/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
@@ -77,6 +77,16 @@ type cksService struct {
 	client APIClient
 }
 
+func virtaulMachinesToMap(vms []*VirtualMachine) map[string]*VirtualMachine {
+	vmMap := make(map[string]*VirtualMachine)
+	for _, vm := range vms {
+		if vm.Name != "" {
+			vmMap[vm.Name] = vm
+		}
+	}
+	return vmMap
+}
+
 func (service *cksService) GetClusterDetails(clusterID string) (*Cluster, error) {
 	var out ListClusterResponse
 	_, err := service.client.NewRequest("listKubernetesClusters", map[string]string{
@@ -91,7 +101,9 @@ func (service *cksService) GetClusterDetails(clusterID string) (*Cluster, error)
 	if len(clusters) == 0 {
 		return nil, fmt.Errorf("Unable to fetch cluster with id : %v", clusterID)
 	}
-	return clusters[0], err
+	cluster := clusters[0]
+	cluster.VirtualMachineMap = virtaulMachinesToMap(cluster.VirtualMachines)
+	return cluster, err
 }
 
 func (service *cksService) ScaleCluster(clusterID string, workerCount int) (*Cluster, error) {
@@ -104,7 +116,9 @@ func (service *cksService) ScaleCluster(clusterID string, workerCount int) (*Clu
 	if err != nil {
 		return nil, fmt.Errorf("Unable to scale cluster : %v", err)
 	}
-	return out.Cluster, err
+	cluster := out.Cluster
+	cluster.VirtualMachineMap = virtaulMachinesToMap(cluster.VirtualMachines)
+	return cluster, err
 }
 
 func (service *cksService) RemoveNodesFromCluster(clusterID string, nodeIDs ...string) (*Cluster, error) {
@@ -116,7 +130,9 @@ func (service *cksService) RemoveNodesFromCluster(clusterID string, nodeIDs ...s
 	if err != nil {
 		return nil, fmt.Errorf("Unable to delete %v from cluster : %v", nodeIDs, err)
 	}
-	return out.Cluster, err
+	cluster := out.Cluster
+	cluster.VirtualMachineMap = virtaulMachinesToMap(cluster.VirtualMachines)
+	return cluster, err
 }
 
 func (service *cksService) Close() {


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler / cloudprovider / cloudstack

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Previously, nodes were identified by their system UUID. This sometimes causes issues as the hypervisor has a VM UUID, which differs from the one CloudStack uses. In such a case, identify the node by name


