### PR TITLE
Add podScaleUpDelay annotation support

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package core
 
 import (
+	"bytes"
+	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -46,6 +49,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	v1appslister "k8s.io/client-go/listers/apps/v1"
@@ -952,7 +956,6 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 }
 
 func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
-
 	// setup
 	provider := &mockprovider.CloudProvider{}
 
@@ -1374,6 +1377,103 @@ func TestSubtractNodes(t *testing.T) {
 	for _, tc := range testCases {
 		got := subtractNodes(tc.a, tc.b)
 		assert.Equal(t, nodeNames(got), nodeNames(tc.c))
+	}
+}
+
+func TestFilterOutYoungPods(t *testing.T) {
+	now := time.Now()
+	klog.InitFlags(nil)
+	flag.CommandLine.Parse([]string{"--logtostderr=false"})
+
+	p1 := BuildTestPod("p1", 500, 1000)
+	p1.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
+	p2 := BuildTestPod("p2", 500, 1000)
+	p2.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
+	p2.Annotations = map[string]string{
+		podScaleUpDelayAnnotationKey: "5m",
+	}
+	p3 := BuildTestPod("p3", 500, 1000)
+	p3.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
+	p3.Annotations = map[string]string{
+		podScaleUpDelayAnnotationKey: "2m",
+	}
+	p4 := BuildTestPod("p4", 500, 1000)
+	p4.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
+	p4.Annotations = map[string]string{
+		podScaleUpDelayAnnotationKey: "error",
+	}
+
+	tests := []struct {
+		name               string
+		newPodScaleUpDelay time.Duration
+		runTime            time.Time
+		pods               []*apiv1.Pod
+		expectedPods       []*apiv1.Pod
+		expectedError      string
+	}{
+		{
+			name:               "annotation delayed pod checking now",
+			newPodScaleUpDelay: 0,
+			runTime:            now,
+			pods:               []*apiv1.Pod{p1, p2},
+			expectedPods:       []*apiv1.Pod{p1},
+		},
+		{
+			name:               "annotation delayed pod checking after delay",
+			newPodScaleUpDelay: 0,
+			runTime:            now.Add(5 * time.Minute),
+			pods:               []*apiv1.Pod{p1, p2},
+			expectedPods:       []*apiv1.Pod{p1, p2},
+		},
+		{
+			name:               "globally delayed pods",
+			newPodScaleUpDelay: 5 * time.Minute,
+			runTime:            now,
+			pods:               []*apiv1.Pod{p1, p2},
+			expectedPods:       []*apiv1.Pod(nil),
+		},
+		{
+			name:               "annotation delay smaller than global",
+			newPodScaleUpDelay: 5 * time.Minute,
+			runTime:            now.Add(2 * time.Minute),
+			pods:               []*apiv1.Pod{p1, p3},
+			expectedPods:       []*apiv1.Pod(nil),
+			expectedError:      "Failed to set pod scale up delay for",
+		},
+		{
+			name:               "annotation delay with error",
+			newPodScaleUpDelay: 0,
+			runTime:            now,
+			pods:               []*apiv1.Pod{p1, p4},
+			expectedPods:       []*apiv1.Pod{p1, p4},
+			expectedError:      "Failed to parse pod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context := context.AutoscalingContext{
+				AutoscalingOptions: config.AutoscalingOptions{
+					NewPodScaleUpDelay: tt.newPodScaleUpDelay,
+				},
+			}
+			autoscaler := &StaticAutoscaler{
+				AutoscalingContext: &context,
+			}
+
+			var buf bytes.Buffer
+			klog.SetOutput(&buf)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+			}()
+
+			actual := autoscaler.filterOutYoungPods(tt.pods, tt.runTime)
+
+			assert.Equal(t, tt.expectedPods, actual)
+			if tt.expectedError != "" {
+				assert.Contains(t, buf.String(), tt.expectedError)
+			}
+		})
 	}
 }
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -176,7 +176,7 @@ var (
 	unremovableNodeRecheckTimeout = flag.Duration("unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
 	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
-	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up.")
+	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
 	ignoreTaintsFlag                   = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
 	balancingIgnoreLabelsFlag          = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Extends existing option/feature `new-pod-scale-up-delay` that is global for all the pods and adds ability to specify custom delay per pod through annotation `cluster-autoscaler.kubernetes.io/pod-scale-up-delay`. This allows better control over scale up process in the situations when we are running a lot of batch jobs at the regular intervals, like _run this job every hour, but it is ok to wait 5 minutes to start_. 

#### Which issue(s) this PR fixes:

There was a discussion on this issue and someone suggested this solution. I liked it, implemented it, and it worked well for what I needed.
https://github.com/kubernetes/autoscaler/issues/3916

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
A new annotation `cluster-autoscaler.kubernetes.io/pod-scale-up-delay` has been added, which allows user to set `new-pod-scale-up-delay` per pod, instead of autoscaler wide configuration. Annotation value will be used only if it is larger then global `new-pod-scale-up-delay`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
