### PR TITLE
CA: GCE: implement GetMachineFamily, fix IsCustomMachine

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -19,7 +19,6 @@ package gce
 import (
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -142,10 +141,10 @@ func (model *GcePriceModel) getPreemptibleDiscount(node *apiv1.Node) float64 {
 	if !found {
 		return 1.0
 	}
-	instanceFamily := getInstanceFamily(instanceType)
+	instanceFamily, _ := GetMachineFamily(instanceType)
 
 	discountMap := model.PriceInfo.PredefinedPreemptibleDiscount()
-	if isInstanceCustom(instanceType) {
+	if IsCustomMachine(instanceType) {
 		discountMap = model.PriceInfo.CustomPreemptibleDiscount()
 	}
 
@@ -171,8 +170,8 @@ func (model *GcePriceModel) getBasePrice(resources apiv1.ResourceList, instanceT
 		return 0
 	}
 	hours := getHours(startTime, endTime)
-	instanceFamily := getInstanceFamily(instanceType)
-	isCustom := isInstanceCustom(instanceType)
+	instanceFamily, _ := GetMachineFamily(instanceType)
+	isCustom := IsCustomMachine(instanceType)
 	price := 0.0
 
 	cpu := resources[apiv1.ResourceCPU]
@@ -222,14 +221,6 @@ func getHours(startTime time.Time, endTime time.Time) float64 {
 	minutes := math.Ceil(float64(endTime.Sub(startTime)) / float64(time.Minute))
 	hours := minutes / 60.0
 	return hours
-}
-
-func getInstanceFamily(instanceType string) string {
-	return strings.Split(instanceType, "-")[0]
-}
-
-func isInstanceCustom(instanceType string) bool {
-	return strings.Contains(instanceType, "custom")
 }
 
 // hasPreemptiblePricing returns whether we should use preemptible pricing for a node, based on labels. Spot VMs have


### PR DESCRIPTION
IsCustomMachine didn't take machine types with family prefix
(e.g. n2-custom-2-2816) into account.