### PR TITLE
Deduplicate Migration Doc from README.

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -64,7 +64,7 @@ The VPA objects in this version will no longer receive recommendations and
 existing recommendations will be removed. The objects will remain present though
 and a ConfigUnsupported condition will be set on them.
 
-This doc is for installing latest VPA. For instructions on migration from older versions see Migration Doc [Migration Doc](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/MIGRATE.md)
+This doc is for installing latest VPA. For instructions on migration from older versions see [Migration Doc](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/MIGRATE.md).
 
 
 ### Prerequisites


### PR DESCRIPTION
#### Which component this PR applies to?

 vertical-pod-autoscaler

#### What type of PR is this?

/kind bug
/kind documentation


#### What this PR does / why we need it:
This PR removes the Migration Doc word which appears 2 times in README. And Attach the **Vertical Pod Autoscaler Migration** link to it. For the better uniformity of the docs.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
NONE

```
