### PR TITLE
cluster-autoscaler balanced nodegroups: allow ignoring missing expansion during pod filtering

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -158,6 +158,8 @@ type AutoscalingOptions struct {
 	StatusConfigMapName string
 	// BalanceSimilarNodeGroups enables logic that identifies node groups with similar machines and tries to balance node count between them.
 	BalanceSimilarNodeGroups bool
+	// BalanceIgnoreMissingExpansion When balancing nodegroups, sometimes expansion options are unknown, in that case proceed with scheduling pods
+	BalanceIgnoreMissingExpansion bool
 	// ConfigNamespace is the namespace cluster-autoscaler is running in and all related configmaps live in
 	ConfigNamespace string
 	// ClusterName if available

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -373,7 +373,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 					typedErr.AddPrefix("failed to find matching node groups: "))
 			}
 
-			similarNodeGroups = filterNodeGroupsByPods(similarNodeGroups, bestOption.Pods, expansionOptions)
+			similarNodeGroups = filterNodeGroupsByPods(context, similarNodeGroups, bestOption.Pods, expansionOptions)
 			for _, ng := range similarNodeGroups {
 				if clusterStateRegistry.IsNodeGroupSafeToScaleUp(ng, now) {
 					targetNodeGroups = append(targetNodeGroups, ng)
@@ -572,17 +572,25 @@ func getPodsAwaitingEvaluation(egs []*podEquivalenceGroup, bestOption string) []
 }
 
 func filterNodeGroupsByPods(
+	context *context.AutoscalingContext,
 	groups []cloudprovider.NodeGroup,
 	podsRequiredToFit []*apiv1.Pod,
-	expansionOptions map[string]expander.Option) []cloudprovider.NodeGroup {
-
+	expansionOptions map[string]expander.Option,
+) []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0)
 
 	for _, group := range groups {
 		option, found := expansionOptions[group.Id()]
 		if !found {
-			klog.V(1).Infof("No info about pods passing predicates found for group %v, skipping it from scale-up consideration", group.Id())
-			continue
+			if context.BalanceIgnoreMissingExpansion {
+				// still show that something went wrong so users can see when the issue was resolved
+				klog.V(1).Infof("No info about pods passing predicates found for group %v, ignoring", group.Id())
+				result = append(result, group)
+				continue
+			} else {
+				klog.V(1).Infof("No info about pods passing predicates found for group %v, skipping it from scale-up consideration", group.Id())
+				continue
+			}
 		}
 		fittingPods := make(map[*apiv1.Pod]bool, len(option.Pods))
 		for _, pod := range option.Pods {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -176,6 +176,7 @@ var (
 	maxInactivityTimeFlag            = flag.Duration("max-inactivity", 10*time.Minute, "Maximum time from last recorded autoscaler activity before automatic restart")
 	maxFailingTimeFlag               = flag.Duration("max-failing-time", 15*time.Minute, "Maximum time from last recorded successful autoscaler run before automatic restart")
 	balanceSimilarNodeGroupsFlag     = flag.Bool("balance-similar-node-groups", false, "Detect similar node groups and balance the number of nodes between them")
+	balanceIgnoreMissingExpansion    = flag.Bool("balance-ignore-missing-expansion", false, "When balancing nodegroups, sometimes expansion options are unknown, in that case proceed with scheduling pods")
 	nodeAutoprovisioningEnabled      = flag.Bool("node-autoprovisioning-enabled", false, "Should CA autoprovision node groups when needed")
 	maxAutoprovisionedNodeGroupCount = flag.Int("max-autoprovisioned-node-group-count", 15, "The maximum number of autoprovisioned groups in the cluster.")
 
@@ -285,6 +286,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		WriteStatusConfigMap:               *writeStatusConfigMapFlag,
 		StatusConfigMapName:                *statusConfigMapName,
 		BalanceSimilarNodeGroups:           *balanceSimilarNodeGroupsFlag,
+		BalanceIgnoreMissingExpansion:      *balanceIgnoreMissingExpansion,
 		ConfigNamespace:                    *namespace,
 		ClusterName:                        *clusterName,
 		NodeAutoprovisioningEnabled:        *nodeAutoprovisioningEnabled,


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We saw issues with betting a good balance from this error:
```
No info about pods passing predicates found for group euc1c-1234, skipping it from scale-up consideration
```

Since all our nodegroups are the same, all pods will fit them, so we do not need this check.
Add a new flag to disable the check so we have 1 less things to worry about / debug.

#### Does this PR introduce a user-facing change?

```release-note
Add balance-ignore-missing-expansion flag to allow skipping pod filtering when expansion option failed to be computed
```