### PR TITLE
Add a new error code to GCE autoscaling client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -143,6 +143,7 @@ func TestErrors(t *testing.T) {
 
 	testCases := []struct {
 		errorCodes         []string
+		errorMessage       string
 		expectedErrorCode  string
 		expectedErrorClass cloudprovider.InstanceErrorClass
 	}{
@@ -167,6 +168,12 @@ func TestErrors(t *testing.T) {
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
 		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Instance 'myinst' creation failed: Constraint constraints/compute.vmExternalIpAccess violated for project 1234567890.",
+			expectedErrorCode:  "VM_EXTERNAL_IP_ACCESS_POLICY_CONSTRAINT",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
 			errorCodes:         []string{"xyz", "abc"},
 			expectedErrorCode:  "OTHER",
 			expectedErrorClass: cloudprovider.OtherErrorClass,
@@ -183,7 +190,8 @@ func TestErrors(t *testing.T) {
 							Errors: &gce_api.ManagedInstanceLastAttemptErrors{
 								Errors: []*gce_api.ManagedInstanceLastAttemptErrorsErrors{
 									{
-										Code: errorCode,
+										Code:    errorCode,
+										Message: tc.errorMessage,
 									},
 								},
 							},


### PR DESCRIPTION

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a new error code `VM_EXTERNAL_IP_ACCESS_POLICY_CONSTRAINT` to GCE autoscaling client to provide better visibility into errors caused by the org policy misconfiguration.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
-

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
