### PR TITLE
Continue CA loop when unregistered nodes were removed

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -346,8 +346,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 			klog.Warningf("Failed to remove unregistered nodes: %v", err)
 		}
 		if removedAny {
-			klog.V(0).Infof("Some unregistered nodes were removed, skipping iteration")
-			return nil
+			klog.V(0).Infof("Some unregistered nodes were removed")
 		}
 	}
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -291,8 +291,10 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	readyNodeLister.SetNodes([]*apiv1.Node{n1, n2})
 	allNodeLister.SetNodes([]*apiv1.Node{n1, n2})
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Twice()
+	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	onScaleDownMock.On("ScaleDown", "ng2", "n3").Return(nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
 	err = autoscaler.RunOnce(time.Now().Add(5 * time.Hour))
 	waitForDeleteToFinish(t, autoscaler.scaleDown)
@@ -567,8 +569,10 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	readyNodeLister.SetNodes([]*apiv1.Node{n1, n2})
 	allNodeLister.SetNodes([]*apiv1.Node{n1, n2})
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Twice()
+	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
 	onScaleDownMock.On("ScaleDown", "ng1", "broken").Return(nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
 	err = autoscaler.RunOnce(later.Add(2 * time.Hour))
 	waitForDeleteToFinish(t, autoscaler.scaleDown)


### PR DESCRIPTION
#### Which component this PR applies to?

Cluster Autoscaler

#### What type of PR is this?

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:

If LongUnregistered nodes are present and couldn't be removed for long time they block Cluster Autoscaler. 

#### Special notes for your reviewer:
Basic Scale Up and Scale Down are tested with current change. 

#### Does this PR introduce a user-facing change?

```release-note
LongUnregistered nodes don't block Cluster Autoscaler. 
```