### PR TITLE
Make NodeDeletionTracker implement ActuationStatus interface

### DIFF
--- a/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
+++ b/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
@@ -18,92 +18,153 @@ package deletiontracker
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/expiring"
+
+	apiv1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 )
 
 // NodeDeletionTracker keeps track of node deletions.
-// TODO: extend to implement ActuationStatus interface
 type NodeDeletionTracker struct {
 	sync.Mutex
-	nonEmptyNodeDeleteInProgress bool
-	// A map of node delete results by node name. It's being constantly emptied into ScaleDownStatus
-	// objects in order to notify the ScaleDownStatusProcessor that the node drain has ended or that
-	// an error occurred during the deletion process.
-	nodeDeleteResults map[string]status.NodeDeleteResult
 	// A map which keeps track of deletions in progress for nodepools.
 	// Key is a node group id and value is a number of node deletions in progress.
-	deletionsInProgress map[string]int
+	deletionsPerNodeGroup map[string]int
+	// This mapping contains node names of all empty nodes currently undergoing deletion.
+	emptyNodeDeletions map[string]bool
+	// This mapping contains node names of all nodes currently undergoing drain and deletion.
+	drainedNodeDeletions map[string]bool
+	// Clock for checking current time.
+	clock clock.PassiveClock
+	// Helper struct for tracking pod evictions.
+	evictions *expiring.List
+	// How long evictions are considered as recent.
+	evictionsTTL time.Duration
+	// Helper struct for tracking deletion results.
+	deletionResults *expiring.List
+}
+
+type deletionResult struct {
+	nodeName string
+	result   status.NodeDeleteResult
 }
 
 // NewNodeDeletionTracker creates new NodeDeletionTracker.
