### PR TITLE
balance nodegroups by capacity and not node count

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -158,6 +158,8 @@ type AutoscalingOptions struct {
 	StatusConfigMapName string
 	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
 	BalanceSimilarNodeGroups bool
+	// BalanceSimilarNodeGroupsBy decides what to balance nodegroups by default is node "count", other options are "cpu" and "memory"
+	BalanceSimilarNodeGroupsBy string
 	// ConfigNamespace is the namespace cluster-autoscaler is running in and all related configmaps live in
 	ConfigNamespace string
 	// ClusterName if available

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -395,7 +395,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		}
 
 		scaleUpInfos, typedErr := processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(
-			context, targetNodeGroups, newNodes)
+			context, targetNodeGroups, newNodes, nodes)
 		if typedErr != nil {
 			return scaleUpError(
 				&status.ScaleUpStatus{CreateNodeGroupResults: createNodeGroupResults, PodsTriggeredScaleUp: bestOption.Pods},

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -175,6 +175,7 @@ var (
 	maxInactivityTimeFlag            = flag.Duration("max-inactivity", 10*time.Minute, "Maximum time from last recorded autoscaler activity before automatic restart")
 	maxFailingTimeFlag               = flag.Duration("max-failing-time", 15*time.Minute, "Maximum time from last recorded successful autoscaler run before automatic restart")
 	balanceSimilarNodeGroupsFlag     = flag.Bool("balance-similar-node-groups", false, "Detect similar node groups and balance the number of nodes between them")
+	balanceSimilarNodeGroupsByFlag   = flag.String("balance-similar-node-groups-by", "count", "Decides what to balance nodegroups by: \"count\", \"cpu\", or \"memory\"")
 	nodeAutoprovisioningEnabled      = flag.Bool("node-autoprovisioning-enabled", false, "Should CA autoprovision node groups when needed")
 	maxAutoprovisionedNodeGroupCount = flag.Int("max-autoprovisioned-node-group-count", 15, "The maximum number of autoprovisioned groups in the cluster.")
 
@@ -226,10 +227,12 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 	if err != nil {
 		klog.Fatalf("Failed to parse flags: %v", err)
 	}
+
 	minMemoryTotal, maxMemoryTotal, err := parseMinMaxFlag(*memoryTotal)
 	if err != nil {
 		klog.Fatalf("Failed to parse flags: %v", err)
 	}
+
 	// Convert memory limits to bytes.
 	minMemoryTotal = minMemoryTotal * units.GiB
 	maxMemoryTotal = maxMemoryTotal * units.GiB
@@ -238,9 +241,15 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 	if err != nil {
 		klog.Fatalf("Failed to parse flags: %v", err)
 	}
+
+	if !nodegroupset.BalanceBySupported[*balanceSimilarNodeGroupsByFlag] {
+		klog.Fatalf("Unsupported value for --balance-similar-node-groups-by: %v", balanceSimilarNodeGroupsByFlag)
+	}
+
 	if *maxDrainParallelismFlag > 1 && !*parallelDrain {
 		klog.Fatalf("Invalid configuration, could not use --max-drain-parallelism > 1 if --parallel-drain is false")
 	}
+
 	return config.AutoscalingOptions{
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
 			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
@@ -284,6 +293,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		WriteStatusConfigMap:               *writeStatusConfigMapFlag,
 		StatusConfigMapName:                *statusConfigMapName,
 		BalanceSimilarNodeGroups:           *balanceSimilarNodeGroupsFlag,
+		BalanceSimilarNodeGroupsBy:         *balanceSimilarNodeGroupsByFlag,
 		ConfigNamespace:                    *namespace,
 		ClusterName:                        *clusterName,
 		NodeAutoprovisioningEnabled:        *nodeAutoprovisioningEnabled,

--- a/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
@@ -19,6 +19,7 @@ package nodegroupset
 import (
 	"fmt"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
@@ -36,6 +37,8 @@ type ScaleUpInfo struct {
 	NewSize int
 	// MaxSize is the maximum allowed size of the Group
 	MaxSize int
+	// Weight is the average allocatable resource of the Group (either cpu, memory, or 1 (for count), depending on flag)
+	Weight int
 }
 
 // String is used for printing ScaleUpInfo for logging, etc
@@ -43,12 +46,17 @@ func (s ScaleUpInfo) String() string {
 	return fmt.Sprintf("{%v %v->%v (max: %v)}", s.Group.Id(), s.CurrentSize, s.NewSize, s.MaxSize)
 }
 
+// TotalWeight is the amount of resources this group can allocate (either cpu or memory depending on flag)
+func (s ScaleUpInfo) TotalWeight() int {
+	return s.Weight * s.NewSize
+}
+
 // NodeGroupSetProcessor finds nodegroups that are similar and allows balancing scale-up between them.
 type NodeGroupSetProcessor interface {
 	FindSimilarNodeGroups(context *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 		nodeInfosForGroups map[string]*schedulerframework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError)
 
-	BalanceScaleUpBetweenGroups(context *context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError)
+	BalanceScaleUpBetweenGroups(context *context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int, nodes []*apiv1.Node) ([]ScaleUpInfo, errors.AutoscalerError)
 	CleanUp()
 }
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Scale nodegroups by their resource capacity (cpu or memory) and not by the count of their nodes.

Given a cluster with nodegroups with different node sizes (a=1 x 4 cpu, b=1 x 4 cpu, c=1 x 12 cpu)
and a need for 3 new nodes
It should scale to "a:3,b:2,c:1" to have a proper resource balance
and NOT "a:2,b:2,c:2" which it does atm.

verified the patch with a 3 aws asgs where I used 4xl,4xl,12xl and got this:
```
{"level":"INFO","message":"Final scale-up plan: [{usw2c 1->7 (max: 10)} {usw2a 1->6 (max: 10)} {usw2b 1-2 (max: 10)}]"}
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/5072

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
when balancing nodegroups to add new nodes, allow using their allocatable resources (cpu or memory) instead of node count with `--balance-similar-node-groups-by=cpu|memory`
```
