### PR TITLE
Add note in Azure autoscaler documentation about adding accelerator node label on VMSS when GPU nodes are involved.

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -54,6 +54,8 @@ k8s.io_cluster-autoscaler_node-template_resources_cpu: 3800m
 k8s.io_cluster-autoscaler_node-template_resources_memory: 11Gi
 ```
 
+> **_NOTE_**: GPU autoscaling consideration on VMSS : In case of scale set of GPU nodes, kubelet node label `accelerator` have to be added to node provisionned to make GPU scaling works.
+
 #### Autoscaling options
 
 Some autoscaling options can be defined per VM Scale Set, with tags.


### PR DESCRIPTION

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

I struggled for a long running issue arround GPU node scaling in a Rancher RKE Kubernetes Cluster using Azure VM Scale Set. The scale up process freeze after node count back to zero. After digging the source code I discover that label `accelerator` (hardcoded in azure cloud provider) should be setted on kubelet node to make cluster-autoscaler handle correctly GPU ressources.
I guess it would help further user to deal with it.


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
