### PR TITLE
Drop deprecated CAPI annotations

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -26,12 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	deprecatedNodeGroupMinSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
-	deprecatedNodeGroupMaxSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
-	deprecatedClusterNameLabel              = "cluster.k8s.io/cluster-name"
-)
-
 var (
 	// clusterNameLabel is the label applied to objects(Machine, MachineSet, MachineDeployment)
 	// to identify which cluster they are owned by. Because the label can be
@@ -83,9 +77,6 @@ type normalizedProviderID string
 func minSize(annotations map[string]string) (int, error) {
 	val, found := annotations[nodeGroupMinSizeAnnotationKey]
 	if !found {
-		val, found = annotations[deprecatedNodeGroupMinSizeAnnotationKey]
-	}
-	if !found {
 		return 0, errMissingMinAnnotation
 	}
 	i, err := strconv.Atoi(val)
@@ -101,9 +92,6 @@ func minSize(annotations map[string]string) (int, error) {
 // value is not of type int.
 func maxSize(annotations map[string]string) (int, error) {
 	val, found := annotations[nodeGroupMaxSizeAnnotationKey]
-	if !found {
-		val, found = annotations[deprecatedNodeGroupMaxSizeAnnotationKey]
-	}
 	if !found {
 		return 0, errMissingMaxAnnotation
 	}
@@ -183,19 +171,6 @@ func clusterNameFromResource(r *unstructured.Unstructured) string {
 	// Fallback to value of clusterNameLabel
 	if clusterName, ok := r.GetLabels()[clusterNameLabel]; ok {
 		return clusterName
-	}
-
-	// fallback for backward compatibility for deprecatedClusterNameLabel
-	if clusterName, ok := r.GetLabels()[deprecatedClusterNameLabel]; ok {
-		return clusterName
-	}
-
-	// fallback for cluster-api v1alpha1 cluster linking
-	templateLabels, found, err := unstructured.NestedStringMap(r.UnstructuredContent(), "spec", "template", "metadata", "labels")
-	if found {
-		if clusterName, ok := templateLabels[deprecatedClusterNameLabel]; ok {
-			return clusterName
-		}
 	}
 
 	return ""

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -114,24 +114,6 @@ func TestUtilParseScalingBounds(t *testing.T) {
 		},
 		min: 0,
 		max: 1,
-	}, {
-		description: "deprecated min/max annotations still work, result is min 0, max 1",
-		annotations: map[string]string{
-			deprecatedNodeGroupMinSizeAnnotationKey: "0",
-			deprecatedNodeGroupMaxSizeAnnotationKey: "1",
-		},
-		min: 0,
-		max: 1,
-	}, {
-		description: "deprecated min/max annotations do not take precedence over non-deprecated annotations, result is min 1, max 2",
-		annotations: map[string]string{
-			deprecatedNodeGroupMinSizeAnnotationKey: "0",
-			deprecatedNodeGroupMaxSizeAnnotationKey: "1",
-			nodeGroupMinSizeAnnotationKey:           "1",
-			nodeGroupMaxSizeAnnotationKey:           "2",
-		},
-		min: 1,
-		max: 2,
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			machineSet := unstructured.Unstructured{
@@ -486,94 +468,6 @@ func Test_clusterNameFromResource(t *testing.T) {
 			},
 		},
 		want: "",
-	}, {
-		name: "cluster name set in MachineSet labels, v1alpha1 MachineSet",
-		resource: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"kind":       machineSetKind,
-				"apiVersion": "cluster.k8s.io/v1alpha1",
-				"metadata": map[string]interface{}{
-					"name":      "foo",
-					"namespace": "default",
-					"labels": map[string]interface{}{
-						deprecatedClusterNameLabel: "bar",
-					},
-				},
-				"spec": map[string]interface{}{
-					"replicas": int64(1),
-				},
-				"status": map[string]interface{}{},
-			},
-		},
-		want: "bar",
-	}, {
-		name: "cluster name set in MachineDeployment, v1alpha1 MachineDeployment",
-		resource: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"kind":       machineDeploymentKind,
-				"apiVersion": "cluster.k8s.io/v1alpha1",
-				"metadata": map[string]interface{}{
-					"name":      "foo",
-					"namespace": "default",
-					"labels": map[string]interface{}{
-						deprecatedClusterNameLabel: "bar",
-					},
-				},
-				"spec": map[string]interface{}{
-					"replicas": int64(1),
-				},
-				"status": map[string]interface{}{},
-			},
-		},
-		want: "bar",
-	}, {
-		name: "cluster name set in Machine template labels, v1alpha1 MachineSet",
-		resource: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"kind":       machineSetKind,
-				"apiVersion": "cluster.k8s.io/v1alpha1",
-				"metadata": map[string]interface{}{
-					"name":      "foo",
-					"namespace": "default",
-				},
-				"spec": map[string]interface{}{
-					"replicas": int64(1),
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"labels": map[string]interface{}{
-								deprecatedClusterNameLabel: "bar",
-							},
-						},
-					},
-				},
-				"status": map[string]interface{}{},
-			},
-		},
-		want: "bar",
-	}, {
-		name: "cluster name set in Machine template, v1alpha1 MachineDeployment",
-		resource: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"kind":       machineDeploymentKind,
-				"apiVersion": "cluster.k8s.io/v1alpha1",
-				"metadata": map[string]interface{}{
-					"name":      "foo",
-					"namespace": "default",
-				},
-				"spec": map[string]interface{}{
-					"replicas": int64(1),
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"labels": map[string]interface{}{
-								deprecatedClusterNameLabel: "bar",
-							},
-						},
-					},
-				},
-				"status": map[string]interface{}{},
-			},
-		},
-		want: "bar",
 	}, {
 		name: "cluster name not set, v1alpha2 MachineSet",
 		resource: &unstructured.Unstructured{


### PR DESCRIPTION
#### Which component this PR applies to?
Fixes https://github.com/kubernetes/autoscaler/issues/4927

