### PR TITLE
Fixed Typo in aws_wrapper.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -301,7 +301,7 @@ func (m *awsWrapper) getInstanceTypesForAsgs(asgs []*asg) (map[string]string, er
 	for asgName, lt := range launchTemplatesToQuery {
 		instanceType, err := m.getInstanceTypeByLaunchTemplate(lt)
 		if err != nil {
-			klog.Errorf("Failed to query launch tempate %s: %v", lt.name, err)
+			klog.Errorf("Failed to query launch template %s: %v", lt.name, err)
 			continue
 		}
 		results[asgName] = instanceType


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This PR fixed the typo i.e. `tempate` to the `template` in aws_wrapper.go.

#### Which issue(s) this PR fixes:

Fixes #4903

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
NONE
```
