### PR TITLE
Allow checking specific nodes removal in simulator

### DIFF
--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -95,18 +95,32 @@ const (
 	UnexpectedError
 )
 
-// FindNodesToRemove finds nodes that can be removed. Returns also an information about good
-// rescheduling location for each of the pods.
-func FindNodesToRemove(
+// RemovalSimulator is a helper object for simulating node removal scenarios.
+type RemovalSimulator struct {
+	listers          kube_util.ListerRegistry
+	clusterSnapshot  ClusterSnapshot
+	predicateChecker PredicateChecker
+	usageTracker     *UsageTracker
+}
+
+// NewRemovalSimulator returns a new RemovalSimulator.
+func NewRemovalSimulator(listers kube_util.ListerRegistry, clusterSnapshot ClusterSnapshot, predicateChecker PredicateChecker, usageTracker *UsageTracker) *RemovalSimulator {
+	return &RemovalSimulator{
+		listers:          listers,
+		clusterSnapshot:  clusterSnapshot,
+		predicateChecker: predicateChecker,
+		usageTracker:     usageTracker,
+	}
+}
+
+// FindNodesToRemove finds nodes that can be removed. Returns also an
+// information about good rescheduling location for each of the pods.
+func (r *RemovalSimulator) FindNodesToRemove(
 	candidates []string,
 	destinations []string,
-	listers kube_util.ListerRegistry,
-	clusterSnapshot ClusterSnapshot,
-	predicateChecker PredicateChecker,
 	oldHints map[string]string,
-	usageTracker *UsageTracker,
 	timestamp time.Time,
-	podDisruptionBudgets []*policyv1.PodDisruptionBudget,
+	pdbs []*policyv1.PodDisruptionBudget,
 ) (nodesToRemove []NodeToBeRemoved, unremovableNodes []*UnremovableNode, podReschedulingHints map[string]string, finalError errors.AutoscalerError) {
 	result := make([]NodeToBeRemoved, 0)
 	unremovable := make([]*UnremovableNode, 0)
@@ -118,52 +132,66 @@ func FindNodesToRemove(
 	}
 
 	for _, nodeName := range candidates {
-		nodeInfo, err := clusterSnapshot.NodeInfos().Get(nodeName)
-		if err != nil {
-			klog.Errorf("Can't retrieve node %s from snapshot, err: %v", nodeName, err)
-		}
-		klog.V(2).Infof("%s for removal", nodeName)
-
-		if _, found := destinationMap[nodeName]; !found {
-			klog.V(2).Infof("nodeInfo for %s not found", nodeName)
-			unremovable = append(unremovable, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError})
-			continue
-		}
-
-		podsToRemove, daemonSetPods, blockingPod, err := DetailedGetPodsForMove(nodeInfo, *skipNodesWithSystemPods,
-			*skipNodesWithLocalStorage, listers, int32(*minReplicaCount), podDisruptionBudgets, timestamp)
-		if err != nil {
-			klog.V(2).Infof("node %s cannot be removed: %v", nodeName, err)
-			if blockingPod != nil {
-				unremovable = append(unremovable, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: blockingPod})
-			} else {
-				unremovable = append(unremovable, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError})
-			}
-			continue
-		}
-
-		findProblems := findPlaceFor(nodeName, podsToRemove, destinationMap, clusterSnapshot,
-			predicateChecker, oldHints, newHints, usageTracker, timestamp)
-		if findProblems == nil {
-			result = append(result, NodeToBeRemoved{
-				Node:             nodeInfo.Node(),
-				PodsToReschedule: podsToRemove,
-				DaemonSetPods:    daemonSetPods,
-			})
-			klog.V(2).Infof("node %s may be removed", nodeName)
-		} else {
-			klog.V(2).Infof("node %s is not suitable for removal: %v", nodeName, findProblems)
-			unremovable = append(unremovable, &UnremovableNode{Node: nodeInfo.Node(), Reason: NoPlaceToMovePods})
+		rn, urn := r.CheckNodeRemoval(nodeName, destinationMap, oldHints, newHints, timestamp, pdbs)
+		if rn != nil {
+			result = append(result, *rn)
+		} else if urn != nil {
+			unremovable = append(unremovable, urn)
 		}
 	}
 	return result, unremovable, newHints, nil
 }
 
