### PR TITLE
OCI cloud provider : Optional Feature - Skip time-consuming findInstanceByDetails API call by adding non_pool_member annotation to the node

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -118,8 +118,9 @@ Configuration via environment-variables:
 
 - `OCI_USE_INSTANCE_PRINCIPAL` - Whether to use Instance Principals for authentication rather than expecting an OCI config file to be mounted in the container. Defaults to false.
 - `OCI_REGION` - **Required** when using Instance Principals. e.g. `OCI_REGION=us-phoenix-1`. See [region list](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) for identifiers.
-- `OCI_COMPARTMENT_ID`  - Restrict the cluster-autoscaler to instance-pools in a single compartment. When unset, the cluster-autoscaler will manage each specified instance-pool no matter which compartment they are in.
-- `OCI_REFRESH_INTERVAL`  - Optional refresh interval to sync internal cache with OCI API defaults to `2m`.
+- `OCI_COMPARTMENT_ID` - Restrict the cluster-autoscaler to instance-pools in a single compartment. When unset, the cluster-autoscaler will manage each specified instance-pool no matter which compartment they are in.
+- `OCI_REFRESH_INTERVAL` - Optional refresh interval to sync internal cache with OCI API defaults to `2m`.
+- `OCI_USE_NON_POOL_MEMBER_ANNOTATION` - Optional. If true, the node will be annotated as non-pool-member if it doesn't belong to any instance pool and the time-consuming instance pool lookup will be skipped.
 
 ## Deployment
 

--- a/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
@@ -31,11 +31,12 @@ import (
 )
 
 const (
-	ociUseInstancePrincipalEnvVar = "OCI_USE_INSTANCE_PRINCIPAL"
-	ociCompartmentEnvVar          = "OCI_COMPARTMENT_ID"
-	ociRegionEnvVar               = "OCI_REGION"
-	ociRefreshInterval            = "OCI_REFRESH_INTERVAL"
-	ociAnnotationCompartmentID    = "oci.oraclecloud.com/compartment-id"
+	ociUseInstancePrincipalEnvVar       = "OCI_USE_INSTANCE_PRINCIPAL"
+	ociUseNonPoolMemberAnnotationEnvVar = "OCI_USE_NON_POOL_MEMBER_ANNOTATION"
+	ociCompartmentEnvVar                = "OCI_COMPARTMENT_ID"
+	ociRegionEnvVar                     = "OCI_REGION"
+	ociRefreshInterval                  = "OCI_REFRESH_INTERVAL"
+	ociAnnotationCompartmentID          = "oci.oraclecloud.com/compartment-id"
 	// ResourceGPU is the GPU resource type
 	ResourceGPU            apiv1.ResourceName = "nvidia.com/gpu"
 	defaultRefreshInterval                    = 5 * time.Minute
@@ -51,10 +52,11 @@ type OciCloudProvider struct {
 // CloudConfig holds the cloud config for OCI provider.
 type CloudConfig struct {
 	Global struct {
-		RefreshInterval       time.Duration `gcfg:"refresh-interval"`
-		CompartmentID         string        `gcfg:"compartment-id"`
-		Region                string        `gcfg:"region"`
-		UseInstancePrinciples bool          `gcfg:"use-instance-principals"`
+		RefreshInterval        time.Duration `gcfg:"refresh-interval"`
+		CompartmentID          string        `gcfg:"compartment-id"`
+		Region                 string        `gcfg:"region"`
+		UseInstancePrinciples  bool          `gcfg:"use-instance-principals"`
+		UseNonMemberAnnotation bool          `gcfg:"use-non-member-annotation"`
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
@@ -35,6 +35,9 @@ const (
 	instanceIDLabelSuffix        = "instance-id_suffix"
 	ociInstancePoolIDAnnotation  = "oci.oraclecloud.com/instancepool-id"
 	ociInstancePoolResourceIdent = "instancepool"
+
+	// Overload ociInstancePoolIDAnnotation to indicate a kubernetes node doesn't belong to any OCI Instance Pool.
+	ociInstancePoolIDNonPoolMember = "non_pool_member"
 )
 
 // InstancePoolNodeGroup implements the NodeGroup interface using OCI instance pools.

--- a/cluster-autoscaler/cloudprovider/oci/oci_instance_pool_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_instance_pool_manager_test.go
@@ -147,7 +147,7 @@ func TestInstancePoolFromArgs(t *testing.T) {
 func TestGetSetInstancePoolSize(t *testing.T) {
 
 	nodePoolCache := newInstancePoolCache(computeManagementClient, computeClient, virtualNetworkClient)
-	nodePoolCache.targetSize["ocid1.instancepool.oc1.phx.aaaaaaaai"] = 2
+	nodePoolCache.poolCache["ocid1.instancepool.oc1.phx.aaaaaaaai"] = &core.InstancePool{Size: common.Int(2)}
 
 	manager := &InstancePoolManagerImpl{instancePoolCache: nodePoolCache}
 	size, err := manager.GetInstancePoolSize(InstancePoolNodeGroup{id: "ocid1.instancepool.oc1.phx.aaaaaaaai"})


### PR DESCRIPTION
This feature can be turned on by setting environment variable _**OCI_USE_NON_MEMBER_ANNOTATION**_ to true.
    
For example, if a node is not belong to any instance pool,  during the very first GetInstancePoolForInstance call, the node will be annotated with _**oci.oraclecloud.com/instancepool-id: non_pool_member**_.
After new annotation is added to the node, all future GetInstancePoolForInstance calls related to the non-pool-member node will skip the time-consuming findInstanceByDetails API call.
    
    Minor refactoring - when retrieving pool size from instancePoolCache object, use the pool size defined inside the poolCache map instead.