### PR TITLE
[Helm] Support policy/v1 for PodDisruptionBudget for v1.21+

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -17,4 +17,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.18.0
+version: 9.18.1

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -76,6 +76,18 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for podDisruptionBudget.
+*/}}
+{{- define "podDisruptionBudget.apiVersion" -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.21-0" $kubeTargetVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the service account name used by the pod.
 */}}
 {{- define "cluster-autoscaler.serviceAccountName" -}}

--- a/charts/cluster-autoscaler/templates/pdb.yaml
+++ b/charts/cluster-autoscaler/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
#### Which component this PR applies to?

`helm-charts`

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Remove warning of policy/v1beta1 deprecation
```
Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

n/a

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

```docs
Migrate manifests and API clients to use the policy/v1 API version, available since v1.21.
```

Fixes: #4285 