+// CheckNodeRemoval checks whether a specific node can be removed. Depending on
+// the outcome, exactly one of (NodeToBeRemoved, UnremovableNode) will be
+// populated in the return value, the other will be nil.
+func (r *RemovalSimulator) CheckNodeRemoval(
+	nodeName string,
+	destinationMap map[string]bool,
+	oldHints map[string]string,
+	newHints map[string]string,
+	timestamp time.Time,
+	pdbs []*policyv1.PodDisruptionBudget,
+) (*NodeToBeRemoved, *UnremovableNode) {
+	nodeInfo, err := r.clusterSnapshot.NodeInfos().Get(nodeName)
+	if err != nil {
+		klog.Errorf("Can't retrieve node %s from snapshot, err: %v", nodeName, err)
+	}
+	klog.V(2).Infof("%s for removal", nodeName)
+
+	if _, found := destinationMap[nodeName]; !found {
+		klog.V(2).Infof("nodeInfo for %s not found", nodeName)
+		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError}
+	}
+
+	podsToRemove, daemonSetPods, blockingPod, err := DetailedGetPodsForMove(nodeInfo, *skipNodesWithSystemPods,
+		*skipNodesWithLocalStorage, r.listers, int32(*minReplicaCount), pdbs, timestamp)
+	if err != nil {
+		klog.V(2).Infof("node %s cannot be removed: %v", nodeName, err)
+		if blockingPod != nil {
+			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: blockingPod}
+		}
+		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError}
+	}
+
+	err = r.findPlaceFor(nodeName, podsToRemove, destinationMap, oldHints, newHints, timestamp)
+	if err != nil {
+		klog.V(2).Infof("node %s is not suitable for removal: %v", nodeName, err)
+		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: NoPlaceToMovePods}
+	}
+	klog.V(2).Infof("node %s may be removed", nodeName)
+	return &NodeToBeRemoved{
+		Node:             nodeInfo.Node(),
+		PodsToReschedule: podsToRemove,
+		DaemonSetPods:    daemonSetPods,
+	}, nil
+}
+
 // FindEmptyNodesToRemove finds empty nodes that can be removed.
-func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string, timestamp time.Time) []string {
+func (r *RemovalSimulator) FindEmptyNodesToRemove(candidates []string, timestamp time.Time) []string {
 	result := make([]string, 0)
 	for _, node := range candidates {
-		nodeInfo, err := snapshot.NodeInfos().Get(node)
+		nodeInfo, err := r.clusterSnapshot.NodeInfos().Get(node)
 		if err != nil {
 			klog.Errorf("Can't retrieve node %s from snapshot, err: %v", node, err)
 			continue
@@ -177,15 +205,14 @@ func FindEmptyNodesToRemove(snapshot ClusterSnapshot, candidates []string, times
 	return result
 }
 
-func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
-	clusterSnapshot ClusterSnapshot, predicateChecker PredicateChecker, oldHints map[string]string, newHints map[string]string, usageTracker *UsageTracker,
-	timestamp time.Time) error {
+func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
+	oldHints map[string]string, newHints map[string]string, timestamp time.Time) error {
 
-	if err := clusterSnapshot.Fork(); err != nil {
+	if err := r.clusterSnapshot.Fork(); err != nil {
 		return err
 	}
 	defer func() {
-		err := clusterSnapshot.Revert()
+		err := r.clusterSnapshot.Revert()
 		if err != nil {
 			klog.Fatalf("Got error when calling ClusterSnapshot.Revert(); %v", err)
 		}
@@ -203,7 +230,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 
 	// remove pods from clusterSnapshot first
 	for _, pod := range pods {
-		if err := clusterSnapshot.RemovePod(pod.Namespace, pod.Name, removedNode); err != nil {
+		if err := r.clusterSnapshot.RemovePod(pod.Namespace, pod.Name, removedNode); err != nil {
 			// just log error
 			klog.Errorf("Simulating removal of %s/%s return error; %v", pod.Namespace, pod.Name, err)
 		}
@@ -220,9 +247,9 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 		klog.V(5).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
 
 		if hintedNode, hasHint := oldHints[podKey(pod)]; hasHint && isCandidateNode(hintedNode) {
-			if err := predicateChecker.CheckPredicates(clusterSnapshot, pod, hintedNode); err == nil {
+			if err := r.predicateChecker.CheckPredicates(r.clusterSnapshot, pod, hintedNode); err == nil {
 				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, hintedNode)
-				if err := clusterSnapshot.AddPod(pod, hintedNode); err != nil {
+				if err := r.clusterSnapshot.AddPod(pod, hintedNode); err != nil {
 					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, hintedNode, err)
 				}
 				newHints[podKey(pod)] = hintedNode
@@ -232,12 +259,12 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 		}
 
 		if !foundPlace {
-			newNodeName, err := predicateChecker.FitsAnyNodeMatching(clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
+			newNodeName, err := r.predicateChecker.FitsAnyNodeMatching(r.clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
 				return isCandidateNode(nodeInfo.Node().Name)
 			})
 			if err == nil {
 				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, newNodeName)
-				if err := clusterSnapshot.AddPod(pod, newNodeName); err != nil {
+				if err := r.clusterSnapshot.AddPod(pod, newNodeName); err != nil {
 					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, newNodeName, err)
 				}
 				newHints[podKey(pod)] = newNodeName
@@ -247,7 +274,7 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
 			}
 		}
 
-		usageTracker.RegisterUsage(removedNode, targetNode, timestamp)
+		r.usageTracker.RegisterUsage(removedNode, targetNode, timestamp)
 	}
 	return nil
 }


### PR DESCRIPTION
Wraps simulator functions into an object, so that there's no need to
pass around parametrs that are not changing between CA loop iterations.

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Required for parallel scale down implementation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/autoscaler/blob/48273b7affaa9463b37c72146a3b3de2ac06fc06/cluster-autoscaler/proposals/parallel_drain.md
```

/assign @towca 
