### PR TITLE
Don't deref nil nodegroup in deleteCreatedNodesWithErrors

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -951,7 +951,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
 }
 
-func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
+func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 
 	// setup
 	provider := &mockprovider.CloudProvider{}
@@ -1086,7 +1086,9 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
 
 	// delete nodes with create errors
-	assert.True(t, autoscaler.deleteCreatedNodesWithErrors())
+	removedNodes, err := autoscaler.deleteCreatedNodesWithErrors()
+	assert.True(t, removedNodes)
+	assert.NoError(t, err)
 
 	// check delete was called on correct nodes
 	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
@@ -1110,7 +1112,9 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
 
 	// delete nodes with create errors
-	assert.True(t, autoscaler.deleteCreatedNodesWithErrors())
+	removedNodes, err = autoscaler.deleteCreatedNodesWithErrors()
+	assert.True(t, removedNodes)
+	assert.NoError(t, err)
 
 	// nodes should be deleted again
 	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
@@ -1173,10 +1177,48 @@ func TestStaticAutoscalerInstaceCreationErrors(t *testing.T) {
 	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
 
 	// delete nodes with create errors
-	assert.False(t, autoscaler.deleteCreatedNodesWithErrors())
+	removedNodes, err = autoscaler.deleteCreatedNodesWithErrors()
+	assert.False(t, removedNodes)
+	assert.NoError(t, err)
 
 	// we expect no more Delete Nodes
 	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", 2)
+
+	// failed node not included by NodeGroupForNode
+	nodeGroupC := &mockprovider.NodeGroup{}
+	nodeGroupC.On("Exist").Return(true)
+	nodeGroupC.On("Autoprovisioned").Return(false)
+	nodeGroupC.On("TargetSize").Return(1, nil)
+	nodeGroupC.On("Id").Return("C")
+	nodeGroupC.On("DeleteNodes", mock.Anything).Return(nil)
+	nodeGroupC.On("Nodes").Return([]cloudprovider.Instance{
+		{
+			Id: "C1",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:  "QUOTA",
+				},
+			},
+		},
+	}, nil)
+	provider = &mockprovider.CloudProvider{}
+	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
+	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
+
+	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
+	clusterState.RefreshCloudProviderNodeInstancesCache()
+	autoscaler.clusterStateRegistry = clusterState
+
+	// update cluster state
+	clusterState.UpdateNodes([]*apiv1.Node{}, nil, time.Now())
+
+	// return early on failed nodes without matching nodegroups
+	removedNodes, err = autoscaler.deleteCreatedNodesWithErrors()
+	assert.False(t, removedNodes)
+	assert.Error(t, err)
+	nodeGroupC.AssertNumberOfCalls(t, "DeleteNodes", 0)
 }
 
 func TestStaticAutoscalerProcessorCallbacks(t *testing.T) {


### PR DESCRIPTION
Various cloudproviders' `NodeGroupForNode()` implementations (including [aws](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go#L114), [azure](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go#L98), and [gce](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go#L99)) can returns a `nil` error _and_ a `nil` nodegroup. For instance we're seeing AWS returning that on failed upscales on live clusters, with a recent cluster-autoscaler build.

So checking that `deleteCreatedNodesWithErrors` doesn't return an error is not enough to safely dereference the nodegroup (as returned by `NodeGroupForNode()`) by calling nodegroup.Id().

In that situation, logging and returning early seems the safest option, to give various caches (eg. clusterstateregistry's and cloud provider's) the opportunity to eventually converge, rather than resuming with an inconsistent internal state.

===

With regards to the AWS cloudprovider triggering that issue with recent CA builds:

What we're seeing is:
```
I0523 16:37:53.847080     228 aws_manager.go:262] Refreshed ASG list, next refresh after 2022-05-23 16:38:53.847076185 +0000 UTC m=+559.468661724
W0523 16:37:53.905286     228 clusterstate.go:594] Nodegroup is nil for aws:///us-east-1b/i-placeholder-redacted-766c0982e71f-2
I0523 16:37:53.905533     228 clusterstate.go:1008] Found 1 instances with errorCode OutOfResource.placeholder-cannot-be-fulfilled in nodeGroup redacted-d63729665fff
I0523 16:37:53.905546     228 clusterstate.go:1026] Failed adding 1 nodes (0 unseen previously) to group redacted-d63729665fff due to OutOfResource.placeholder-cannot-be-fulfilled; errorMessages=[]string{"AWS cannot provision any more instances for this node group"}
[...]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x3639435]
goroutine 63 [running]:
k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).deleteCreatedNodesWithErrors(0xc03e307d00)
        /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:677 +0x275
k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce(0xc03e307d00, {0x4, 0x0, 0x7b9b840})
        /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:360 +0x12a5
main.run(0xc00088ae00, {0x4dc8998, 0xc000855230})
        /go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:392 +0x2ad
main.main.func2({0x0, 0x0})
        /go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:479 +0x25
created by k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
        /go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:211 +0x154
```

I can't easily reproduce the issue to verify that hypothesis, but it seems likely that this is due to the clusterstateregistry and the AWS caches being out-of-sync. That failure path is new, because flagging "failed at creation" instances was recently introduced for AWS provider (8ac87b3f34a43e3af9f7011531870ef5dc724bed).

We might get the following sequence:
1. RunOnce 1 : an AWS upscale is attempted (but the AWS ASG fails to create an instance)
2. RunOnce 2 : a Refresh() call prompts the AWS cloudprovider to regenerate the instances lists and ASG mappings, including by generating a new fake/placeholder for that failed instance
3. RunOnce 2 : clusterstateregistry gather and caches (for 2mn) the nodes list (which includes the placeholder instance)
4. RunOnce 2 : deleteCreatedNodesWithErrors() is called to gc the failed instance
5. RunOnce 3 : a Refresh() call regenerates the nodes/asg mapping, now there's no dangling placeholder nodes anymore
6. RunOnce 3 : deleteCreatedNodesWithErrors() is called and uses the outdated clusterstateregistry cache, tries to deref a nil nodegroup for a deposed placeholder instance, causes a segfault

/kind bug
/kind regression
