### PR TITLE
Various fixes to the OVHcloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovhcloud
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud/sdk"
+)
+
+func newTestManager(t *testing.T) *OvhCloudManager {
+	cfg := `{
+		"project_id": "projectID",
+		"cluster_id": "clusterID",
+		"authentication_type": "consumer",
+		"application_endpoint": "ovh-eu",
+		"application_key": "key",
+		"application_secret": "secret",
+		"application_consumer_key": "consumer_key"
+	}`
+
+	manager, err := NewManager(bytes.NewBufferString(cfg))
+	if err != nil {
+		assert.FailNow(t, "failed to create manager", err)
+	}
+
+	client := &sdk.ClientMock{}
+	ctx := context.Background()
+
+	client.On("ListClusterFlavors", ctx, "projectID", "clusterID").Return(
+		[]sdk.Flavor{
+			{
+				Name:     "b2-7",
+				Category: "b",
+				State:    "available",
+				VCPUs:    2,
+				GPUs:     0,
+				RAM:      7,
+			},
+			{
+				Name:     "t1-45",
+				Category: "t",
+				State:    "available",
+				VCPUs:    8,
+				GPUs:     1,
+				RAM:      45,
+			},
+			{
+				Name:     "unknown",
+				Category: "",
+				State:    "unavailable",
+				VCPUs:    2,
+				GPUs:     0,
+				RAM:      7,
+			},
+		}, nil,
+	)
+	manager.Client = client
+
+	return manager
+}
+
+func TestOvhCloudManager_getFlavorsByName(t *testing.T) {
+	expectedFlavorsByNameFromAPICall := map[string]sdk.Flavor{
+		"b2-7": {
+			Name:     "b2-7",
+			Category: "b",
+			State:    "available",
+			VCPUs:    2,
+			GPUs:     0,
+			RAM:      7,
+		},
+		"t1-45": {
+			Name:     "t1-45",
+			Category: "t",
+			State:    "available",
+			VCPUs:    8,
+			GPUs:     1,
+			RAM:      45,
+		},
+		"unknown": {
+			Name:     "unknown",
+			Category: "",
+			State:    "unavailable",
+			VCPUs:    2,
+			GPUs:     0,
+			RAM:      7,
+		},
+	}
+
+	t.Run("brand new manager: list from api", func(t *testing.T) {
+		ng := newTestManager(t)
+		flavorsByName, err := ng.getFlavorsByName()
+
+		ng.Client.(*sdk.ClientMock).AssertCalled(t, "ListClusterFlavors", context.Background(), "projectID", "clusterID")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedFlavorsByNameFromAPICall, flavorsByName)
+		assert.Equal(t, expectedFlavorsByNameFromAPICall, ng.FlavorsCache)
+	})
+
+	t.Run("flavors cache expired: renew and list from api", func(t *testing.T) {
+		initialFlavorsCache := map[string]sdk.Flavor{
+			"custom": {
+				Name: "custom",
+			},
+		}
+
+		ng := newTestManager(t)
+		ng.FlavorsCache = initialFlavorsCache
+		ng.FlavorsCacheExpirationTime = time.Now()
+
+		flavorsByName, err := ng.getFlavorsByName()
+
+		ng.Client.(*sdk.ClientMock).AssertCalled(t, "ListClusterFlavors", context.Background(), "projectID", "clusterID")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedFlavorsByNameFromAPICall, flavorsByName)
+		assert.Equal(t, expectedFlavorsByNameFromAPICall, ng.FlavorsCache)
+	})
+
+	t.Run("flavors cache still valid: list from cache", func(t *testing.T) {
+		initialFlavorsCache := map[string]sdk.Flavor{
+			"custom": {
+				Name: "custom",
+			},
+		}
+
+		ng := newTestManager(t)
+		ng.FlavorsCache = initialFlavorsCache
+		ng.FlavorsCacheExpirationTime = time.Now().Add(time.Minute)
+
+		flavorsByName, err := ng.getFlavorsByName()
+
+		ng.Client.(*sdk.ClientMock).AssertNotCalled(t, "ListClusterFlavors", context.Background(), "projectID", "clusterID")
+		assert.NoError(t, err)
+		assert.Equal(t, initialFlavorsCache, flavorsByName)
+		assert.Equal(t, initialFlavorsCache, ng.FlavorsCache)
+	})
+}
+
+func TestOvhCloudManager_getFlavorByName(t *testing.T) {
+	ng := newTestManager(t)
+
+	t.Run("check default node group max size", func(t *testing.T) {
+		flavor, err := ng.getFlavorByName("b2-7")
+		assert.NoError(t, err)
+		assert.Equal(t, sdk.Flavor{
+			Name:     "b2-7",
+			Category: "b",
+			State:    "available",
+			VCPUs:    2,
+			GPUs:     0,
+			RAM:      7,
+		}, flavor)
+	})
+}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/consumer_key.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/consumer_key.go
@@ -119,7 +119,7 @@ func (ck *CkRequest) AddRecursiveRules(methods []string, path string) {
 // and return the URL the user needs to visit to validate the key
 func (ck *CkRequest) Do() (*CkValidationState, error) {
 	state := CkValidationState{}
-	err := ck.client.PostUnAuth("/auth/credential", ck, &state)
+	err := ck.client.PostUnAuth("/auth/credential", ck, &state, nil)
 
 	if err == nil {
 		ck.client.ConsumerKey = state.ConsumerKey

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/flavor.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/flavor.go
@@ -26,10 +26,13 @@ type Flavor struct {
 	Name     string `json:"name"`
 	Category string `json:"category"`
 	State    string `json:"state"`
+	VCPUs    int    `json:"vCPUs"`
+	GPUs     int    `json:"gpus"`
+	RAM      int    `json:"ram"`
 }
 
-// ListFlavors allows to display flavors available for nodes templates
-func (c *Client) ListFlavors(ctx context.Context, projectID string, clusterID string) ([]Flavor, error) {
+// ListClusterFlavors allows to display flavors available for nodes templates
+func (c *Client) ListClusterFlavors(ctx context.Context, projectID string, clusterID string) ([]Flavor, error) {
 	flavors := make([]Flavor, 0)
 
 	return flavors, c.CallAPIWithContext(
@@ -38,6 +41,7 @@ func (c *Client) ListFlavors(ctx context.Context, projectID string, clusterID st
 		fmt.Sprintf("/cloud/project/%s/kube/%s/flavors", projectID, clusterID),
 		nil,
 		&flavors,
+		nil,
 		nil,
 		true,
 	)

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/mock.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/mock.go
@@ -62,8 +62,8 @@ func (m *ClientMock) DeleteNodePool(ctx context.Context, projectID string, clust
 	return args.Get(0).(*NodePool), args.Error(1)
 }
 
-// ListFlavors mocks API call for listing available flavors in cluster
-func (m *ClientMock) ListFlavors(ctx context.Context, projectID string, clusterID string) ([]Flavor, error) {
+// ListClusterFlavors mocks API call for listing available flavors in cluster
+func (m *ClientMock) ListClusterFlavors(ctx context.Context, projectID string, clusterID string) ([]Flavor, error) {
 	args := m.Called(ctx, projectID, clusterID)
 
 	return args.Get(0).([]Flavor), args.Error(1)

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/nodepool.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/nodepool.go
@@ -74,6 +74,7 @@ func (c *Client) ListNodePools(ctx context.Context, projectID, clusterID string)
 		nil,
 		&nodepools,
 		nil,
+		nil,
 		true,
 	)
 }
@@ -89,6 +90,7 @@ func (c *Client) GetNodePool(ctx context.Context, projectID string, clusterID st
 		nil,
 		&nodepool,
 		nil,
+		nil,
 		true,
 	)
 }
@@ -103,6 +105,7 @@ func (c *Client) ListNodePoolNodes(ctx context.Context, projectID string, cluste
 		fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool/%s/nodes", projectID, clusterID, poolID),
 		nil,
 		&nodes,
+		nil,
 		nil,
 		true,
 	)
@@ -133,6 +136,7 @@ func (c *Client) CreateNodePool(ctx context.Context, projectID string, clusterID
 		opts,
 		&nodepool,
 		nil,
+		nil,
 		true,
 	)
 }
@@ -159,6 +163,7 @@ func (c *Client) UpdateNodePool(ctx context.Context, projectID string, clusterID
 		opts,
 		&nodepool,
 		nil,
+		nil,
 		true,
 	)
 }
@@ -173,6 +178,7 @@ func (c *Client) DeleteNodePool(ctx context.Context, projectID string, clusterID
 		fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool/%s", projectID, clusterID, poolID),
 		nil,
 		&nodepool,
+		nil,
 		nil,
 		true,
 	)

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -176,83 +177,83 @@ func (c *Client) Time() (*time.Time, error) {
 //
 
 // Get is a wrapper for the GET method
-func (c *Client) Get(url string, resType interface{}) error {
-	return c.CallAPI("GET", url, nil, resType, true)
+func (c *Client) Get(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("GET", url, nil, result, queryParams, true)
 }
 
 // GetUnAuth is a wrapper for the unauthenticated GET method
-func (c *Client) GetUnAuth(url string, resType interface{}) error {
-	return c.CallAPI("GET", url, nil, resType, false)
+func (c *Client) GetUnAuth(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("GET", url, nil, result, queryParams, false)
 }
 
 // Post is a wrapper for the POST method
-func (c *Client) Post(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("POST", url, reqBody, resType, true)
+func (c *Client) Post(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("POST", url, reqBody, result, queryParams, true)
 }
 
 // PostUnAuth is a wrapper for the unauthenticated POST method
-func (c *Client) PostUnAuth(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("POST", url, reqBody, resType, false)
+func (c *Client) PostUnAuth(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("POST", url, reqBody, result, queryParams, false)
 }
 
 // Put is a wrapper for the PUT method
-func (c *Client) Put(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("PUT", url, reqBody, resType, true)
+func (c *Client) Put(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("PUT", url, reqBody, result, queryParams, true)
 }
 
 // PutUnAuth is a wrapper for the unauthenticated PUT method
-func (c *Client) PutUnAuth(url string, reqBody, resType interface{}) error {
-	return c.CallAPI("PUT", url, reqBody, resType, false)
+func (c *Client) PutUnAuth(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("PUT", url, reqBody, result, queryParams, false)
 }
 
 // Delete is a wrapper for the DELETE method
-func (c *Client) Delete(url string, resType interface{}) error {
-	return c.CallAPI("DELETE", url, nil, resType, true)
+func (c *Client) Delete(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("DELETE", url, nil, result, queryParams, true)
 }
 
 // DeleteUnAuth is a wrapper for the unauthenticated DELETE method
-func (c *Client) DeleteUnAuth(url string, resType interface{}) error {
-	return c.CallAPI("DELETE", url, nil, resType, false)
+func (c *Client) DeleteUnAuth(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("DELETE", url, nil, result, queryParams, false)
 }
 
 // GetWithContext is a wrapper for the GET method
-func (c *Client) GetWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, nil, true)
+func (c *Client) GetWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, result, queryParams, nil, true)
 }
 
 // GetUnAuthWithContext is a wrapper for the unauthenticated GET method
-func (c *Client) GetUnAuthWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, nil, false)
+func (c *Client) GetUnAuthWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, result, queryParams, nil, false)
 }
 
 // PostWithContext is a wrapper for the POST method
-func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, nil, true)
+func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, result, queryParams, nil, true)
 }
 
 // PostUnAuthWithContext is a wrapper for the unauthenticated POST method
-func (c *Client) PostUnAuthWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, nil, false)
+func (c *Client) PostUnAuthWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, result, queryParams, nil, false)
 }
 
 // PutWithContext is a wrapper for the PUT method
