### PR TITLE
fix autoscaling due to VMSS tag prefix issue - cherry pick for release 1.23

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
@@ -32,6 +32,11 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
+const (
+	aksManagedPoolNameTag = "aks-managed-poolName"
+	legacyAKSPoolNameTag  = "poolName"
+)
+
 //AKSAgentPool implements NodeGroup interface for agent pool deployed in AKS
 type AKSAgentPool struct {
 	azureRef
@@ -315,7 +320,10 @@ func (agentPool *AKSAgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 
 //IsAKSNode checks if the tag from the vm matches the agentPool name
 func (agentPool *AKSAgentPool) IsAKSNode(tags map[string]*string) bool {
-	poolName := tags["poolName"]
+	poolName := tags[aksManagedPoolNameTag]
+	if poolName == nil {
+		poolName = tags[legacyAKSPoolNameTag]
+	}
 	if poolName != nil {
 		klog.V(5).Infof("Matching agentPool name: %s with tag name: %s", agentPool.azureRef.Name, *poolName)
 		if strings.EqualFold(*poolName, agentPool.azureRef.Name) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool_test.go
@@ -265,13 +265,17 @@ func TestAKSIncreaseSize(t *testing.T) {
 
 func TestIsAKSNode(t *testing.T) {
 	aksPool := getTestAKSPool(newTestAzureManager(t), testAKSPoolName)
-	tags := map[string]*string{"poolName": to.StringPtr(testAKSPoolName)}
+	tags := map[string]*string{aksManagedPoolNameTag: to.StringPtr(testAKSPoolName)}
 	isAKSNode := aksPool.IsAKSNode(tags)
 	assert.True(t, isAKSNode)
 
-	tags = map[string]*string{"poolName": to.StringPtr("fake")}
+	tags = map[string]*string{aksManagedPoolNameTag: to.StringPtr("fake")}
 	isAKSNode = aksPool.IsAKSNode(tags)
 	assert.False(t, isAKSNode)
+
+	tags = map[string]*string{legacyAKSPoolNameTag: to.StringPtr(testAKSPoolName)}
+	isAKSNode = aksPool.IsAKSNode(tags)
+	assert.True(t, isAKSNode)
 }
 
 func TestDeleteNodesAKS(t *testing.T) {
@@ -346,7 +350,7 @@ func TestAKSNodes(t *testing.T) {
 		{
 			Name: to.StringPtr("name"),
 			ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/provider/vm1"),
-			Tags: map[string]*string{"poolName": to.StringPtr(testAKSPoolName)},
+			Tags: map[string]*string{aksManagedPoolNameTag: to.StringPtr(testAKSPoolName)},
 		},
 	}
 
@@ -394,7 +398,7 @@ func TestAKSDecreaseTargetSize(t *testing.T) {
 		{
 			Name: to.StringPtr("name"),
 			ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/provider/vm1"),
-			Tags: map[string]*string{"poolName": to.StringPtr(testAKSPoolName)},
+			Tags: map[string]*string{aksManagedPoolNameTag: to.StringPtr(testAKSPoolName)},
 		},
 	}
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)


### PR DESCRIPTION
corrected the azure_kubernetes_ercice_pool_test unit test cases involving the changed tag prefix

added const aksManagedPoolName attribute to the top of the code and fixed file name sercice -> service

added logic for old clusters that still have poolName

added legacy tag for poolName

Fixed Autoscaling due to VMSS tag prefix issue, added tags for legacy poolName and aksManagedPoolName, and corrected file name sercice->service

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

cluster-autoscaler

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/cherry-pick off an already approved PR https://github.com/kubernetes/autoscaler/commit/d2216e020fcddb1325a921b1a421bdb30dab7bf4

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
