### PR TITLE
use strings.Join to build list of names

### DIFF
--- a/cluster-autoscaler/cloudprovider/resource_limiter.go
+++ b/cluster-autoscaler/cloudprovider/resource_limiter.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cloudprovider
 
 import (
-	"bytes"
 	"fmt"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"math"
+	"strings"
 )
 
 // ResourceLimiter contains limits (max, min) for resources (cores, memory etc.).
@@ -82,12 +82,9 @@ func (r *ResourceLimiter) HasMaxLimitSet(resourceName string) bool {
 }
 
 func (r *ResourceLimiter) String() string {
-	var buffer bytes.Buffer
+	var resourceDetails = []string{}
 	for _, name := range r.GetResources() {
-		if buffer.Len() > 0 {
-			buffer.WriteString(", ")
-		}
-		buffer.WriteString(fmt.Sprintf("{%s : %d - %d}", name, r.GetMin(name), r.GetMax(name)))
+		resourceDetails = append(resourceDetails, fmt.Sprintf("{%s : %d - %d}", name, r.GetMin(name), r.GetMax(name)))
 	}
-	return buffer.String()
+	return strings.Join(resourceDetails, ", ")
 }

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -17,7 +17,6 @@ limitations under the License.
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -575,14 +574,11 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 				}
 			}
 			if len(targetNodeGroups) > 1 {
-				var buffer bytes.Buffer
-				for i, ng := range targetNodeGroups {
-					if i > 0 {
-						buffer.WriteString(", ")
-					}
-					buffer.WriteString(ng.Id())
+				var names = []string{}
+				for _, ng := range targetNodeGroups {
+					names = append(names, ng.Id())
 				}
-				klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), buffer.String())
+				klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), strings.Join(names, ", "))
 			}
 		}
 		scaleUpInfos, typedErr := processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(


### PR DESCRIPTION
random little cleanup to make the code more readable / ideomatic
... what we are doing is joining string together, so use `strings.Join` instead of buffer math