### PR TITLE
Move GetMatchingPods into block guarded by klog.V(4)

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -114,14 +114,16 @@ func (r *recommender) UpdateVPAs() {
 		vpa.UpdateConditions(hasMatchingPods)
 		if err := r.clusterState.RecordRecommendation(vpa, time.Now()); err != nil {
 			klog.Warningf("%v", err)
-			klog.V(4).Infof("VPA dump")
-			klog.V(4).Infof("%+v", vpa)
-			klog.V(4).Infof("HasMatchingPods: %v", hasMatchingPods)
-			klog.V(4).Infof("PodCount: %v", vpa.PodCount)
-			pods := r.clusterState.GetMatchingPods(vpa)
-			klog.V(4).Infof("MatchingPods: %+v", pods)
-			if len(pods) != vpa.PodCount {
-				klog.Errorf("ClusterState pod count and matching pods disagree for vpa %v/%v", vpa.ID.Namespace, vpa.ID.VpaName)
+			if klog.V(4).Enabled() {
+				klog.Infof("VPA dump")
+				klog.Infof("%+v", vpa)
+				klog.Infof("HasMatchingPods: %v", hasMatchingPods)
+				klog.Infof("PodCount: %v", vpa.PodCount)
+				pods := r.clusterState.GetMatchingPods(vpa)
+				klog.Infof("MatchingPods: %+v", pods)
+				if len(pods) != vpa.PodCount {
+					klog.Errorf("ClusterState pod count and matching pods disagree for vpa %v/%v", vpa.ID.Namespace, vpa.ID.VpaName)
+				}
 			}
 		}
 		cnt.Add(vpa)


### PR DESCRIPTION
#### Which component this PR applies to?
vertical-pod-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Previously, GetMatchingPods was executed even if the log statement was never printed. Given that this is a costly operation which traverses all known Pods, we only want to do this if it is actually useful.

We are using VPA in big clusters with ~4000 VPA objects. Because of automatic downscaling of the workload running in there, it happens that most of the time ~1000 VPA objects don't match any Pods.[ If workload is scaled down for longer than 30 minutes](https://github.com/kubernetes/autoscaler/blob/3cc40495c9aea057c1fda5a1fd8d60880fe3d650/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go#L115), the `UpdateVPAs` step will for each of these non-matching VPAs [will execute `GetMatchingPods`](https://github.com/kubernetes/autoscaler/blob/3cc40495c9aea057c1fda5a1fd8d60880fe3d650/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go#L121), therefore resulting in 1000*4000= 4 000 000 Pods being traversed every 60 seconds – just for a log statement that will never be printed, as we're running with `V(2)`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Don't execute costly operations to gather diagnostic information when the required log level is not enabled.
```

