### PR TITLE
CA: make legacy SD wrapper always return nodeDeleteResults

### DIFF
--- a/cluster-autoscaler/core/scaledown/legacy/wrapper.go
+++ b/cluster-autoscaler/core/scaledown/legacy/wrapper.go
@@ -95,7 +95,16 @@ func (p *ScaleDownWrapper) NodesToDelete(currentTime time.Time) (empty, needDrai
 func (p *ScaleDownWrapper) StartDeletion(empty, needDrain []*apiv1.Node, currentTime time.Time) (*status.ScaleDownStatus, errors.AutoscalerError) {
 	// Done to preserve legacy behavior, see comment on NodesToDelete.
 	if p.lastNodesToDeleteErr != nil || p.lastNodesToDeleteResult != status.ScaleDownNodeDeleteStarted {
-		return &status.ScaleDownStatus{Result: p.lastNodesToDeleteResult}, p.lastNodesToDeleteErr
+		// When there is no need for scale-down, p.lastNodesToDeleteResult is set to ScaleDownNoUnneeded. We have to still report node delete
+		// results in this case, otherwise they wouldn't get reported until the next call to actuator.StartDeletion (i.e. until the next scale-down
+		// attempt).
+		// Run actuator.StartDeletion with no nodes just to grab the delete results.
+		origStatus, _ := p.actuator.StartDeletion(nil, nil, currentTime)
+		return &status.ScaleDownStatus{
+			Result:                p.lastNodesToDeleteResult,
+			NodeDeleteResults:     origStatus.NodeDeleteResults,
+			NodeDeleteResultsAsOf: origStatus.NodeDeleteResultsAsOf,
+		}, p.lastNodesToDeleteErr
 	}
 	return p.actuator.StartDeletion(empty, needDrain, currentTime)
 }


### PR DESCRIPTION
Previously it'd only return nodeDeleteResults if a subsequent
scale-down attempt was made, which is sub-optimal, and doesn't
match legacy behavior.