### PR TITLE
Adapt e2e OOM test to CrashLoopBackOff scenario

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "8000"}
+	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "40000"}
 )
 
 var (
@@ -443,8 +443,8 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 		Timeout:     timeoutRC,
 		Replicas:    replicas,
 		Annotations: make(map[string]string),
-		MemRequest:  1024 * 1024 * 1024,
-		MemLimit:    1024 * 1024 * 1024,
+		MemRequest:  1024 * 1024 * 300,
+		MemLimit:    1024 * 1024 * 500,
 	}
 
 	dpConfig := testutils.DeploymentConfig{


### PR DESCRIPTION
**DO NOT MERGE THIS INTO MASTER, AS IT BREAKS EXISTING TESTS**

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
vertical-pod-autoscaler

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
Translating the repro example of #4981 into the already existing e2e test for OOMKills. As described in the original issue: Pods get into `CrashLoopBackOff`, the VPA status stays empty, but the VPA observes OOMKill events.

The Recommender logs show that the OOMKill events are correctly observed
```
I0715 15:16:09.485249       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:15:47 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-fn87z} ContainerName:hamster}}
I0715 15:16:09.485287       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:15:46 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-phhvs} ContainerName:hamster}}
I0715 15:16:09.485307       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:15:46 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-5cr6k} ContainerName:hamster}}
I0715 15:17:09.486781       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:02 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-fn87z} ContainerName:hamster}}
I0715 15:17:09.486818       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:02 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-5cr6k} ContainerName:hamster}}
I0715 15:17:09.486844       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:02 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-phhvs} ContainerName:hamster}}
I0715 15:17:09.486865       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:29 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-fn87z} ContainerName:hamster}}
I0715 15:17:09.486889       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:33 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-phhvs} ContainerName:hamster}}
I0715 15:17:09.486907       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-15 15:16:30 +0000 UTC Memory:314572800 ContainerID:{PodID:{Namespace:vertical-pod-autoscaling-362 PodName:hamster-76b847ffdf-5cr6k} ContainerName:hamster}}
```

but the VPA status remains empty and does never get a recommendation
```
status:
  conditions:
  - lastTransitionTime: "2022-07-15T15:16:09Z"
    status: "False"
    type: RecommendationProvided
  recommendation: {}
```

#### Special notes for your reviewer:
* merge this PR
* run the e2e tests
* see the test 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

