### PR TITLE
GCE: Always add boot disk annotations to templates

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -96,7 +96,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 		// Boot disk price
 		bootDiskSize, _ := strconv.ParseInt(node.Annotations[BootDiskSizeAnnotation], 10, 64)
 		if bootDiskSize == 0 {
-			klog.Error("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSize)
+			klog.Errorf("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSize)
 			bootDiskSize = DefaultBootDiskSize
 		}
 		bootDiskType := node.Annotations[BootDiskTypeAnnotation]
@@ -104,7 +104,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 			bootDiskType = val
 		}
 		if bootDiskType == "" {
-			klog.Error("Boot disk type is not found for node %s, using default type %s", node.Name, DefaultBootDiskType)
+			klog.Errorf("Boot disk type is not found for node %s, using default type %s", node.Name, DefaultBootDiskType)
 			bootDiskType = DefaultBootDiskType
 		}
 		bootDiskPrice := model.PriceInfo.BootDiskPricePerHour()[bootDiskType]

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -159,6 +159,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			kubeEnv:                       "AUTOSCALER_ENV_VARS: os_distribution=cos;os=linux;ephemeral_storage_local_ssd_count=2\n",
 			physicalCpu:                   8,
 			physicalMemory:                200 * units.MiB,
+			bootDiskSizeGiB:               300,
 			ephemeralStorageLocalSSDCount: 2,
 			attachedLocalSSDCount:         2,
 			expectedErr:                   false,


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler


