### PR TITLE
add flag to ignore requests scaling up or down

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -27,7 +27,7 @@ REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.15
+TAG = 1.8.16
 
 BASEIMAGE?=gcr.io/distroless/static:latest
 

--- a/addon-resizer/README.md
+++ b/addon-resizer/README.md
@@ -28,6 +28,7 @@ Usage of pod_nanny:
       --storage="MISSING": The base storage resource requirement.
       --threshold=0: A number between 0-100. The dependent's resources are rewritten when they deviate from expected by more than threshold.
       --use-metrics=false: Whether to use apiserver metrics to detect cluster size instead of the default method of listing node objects from the Kubernetes API.
+      --ignoreResourceRequests=false: ignoring scaling up or down of the resource requests if this flag is true.
 ```
 
 ## Example deployment file

--- a/addon-resizer/nanny/kubernetes_client_test.go
+++ b/addon-resizer/nanny/kubernetes_client_test.go
@@ -97,7 +97,7 @@ func TestMergeResources(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mergeResources(tc.current, tc.new)
+			got := mergeResources(tc.current, tc.new, false)
 			verifyResources(t, "limits", got.Limits, tc.want.Limits)
 			verifyResources(t, "requests", got.Requests, tc.want.Requests)
 		})

--- a/addon-resizer/nanny/nanny_lib_test.go
+++ b/addon-resizer/nanny/nanny_lib_test.go
@@ -219,7 +219,7 @@ func TestShouldOverwriteResources(t *testing.T) {
 	}
 	for i, tc := range testCases {
 
-		gotOverwrite, gotOp := shouldOverwriteResources(tc.th, tc.x, tc.x, tc.y, tc.x)
+		gotOverwrite, gotOp := shouldOverwriteResources(tc.th, tc.x, tc.x, tc.y, tc.x, false)
 		if tc.wantOverwrite != gotOverwrite || tc.wantOp != gotOp {
 			t.Errorf("shouldOverwriteResources got (%t, %v), want (%t, %v) for test case %d.", gotOverwrite, gotOp, tc.wantOverwrite, tc.wantOp, i)
 		}
@@ -259,7 +259,7 @@ func TestUpdateResources(t *testing.T) {
 	for i, tc := range testCases {
 		k8s := newFakeKubernetesClient(10, tc.x, tc.x)
 		est := newFakeResourceEstimator(tc.y, tc.x)
-		got := updateResources(k8s, est, now, tc.lc, tc.sdd, tc.sud, tc.th, noChange)
+		got := updateResources(k8s, est, now, tc.lc, tc.sdd, tc.sud, tc.th, noChange, false)
 		if tc.want != got {
 			t.Errorf("updateResources got %d, want %d for test case %d.", got, tc.want, i)
 		}


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
addon-resizer
#### What type of PR is this?
feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR exposes flag to ignore the scaling of the requests and only scale the limits. In large clusters, scaling requests will cause the scheduling issues for other workload pods.  This flag enables to scale only the limits and have the specified fixed requests as is.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced --ignoreResourceRequests flag to ignore the scaling of the resource requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
