### PR TITLE
chore: Document params for VPA recommender & updater (similar to CA's FAQs)

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -144,3 +144,61 @@ spec:
 ```
 
 and then deploy it manually if your vpa is already configured.
+
+## What are the parameters to Recommender?
+
+The following startup parameters are supported for VPA recommender:
+
+Name | Type | Description | Default
+|-|-|-|-|
+`recommendation-margin-fraction` | Float64 | Fraction of usage added as the safety margin to the recommended request | 0.15
+`pod-recommendation-min-cpu-millicores` | Float64 | Minimum CPU recommendation for a pod | 25
+`pod-recommendation-min-memory-mb` | Float64 | Minimum memory recommendation for a pod | 250
+`checkpoints-timeout` | Duration | Timeout for writing checkpoints since the start of the recommender's main loop | time.Minute
+`min-checkpoints` | Int | Minimum number of checkpoints to write per recommender's main loop | 10
+`memory-saver` | Bool | If true, only track pods which have an associated VPA | false
+`recommender-interval` | Duration | How often metrics should be fetched | 1*time.Minute
+`checkpoints-gc-interval` | Duration | How often orphaned checkpoints should be garbage collected | 10*time.Minute
+`prometheus-address` | String | Where to reach for Prometheus metrics | ""
+`prometheus-cadvisor-job-name` | String | Name of the prometheus job name which scrapes the cAdvisor metrics | "kubernetes-cadvisor"
+`address` | String | The address to expose Prometheus metrics. | ":8942"
+`kubeconfig` | String | Path to a kubeconfig. Only required if out-of-cluster. | ""
+`kube-api-qps` | Float64 | QPS limit when making requests to Kubernetes apiserver | 5.0
+`kube-api-burst` | Float64 | QPS burst limit when making requests to Kubernetes apiserver | 10.0
+`storage` | String | Specifies storage mode. Supported values: prometheus, checkpoint (default | ""
+`history-length` | String | How much time back prometheus have to be queried to get historical metrics | "8d"
+`history-resolution` | String | Resolution at which Prometheus is queried for historical metrics | "1h"
+`prometheus-query-timeout` | String | How long to wait before killing long queries | "5m"
+`pod-label-prefix` | String | Which prefix to look for pod labels in metrics | "pod_label_"
+`metric-for-pod-labels` | String | Which metric to look for pod labels in metrics | "up{job=\"kubernetes-pods\"}"
+`pod-namespace-label` | String | Label name to look for pod namespaces | "kubernetes_namespace"
+`pod-name-label` | String | Label name to look for pod names | "kubernetes_pod_name"
+`container-namespace-label` | String | Label name to look for container namespaces | "namespace"
+`container-pod-name-label` | String | Label name to look for container pod names | "pod_name"
+`container-name-label` | String | Label name to look for container names | "name"
+`vpa-object-namespace` | String | Namespace to search for VPA objects and pod stats. Empty means all namespaces will be used. | apiv1.NamespaceAll
+`memory-aggregation-interval` | Duration | The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval | model.DefaultMemoryAggregationInterval
+`memory-aggregation-interval-count` | Int64 | The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count. | model.DefaultMemoryAggregationIntervalCount
+`memory-histogram-decay-half-life` | Duration | The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period. | model.DefaultMemoryHistogramDecayHalfLife
+`cpu-histogram-decay-half-life` | Duration | The amount of time it takes a historical CPU usage sample to lose half of its weight. | model.DefaultCPUHistogramDecayHalfLife
+
+## What are the parameters to Updater?
+
+The following startup parameters are supported for VPA updater:
+
+Name | Type | Description | Default
+|-|-|-|-|
+`pod-update-threshold` | Float64 | Ignore updates that have priority lower than the value of this flag | 0.1
+`in-recommendation-bounds-eviction-lifetime-threshold` | Duration | Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range | time.Hour*12
+`evict-after-oom-threshold` | Duration | Evict pod that has only one container and it OOMed in less than evict-after-oom-threshold since start. | 10*time.Minute
+`updater-interval` | Duration | How often updater should run | 1*time.Minute
+`min-replicas` | Int | Minimum number of replicas to perform update | 2
+`eviction-tolerance` | Float64 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted. | 0.5
+`eviction-rate-limit` | Float64 | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable the rate limiter. | -1
+`eviction-rate-burst` | Int | Burst of pods that can be evicted. | 1
+`address` | String | The address to expose Prometheus metrics. | ":8943"
+`kubeconfig` | String | Path to a kubeconfig. Only required if out-of-cluster. | ""
+`kube-api-qps` | Float64 | QPS limit when making requests to Kubernetes apiserver | 5.0
+`kube-api-burst` | Float64 | QPS burst limit when making requests to Kubernetes apiserver | 10.0
+`use-admission-controller-status` | Bool | If true, updater will only evict pods when admission controller status is valid. | true
+`vpa-object-namespace` | String | Namespace to search for VPA objects. Empty means all namespaces will be used. | apiv1.NamespaceAll


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

CA has parameters documented: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca

However, I don't see parameters for VPA. This adds them to the FAQ, similar how the cluster-autoscaler lists the parameters in it's respective FAQ.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/5020

#### Special notes for your reviewer:

I tried to automate a bit of this w/ a Python script, looking for another pair of eyes make sure the parameters & descriptions line up. I spot-checked and it was looking okay to me. [Script](https://dev.to/gsweene2/find-document-a-go-projects-flags-as-markdown-5689)

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
