### PR TITLE
add apiVersiom helper for PodDisruptionBudget and use

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.16.2
+version: 9.16.3

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -64,6 +64,18 @@ Return the appropriate apiVersion for deployment.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "poddisruptionbudget.apiVersion" -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.21-0" $kubeTargetVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "podsecuritypolicy.apiVersion" -}}

--- a/charts/cluster-autoscaler/templates/pdb.yaml
+++ b/charts/cluster-autoscaler/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
#### Which component this PR applies to?

helm charts

#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

If a PodDisruptionBudget is enabled, it uses `policy/v1beta1`, causing API deprecation warnings on 1.21+ clusters.

This creates a poddisruptionbudget.apiVersion helper template and changes the pdb resource to use it when setting the version, supporting old and new clusters.

#### Which issue(s) this PR fixes:

Did not open a PR.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Allows warning-free deployment on 1.21+ clusters.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
