### PR TITLE
CA - AWS - Instance List Update 2022-05-30

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
+++ b/cluster-autoscaler/cloudprovider/aws/ec2_instance_types.go
@@ -28,7 +28,7 @@ type InstanceType struct {
 }
 
 // StaticListLastUpdateTime is a string declaring the last time the static list was updated.
-var StaticListLastUpdateTime = "2022-05-25"
+var StaticListLastUpdateTime = "2022-05-30"
 
 // InstanceTypes is a map of ec2 resources
 var InstanceTypes = map[string]*InstanceType{
@@ -769,6 +769,76 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"c6i.xlarge": {
 		InstanceType: "c6i.xlarge",
+		VCPU:         4,
+		MemoryMb:     8192,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.12xlarge": {
+		InstanceType: "c6id.12xlarge",
+		VCPU:         48,
+		MemoryMb:     98304,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.16xlarge": {
+		InstanceType: "c6id.16xlarge",
+		VCPU:         64,
+		MemoryMb:     131072,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.24xlarge": {
+		InstanceType: "c6id.24xlarge",
+		VCPU:         96,
+		MemoryMb:     196608,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.2xlarge": {
+		InstanceType: "c6id.2xlarge",
+		VCPU:         8,
+		MemoryMb:     16384,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.32xlarge": {
+		InstanceType: "c6id.32xlarge",
+		VCPU:         128,
+		MemoryMb:     262144,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.4xlarge": {
+		InstanceType: "c6id.4xlarge",
+		VCPU:         16,
+		MemoryMb:     32768,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.8xlarge": {
+		InstanceType: "c6id.8xlarge",
+		VCPU:         32,
+		MemoryMb:     65536,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.large": {
+		InstanceType: "c6id.large",
+		VCPU:         2,
+		MemoryMb:     4096,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.metal": {
+		InstanceType: "c6id.metal",
+		VCPU:         128,
+		MemoryMb:     262144,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"c6id.xlarge": {
+		InstanceType: "c6id.xlarge",
 		VCPU:         4,
 		MemoryMb:     8192,
 		GPU:          0,
@@ -2316,6 +2386,76 @@ var InstanceTypes = map[string]*InstanceType{
 	},
 	"m6i.xlarge": {
 		InstanceType: "m6i.xlarge",
+		VCPU:         4,
+		MemoryMb:     16384,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.12xlarge": {
+		InstanceType: "m6id.12xlarge",
+		VCPU:         48,
+		MemoryMb:     196608,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.16xlarge": {
+		InstanceType: "m6id.16xlarge",
+		VCPU:         64,
+		MemoryMb:     262144,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.24xlarge": {
+		InstanceType: "m6id.24xlarge",
+		VCPU:         96,
+		MemoryMb:     393216,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.2xlarge": {
+		InstanceType: "m6id.2xlarge",
+		VCPU:         8,
+		MemoryMb:     32768,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.32xlarge": {
+		InstanceType: "m6id.32xlarge",
+		VCPU:         128,
+		MemoryMb:     524288,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.4xlarge": {
+		InstanceType: "m6id.4xlarge",
+		VCPU:         16,
+		MemoryMb:     65536,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.8xlarge": {
+		InstanceType: "m6id.8xlarge",
+		VCPU:         32,
+		MemoryMb:     131072,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.large": {
+		InstanceType: "m6id.large",
+		VCPU:         2,
+		MemoryMb:     8192,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.metal": {
+		InstanceType: "m6id.metal",
+		VCPU:         128,
+		MemoryMb:     524288,
+		GPU:          0,
+		Architecture: "amd64",
+	},
+	"m6id.xlarge": {
+		InstanceType: "m6id.xlarge",
 		VCPU:         4,
 		MemoryMb:     16384,
 		GPU:          0,


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature
/area provider/aws

#### What this PR does / why we need it:

Two new instance families were introduced in the last few days since #4917:

https://aws.amazon.com/about-aws/whats-new/2022/05/introducing-amazon-ec2-c6id-instances/
https://aws.amazon.com/about-aws/whats-new/2022/05/introducing-amazon-ec2-m6id-instances/

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @gjtempleton 

#### Does this PR introduce a user-facing change?
```release-note
Updated AWS instance types, including c6id and m6id families.
```