-func NewNodeDeletionTracker() *NodeDeletionTracker {
+func NewNodeDeletionTracker(podEvictionsTTL time.Duration) *NodeDeletionTracker {
 	return &NodeDeletionTracker{
-		nodeDeleteResults:   make(map[string]status.NodeDeleteResult),
-		deletionsInProgress: make(map[string]int),
+		deletionsPerNodeGroup: make(map[string]int),
+		emptyNodeDeletions:    make(map[string]bool),
+		drainedNodeDeletions:  make(map[string]bool),
+		clock:                 clock.RealClock{},
+		evictions:             expiring.NewList(),
+		evictionsTTL:          podEvictionsTTL,
+		deletionResults:       expiring.NewList(),
 	}
-}
-
-// IsNonEmptyNodeDeleteInProgress returns true if a non empty node is being deleted.
-func (n *NodeDeletionTracker) IsNonEmptyNodeDeleteInProgress() bool {
-	n.Lock()
-	defer n.Unlock()
-	return n.nonEmptyNodeDeleteInProgress
-}
-
-// SetNonEmptyNodeDeleteInProgress sets non empty node deletion in progress status.
-func (n *NodeDeletionTracker) SetNonEmptyNodeDeleteInProgress(status bool) {
-	n.Lock()
-	defer n.Unlock()
-	n.nonEmptyNodeDeleteInProgress = status
 }
 
 // StartDeletion increments node deletion in progress counter for the given nodegroup.
-func (n *NodeDeletionTracker) StartDeletion(nodeGroupId string) {
+func (n *NodeDeletionTracker) StartDeletion(nodeGroupId, nodeName string) {
 	n.Lock()
 	defer n.Unlock()
-	n.deletionsInProgress[nodeGroupId]++
+	n.deletionsPerNodeGroup[nodeGroupId]++
+	n.emptyNodeDeletions[nodeName] = true
+}
+
+// StartDeletionWithDrain is equivalent to StartDeletion, but for counting nodes that are drained first.
+func (n *NodeDeletionTracker) StartDeletionWithDrain(nodeGroupId, nodeName string) {
+	n.Lock()
+	defer n.Unlock()
+	n.deletionsPerNodeGroup[nodeGroupId]++
+	n.drainedNodeDeletions[nodeName] = true
 }
 
 // EndDeletion decrements node deletion in progress counter for the given nodegroup.
-func (n *NodeDeletionTracker) EndDeletion(nodeGroupId string) {
+func (n *NodeDeletionTracker) EndDeletion(nodeGroupId, nodeName string, result status.NodeDeleteResult) {
 	n.Lock()
 	defer n.Unlock()
 
-	value, found := n.deletionsInProgress[nodeGroupId]
+	n.deletionResults.RegisterElement(&deletionResult{nodeName, result})
+	value, found := n.deletionsPerNodeGroup[nodeGroupId]
 	if !found {
-		klog.Errorf("This should never happen, counter for %s in DelayedNodeDeletionStatus wasn't found", nodeGroupId)
+		klog.Errorf("This should never happen, counter for %s in NodeDeletionTracker wasn't found", nodeGroupId)
 		return
 	}
 	if value <= 0 {
-		klog.Errorf("This should never happen, counter for %s in DelayedNodeDeletionStatus isn't greater than 0, counter value is %d", nodeGroupId, value)
+		klog.Errorf("This should never happen, counter for %s in NodeDeletionTracker isn't greater than 0, counter value is %d", nodeGroupId, value)
 	}
-	n.deletionsInProgress[nodeGroupId]--
-	if n.deletionsInProgress[nodeGroupId] <= 0 {
-		delete(n.deletionsInProgress, nodeGroupId)
+	n.deletionsPerNodeGroup[nodeGroupId]--
+	if n.deletionsPerNodeGroup[nodeGroupId] <= 0 {
+		delete(n.deletionsPerNodeGroup, nodeGroupId)
 	}
+	delete(n.emptyNodeDeletions, nodeName)
+	delete(n.drainedNodeDeletions, nodeName)
 }
 
-// GetDeletionsInProgress returns the number of deletions in progress for the given node group.
-func (n *NodeDeletionTracker) GetDeletionsInProgress(nodeGroupId string) int {
+// DeletionsInProgress returns a list of all node names currently undergoing deletion.
+func (n *NodeDeletionTracker) DeletionsInProgress() ([]string, []string) {
 	n.Lock()
 	defer n.Unlock()
-	return n.deletionsInProgress[nodeGroupId]
+	return mapKeysSlice(n.emptyNodeDeletions), mapKeysSlice(n.drainedNodeDeletions)
 }
 
-// AddNodeDeleteResult adds a node delete result to the result map.
-func (n *NodeDeletionTracker) AddNodeDeleteResult(nodeName string, result status.NodeDeleteResult) {
-	n.Lock()
-	defer n.Unlock()
-	n.nodeDeleteResults[nodeName] = result
+func mapKeysSlice(m map[string]bool) []string {
+	s := make([]string, len(m))
+	i := 0
+	for k := range m {
+		s[i] = k
+		i++
+	}
+	return s
 }
 
-// GetAndClearNodeDeleteResults returns the whole result map and replaces it with a new empty one.
-func (n *NodeDeletionTracker) GetAndClearNodeDeleteResults() map[string]status.NodeDeleteResult {
+// RegisterEviction stores information about a pod that was recently evicted.
+func (n *NodeDeletionTracker) RegisterEviction(pod *apiv1.Pod) {
 	n.Lock()
 	defer n.Unlock()
-	results := n.nodeDeleteResults
-	n.nodeDeleteResults = make(map[string]status.NodeDeleteResult)
-	return results
+	n.evictions.RegisterElement(pod)
+}
+
+// RecentEvictions returns a list of pods that were recently evicted by Cluster Autoscaler.
+func (n *NodeDeletionTracker) RecentEvictions() []*apiv1.Pod {
+	n.Lock()
+	defer n.Unlock()
+	n.evictions.DropNotNewerThan(n.clock.Now().Add(-n.evictionsTTL))
+	els := n.evictions.ToSlice()
+	pods := make([]*apiv1.Pod, 0, len(els))
+	for _, el := range els {
+		pods = append(pods, el.(*apiv1.Pod))
+	}
+	return pods
+}
+
+// DeletionsCount returns the number of deletions in progress for the given node group.
+func (n *NodeDeletionTracker) DeletionsCount(nodeGroupId string) int {
+	n.Lock()
+	defer n.Unlock()
+	return n.deletionsPerNodeGroup[nodeGroupId]
+}
+
+// DeletionResults returns deletion results in a map form, along with the timestamp of last result.
+func (n *NodeDeletionTracker) DeletionResults() (map[string]status.NodeDeleteResult, time.Time) {
+	n.Lock()
+	defer n.Unlock()
+	els, ts := n.deletionResults.ToSliceWithTimestamp()
+	drs := make(map[string]status.NodeDeleteResult)
+	for _, el := range els {
+		dr := el.(*deletionResult)
+		drs[dr.nodeName] = dr.result
+	}
+	return drs, ts
+}
+
+// ClearResultsNotNewerThan iterates over existing deletion results and keeps
+// only the ones that are newer than the provided timestamp.
+func (n *NodeDeletionTracker) ClearResultsNotNewerThan(t time.Time) {
+	n.Lock()
+	defer n.Unlock()
+	n.deletionResults.DropNotNewerThan(t)
 }

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -67,9 +67,10 @@ type Actuator interface {
 
 // ActuationStatus is used for feeding Actuator status back into Planner
 type ActuationStatus interface {
-	// DeletionsInProgress returns a list of nodes that are currently
-	// undergoing deletion.
-	DeletionsInProgress() (nodeNames []string)
+	// DeletionsInProgress returns two lists of node names that are
+	// currently undergoing deletion, for empty and non-empty (i.e. drained)
+	// nodes separately.
+	DeletionsInProgress() (empty, drained []string)
 	// DeletionsCount returns total number of ongoing deletions in a given
 	// node group.
 	DeletionsCount(nodeGroupId string) int
@@ -80,5 +81,7 @@ type ActuationStatus interface {
 	// DeletionResults returns a map of recent node deletion results, keyed
 	// by the node name. Note: if node deletion was scheduled more than
 	// once, only the latest result will be present.
-	DeletionResults() map[string]status.NodeDeleteResult
+	// The timestamp returned as the second value indicates the time at
+	// which the last result was collected.
+	DeletionResults() (map[string]status.NodeDeleteResult, time.Time)
 }

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1331,7 +1331,9 @@ func nodeNames(ns []*apiv1.Node) []string {
 
 func waitForDeleteToFinish(t *testing.T, sda scaledown.Actuator) {
 	for start := time.Now(); time.Since(start) < 20*time.Second; time.Sleep(100 * time.Millisecond) {
-		if len(sda.CheckStatus().DeletionsInProgress()) == 0 {
+		_, dip := sda.CheckStatus().DeletionsInProgress()
+		klog.Infof("Non empty deletions in progress: %v", dip)
+		if len(dip) == 0 {
 			return
 		}
 	}

--- a/cluster-autoscaler/processors/status/scale_down_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_down_status_processor.go
@@ -17,6 +17,8 @@ limitations under the License.
 package status
 
 import (
+	"time"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
@@ -28,11 +30,12 @@ import (
 
 // ScaleDownStatus represents the state of scale down.
 type ScaleDownStatus struct {
-	Result            ScaleDownResult
-	ScaledDownNodes   []*ScaleDownNode
-	UnremovableNodes  []*UnremovableNode
-	RemovedNodeGroups []cloudprovider.NodeGroup
-	NodeDeleteResults map[string]NodeDeleteResult
+	Result                ScaleDownResult
+	ScaledDownNodes       []*ScaleDownNode
+	UnremovableNodes      []*UnremovableNode
+	RemovedNodeGroups     []cloudprovider.NodeGroup
+	NodeDeleteResults     map[string]NodeDeleteResult
+	NodeDeleteResultsAsOf time.Time
 }
 
 // SetUnremovableNodesInfo sets the status of nodes that were found to be unremovable.

--- a/cluster-autoscaler/utils/expiring/list.go
+++ b/cluster-autoscaler/utils/expiring/list.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expiring
+
+import (
+	"container/list"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+type elementWithTimestamp struct {
+	value interface{}
+	added time.Time
+}
+
+// List tracks elements along with their creation times.
+// This is essentially a linked list with timestamp on each entry, allowing
+// dropping old entries. This struct is not thread safe.
+// TODO(x13n): Migrate to generics once supported by Go stdlib (container/list
+// in particular).
+type List struct {
+	lst   list.List
+	clock clock.PassiveClock
+}
+
+// NewList creates a new expiring list.
+func NewList() *List {
+	return newListWithClock(clock.RealClock{})
+}
+
+// Warning: This object doesn't support time travel. Subsequent calls to
+// clock.Now are expected to return non-decreasing time values.
+func newListWithClock(clock clock.PassiveClock) *List {
+	return &List{
+		clock: clock,
+	}
+}
+
+// ToSlice converts the underlying list of elements into a slice.
+func (e *List) ToSlice() []interface{} {
+	p := e.lst.Front()
+	ps := make([]interface{}, 0, e.lst.Len())
+	for p != nil {
+		ps = append(ps, p.Value.(*elementWithTimestamp).value)
+		p = p.Next()
+	}
+	return ps
+}
+
+// ToSliceWithTimestamp is identical to ToSlice, but additionally returns the
+// timestamp of newest entry (or current time if there are no entries).
+func (e *List) ToSliceWithTimestamp() ([]interface{}, time.Time) {
+	if e.lst.Len() == 0 {
+		return nil, e.clock.Now()
+	}
+	return e.ToSlice(), e.lst.Back().Value.(*elementWithTimestamp).added
+}
+
+// RegisterElement adds new element to the list.
+func (e *List) RegisterElement(elem interface{}) {
+	e.lst.PushBack(&elementWithTimestamp{elem, e.clock.Now()})
+}
+
+// DropNotNewerThan removes all elements of the list that are older or exactly
+// as old as the provided time.
+func (e *List) DropNotNewerThan(expiry time.Time) {
+	p := e.lst.Front()
+	for p != nil {
+		if p.Value.(*elementWithTimestamp).added.After(expiry) {
+			// First not-expired element on the list, skip checking
+			// the rest.
+			return
+		}
+		d := p
+		p = p.Next()
+		e.lst.Remove(d)
+	}
+}

--- a/cluster-autoscaler/utils/expiring/list_test.go
+++ b/cluster-autoscaler/utils/expiring/list_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expiring
+
+import (
+	"testing"
+	"testing/quick"
+	"time"
+
+	klog "k8s.io/klog/v2"
+	clock "k8s.io/utils/clock/testing"
+)
+
+func TestToSlice(t *testing.T) {
+	if err := quick.Check(identityCheck, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func identityCheck(list []int) bool {
+	l := NewList()
+	l.registerElementsFrom(list)
+	return l.equals(list)
+}
+
+func TestDropNotNewer(t *testing.T) {
+	if err := quick.Check(dropChecks, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func dropChecks(l1, l2, l3 []int) bool {
+	t0 := time.Now()
+	c := clock.NewFakePassiveClock(t0)
+	t1, t2 := t0.Add(1*time.Minute), t0.Add(2*time.Minute)
+	l := newListWithClock(c)
+	l.registerElementsFrom(l1)
+	c.SetTime(t1)
+	l.registerElementsFrom(l2)
+	c.SetTime(t2)
+	if !l.equals(append(l1, l2...)) {
+		return false
+	}
+	l.DropNotNewerThan(t0)
+	if !l.equals(l2) {
+		return false
+	}
+	l.registerElementsFrom(l3)
+	if !l.equals(append(l2, l3...)) {
+		return false
+	}
+	l.DropNotNewerThan(t1)
+	if !l.equals(l3) {
+		return false
+	}
+	l.DropNotNewerThan(t2)
+	return len(l.ToSlice()) == 0
+}
+
+func (e *List) registerElementsFrom(list []int) {
+	for _, i := range list {
+		e.RegisterElement(i)
+	}
+}
+
+func (e *List) equals(want []int) bool {
+	got := e.ToSlice()
+	if len(got) != len(want) {
+		klog.Errorf("len(%v) != len(%v)", got, want)
+		return false
+	}
+	for i, g := range got {
+		w := want[i]
+		if g.(int) != w {
+			klog.Errorf("%v != %v (difference at index %v)", got, want, i)
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is a step towards implementing parallel drain logic. The refactor in https://github.com/kubernetes/autoscaler/pull/4806 splitted ScaleDown logic into separate Planner and Actuator objects. NodeDeletionTracker represents the ActuationStatus, which is used to feed back information about actuation progress into the planning logic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Since https://github.com/kubernetes/autoscaler/pull/4806 didn't merge yet, this PR is quite large, but in reality it is only the last commit that is different. Once the other PR merges, I will rebase this one. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/autoscaler/blob/48273b7affaa9463b37c72146a3b3de2ac06fc06/cluster-autoscaler/proposals/parallel_drain.md
```

/cc @MaciekPytel @towca 