### PR TITLE
add metric for skipped scaling events

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -431,6 +431,16 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		if checkResult.exceeded {
 			klog.V(4).Infof("Skipping node group %s; maximal limit exceeded for %v", nodeGroup.Id(), checkResult.exceededResources)
 			skippedNodeGroups[nodeGroup.Id()] = maxResourceLimitReached(checkResult.exceededResources)
+			for _, resource := range checkResult.exceededResources {
+				switch resource {
+				case cloudprovider.ResourceNameCores:
+					metrics.RegisterSkippedScaleUpCPU()
+				case cloudprovider.ResourceNameMemory:
+					metrics.RegisterSkippedScaleUpMemory()
+				default:
+					continue
+				}
+			}
 			continue
 		}
 

--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -706,6 +706,16 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		if checkResult.exceeded {
 			klog.V(4).Infof("Skipping %s - minimal limit exceeded for %v", node.Name, checkResult.exceededResources)
 			sd.unremovableNodes.AddReason(node, simulator.MinimalResourceLimitExceeded)
+			for _, resource := range checkResult.exceededResources {
+				switch resource {
+				case cloudprovider.ResourceNameCores:
+					metrics.RegisterSkippedScaleDownCPU()
+				case cloudprovider.ResourceNameMemory:
+					metrics.RegisterSkippedScaleDownMemory()
+				default:
+					continue
+				}
+			}
 			continue
 		}
 

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -85,6 +85,7 @@ This metrics describe internal state and actions taken by Cluster Autoscaler.
 | evicted_pods_total | Counter | | Number of pods evicted by CA. |
 | unneeded_nodes_count | Gauge | | Number of nodes currently considered unneeded by CA. |
 | old_unregistered_nodes_removed_count | Counter | | Number of unregistered nodes removed by CA. |
+| skipped_scale_events_count | Counter | `direction`=&lt;scaling-direction&gt;, `reason`=&lt;skipped-scale-reason&gt; | Number of times scaling has been skipped due to a resource limit being reached, or similar event. |
 
 * `errors_total` counter increases every time main CA loop encounters an error.
   * Growing `errors_total` count signifies an internal error in CA or a problem
@@ -120,6 +121,12 @@ scale down reasons are `empty`, `underutilized`, `unready`.
 * `scaled_down_gpu_nodes_total` counts the number of nodes removed by CA. Scale
   down reasons are identical to `scaled_down_nodes_total`, `gpu_name` to
   `scaled_up_gpu_nodes_total`.
+* `skipped_scale_events_count` counts the number of times that the
+  autoscaler has declined to scale a node group because of a resource limit being reached or
+  similar internal event. Scale direction can be either `up` or `down`, and the reason explains
+  why the scaling was skipped (eg `CPULimitReached`, `MemoryLimitReached`). This is
+  different than failed scaling events in that the autoscaler is choosing not to perform
+  a scaling action.
 
 ### Node Autoprovisioning operations
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change adds a new metric, skipped_scale_events_count, which will
record the number of times that the CA has chosen to skip a scaling
event. The metric contains a label for the scaling direction (up or down)
and the reason.

This patch includes usages for the new metric based on CPU or Memory
limits being reached in eiter a scale up or down.

*User Story*

As a cluster autoscaler user, I would like to create alerts to inform me when my cluster is exceeding its resource limits. Having a Prometheus metric to measure this would allow me to create automated alerting.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new metric ("cluster_autoscaler_skipped_scale_events_count") has been added to monitor when CPU and memory resource limits have been exceeded.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
