### PR TITLE
Replacing DeletedNode struct usage with *apiv1.Node directly

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -626,7 +626,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
-	assert.Equal(t, "ng1-2", clusterstate.GetCloudProviderDeletedNodes()[0].Node.Name)
+	assert.Equal(t, "ng1-2", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
 	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
 
 	// The node is removed from Kubernetes


### PR DESCRIPTION


#### Which component this PR applies to?
cluster-autoscaler

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR is a follow-up to the approved PR #4896.  The struct usage (and timestamp field) were unnecessary and didn't serve a purpose in this use-case.  This code change is meant to replace the usage of the newly defined struct in favor of using apiv1.Node directly instead.  A few function definitions have been modified to reflect the new return type and to remove unnecessary parameters for timestamps, which were only utilized in the struct.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
