### PR TITLE
Update the README to show correct number of modes

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -130,7 +130,7 @@ resource requests for your pods.
 In order to use it you need to insert a *Vertical Pod Autoscaler* resource for
 each controller that you want to have automatically computed resource requirements.
 This will be most commonly a **Deployment**.
-There are three modes in which *VPAs* operate:
+There are four modes in which *VPAs* operate:
 
 * `"Auto"`: VPA assigns resource requests on pod creation as well as updates
   them on existing pods using the preferred update mechanism. Currently this is


### PR DESCRIPTION


#### Which component this PR applies to?
Documentation
#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
As seen [here](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L126-L143) there are four modes in which VPA operates, updating the readme to reflect that change.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE