### PR TITLE
[CA][Helm] Allow skipping service creation

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.18.1
+version: 9.19.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -356,6 +356,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | resources | object | `{}` | Pod resource requests and limits. |
 | securityContext | object | `{}` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | service.annotations | object | `{}` | Annotations to add to service |
+| service.create | bool | `true` | If `true`, a Service will be created. |
 | service.externalIPs | list | `[]` | List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips. |
 | service.labels | object | `{}` | Labels to add to service |
 | service.loadBalancerIP | string | `""` | IP address to assign to load balancer (if supported). |

--- a/charts/cluster-autoscaler/templates/service.yaml
+++ b/charts/cluster-autoscaler/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -35,3 +36,4 @@ spec:
   selector:
 {{ include "cluster-autoscaler.instance-name" . | indent 4 }}
   type: "{{ .Values.service.type }}"
+{{- end }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -306,6 +306,8 @@ securityContext: {}
   # runAsGroup: 1001
 
 service:
+  # service.create -- If `true`, a Service will be created.
+  create: true
   # service.annotations -- Annotations to add to service
   annotations: {}
   # service.labels -- Labels to add to service


### PR DESCRIPTION
#### Which component this PR applies to?

helm charts

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The service is the only resource that can't be disabled. As I see it its only purpose is to expose metrics and some optional things like profiling and snapshots. If none of these are used a service shouldn't be required.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Optionally exclude service from templated resources
```