### PR TITLE
use the PreFilterResult in SchedulerBasedPredicateChecker

### DIFF
--- a/cluster-autoscaler/simulator/predicate_error.go
+++ b/cluster-autoscaler/simulator/predicate_error.go
@@ -25,7 +25,7 @@ import (
 type PredicateErrorType int
 
 const (
-	// NotSchedulablePredicateError means that one of the filters retuned that pod does not fit a node
+	// NotSchedulablePredicateError means that one of the filters returned that pod does not fit a node
 	NotSchedulablePredicateError PredicateErrorType = iota
 	// InternalPredicateError denotes internal unexpected error while calling PredicateChecker
 	InternalPredicateError

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -103,7 +103,7 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot Clu
 	defer p.delegatingSharedLister.ResetDelegate()
 
 	state := schedulerframework.NewCycleState()
-	_, preFilterStatus := p.framework.RunPreFilterPlugins(context.TODO(), state, pod)
+	preFilterResult, preFilterStatus := p.framework.RunPreFilterPlugins(context.TODO(), state, pod)
 	if !preFilterStatus.IsSuccess() {
 		return "", fmt.Errorf("error running pre filter plugins for pod %s; %s", pod.Name, preFilterStatus.Message())
 	}
@@ -111,6 +111,10 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot Clu
 	for i := range nodeInfosList {
 		nodeInfo := nodeInfosList[(p.lastIndex+i)%len(nodeInfosList)]
 		if !nodeMatches(nodeInfo) {
+			continue
+		}
+
+		if !preFilterResult.AllNodes() && !preFilterResult.NodeNames.Has(nodeInfo.Node().Name) {
 			continue
 		}
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Use the node names given in the new `PreFilterResult` to skip nodes in `FitsAnyNode`.

It did not seem ideal to also use the result in `CheckPredicates`. The pre-filter result does not include a message or reason like the filter result, so it would provide less information to the caller to return a generic pre-filter error. Let me know if the intent was to modify this as well.

#### Which issue(s) this PR fixes:

Fixes #4745

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
