### PR TITLE
properly name secret

### DIFF
--- a/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-secret.yaml
+++ b/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-secret.yaml
@@ -41,12 +41,15 @@ stringData:
 # The following secret is only required when using bootstrap tokens in cloudinit
 # like in the above example. For more info on bootstrap tokens check
 # https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/
-# IMPORTANT: change the token-id & token-secret values below before applying
+# IMPORTANT: change the following before applying:
+# * token-id
+# * token-secret
+# * name
 apiVersion: v1
 kind: Secret
 type: bootstrap.kubernetes.io/token
 metadata:
-  name: bootstrap-token-cluster-autoscaler-cherry
+  name: bootstrap-token-YOUR_TOKEN_ID
   namespace: kube-system
 stringData:
   description: "The default bootstrap token used by cluster-autoscaler on Cherry Servers."


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

cluster-autoscaler

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The cherry cluster-autoscaler had named the example secret `bootstrap-token-cluster-autoscaler-cherry`. This is fine, except that the cloud-node controller and bootstrap-signer won't JWS sign the cluster-info configmap unless it is named `bootstrap-token-<TOKEN_ID>`.

