### PR TITLE
use docker buildx to buld multi-arch image (#4407)

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -28,6 +28,8 @@ IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 TAG = 1.8.15
+# The output type could either be docker (local), or registry.
+OUTPUT_TYPE ?= docker
 
 BASEIMAGE?=gcr.io/distroless/static:latest
 
@@ -44,8 +46,12 @@ sub-push-%:
 all-container: test $(addprefix sub-container-,$(ALL_ARCH))
 
 all-push: $(addprefix sub-push-,$(ALL_ARCH)) push-multi-arch
+
+buildx-setup:
+	docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
+
 container: .container-$(ARCH)
-.container-$(ARCH):
+.container-$(ARCH): buildx-setup
 	cp -r * $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
@@ -55,7 +61,11 @@ container: .container-$(ARCH)
             cd /go/src/k8s.io/autoscaler/addon-resizer/ && \
             CGO_ENABLED=0 GOARM=$(GOARM) GOARCH=$(ARCH) go build -a -installsuffix cgo --ldflags '-w -X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=$(TAG)' -o $(TEMP_DIR)/pod_nanny nanny/main/pod_nanny.go"
 
-	docker build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
+	docker buildx build \
+		--pull \
+		--platform linux/$(ARCH) \
+		--output=type=$(OUTPUT_TYPE) \
+		-t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
 
 test:
 	docker run --rm -it -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
currently, we can build image with the same arch as the host node, for cross-arch building, we need docker buildx
The following image is build by ARCH=arm64 make container on a amd64-based host and pushed into ACR, manifest inspect shows it still uses amd64 even though we build the image specifying ARCH=arm64

This PR cherry-picks the change from https://github.com/kubernetes/autoscaler/pull/4407

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
