### PR TITLE
VPA release 0.11.0

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "0.10.0"
+const VerticalPodAutoscalerVersion = "0.11.0"


### PR DESCRIPTION
Increase VPA version, first step to cutting a new release.

Previous version is [0.10.0](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.10.0), released on 2022-01-26.

K8s 1.24 [has been release on 2022-05-03](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/) so I want to release a new version of VPA too.
