### PR TITLE
remove check for returning in-memory size when VMSS is in updating state

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 var (
@@ -152,12 +151,6 @@ func (scaleSet *ScaleSet) getCurSize() (int64, error) {
 	if err != nil {
 		klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
 		return -1, err
-	}
-
-	// If VMSS state is updating, return the currentSize which would've been proactively incremented or decremented by CA
-	if set.VirtualMachineScaleSetProperties != nil && strings.EqualFold(to.String(set.VirtualMachineScaleSetProperties.ProvisioningState), string(compute.ProvisioningStateUpdating)) {
-		klog.V(3).Infof("VMSS %q is in updating state, returning in-memory size: %d", scaleSet.Name, scaleSet.curSize)
-		return scaleSet.curSize, nil
 	}
 
 	vmssSizeMutex.Lock()


### PR DESCRIPTION
We've had this logic for a while now. If the VMSS is updating state, return the in-memory size for a nodegroup/scale-set.

This was trying to guard from a scenario like below:

1. Autoscaler scales up to 4 instances
2. We get hit by a cache refresh
3. ARM hasn't registered our new capacity goal so we get stale data and we end up updating the in-memory cache to a lower value.

We've recently guarded against this case by [this](https://github.com/kubernetes/autoscaler/pull/4685) PR, where we extend our in-memory TTL so we should never hit that scenario.

For cases where the TTL is long, I believe this "Updating" logic can lead to a bad scenario where we take very long to reconcile with the real IaaS capacity goal if you for example get hit by multiple scale ups and it takes VMSS too long to scale or if cloudprovider is updating the network profile. In this case, it's best to not have it.

In the case where you're also experiencing rapid spot evictions, the VMSS state will be "updating" so you'll miss the chance of noticing a Spot eviction and reacting to it before the node object gets removed and pods evicted.

/area provider/azure

