### PR TITLE
Update owners for cluster-autoscaler Equnix Metal provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/packet/OWNERS
+++ b/cluster-autoscaler/cloudprovider/packet/OWNERS
@@ -1,14 +1,13 @@
 approvers:
+- cprivitere
 - d-mo
-- detiber
 - deitch
+- detiber
 - displague
-- gianarb
 reviewers:
+- cprivitere
 - d-mo
 - deitch
 - detiber
 - displague
-- gianarb
 - v-pap
-- rawkode


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update owners for cluster-autoscaler Equnix Metal provider
- Add cprivite, as he'll be taking over primary support responsibility for the Equinix Metal provider for cluster-autoscaler
- Remove gianrb and rawkode, since they are no longer active contributors.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Pending org membership for @cprivite here: https://github.com/kubernetes/org/issues/3355