### PR TITLE
added replicas count for daemonsets to prevent massive pod eviction

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -75,6 +75,7 @@ type podsEvictionRestrictionFactoryImpl struct {
 	rcInformer                cache.SharedIndexInformer // informer for Replication Controllers
 	ssInformer                cache.SharedIndexInformer // informer for Stateful Sets
 	rsInformer                cache.SharedIndexInformer // informer for Replica Sets
+	dsInformer                cache.SharedIndexInformer // informer for Daemon Sets
 	minReplicas               int
 	evictionToleranceFraction float64
 }
@@ -85,6 +86,7 @@ const (
 	replicationController controllerKind = "ReplicationController"
 	statefulSet           controllerKind = "StatefulSet"
 	replicaSet            controllerKind = "ReplicaSet"
+	daemonSet             controllerKind = "DaemonSet"
 	job                   controllerKind = "Job"
 )
 
@@ -171,11 +173,16 @@ func NewPodsEvictionRestrictionFactory(client kube_client.Interface, minReplicas
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create rsInformer: %v", err)
 	}
+	dsInformer, err := setUpInformer(client, daemonSet)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create dsInformer: %v", err)
+	}
 	return &podsEvictionRestrictionFactoryImpl{
 		client:                    client,
 		rcInformer:                rcInformer, // informer for Replication Controllers
 		ssInformer:                ssInformer, // informer for Replica Sets
 		rsInformer:                rsInformer, // informer for Stateful Sets
+		dsInformer:                dsInformer, // informer for Daemon Sets
 		minReplicas:               minReplicas,
 		evictionToleranceFraction: evictionToleranceFraction}, nil
 }
@@ -325,6 +332,23 @@ func (f *podsEvictionRestrictionFactoryImpl) getReplicaCount(creator podReplicaC
 			return 0, fmt.Errorf("stateful set %s/%s has no replicas config", creator.Namespace, creator.Name)
 		}
 		return int(*ss.Spec.Replicas), nil
+
+	case daemonSet:
+		dsObj, exists, err := f.dsInformer.GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
+		if err != nil {
+			return 0, fmt.Errorf("daemon set %s/%s is not available, err: %v", creator.Namespace, creator.Name, err)
+		}
+		if !exists {
+			return 0, fmt.Errorf("daemon set %s/%s does not exist", creator.Namespace, creator.Name)
+		}
+		ds, ok := dsObj.(*appsv1.DaemonSet)
+		if !ok {
+			return 0, fmt.Errorf("Failed to parse DaemonSet")
+		}
+		if ds.Status.NumberReady == 0 {
+			return 0, fmt.Errorf("daemon set %s/%s has no number ready pods", creator.Namespace, creator.Name)
+		}
+		return int(ds.Status.NumberReady), nil
 	}
 
 	return 0, nil
@@ -352,6 +376,9 @@ func setUpInformer(kubeClient kube_client.Interface, kind controllerKind) (cache
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	case statefulSet:
 		informer = appsinformer.NewStatefulSetInformer(kubeClient, apiv1.NamespaceAll,
+			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	case daemonSet:
+		informer = appsinformer.NewDaemonSetInformer(kubeClient, apiv1.NamespaceAll,
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	default:
 		return nil, fmt.Errorf("Unknown controller kind: %v", kind)


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
vertical-pod-autoscaler
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
This PR adds ability to count "replicas" in daemonsets, to prevent massive one-time pod restart  in daemonsets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for counting replicas in deamonsets to limit how fast VPA evicts them.
```
NONE
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
