### PR TITLE
Correction of Pod creation fails if VPA has only one controlledResources

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -116,41 +116,39 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 		requests := core.ResourceList{}
 		limits := core.ResourceList{}
 		quant := containerResource.Requests["memory"]
-		if containerResource.Requests.Memory != nil && !quant.IsZero() {
+		if !quant.IsZero() {
 			requests["memory"] = quant
 		}
 
 		quant = containerResource.Limits["memory"]
-		if containerResource.Limits.Memory != nil && !quant.IsZero() {
+		if !quant.IsZero() {
 			limits["memory"] = quant
 		} else {
-			if containerResource.Requests.Memory != nil && pod.Spec.Containers[i].Resources.Limits.Memory != nil {
-				quant1 := pod.Spec.Containers[i].Resources.Limits["memory"]
-				quant2 := containerResource.Requests["memory"]
-				// Verify Limit is Enougth for Request
-				if quant1.Cmp(quant2) < 0 {
-					q := int64(quant2.Value() * 5.0)
-					limits["memory"] = *vpa_resource.NewQuantity(q, vpa_resource.BinarySI)
-				}
+			quant1 := pod.Spec.Containers[i].Resources.Limits["memory"]
+			quant2 := containerResource.Requests["memory"]
+
+			// Verify Limit is Enougth for Request
+			if quant1 > 0 && quant2 > 0 && quant1.Cmp(quant2) < 0 {
+				q := int64(quant2.Value() * 5.0)
+				limits["memory"] = *vpa_resource.NewQuantity(q, vpa_resource.BinarySI)
 			}
 		}
 
 		quant = containerResource.Requests["cpu"]
-		if containerResource.Requests.Cpu != nil && !quant.IsZero() {
+		if !quant.IsZero() {
 			requests["cpu"] = quant
 		}
 		quant = containerResource.Limits["cpu"]
-		if containerResource.Limits.Cpu != nil && !quant.IsZero() {
+		if !quant.IsZero() {
 			limits["cpu"] = quant
 		} else {
-			if containerResource.Requests.Cpu != nil && pod.Spec.Containers[i].Resources.Limits.Cpu != nil {
-				quant1 := pod.Spec.Containers[i].Resources.Limits["cpu"]
-				quant2 := containerResource.Requests["cpu"]
-				// Verify Limit is Enougth for Request
-				if quant1.Cmp(quant2) < 0 {
-					q := int64(quant2.MilliValue() * 5.0)
-					limits["cpu"] = *vpa_resource.NewMilliQuantity(q, vpa_resource.BinarySI)
-				}
+			quant1 := pod.Spec.Containers[i].Resources.Limits["cpu"]
+			quant2 := containerResource.Requests["cpu"]
+
+			// Verify Limit is Enougth for Request
+			if quant1 > 0 && quant2 > 0 && quant1.Cmp(quant2) < 0 {
+				q := int64(quant2.MilliValue() * 5.0)
+				limits["cpu"] = *vpa_resource.NewMilliQuantity(q, vpa_resource.BinarySI)
 			}
 		}
 		containerResource.Requests = requests

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	core "k8s.io/api/core/v1"
-	vpa_resource "k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
@@ -127,10 +126,9 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 			quant1 := pod.Spec.Containers[i].Resources.Limits["memory"]
 			quant2 := containerResource.Requests["memory"]
 
-			// Verify Limit is Enougth for Request
+			// Verify Limit is Enougth for the Request
 			if !quant1.IsZero() && !quant2.IsZero() && quant1.Cmp(quant2) < 0 {
-				q := int64(quant2.Value() * 5.0)
-				limits["memory"] = *vpa_resource.NewQuantity(q, vpa_resource.BinarySI)
+				limits["memory"] = quant2
 			}
 		}
 
@@ -145,10 +143,9 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 			quant1 := pod.Spec.Containers[i].Resources.Limits["cpu"]
 			quant2 := containerResource.Requests["cpu"]
 
-			// Verify Limit is Enougth for Request
+			// Verify Limit is Enougth for the Request
 			if !quant1.IsZero() && !quant2.IsZero() && quant1.Cmp(quant2) < 0 {
-				q := int64(quant2.MilliValue() * 5.0)
-				limits["cpu"] = *vpa_resource.NewMilliQuantity(q, vpa_resource.BinarySI)
+				limits["cpu"] = quant2
 			}
 		}
 		containerResource.Requests = requests

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	core "k8s.io/api/core/v1"
+	vpa_resource "k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
@@ -109,5 +110,51 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 		resourcePolicy = vpa.Spec.ResourcePolicy
 	}
 	containerResources := GetContainersResources(pod, resourcePolicy, *recommendedPodResources, containerLimitRange, false, annotations)
+
+	// Remove zero recommendations
+	for i, containerResource := range containerResources {
+		requests := core.ResourceList{}
+		limits := core.ResourceList{}
+		quant := containerResource.Requests["memory"]
+		if containerResource.Requests.Memory != nil && !quant.IsZero() {
+			requests["memory"] = quant
+		}
+
+		quant = containerResource.Limits["memory"]
+		if containerResource.Limits.Memory != nil && !quant.IsZero() {
+			limits["memory"] = quant
+		} else {
+			if containerResource.Requests.Memory != nil && pod.Spec.Containers[i].Resources.Limits.Memory != nil {
+				quant1 := pod.Spec.Containers[i].Resources.Limits["memory"]
+				quant2 := containerResource.Requests["memory"]
+				// Verify Limit is Enougth for Request
+				if quant1.Cmp(quant2) < 0 {
+					q := int64(quant2.Value() * 5.0)
+					limits["memory"] = *vpa_resource.NewQuantity(q, vpa_resource.BinarySI)
+				}
+			}
+		}
+
+		quant = containerResource.Requests["cpu"]
+		if containerResource.Requests.Cpu != nil && !quant.IsZero() {
+			requests["cpu"] = quant
+		}
+		quant = containerResource.Limits["cpu"]
+		if containerResource.Limits.Cpu != nil && !quant.IsZero() {
+			limits["cpu"] = quant
+		} else {
+			if containerResource.Requests.Cpu != nil && pod.Spec.Containers[i].Resources.Limits.Cpu != nil {
+				quant1 := pod.Spec.Containers[i].Resources.Limits["cpu"]
+				quant2 := containerResource.Requests["cpu"]
+				// Verify Limit is Enougth for Request
+				if quant1.Cmp(quant2) < 0 {
+					q := int64(quant2.MilliValue() * 5.0)
+					limits["cpu"] = *vpa_resource.NewMilliQuantity(q, vpa_resource.BinarySI)
+				}
+			}
+		}
+		containerResource.Requests = requests
+		containerResource.Limits = limits
+	}
 	return containerResources, annotations, nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -128,7 +128,7 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 			quant2 := containerResource.Requests["memory"]
 
 			// Verify Limit is Enougth for Request
-			if quant1 > 0 && quant2 > 0 && quant1.Cmp(quant2) < 0 {
+			if !quant1.IsZero() && !quant2.IsZero() && quant1.Cmp(quant2) < 0 {
 				q := int64(quant2.Value() * 5.0)
 				limits["memory"] = *vpa_resource.NewQuantity(q, vpa_resource.BinarySI)
 			}
@@ -146,7 +146,7 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 			quant2 := containerResource.Requests["cpu"]
 
 			// Verify Limit is Enougth for Request
-			if quant1 > 0 && quant2 > 0 && quant1.Cmp(quant2) < 0 {
+			if !quant1.IsZero() && !quant2.IsZero() && quant1.Cmp(quant2) < 0 {
 				q := int64(quant2.MilliValue() * 5.0)
 				limits["cpu"] = *vpa_resource.NewMilliQuantity(q, vpa_resource.BinarySI)
 			}


### PR DESCRIPTION
#### Which component this PR applies to?
vertical-pod-autoscaler

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Correction of Pod creation fails if VPA has only one controlledResources

#### Which issue(s) this PR fixes:
Fixes #3902

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

