### PR TITLE
cluster-autoscaler: Add option to disable scale down for unready nodes

### DIFF
--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -772,6 +772,13 @@ func (sd *ScaleDown) TryToScaleDown(
 				klog.Errorf("Error trying to get ScaleDownUnreadyTime for node %s (in group: %s)", node.Name, nodeGroup.Id())
 				continue
 			}
+
+			// Negative unreadyTime indicates that scale down is disabled for unready nodes of the nodegroup.
+			if unreadyTime < 0 {
+				sd.addUnremovableNodeReason(node, simulator.UnreadyScaleDownDisabled)
+				continue
+			}
+
 			if !unneededSince.Add(unreadyTime).Before(currentTime) {
 				sd.addUnremovableNodeReason(node, simulator.NotUnreadyLongEnough)
 				continue

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -102,7 +102,7 @@ var (
 	scaleDownUnneededTime = flag.Duration("scale-down-unneeded-time", 10*time.Minute,
 		"How long a node should be unneeded before it is eligible for scale down")
 	scaleDownUnreadyTime = flag.Duration("scale-down-unready-time", 20*time.Minute,
-		"How long an unready node should be unneeded before it is eligible for scale down")
+		"How long an unready node should be unneeded before it is eligible for scale down. To disable scale down of unready nodes, set to a negative number.")
 	scaleDownUtilizationThreshold = flag.Float64("scale-down-utilization-threshold", 0.5,
 		"Sum of cpu or memory of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down")
 	scaleDownGpuUtilizationThreshold = flag.Float64("scale-down-gpu-utilization-threshold", 0.5,

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -75,6 +75,8 @@ const (
 	NotUnneededLongEnough
 	// NotUnreadyLongEnough - node can't be removed because it wasn't unready for long enough.
 	NotUnreadyLongEnough
+	// UnreadyScaleDownDisabled - node can't be removed because it is unready and scale down is disabled for unready nodes.
+	UnreadyScaleDownDisabled
 	// NodeGroupMinSizeReached - node can't be removed because its node group is at its minimal size already.
 	NodeGroupMinSizeReached
 	// MinimalResourceLimitExceeded - node can't be removed because it would violate cluster-wide minimal resource limits.


### PR DESCRIPTION
Disable scale down for unready nodes if '--scale-down-unready-time' is
negative.

Signed-off-by: Grigoris Thanasoulas <gregth@arrikto.com>

#### Which component this PR applies to?
Cluster Autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the option to disable scale down for unready nodes. 

There are cases where a user may not want the unready nodes to be removed from a cluster.
As an example, but not limited to, this might me useful in case a node is unreachable for a period of a time and local data live there, the node shall remain in the cluster, and possibly an admin may want to take any actions for recovering it.

This PR extends the cluster autoscaler logic and if `--scale-down-unready-time` is set to negative value, it disables the scale down for unready nodes.  Till now, if the flag was set to a negative value, the unready nodes would be removed immediately.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4876.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Set the -scale-down-unready-time flag to a negative value in order to disable scale down for unready nodes. 
Set the flag to 0 to immediately remove nodes or to a positive value to remove an unready node after the specified duration elapses (current behavior). 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
