### PR TITLE
cluster-autoscaler/cloudprovider/clusterapi/README.md - simple typo fix

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -176,7 +176,7 @@ annotations for minimum and maximum size to change.
 This behavior will also affect the machine annotation on nodes, the machine deletion annotation,
 and the cluster name label. For example, if `CAPI_GROUP=test.k8s.io`
 then the minimum size annotation key will be `test.k8s.io/cluster-api-autoscaler-node-group-min-size`,
-the machine annotation on nodes will be `test.8s.io/machine`, the machine deletion
+the machine annotation on nodes will be `test.k8s.io/machine`, the machine deletion
 annotation will be `test.k8s.io/delete-machine`, and the cluster name label will be
 `test.k8s.io/cluster-name`.
 


### PR DESCRIPTION
Fixing typo in Specifying a Custom Resource Group section in annotation examples.

#### Which component this PR applies to?
cluster-autoscaler

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR is a simple documentation typo fix.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
