### PR TITLE
Minor bugfix to update-vendor script

### DIFF
--- a/cluster-autoscaler/hack/update-vendor.sh
+++ b/cluster-autoscaler/hack/update-vendor.sh
@@ -62,8 +62,8 @@ for MOD in "${MODS[@]}"; do
     go mod edit "-replace=${MOD}=${MOD}@${V}"
 done
 go get "k8s.io/kubernetes@v${VERSION}"
-go mod vendor
 go mod tidy
+go mod vendor
 git rm -r --force --ignore-unmatch kubernetes
 
 sed -i "s|\(const ClusterAutoscalerVersion = \)\".*\"|\1\"$VERSION\"|" version/version.go


### PR DESCRIPTION
#### Which component this PR applies to?

Cluster Autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Previously we would run `go mod vendor` before `go mod tidy`, meaning
that we were snapshotting dependencies before we were really finished
updating them.