-func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, nil, true)
+func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, result, queryParams, nil, true)
 }
 
 // PutUnAuthWithContext is a wrapper for the unauthenticated PUT method
-func (c *Client) PutUnAuthWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, nil, false)
+func (c *Client) PutUnAuthWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, result, queryParams, nil, false)
 }
 
 // DeleteWithContext is a wrapper for the DELETE method
-func (c *Client) DeleteWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, nil, true)
+func (c *Client) DeleteWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, result, queryParams, nil, true)
 }
 
 // DeleteUnAuthWithContext is a wrapper for the unauthenticated DELETE method
-func (c *Client) DeleteUnAuthWithContext(ctx context.Context, url string, resType interface{}) error {
-	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, nil, false)
+func (c *Client) DeleteUnAuthWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, result, queryParams, nil, false)
 }
 
 // timeDelta returns the time  delta between the host and the remote API
@@ -284,7 +285,7 @@ func (c *Client) getTimeDelta() (time.Duration, error) {
 func (c *Client) getTime() (*time.Time, error) {
 	var timestamp int64
 
-	err := c.GetUnAuth("/auth/time", &timestamp)
+	err := c.GetUnAuth("/auth/time", &timestamp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +307,7 @@ var getEndpointForSignature = func(c *Client) string {
 }
 
 // NewRequest returns a new HTTP request
-func (c *Client) NewRequest(method, path string, reqBody interface{}, headers map[string]interface{}, needAuth bool) (*http.Request, error) {
+func (c *Client) NewRequest(method, path string, reqBody interface{}, queryParams url.Values, headers map[string]interface{}, needAuth bool) (*http.Request, error) {
 	var body []byte
 	var err error
 
@@ -402,10 +403,10 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // argument is not nil, it will also serialize it as json and inject
 // the required Content-Type header.
 //
-// If everything went fine, unmarshall response into resType and return nil
+// If everything went fine, unmarshall response into result and return nil
 // otherwise, return the error
-func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, needAuth bool) error {
-	return c.CallAPIWithContext(context.Background(), method, path, reqBody, resType, nil, needAuth)
+func (c *Client) CallAPI(method, path string, reqBody, result interface{}, queryParams url.Values, needAuth bool) error {
+	return c.CallAPIWithContext(context.Background(), method, path, reqBody, result, queryParams, nil, needAuth)
 }
 
 // CallAPIWithContext is the lowest level call helper. If needAuth is true,
@@ -426,10 +427,10 @@ func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, need
 // argument is not nil, it will also serialize it as json and inject
 // the required Content-Type header.
 //
-// If everything went fine, unmarshall response into resType and return nil
+// If everything went fine, unmarshall response into result and return nil
 // otherwise, return the error
-func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, resType interface{}, headers map[string]interface{}, needAuth bool) error {
-	req, err := c.NewRequest(method, path, reqBody, headers, needAuth)
+func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, result interface{}, queryParams url.Values, headers map[string]interface{}, needAuth bool) error {
+	req, err := c.NewRequest(method, path, reqBody, queryParams, headers, needAuth)
 	if err != nil {
 		return err
 	}
@@ -438,12 +439,12 @@ func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, re
 	if err != nil {
 		return err
 	}
-	return c.UnmarshalResponse(response, resType)
+	return c.UnmarshalResponse(response, result)
 }
 
 // UnmarshalResponse checks the response and unmarshals it into the response
 // type if needed Helper function, called from CallAPI
-func (c *Client) UnmarshalResponse(response *http.Response, resType interface{}) error {
+func (c *Client) UnmarshalResponse(response *http.Response, result interface{}) error {
 	// Read all the response body
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
@@ -463,9 +464,9 @@ func (c *Client) UnmarshalResponse(response *http.Response, resType interface{})
 	}
 
 	// Nothing to unmarshal
-	if len(body) == 0 || resType == nil {
+	if len(body) == 0 || result == nil {
 		return nil
 	}
 
-	return json.Unmarshal(body, &resType)
+	return json.Unmarshal(body, &result)
 }


### PR DESCRIPTION
Various bug fixes to the OVHcloud provider:

- Fix silent failure of upscale/downscale due to the node group status being not READY
- Fix Instance.ID to the actual value of Node.Spec.ProviderID
- Fix infinite looping when DecreaseTargetSize is called
- Fix the way we determine to which node group a node belongs to
- Fix handling of non-autoscaled nodepools (now considered as autoscaled nodepools with no margin of action)
- Fix TemplateNodeInfo with correct allocatable resources from the instance flavor specs

Signed-off-by: Xavier Duthil <xavier.duthil@ovhcloud.com>

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Various fixes to the OVHcloud provider (see top of description for the list of fixes).

Those fixes have already been released in production on the OVHcloud Managed Kubernetes product.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This PR is also the continuation from the outdated draft PR https://github.com/kubernetes/autoscaler/pull/4248.

I squashes all commits for convenience but I can split them back to 5-6 commits if needed.

#### Does this PR introduce a user-facing change?

```release-note
## OVHcloud
- Fix node resources during upscaling simulations
- Fix associations between nodes with their node group
- Fix silent failure of upscale/downscale due to the node group status being not READY
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
