### PR TITLE
Get capi targetsize from cache

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1072,7 +1072,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		ng = nodegroups[0]
 
 		// Check the nodegroup is at the expected size
-		actualSize, err := ng.TargetSize()
+		actualSize, err := ng.scalableResource.Replicas()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -60,6 +60,17 @@ func TestSetSize(t *testing.T) {
 		if s.Spec.Replicas != int32(updatedReplicas) {
 			t.Errorf("expected %v, got: %v", updatedReplicas, s.Spec.Replicas)
 		}
+
+		replicas, found, err := unstructured.NestedInt64(sr.unstructured.Object, "spec", "replicas")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found {
+			t.Fatal("replicas = 0")
+		}
+		if replicas != int64(updatedReplicas) {
+			t.Errorf("expected %v, got: %v", updatedReplicas, replicas)
+		}
 	}
 
 	t.Run("MachineSet", func(t *testing.T) {


### PR DESCRIPTION
#### Which component this PR applies to?

Cluster autoscaler - cluster api.

#### What type of PR is this?
This ensured that access to replicas during scale down operations were never stale by accessing the API server https://github.com/kubernetes/autoscaler/issues/3104.

This honoured that behaviour while moving to unstructured client https://github.com/kubernetes/autoscaler/pull/3312.

This regressed that behaviour while trying to reduce the API server load https://github.com/kubernetes/autoscaler/pull/4443.

This put back the never stale replicas behaviour at the cost of loading back the API server https://github.com/kubernetes/autoscaler/pull/4634.

Currently on e.g a 48 minutes cluster with no scaling activity it does 1.4k get request to the scale subresource.
This PR tries to satisfy both non stale replicas during scale down and prevent the API server from being overloaded. To achieve that it lets TargetSize which is called on every autoscaling cluster state loop from come from cache while getting fresh replicas at the time of perform the operations.

Also note that the scale down implementation has changed https://github.com/kubernetes/autoscaler/commits/master/cluster-autoscaler/core/scaledown.


/area provider/cluster-api

/kind bug
/kind cleanup



