### PR TITLE
Handle gracefully empty arch in kube env.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -599,7 +599,7 @@ func ToSystemArchitecture(arch string) SystemArchitecture {
 	case string(Amd64):
 		return Amd64
 	default:
-		return UnknownArch
+		return DefaultArch
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -171,6 +171,15 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			expectedErr:                   false,
 		},
 		{
+			scenario:                      "handle empty arch gracefully",
+			kubeEnv:                       "AUTOSCALER_ENV_VARS: os_distribution=cos;arch=;os=linux;ephemeral_storage_local_ssd_count=2\n",
+			physicalCpu:                   8,
+			physicalMemory:                200 * units.MiB,
+			ephemeralStorageLocalSSDCount: 2,
+			attachedLocalSSDCount:         4,
+			expectedErr:                   false,
+		},
+		{
 			scenario:                      "ephemeral storage on local SSDs with kube-reserved",
 			kubeEnv:                       "AUTOSCALER_ENV_VARS: kube_reserved=cpu=0,memory=0,ephemeral-storage=10Gi;os_distribution=cos;os=linux;ephemeral_storage_local_ssd_count=2\n",
 			physicalCpu:                   8,


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It prevents error in cluster-autoscaler in case empty arch is provided in kube env.
