### PR TITLE
Fix updater main

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -113,10 +113,10 @@ func main() {
 		klog.Fatalf("Failed to create updater: %v", err)
 	}
 	ticker := time.Tick(*updaterInterval)
-	ctx, cancel := context.WithTimeout(context.Background(), *updaterInterval)
-	defer cancel()
 	for range ticker {
+		ctx, cancel := context.WithTimeout(context.Background(), *updaterInterval)
 		updater.RunOnce(ctx)
 		healthCheck.UpdateLastActivity()
+		cancel()
 	}
 }


### PR DESCRIPTION
/kind bug
/kind regression

This should fix at least some e2e test failures, maybe all of them (#4764)

#4723 moved context creation from inside loop (correct) to doing it once, before loop starts (incorrect, context will be done in all loop iterations after the first one).

Fix a bug we had in the old version (using `defer` in a loop would call the deferred function only after we exit `main` not as expected on each loop iteration). Thanks @krzysied for pointing out the bug

@Fedosin FYI