### PR TITLE
GCE: move fetching MachineType to MigInfoProvider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache_test.go
@@ -17,67 +17,48 @@ limitations under the License.
 package gce
 
 import (
-	"errors"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	gce "google.golang.org/api/compute/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
 func TestMachineCache(t *testing.T) {
 	type CacheQuery struct {
-		machineType string
-		zone        string
-		machine     *gce.MachineType
-		err         error
+		zone    string
+		machine MachineType
 	}
 	testCases := []struct {
-		desc     string
-		machines []CacheQuery
-		want     map[MachineTypeKey]uint64
-		wantErr  []MachineTypeKey
+		desc        string
+		machines    []CacheQuery
+		wantCPU     map[MachineTypeKey]int64
+		wantMissing []MachineTypeKey
 	}{
 		{
 			desc: "replacement",
 			machines: []CacheQuery{
 				{
-					machineType: "e2-standard-2",
-					zone:        "myzone",
-					machine:     &gce.MachineType{Id: 1},
+					zone: "myzone",
+					machine: MachineType{
+						Name: "e2-standard-2",
+						CPU:  1,
+					},
 				},
 				{
-					machineType: "e2-standard-2",
-					zone:        "myzone",
-					machine:     &gce.MachineType{Id: 1},
-				},
-				{
-					machineType: "e2-standard-2",
-					zone:        "myzone",
-					machine:     &gce.MachineType{Id: 2},
-				},
-				{
-					machineType: "e2-standard-2",
-					zone:        "myzone",
-					machine:     &gce.MachineType{Id: 2},
-				},
-				{
-					machineType: "e2-standard-4",
-					zone:        "myzone2",
-					err:         errors.New("error"),
+					zone: "myzone",
+					machine: MachineType{
+						Name: "e2-standard-2",
+						CPU:  2,
+					},
 				},
 			},
-			want: map[MachineTypeKey]uint64{
+			wantCPU: map[MachineTypeKey]int64{
 				{
-					MachineType: "e2-standard-2",
-					Zone:        "myzone",
+					MachineTypeName: "e2-standard-2",
+					Zone:            "myzone",
 				}: 2,
 			},
-			wantErr: []MachineTypeKey{
+			wantMissing: []MachineTypeKey{
 				{
-					Zone:        "myzone2",
-					MachineType: "e2-standard-4",
+					Zone:            "myzone2",
+					MachineTypeName: "e2-standard-4",
 				},
 			},
 		},
@@ -86,36 +67,23 @@ func TestMachineCache(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, m := range tc.machines {
-				if m.err != nil {
-					c.AddMachineToCacheWithError(m.machineType, m.zone, m.err)
-					continue
-				}
-				c.AddMachineToCache(m.machineType, m.zone, m.machine)
+				c.AddMachine(m.machine, m.zone)
 			}
-			for mt, wantId := range tc.want {
-				m, err := c.GetMachineFromCache(mt.MachineType, mt.Zone)
-				if err != nil {
-					t.Errorf("Did not expect error for machine type = %q, zone = %q", mt.MachineType, mt.Zone)
+			for mt, wantCPU := range tc.wantCPU {
+				m, found := c.GetMachine(mt.MachineTypeName, mt.Zone)
+				if !found {
+					t.Errorf("Expected to find machine in cache type = %q, zone = %q", mt.MachineTypeName, mt.Zone)
 				}
-				if m.Id != wantId {
-					t.Errorf("Wanted id %d but got id %d for machine type = %q, zone = %q", wantId, m.Id, mt.MachineType, mt.Zone)
+				if m.CPU != wantCPU {
+					t.Errorf("Wanted CPU %d but got CPU %d for machine type = %q, zone = %q", wantCPU, m.CPU, mt.MachineTypeName, mt.Zone)
 				}
 			}
-			for _, mt := range tc.wantErr {
-				_, err := c.GetMachineFromCache(mt.MachineType, mt.Zone)
-				if err == nil {
-					t.Errorf("Wanted an error but got no error for machine type = %q, zone = %q", mt.MachineType, mt.Zone)
+			for _, mt := range tc.wantMissing {
+				_, found := c.GetMachine(mt.MachineTypeName, mt.Zone)
+				if found {
+					t.Errorf("Didn't expect to find in cache machine type = %q, zone = %q", mt.MachineTypeName, mt.Zone)
 				}
 			}
 		})
 	}
-	gceManagerMock := &gceManagerMock{}
-	gce := &GceCloudProvider{
-		gceManager: gceManagerMock,
-	}
-	mig := &gceMig{gceRef: GceRef{Name: "ng1"}}
-	gceManagerMock.On("GetMigs").Return([]Mig{mig}).Once()
-	result := gce.NodeGroups()
-	assert.Equal(t, []cloudprovider.NodeGroup{mig}, result)
-	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/client-go/util/workqueue"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -483,8 +482,7 @@ func (m *gceManagerImpl) clearMachinesCache() {
 		return
 	}
 
-	machinesCache := make(map[MachineTypeKey]*gce.MachineType)
-	m.cache.SetMachinesCache(machinesCache)
+	m.cache.InvalidateAllMachines()
 	nextRefresh := time.Now()
 	m.machinesCacheLastRefresh = nextRefresh
 	klog.V(2).Infof("Cleared machine types cache, next clear after %v", nextRefresh)
@@ -584,45 +582,14 @@ func (m *gceManagerImpl) GetMigOptions(mig Mig, defaults config.NodeGroupAutosca
 // GetMigTemplateNode constructs a node from GCE instance template of the given MIG.
 func (m *gceManagerImpl) GetMigTemplateNode(mig Mig) (*apiv1.Node, error) {
 	template, err := m.migInfoProvider.GetMigInstanceTemplate(mig.GceRef())
-
 	if err != nil {
 		return nil, err
 	}
-	cpu, mem, err := m.getCpuAndMemoryForMachineType(template.Properties.MachineType, mig.GceRef().Zone)
+	machineType, err := m.migInfoProvider.GetMigMachineType(mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
-	return m.templates.BuildNodeFromTemplate(mig, template, cpu, mem, nil, m.reserved)
-}
-
-func (m *gceManagerImpl) getCpuAndMemoryForMachineType(machineType string, zone string) (cpu int64, mem int64, err error) {
-	if strings.HasPrefix(machineType, "custom-") {
-		return parseCustomMachineType(machineType)
-	}
-	machine, _ := m.cache.GetMachineFromCache(machineType, zone)
-	if machine == nil {
-		machine, err = m.GceService.FetchMachineType(zone, machineType)
-		if err != nil {
-			return 0, 0, err
-		}
-		m.cache.AddMachineToCache(machineType, zone, machine)
-	}
-	return machine.GuestCpus, machine.MemoryMb * units.MiB, nil
-}
-
-func parseCustomMachineType(machineType string) (cpu, mem int64, err error) {
-	// example custom-2-2816
-	var count int
-	count, err = fmt.Sscanf(machineType, "custom-%d-%d", &cpu, &mem)
-	if err != nil {
-		return
-	}
-	if count != 2 {
-		return 0, 0, fmt.Errorf("failed to parse all params in %s", machineType)
-	}
-	// Mb to bytes
-	mem = mem * units.MiB
-	return
+	return m.templates.BuildNodeFromTemplate(mig, template, machineType.CPU, machineType.Memory, nil, m.reserved)
 }
 
 // parseMIGAutoDiscoverySpecs returns any provided NodeGroupAutoDiscoverySpecs

--- a/cluster-autoscaler/cloudprovider/gce/machine_types.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+
+	gce_api "google.golang.org/api/compute/v1"
+)
+
+// MachineType represents information about underlying GCE machine used by one
+// or more MIGs.
+type MachineType struct {
+	// Name is the name of the particular MachineType (ex. e2-standard-4)
+	Name string
+	// CPU is the number of cores the machine has.
+	CPU int64
+	// Memory is the memory capacity of the machine in bytes.
+	Memory int64
+}
+
+// IsCustomMachine checks if a machine type is custom or predefined.
+func IsCustomMachine(name string) bool {
+	return strings.HasPrefix(name, "custom-")
+}
+
+// NewMachineTypeFromAPI creates a MachineType object based on machine type representation
+// from GCE API client.
+func NewMachineTypeFromAPI(name string, mt *gce_api.MachineType) (MachineType, error) {
+	if mt == nil {
+		return MachineType{}, fmt.Errorf("Failed to create MachineType %s from empty API object", name)
+	}
+	return MachineType{
+		Name:   name,
+		CPU:    mt.GuestCpus,
+		Memory: mt.MemoryMb * units.MiB,
+	}, nil
+}
+
+// NewCustomMachineType creates a MachineType object describing a custom GCE machine.
+// CPU and Memory are based on parsing custom machine name.
+func NewCustomMachineType(name string) (MachineType, error) {
+	// example custom-2-2816
+	var cpu, mem int64
+	var count int
+	count, err := fmt.Sscanf(name, "custom-%d-%d", &cpu, &mem)
+	if err != nil {
+		return MachineType{}, err
+	}
+	if count != 2 {
+		return MachineType{}, fmt.Errorf("failed to parse all params in %s", name)
+	}
+	mem = mem * units.MiB
+	return MachineType{
+		Name:   name,
+		CPU:    cpu,
+		Memory: mem,
+	}, nil
+}

--- a/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"testing"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCustomMachineType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		expectCustom bool
+		expectCPU    int64
+		expectMemory int64
+	}{
+		{
+			name:         "custom-2-2816",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2816 * units.MiB,
+		},
+		{
+			name: "other-a2-2816",
+		},
+		{
+			name: "other-2-2816",
+		},
+		{
+			name: "n1-standard-8",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectCustom, IsCustomMachine(tc.name))
+			m, err := NewCustomMachineType(tc.name)
+			if tc.expectCustom {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectCPU, m.CPU)
+				assert.Equal(t, tc.expectMemory, m.Memory)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler (GCE provider)

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move fetching MachineType for MIG to MigInforProvider. This allows
more consistent error handling with other GCE API calls and wraps
information about machine in a new struct, removing the need to interact
directly with raw GCE client objects in most CA provider code.
Also removed caching errors for MachineType API in cache.go, since
it was never never used anyway and it's inconsistent with error handling
for other APIs.

#### Does this PR introduce a user-facing change?

No