### PR TITLE
Fix fallback for aws cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -383,7 +383,10 @@ func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 
 		generatedInstanceTypes, err := GenerateEC2InstanceTypes(region)
 		if err != nil {
-			klog.Fatalf("Failed to generate AWS EC2 Instance Types: %v", err)
+			klog.Errorf("Failed to generate AWS EC2 Instance Types: %v, falling back to static list with last update time: %s", err, lastUpdateTime)
+		}
+		if generatedInstanceTypes == nil {
+			generatedInstanceTypes = map[string]*InstanceType{}
 		}
 		// fallback on the static list if we miss any instance types in the generated output
 		// credits to: https://github.com/lyft/cni-ipvlan-vpc-k8s/pull/80

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
 var testAwsManager = &AwsManager{
@@ -107,6 +109,23 @@ func TestBuildAwsCloudProvider(t *testing.T) {
 
 	_, err := BuildAwsCloudProvider(testAwsManager, resourceLimiter)
 	assert.NoError(t, err)
+}
+
+func TestInstanceTypeFallback(t *testing.T) {
+	resourceLimiter := cloudprovider.NewResourceLimiter(
+		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+
+	do := cloudprovider.NodeGroupDiscoveryOptions{}
+	opts := config.AutoscalingOptions{}
+
+	os.Setenv("AWS_REGION", "non-existent-region")
+	defer os.Unsetenv("AWS_REGION")
+
+	// This test ensures that no klog.Fatalf calls occur when constructing the AWS cloud provider.  Specifically it is
+	// intended to ensure that instance type fallback works correctly in the event of an error enumerating instance
+	// types.
+	_ = BuildAWS(opts, do, resourceLimiter)
 }
 
 func TestName(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -347,7 +347,7 @@ func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscaling
 
 	if stringOpt, found := options[config.DefaultScaleDownUtilizationThresholdKey]; found {
 		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
-			klog.Warning("failed to convert asg %s %s tag to float: %v",
+			klog.Warningf("failed to convert asg %s %s tag to float: %v",
 				asg.Name, config.DefaultScaleDownUtilizationThresholdKey, err)
 		} else {
 			defaults.ScaleDownUtilizationThreshold = opt
@@ -356,7 +356,7 @@ func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscaling
 
 	if stringOpt, found := options[config.DefaultScaleDownGpuUtilizationThresholdKey]; found {
 		if opt, err := strconv.ParseFloat(stringOpt, 64); err != nil {
-			klog.Warning("failed to convert asg %s %s tag to float: %v",
+			klog.Warningf("failed to convert asg %s %s tag to float: %v",
 				asg.Name, config.DefaultScaleDownGpuUtilizationThresholdKey, err)
 		} else {
 			defaults.ScaleDownGpuUtilizationThreshold = opt
@@ -365,7 +365,7 @@ func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscaling
 
 	if stringOpt, found := options[config.DefaultScaleDownUnneededTimeKey]; found {
 		if opt, err := time.ParseDuration(stringOpt); err != nil {
-			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+			klog.Warningf("failed to convert asg %s %s tag to duration: %v",
 				asg.Name, config.DefaultScaleDownUnneededTimeKey, err)
 		} else {
 			defaults.ScaleDownUnneededTime = opt
@@ -374,7 +374,7 @@ func (m *AwsManager) GetAsgOptions(asg asg, defaults config.NodeGroupAutoscaling
 
 	if stringOpt, found := options[config.DefaultScaleDownUnreadyTimeKey]; found {
 		if opt, err := time.ParseDuration(stringOpt); err != nil {
-			klog.Warning("failed to convert asg %s %s tag to duration: %v",
+			klog.Warningf("failed to convert asg %s %s tag to duration: %v",
 				asg.Name, config.DefaultScaleDownUnreadyTimeKey, err)
 		} else {
 			defaults.ScaleDownUnreadyTime = opt


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If instance type listing fails, the autoscaler would fail to work.  This change modifies behavior so that it falls back
to the static list of instance types.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
