### PR TITLE
Identifying cloud provider deleted nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -127,8 +127,8 @@ func (ali *aliCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return ali.manager.GetAsgForInstance(instanceId)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (ali *aliCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (ali *aliCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -127,6 +127,11 @@ func (ali *aliCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return ali.manager.GetAsgForInstance(instanceId)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (ali *aliCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (ali *aliCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -120,6 +120,11 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	}, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (aws *awsCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (aws *awsCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -120,8 +120,8 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	}, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (aws *awsCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (aws *awsCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -106,6 +106,11 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 	return azure.azureManager.GetNodeGroupForInstance(ref)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (azure *AzureCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (azure *AzureCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -108,7 +108,7 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 
 // NodeExists returns whether node exists in this cloud provider
 func (azure *AzureCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -106,8 +106,8 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 	return azure.azureManager.GetNodeGroupForInstance(ref)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (azure *AzureCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (azure *AzureCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -180,8 +180,8 @@ func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (c
 	return asg, err
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (baiducloud *baiducloudCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (baiducloud *baiducloudCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -182,7 +182,7 @@ func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (c
 
 // NodeExists returns whether node exists in this cloud provider
 func (baiducloud *baiducloudCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -180,6 +180,11 @@ func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (c
 	return asg, err
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (baiducloud *baiducloudCloudProvider) NodeExists(*apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (baiducloud *baiducloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
@@ -104,6 +104,11 @@ func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (d *bizflycloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
 func (d *bizflycloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
@@ -104,8 +104,8 @@ func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (d *bizflycloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (d *bizflycloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
@@ -106,7 +106,7 @@ func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 
 // NodeExists returns whether node exists in this cloud provider
 func (d *bizflycloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
@@ -83,7 +83,7 @@ func (b *brightboxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 
 // NodeExists returns whether node exists in this cloud provider
 func (b *brightboxCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Refresh is before every main loop and can be used to dynamically

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
@@ -81,6 +81,11 @@ func (b *brightboxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (b *brightboxCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Refresh is before every main loop and can be used to dynamically
 // update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
@@ -81,8 +81,8 @@ func (b *brightboxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (b *brightboxCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (b *brightboxCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
@@ -124,7 +124,7 @@ func (ccp *cherryCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 
 // NodeExists returns whether node exists in this cloud provider
 func (ccp *cherryCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
@@ -122,6 +122,11 @@ func (ccp *cherryCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (ccp *cherryCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (ccp *cherryCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
@@ -122,8 +122,8 @@ func (ccp *cherryCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (ccp *cherryCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (ccp *cherryCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
@@ -99,8 +99,8 @@ func (d *civoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (d *civoCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (d *civoCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
@@ -101,7 +101,7 @@ func (d *civoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 
 // NodeExists returns whether node exists in this cloud provider
 func (d *civoCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
@@ -99,6 +99,11 @@ func (d *civoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (d *civoCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
 func (d *civoCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -100,6 +100,10 @@ type CloudProvider interface {
 	// occurred. Must be implemented.
 	NodeGroupForNode(*apiv1.Node) (NodeGroup, error)
 
+	// NodeExists returns whether the node exists in cloud provider,
+	// true if the node is available, false if it has been deleted
+	NodeExists(*apiv1.Node) (bool, error)
+
 	// Pricing returns pricing model for this cloud provider or error if not available.
 	// Implementation optional.
 	Pricing() (PricingModel, errors.AutoscalerError)

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -100,9 +100,9 @@ type CloudProvider interface {
 	// occurred. Must be implemented.
 	NodeGroupForNode(*apiv1.Node) (NodeGroup, error)
 
-	// NodeExists returns whether the node exists in cloud provider,
-	// true if the node is available, false if it has been deleted
-	NodeExists(*apiv1.Node) (bool, error)
+	// HasInstance returns whether the node has corresponding instance in cloud provider,
+	// true if the node has an instance, false if it no longer exists
+	HasInstance(*apiv1.Node) (bool, error)
 
 	// Pricing returns pricing model for this cloud provider or error if not available.
 	// Implementation optional.

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -68,8 +68,8 @@ func (provider *cloudStackCloudProvider) NodeGroupForNode(node *v1.Node) (cloudp
 	return provider.manager.clusterForNode(node)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (provider *cloudStackCloudProvider) NodeExists(node *v1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (provider *cloudStackCloudProvider) HasInstance(node *v1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
@@ -155,7 +155,7 @@ func BuildCloudStack(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	}
 
 	return &cloudStackCloudProvider{
-		manager:         manager,
+		manager: manager,
 		resourceLimiter: rl,
 	}
 }

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -70,7 +70,7 @@ func (provider *cloudStackCloudProvider) NodeGroupForNode(node *v1.Node) (cloudp
 
 // NodeExists returns whether node exists in this cloud provider
 func (provider *cloudStackCloudProvider) NodeExists(node *v1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -155,7 +155,7 @@ func BuildCloudStack(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	}
 
 	return &cloudStackCloudProvider{
-		manager: manager,
+		manager:         manager,
 		resourceLimiter: rl,
 	}
 }

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -68,6 +68,11 @@ func (provider *cloudStackCloudProvider) NodeGroupForNode(node *v1.Node) (cloudp
 	return provider.manager.clusterForNode(node)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (provider *cloudStackCloudProvider) NodeExists(node *v1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
 func (provider *cloudStackCloudProvider) Cleanup() error {
 	return provider.manager.cleanup()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -81,8 +81,8 @@ func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup,
 	return ng, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (p *provider) NodeExists(node *corev1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (p *provider) HasInstance(node *corev1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -81,6 +81,11 @@ func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup,
 	return ng, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (p *provider) NodeExists(node *corev1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 func (*provider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -83,7 +83,7 @@ func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup,
 
 // NodeExists returns whether node exists in this cloud provider
 func (p *provider) NodeExists(node *corev1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 func (*provider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -101,6 +101,11 @@ func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (d *digitaloceanCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
 func (d *digitaloceanCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -103,7 +103,7 @@ func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 
 // NodeExists returns whether node exists in this cloud provider
 func (d *digitaloceanCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -101,8 +101,8 @@ func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (d *digitaloceanCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (d *digitaloceanCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -131,6 +131,11 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nodeGroup, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (e *exoscaleCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (e *exoscaleCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -133,7 +133,7 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 
 // NodeExists returns whether node exists in this cloud provider
 func (e *exoscaleCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -131,8 +131,8 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nodeGroup, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (e *exoscaleCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (e *exoscaleCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -134,6 +134,11 @@ func (e *externalGrpcCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 	return ng, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (e *externalGrpcCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // pricingModel implements cloudprovider.PricingModel interface.
 type pricingModel struct {
 	client protos.CloudProviderClient

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -134,8 +134,8 @@ func (e *externalGrpcCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 	return ng, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (e *externalGrpcCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (e *externalGrpcCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -136,7 +136,7 @@ func (e *externalGrpcCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 
 // NodeExists returns whether node exists in this cloud provider
 func (e *externalGrpcCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // pricingModel implements cloudprovider.PricingModel interface.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -101,6 +101,11 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return mig, err
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (gce *GceCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (gce *GceCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return gce.pricingModel, nil

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -101,8 +101,8 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return mig, err
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (gce *GceCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (gce *GceCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -103,7 +103,7 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 
 // NodeExists returns whether node exists in this cloud provider
 func (gce *GceCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -101,7 +101,7 @@ func (d *HetznerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider
 
 // NodeExists returns whether node exists in this cloud provider
 func (d *HetznerCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -99,6 +99,11 @@ func (d *HetznerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider
 	return group, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (d *HetznerCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
 func (d *HetznerCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -99,8 +99,8 @@ func (d *HetznerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider
 	return group, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (d *HetznerCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (d *HetznerCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -125,7 +125,7 @@ func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpr
 
 // NodeExists returns whether node exists in this cloud provider
 func (hcp *huaweicloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available. Not implemented.

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -123,8 +123,8 @@ func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpr
 	return hcp.cloudServiceManager.GetAsgForInstance(instanceID)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (hcp *huaweicloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (hcp *huaweicloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -123,6 +123,11 @@ func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpr
 	return hcp.cloudServiceManager.GetAsgForInstance(instanceID)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (hcp *huaweicloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available. Not implemented.
 func (hcp *huaweicloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -232,6 +232,11 @@ func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (ic *IonosCloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
 func (ic *IonosCloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -232,8 +232,8 @@ func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (ic *IonosCloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (ic *IonosCloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -234,7 +234,7 @@ func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 
 // NodeExists returns whether node exists in this cloud provider
 func (ic *IonosCloudCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
@@ -70,6 +70,11 @@ func (k *kamateraCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (k *kamateraCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (k *kamateraCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
@@ -72,7 +72,7 @@ func (k *kamateraCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 
 // NodeExists returns whether node exists in this cloud provider
 func (k *kamateraCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
@@ -70,8 +70,8 @@ func (k *kamateraCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (k *kamateraCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (k *kamateraCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -139,6 +139,11 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (kubemark *KubemarkCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return false, cloudprovider.ErrNotImplemented
+}
+
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
 func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -141,7 +141,7 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 
 // NodeExists returns whether node exists in this cloud provider
 func (kubemark *KubemarkCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
-	return false, cloudprovider.ErrNotImplemented
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -139,8 +139,8 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (kubemark *KubemarkCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (kubemark *KubemarkCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -80,6 +80,11 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, cloudprovider.ErrNotImplemented
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (kubemark *KubemarkCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
 func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -80,8 +80,8 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (kubemark *KubemarkCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (kubemark *KubemarkCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
@@ -67,6 +67,11 @@ func (l *linodeCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (l *linodeCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (l *linodeCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
@@ -67,8 +67,8 @@ func (l *linodeCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (l *linodeCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (l *linodeCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -135,8 +135,8 @@ func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (mcp *magnumCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (mcp *magnumCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -135,6 +135,11 @@ func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (mcp *magnumCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing is not implemented.
 func (mcp *magnumCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented

--- a/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
+++ b/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
@@ -177,6 +177,29 @@ func (_m *CloudProvider) NodeGroupForNode(_a0 *v1.Node) (cloudprovider.NodeGroup
 	return r0, r1
 }
 
+// NodeExists provides a mock function with given fields:
+func (_m *CloudProvider) NodeExists(_a0 *v1.Node) (bool, error) {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*v1.Node) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(bool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*v1.Node) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NodeGroups provides a mock function with given fields:
 func (_m *CloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	ret := _m.Called()

--- a/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
+++ b/cluster-autoscaler/cloudprovider/mocks/CloudProvider.go
@@ -177,8 +177,8 @@ func (_m *CloudProvider) NodeGroupForNode(_a0 *v1.Node) (cloudprovider.NodeGroup
 	return r0, r1
 }
 
-// NodeExists provides a mock function with given fields:
-func (_m *CloudProvider) NodeExists(_a0 *v1.Node) (bool, error) {
+// HasInstance provides a mock function with given fields:
+func (_m *CloudProvider) HasInstance(_a0 *v1.Node) (bool, error) {
 	ret := _m.Called(_a0)
 
 	var r0 bool

--- a/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
@@ -96,8 +96,8 @@ func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.Node
 	return ng, err
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (ocp *OciCloudProvider) NodeExists(n *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (ocp *OciCloudProvider) HasInstance(n *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_cloud_provider.go
@@ -96,6 +96,11 @@ func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.Node
 	return ng, err
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (ocp *OciCloudProvider) NodeExists(n *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (ocp *OciCloudProvider) Pricing() (cloudprovider.PricingModel, caerrors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -151,8 +151,8 @@ func (provider *OVHCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 	return ng, err
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (provider *OVHCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (provider *OVHCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -151,6 +151,11 @@ func (provider *OVHCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 	return ng, err
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (provider *OVHCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // findNodeGroupFromCache tries to retrieve the associated node group from an already built mapping in cache
 func (provider *OVHCloudProvider) findNodeGroupFromCache(providerID string) cloudprovider.NodeGroup {
 	if ng, ok := provider.manager.NodeGroupPerProviderID[providerID]; ok {

--- a/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
@@ -120,8 +120,8 @@ func (pcp *packetCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, fmt.Errorf("Could not find group for node: %s", node.Spec.ProviderID)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (pcp *packetCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (pcp *packetCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
@@ -120,6 +120,11 @@ func (pcp *packetCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	return nil, fmt.Errorf("Could not find group for node: %s", node.Spec.ProviderID)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (pcp *packetCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 func (pcp *packetCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return &PacketPriceModel{}, nil

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
@@ -171,6 +171,11 @@ func (provider *RancherCloudProvider) NodeGroupForNode(node *corev1.Node) (cloud
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (provider *RancherCloudProvider) NodeExists(node *corev1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
 func (provider *RancherCloudProvider) GetAvailableMachineTypes() ([]string, error) {

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
@@ -171,8 +171,8 @@ func (provider *RancherCloudProvider) NodeGroupForNode(node *corev1.Node) (cloud
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (provider *RancherCloudProvider) NodeExists(node *corev1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (provider *RancherCloudProvider) HasInstance(node *corev1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -162,8 +162,8 @@ func (scw *scalewayCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 	return scw.nodeGroupForNode(node)
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (scw *scalewayCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (scw *scalewayCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -162,6 +162,11 @@ func (scw *scalewayCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 	return scw.nodeGroupForNode(node)
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (scw *scalewayCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 func (scw *scalewayCloudProvider) NodePrice(node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
 	ng, err := scw.nodeGroupForNode(node)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
@@ -109,6 +109,11 @@ func (tencentcloud *tencentCloudProvider) NodeGroupForNode(node *apiv1.Node) (cl
 	return asg, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (tencentcloud *tencentCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // GPULabel returns the label added to nodes with GPU resource.
 func (tencentcloud *tencentCloudProvider) GPULabel() string {
 	return GPULabel

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
@@ -109,8 +109,8 @@ func (tencentcloud *tencentCloudProvider) NodeGroupForNode(node *apiv1.Node) (cl
 	return asg, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (tencentcloud *tencentCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (tencentcloud *tencentCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -253,6 +253,14 @@ func (tcp *TestCloudProvider) AddNode(nodeGroupId string, node *apiv1.Node) {
 	tcp.nodes[node.Name] = nodeGroupId
 }
 
+// DeleteNode delete the given node from the provider.
+func (tcp *TestCloudProvider) DeleteNode(node *apiv1.Node) {
+	tcp.Lock()
+	defer tcp.Unlock()
+
+	delete(tcp.nodes, node.Name)
+}
+
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 func (tcp *TestCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
 	return tcp.resourceLimiter, nil

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
@@ -81,6 +81,11 @@ func (v *vultrCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return nil, nil
 }
 
+// NodeExists returns whether node exists in this cloud provider
+func (v *vultrCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
 func (v *vultrCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
@@ -81,8 +81,8 @@ func (v *vultrCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	return nil, nil
 }
 
-// NodeExists returns whether node exists in this cloud provider
-func (v *vultrCloudProvider) NodeExists(node *apiv1.Node) (bool, error) {
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (v *vultrCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -121,6 +120,7 @@ type ClusterStateRegistry struct {
 	acceptableRanges                   map[string]AcceptableRange
 	incorrectNodeGroupSizes            map[string]IncorrectNodeGroupSize
 	unregisteredNodes                  map[string]UnregisteredNode
+	deletedNodes                       map[string]*apiv1.Node
 	candidatesForScaleDown             map[string][]string
 	backoff                            backoff.Backoff
 	lastStatus                         *api.ClusterAutoscalerStatus
@@ -153,6 +153,7 @@ func NewClusterStateRegistry(cloudProvider cloudprovider.CloudProvider, config C
 		acceptableRanges:                make(map[string]AcceptableRange),
 		incorrectNodeGroupSizes:         make(map[string]IncorrectNodeGroupSize),
 		unregisteredNodes:               make(map[string]UnregisteredNode),
+		deletedNodes:                    make(map[string]*apiv1.Node),
 		candidatesForScaleDown:          make(map[string][]string),
 		backoff:                         backoff,
 		lastStatus:                      emptyStatus,
@@ -292,6 +293,7 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 	}
 
 	cloudProviderNodeInstances, err := csr.getCloudProviderNodeInstances()
+	cloudProviderNodesRemoved := csr.getCloudProviderDeletedNodes(nodes, cloudProviderNodeInstances)
 	if err != nil {
 		return err
 	}
@@ -306,6 +308,7 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 	csr.cloudProviderNodeInstances = cloudProviderNodeInstances
 
 	csr.updateUnregisteredNodes(notRegistered)
+	csr.updateCloudProviderDeletedNodes(cloudProviderNodesRemoved)
 	csr.updateReadinessStats(currentTime)
 
 	// update acceptable ranges based on requests from last loop and targetSizes
@@ -541,7 +544,7 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 
 	update := func(current Readiness, node *apiv1.Node, nr kube_util.NodeReadiness) Readiness {
 		current.Registered++
-		if deletetaint.HasToBeDeletedTaint(node) {
+		if _, exists := csr.deletedNodes[node.Name]; exists {
 			current.Deleted++
 		} else if nr.Ready {
 			current.Ready++
@@ -665,6 +668,30 @@ func (csr *ClusterStateRegistry) GetUnregisteredNodes() []UnregisteredNode {
 	result := make([]UnregisteredNode, 0, len(csr.unregisteredNodes))
 	for _, unregistered := range csr.unregisteredNodes {
 		result = append(result, unregistered)
+	}
+	return result
+}
+
+func (csr *ClusterStateRegistry) updateCloudProviderDeletedNodes(deletedNodes []*apiv1.Node) {
+	result := make(map[string]*apiv1.Node)
+	for _, deleted := range deletedNodes {
+		if prev, found := csr.deletedNodes[deleted.Name]; found {
+			result[deleted.Name] = prev
+		} else {
+			result[deleted.Name] = deleted
+		}
+	}
+	csr.deletedNodes = result
+}
+
+//GetCloudProviderDeletedNodes returns a list of all nodes removed from cloud provider but registered in Kubernetes.
+func (csr *ClusterStateRegistry) GetCloudProviderDeletedNodes() []*apiv1.Node {
+	csr.Lock()
+	defer csr.Unlock()
+
+	result := make([]*apiv1.Node, 0, len(csr.deletedNodes))
+	for _, deleted := range csr.deletedNodes {
+		result = append(result, deleted)
 	}
 	return result
 }
@@ -956,6 +983,47 @@ func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances ma
 		}
 	}
 	return notRegistered
+}
+
+// Calculates which of the registered nodes in Kubernetes that do not exist in cloud provider.
+func (csr *ClusterStateRegistry) getCloudProviderDeletedNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances map[string][]cloudprovider.Instance) []*apiv1.Node {
+	nodesRemoved := make([]*apiv1.Node, 0)
+	currentCloudInstances := make(map[string]string, 0)
+	registeredNodes := make(map[string]*apiv1.Node, 0)
+	for nodeGroupName, instances := range cloudProviderNodeInstances {
+		for _, instance := range instances {
+			currentCloudInstances[instance.Id] = nodeGroupName
+		}
+	}
+	for _, node := range allNodes {
+		registeredNodes[node.Name] = node
+	}
+
+	// Fill previously deleted nodes, if they are still registered in Kubernetes
+	for nodeName, node := range csr.deletedNodes {
+		// Safety check to prevent flagging Kubernetes nodes as deleted
+		// if the Cloud Provider instance is re-discovered
+		_, cloudProviderFound := currentCloudInstances[node.Name]
+		if _, found := registeredNodes[nodeName]; found && !cloudProviderFound {
+			nodesRemoved = append(nodesRemoved, node)
+		}
+	}
+
+	// Seek nodes that may have been deleted since last update
+	// cloudProviderNodeInstances are retrieved by nodeGroup,
+	// not autoscaled nodes will be excluded
+	for _, instances := range csr.cloudProviderNodeInstances {
+		for _, instance := range instances {
+			if _, found := currentCloudInstances[instance.Id]; !found {
+				// Check Kubernetes registered nodes for corresponding deleted
+				// Cloud Provider instance
+				if kubeNode, kubeNodeFound := registeredNodes[instance.Id]; kubeNodeFound {
+					nodesRemoved = append(nodesRemoved, kubeNode)
+				}
+			}
+		}
+	}
+	return nodesRemoved
 }
 
 // GetAutoscaledNodesCount calculates and returns the actual and the target number of nodes

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -294,7 +295,6 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 	}
 
 	cloudProviderNodeInstances, err := csr.getCloudProviderNodeInstances()
-	cloudProviderNodesRemoved := csr.getCloudProviderDeletedNodes(nodes, cloudProviderNodeInstances)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -38,14 +38,15 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 )
 
-// GetCloudProviderDeletedNodes returns a list of all nodes removed from cloud provider but registered in Kubernetes.
-func GetCloudProviderDeletedNodes(csr *ClusterStateRegistry) []*apiv1.Node {
+// GetCloudProviderDeletedNodeNames returns a list of the names of nodes removed
+// from cloud provider but registered in Kubernetes.
+func GetCloudProviderDeletedNodeNames(csr *ClusterStateRegistry) []string {
 	csr.Lock()
 	defer csr.Unlock()
 
-	result := make([]*apiv1.Node, 0, len(csr.deletedNodes))
-	for _, deleted := range csr.deletedNodes {
-		result = append(result, deleted)
+	result := make([]string, 0, len(csr.deletedNodes))
+	for nodeName, _ := range csr.deletedNodes {
+		result = append(result, nodeName)
 	}
 	return result
 }
@@ -671,7 +672,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	// Nodes are registered correctly between Kubernetes and cloud provider.
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(GetCloudProviderDeletedNodes(clusterstate)))
+	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 
 	// The node was removed from Cloud Provider
 	// should be counted as Deleted by cluster state
@@ -683,8 +684,8 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNgNode}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(GetCloudProviderDeletedNodes(clusterstate)))
-	assert.Equal(t, "ng1-2", GetCloudProviderDeletedNodes(clusterstate)[0].Name)
+	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
+	assert.Equal(t, "ng1-2", GetCloudProviderDeletedNodeNames(clusterstate)[0])
 	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
 
 	// The node is removed from Kubernetes
@@ -692,7 +693,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(GetCloudProviderDeletedNodes(clusterstate)))
+	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 
 	// New Node is added afterwards
 	ng1_3 := BuildTestNode("ng1-3", 1000, 1000)
@@ -704,7 +705,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_3, noNgNode}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(GetCloudProviderDeletedNodes(clusterstate)))
+	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 
 	// Newly added node is removed from Cloud Provider
 	// should be counted as Deleted by cluster state
@@ -716,8 +717,8 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(GetCloudProviderDeletedNodes(clusterstate)))
-	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodes(clusterstate)[0].Name)
+	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
+	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodeNames(clusterstate)[0])
 	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
 
 	// Confirm that previously identified deleted Cloud Provider nodes are still included
@@ -726,8 +727,8 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(GetCloudProviderDeletedNodes(clusterstate)))
-	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodes(clusterstate)[0].Name)
+	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
+	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodeNames(clusterstate)[0])
 	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
 
 	// The node is removed from Kubernetes
@@ -735,7 +736,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, nil, now)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(GetCloudProviderDeletedNodes(clusterstate)))
+	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 }
 
 func TestUpdateLastTransitionTimes(t *testing.T) {

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clusterstate
 
 import (
+	"fmt"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"testing"
 	"time"
 
@@ -481,6 +483,22 @@ func TestUpcomingNodes(t *testing.T) {
 	provider.AddNodeGroup("ng4", 1, 10, 1)
 	provider.AddNode("ng4", ng4_1)
 
+	// One node is already there, for a second nde deletion / draining was already started.
+	ng5_1 := BuildTestNode("ng5-1", 1000, 1000)
+	SetNodeReadyState(ng5_1, true, now.Add(-time.Minute))
+	ng5_2 := BuildTestNode("ng5-2", 1000, 1000)
+	SetNodeReadyState(ng5_2, true, now.Add(-time.Minute))
+	ng5_2.Spec.Taints = []apiv1.Taint{
+		{
+			Key:    deletetaint.ToBeDeletedTaint,
+			Value:  fmt.Sprint(time.Now().Unix()),
+			Effect: apiv1.TaintEffectNoSchedule,
+		},
+	}
+	provider.AddNodeGroup("ng5", 1, 10, 2)
+	provider.AddNode("ng5", ng5_1)
+	provider.AddNode("ng5", ng5_2)
+
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
@@ -488,7 +506,7 @@ func TestUpcomingNodes(t *testing.T) {
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff())
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, ng3_1, ng4_1}, nil, now)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, ng3_1, ng4_1, ng5_1, ng5_2}, nil, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 
@@ -497,6 +515,7 @@ func TestUpcomingNodes(t *testing.T) {
 	assert.Equal(t, 1, upcomingNodes["ng2"])
 	assert.Equal(t, 2, upcomingNodes["ng3"])
 	assert.NotContains(t, upcomingNodes, "ng4")
+	assert.NotContains(t, upcomingNodes, "ng5")
 }
 
 func TestIncorrectSize(t *testing.T) {
@@ -568,6 +587,96 @@ func TestUnregisteredNodes(t *testing.T) {
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, nil, time.Now().Add(time.Minute))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetUnregisteredNodes()))
+}
+
+func TestCloudProviderDeletedNodes(t *testing.T) {
+	now := time.Now()
+	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
+	ng1_1.Spec.ProviderID = "ng1-1"
+	ng1_2 := BuildTestNode("ng1-2", 1000, 1000)
+	SetNodeReadyState(ng1_2, true, now.Add(-time.Minute))
+	ng1_2.Spec.ProviderID = "ng1-2"
+	// No Node Group - Not Autoscaled Node
+	noNg := BuildTestNode("no-ng", 1000, 1000)
+	SetNodeReadyState(noNg, true, now.Add(-time.Minute))
+	noNg.Spec.ProviderID = "no-ng"
+	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider.AddNodeGroup("ng1", 1, 10, 2)
+	provider.AddNode("ng1", ng1_1)
+	provider.AddNode("ng1", ng1_2)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	clusterstate := NewClusterStateRegistry(provider, ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+		MaxNodeProvisionTime:      10 * time.Second,
+	}, fakeLogRecorder, newBackoff())
+	now.Add(time.Minute)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNg}, nil, now)
+
+	// Nodes are registered correctly between Kubernetes and cloud provider.
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
+
+	// The node was removed from Cloud Provider
+	// should be counted as Deleted by cluster state
+	nodeGroup, err := provider.NodeGroupForNode(ng1_2)
+	assert.NoError(t, err)
+	provider.DeleteNode(ng1_2)
+	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNg}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
+	assert.Equal(t, "ng1-2", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
+	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
+
+	// The node is removed from Kubernetes
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNg}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
+
+	// New Node is added afterwards
+	ng1_3 := BuildTestNode("ng1-3", 1000, 1000)
+	SetNodeReadyState(ng1_3, true, now.Add(-time.Minute))
+	ng1_3.Spec.ProviderID = "ng1-3"
+	provider.AddNode("ng1", ng1_3)
+	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_3, noNg}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
+
+	// Newly added node is removed from Cloud Provider
+	// should be counted as Deleted by cluster state
+	nodeGroup, err = provider.NodeGroupForNode(ng1_3)
+	assert.NoError(t, err)
+	provider.DeleteNode(ng1_3)
+	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNg, ng1_3}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
+	assert.Equal(t, "ng1-3", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
+	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
+
+	// Confirm that previously identified deleted Cloud Provider nodes are still included
+	// until it is removed from Kubernetes
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNg, ng1_3}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
+	assert.Equal(t, "ng1-3", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
+	assert.Equal(t, 1, clusterstate.GetClusterReadiness().Deleted)
+
+	// The node is removed from Kubernetes
+	now.Add(time.Minute)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNg}, nil, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
 }
 
 func TestUpdateLastTransitionTimes(t *testing.T) {

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -45,7 +45,7 @@ func GetCloudProviderDeletedNodeNames(csr *ClusterStateRegistry) []string {
 	defer csr.Unlock()
 
 	result := make([]string, 0, len(csr.deletedNodes))
-	for nodeName, _ := range csr.deletedNodes {
+	for nodeName := range csr.deletedNodes {
 		result = append(result, nodeName)
 	}
 	return result

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -25,11 +25,11 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/api"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
-  "k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-  "k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/client-go/kubernetes/fake"
 	kube_record "k8s.io/client-go/tools/record"
@@ -668,8 +668,8 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	provider.DeleteNode(ng1_2)
 	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
 	now.Add(time.Minute)
-	
-  err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNgNode}, nil, now)
+
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNgNode}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
 	assert.Equal(t, "ng1-2", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
@@ -677,7 +677,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	// The node is removed from Kubernetes
 	now.Add(time.Minute)
-  
+
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
@@ -689,8 +689,8 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	provider.AddNode("ng1", ng1_3)
 	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
 	now.Add(time.Minute)
-	
-  err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_3, noNgNode}, nil, now)
+
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_3, noNgNode}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))
 
@@ -702,7 +702,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
 	now.Add(time.Minute)
 
-  err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
 	assert.Equal(t, "ng1-3", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
@@ -712,7 +712,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	// until it is removed from Kubernetes
 	now.Add(time.Minute)
 
-  err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetCloudProviderDeletedNodes()))
 	assert.Equal(t, "ng1-3", clusterstate.GetCloudProviderDeletedNodes()[0].Name)
@@ -720,7 +720,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 
 	// The node is removed from Kubernetes
 	now.Add(time.Minute)
-  
+
 	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, nil, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetCloudProviderDeletedNodes()))

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1083,7 +1083,7 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			}
 			return nil
 		}, nil)
-	provider.On("NodeExists", mock.Anything).Return(
+	provider.On("HasInstance", mock.Anything).Return(
 		func(node *apiv1.Node) bool {
 			return false
 		}, nil)
@@ -1215,7 +1215,7 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 	provider = &mockprovider.CloudProvider{}
 	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
 	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
-	provider.On("NodeExists", mock.Anything).Return(
+	provider.On("HasInstance", mock.Anything).Return(
 		func(node *apiv1.Node) bool {
 			return false
 		}, nil)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1083,6 +1083,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			}
 			return nil
 		}, nil)
+	provider.On("NodeExists", mock.Anything).Return(
+		func(node *apiv1.Node) bool {
+			return false
+		}, nil)
 
 	now := time.Now()
 
@@ -1211,6 +1215,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 	provider = &mockprovider.CloudProvider{}
 	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
 	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
+	provider.On("NodeExists", mock.Anything).Return(
+		func(node *apiv1.Node) bool {
+			return false
+		}, nil)
 
 	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
 	clusterState.RefreshCloudProviderNodeInstancesCache()


### PR DESCRIPTION

#### Which component this PR applies to?
cluster-autoscaler

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Attempts to address the issue raised in #5022 from previously approved PR.  Original implementation (previous work was reverted #4896 & #5023) included that changes how Deleted nodes are determined in the cluster state.  New iteration utilizes the previously cached Cloud Provider nodes in the ClusterStateRegistry to perform a diff.  Cloud Provider node instances are retrieved by Node Group, which should avoid not autoscaled nodes from being flagged erroneously.  Test case has been modified to include this scenario.  An additional scenario has been included to ensure that previously identified Cloud Provider nodes will still be tracked until they are no longer registered in Kubernetes.

This PR includes the initial work first introduced in https://github.com/kubernetes/autoscaler/pull/4211. Feedback from that PR indicated that the original intent of determining the deleted nodes was incorrect, which led to the issues reported by other users. The nodes tainted with ToBeDeleted were misidentified as Deleted instead of Ready/Unready, which caused a miscalculation of the node being included as Upcoming. This caused problems described in https://github.com/kubernetes/autoscaler/issues/3949 and https://github.com/kubernetes/autoscaler/issues/4456.

#### Which issue(s) this PR fixes:
Fixes #3949, #4456, #5022

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
