### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package aws
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,8 +118,7 @@ func TestInstanceTypeFallback(t *testing.T) {
 	do := cloudprovider.NodeGroupDiscoveryOptions{}
 	opts := config.AutoscalingOptions{}
 
-	os.Setenv("AWS_REGION", "non-existent-region")
-	defer os.Unsetenv("AWS_REGION")
+	t.Setenv("AWS_REGION", "non-existent-region")
 
 	// This test ensures that no klog.Fatalf calls occur when constructing the AWS cloud provider.  Specifically it is
 	// intended to ensure that instance type fallback works correctly in the event of an error enumerating instance

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -45,22 +45,12 @@ import (
 	provider_aws "k8s.io/legacy-cloud-providers/aws"
 )
 
-// resetAWSRegion resets AWS_REGION environment variable key to its pre-test
-// value, but only if it was originally present among environment variables.
-func resetAWSRegion(value string, present bool) {
-	os.Unsetenv("AWS_REGION")
-	if present {
-		os.Setenv("AWS_REGION", value)
-	}
-}
-
 // TestGetRegion ensures correct source supplies AWS Region.
 func TestGetRegion(t *testing.T) {
 	key := "AWS_REGION"
-	defer resetAWSRegion(os.LookupEnv(key))
 	// Ensure environment variable retains precedence.
 	expected1 := "the-shire-1"
-	os.Setenv(key, expected1)
+	t.Setenv(key, expected1)
 	assert.Equal(t, expected1, getRegion())
 	// Ensure without environment variable, EC2 Metadata is used.
 	expected2 := "mordor-2"
@@ -639,9 +629,7 @@ func TestFetchExplicitAsgs(t *testing.T) {
 			fmt.Sprintf("%d:%d:%s", min, max-1, groupname),
 		},
 	}
-	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
-	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
-	os.Setenv("AWS_REGION", "fanghorn")
+	t.Setenv("AWS_REGION", "fanghorn")
 	instanceTypes, _ := GetStaticEC2InstanceTypes()
 	m, err := createAWSManagerInternal(nil, do, &awsWrapper{a, nil, nil}, instanceTypes)
 	assert.NoError(t, err)
@@ -702,9 +690,7 @@ func TestGetASGTemplate(t *testing.T) {
 				},
 			})
 
-			// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
-			defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
-			os.Setenv("AWS_REGION", "fanghorn")
+			t.Setenv("AWS_REGION", "fanghorn")
 			instanceTypes, _ := GetStaticEC2InstanceTypes()
 			do := cloudprovider.NodeGroupDiscoveryOptions{}
 
@@ -802,9 +788,7 @@ func TestFetchAutoAsgs(t *testing.T) {
 		NodeGroupAutoDiscoverySpecs: []string{fmt.Sprintf("asg:tag=%s", strings.Join(tags, ","))},
 	}
 
-	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
-	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
-	os.Setenv("AWS_REGION", "fanghorn")
+	t.Setenv("AWS_REGION", "fanghorn")
 	// fetchAutoASGs is called at manager creation time, via forceRefresh
 	instanceTypes, _ := GetStaticEC2InstanceTypes()
 	m, err := createAWSManagerInternal(nil, do, &awsWrapper{a, nil, nil}, instanceTypes)

--- a/cluster-autoscaler/cloudprovider/aws/aws_util_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util_test.go
@@ -123,12 +123,7 @@ func TestGetCurrentAwsRegion(t *testing.T) {
 
 func TestGetCurrentAwsRegionWithRegionEnv(t *testing.T) {
 	region := "us-west-2"
-	if oldRegion, found := os.LookupEnv("AWS_REGION"); found {
-		defer os.Setenv("AWS_REGION", oldRegion)
-	} else {
-		defer os.Unsetenv("AWS_REGION")
-	}
-	os.Setenv("AWS_REGION", region)
+	t.Setenv("AWS_REGION", region)
 
 	result, err := GetCurrentAwsRegion()
 	assert.Nil(t, err)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -19,7 +19,6 @@ package aws
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -333,9 +332,7 @@ func TestGetInstanceTypesForAsgs(t *testing.T) {
 		},
 	})
 
-	// #1449 Without AWS_REGION getRegion() lookup runs till timeout during tests.
-	defer resetAWSRegion(os.LookupEnv("AWS_REGION"))
-	os.Setenv("AWS_REGION", "fanghorn")
+	t.Setenv("AWS_REGION", "fanghorn")
 
 	awsWrapper := &awsWrapper{
 		autoScalingI: a,

--- a/cluster-autoscaler/cloudprovider/azure/azure_config_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config_test.go
@@ -18,10 +18,10 @@ package azure
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"os"
-	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 )
 
 func TestInitializeCloudProviderRateLimitConfigWithNoConfigReturnsNoError(t *testing.T) {
@@ -44,8 +44,8 @@ func TestInitializeCloudProviderRateLimitConfigWithReadRateLimitSettingsFromEnv(
 	emptyConfig := &CloudProviderRateLimitConfig{}
 	var rateLimitReadQPS float32 = 3.0
 	rateLimitReadBuckets := 10
-	os.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
-	os.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
+	t.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
+	t.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
 
 	err := initializeCloudProviderRateLimitConfig(emptyConfig)
 	assert.NoError(t, err)
@@ -53,9 +53,6 @@ func TestInitializeCloudProviderRateLimitConfigWithReadRateLimitSettingsFromEnv(
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitBucket, rateLimitReadBuckets)
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitQPSWrite, rateLimitReadQPS)
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitBucketWrite, rateLimitReadBuckets)
-
-	os.Unsetenv(rateLimitReadBucketsEnvVar)
-	os.Unsetenv(rateLimitReadQPSEnvVar)
 }
 
 func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitSettingsFromEnv(t *testing.T) {
@@ -65,10 +62,10 @@ func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitSettings
 	var rateLimitWriteQPS float32 = 6.0
 	rateLimitWriteBuckets := 20
 
-	os.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
-	os.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
-	os.Setenv(rateLimitWriteQPSEnvVar, fmt.Sprintf("%.1f", rateLimitWriteQPS))
-	os.Setenv(rateLimitWriteBucketsEnvVar, fmt.Sprintf("%d", rateLimitWriteBuckets))
+	t.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
+	t.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
+	t.Setenv(rateLimitWriteQPSEnvVar, fmt.Sprintf("%.1f", rateLimitWriteQPS))
+	t.Setenv(rateLimitWriteBucketsEnvVar, fmt.Sprintf("%d", rateLimitWriteBuckets))
 
 	err := initializeCloudProviderRateLimitConfig(emptyConfig)
 
@@ -77,11 +74,6 @@ func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitSettings
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitBucket, rateLimitReadBuckets)
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitQPSWrite, rateLimitWriteQPS)
 	assert.Equal(t, emptyConfig.CloudProviderRateLimitBucketWrite, rateLimitWriteBuckets)
-
-	os.Unsetenv(rateLimitReadQPSEnvVar)
-	os.Unsetenv(rateLimitReadBucketsEnvVar)
-	os.Unsetenv(rateLimitWriteQPSEnvVar)
-	os.Unsetenv(rateLimitWriteBucketsEnvVar)
 }
 
 func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitAlreadySetInConfig(t *testing.T) {
@@ -99,10 +91,10 @@ func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitAlreadyS
 		},
 	}
 
-	os.Setenv(rateLimitReadQPSEnvVar, "99")
-	os.Setenv(rateLimitReadBucketsEnvVar, "99")
-	os.Setenv(rateLimitWriteQPSEnvVar, "99")
-	os.Setenv(rateLimitWriteBucketsEnvVar, "99")
+	t.Setenv(rateLimitReadQPSEnvVar, "99")
+	t.Setenv(rateLimitReadBucketsEnvVar, "99")
+	t.Setenv(rateLimitWriteQPSEnvVar, "99")
+	t.Setenv(rateLimitWriteBucketsEnvVar, "99")
 
 	err := initializeCloudProviderRateLimitConfig(configWithRateLimits)
 
@@ -111,11 +103,6 @@ func TestInitializeCloudProviderRateLimitConfigWithReadAndWriteRateLimitAlreadyS
 	assert.Equal(t, configWithRateLimits.CloudProviderRateLimitBucket, rateLimitReadBuckets)
 	assert.Equal(t, configWithRateLimits.CloudProviderRateLimitQPSWrite, rateLimitWriteQPS)
 	assert.Equal(t, configWithRateLimits.CloudProviderRateLimitBucketWrite, rateLimitWriteBuckets)
-
-	os.Unsetenv(rateLimitReadQPSEnvVar)
-	os.Unsetenv(rateLimitReadBucketsEnvVar)
-	os.Unsetenv(rateLimitWriteQPSEnvVar)
-	os.Unsetenv(rateLimitWriteBucketsEnvVar)
 }
 
 func TestInitializeCloudProviderRateLimitConfigWithInvalidReadAndWriteRateLimitSettingsFromEnv(t *testing.T) {
@@ -163,35 +150,30 @@ func TestInitializeCloudProviderRateLimitConfigWithInvalidReadAndWriteRateLimitS
 
 	for i, test := range testCases {
 		if test.isInvalidRateLimitReadQPSEnvVar {
-			os.Setenv(rateLimitReadQPSEnvVar, invalidSetting)
+			t.Setenv(rateLimitReadQPSEnvVar, invalidSetting)
 		} else {
-			os.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
+			t.Setenv(rateLimitReadQPSEnvVar, fmt.Sprintf("%.1f", rateLimitReadQPS))
 		}
 		if test.isInvalidRateLimitReadBucketsEnvVar {
-			os.Setenv(rateLimitReadBucketsEnvVar, invalidSetting)
+			t.Setenv(rateLimitReadBucketsEnvVar, invalidSetting)
 		} else {
-			os.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
+			t.Setenv(rateLimitReadBucketsEnvVar, fmt.Sprintf("%d", rateLimitReadBuckets))
 		}
 		if test.isInvalidRateLimitWriteQPSEnvVar {
-			os.Setenv(rateLimitWriteQPSEnvVar, invalidSetting)
+			t.Setenv(rateLimitWriteQPSEnvVar, invalidSetting)
 		} else {
-			os.Setenv(rateLimitWriteQPSEnvVar, fmt.Sprintf("%.1f", rateLimitWriteQPS))
+			t.Setenv(rateLimitWriteQPSEnvVar, fmt.Sprintf("%.1f", rateLimitWriteQPS))
 		}
 		if test.isInvalidRateLimitWriteBucketsEnvVar {
-			os.Setenv(rateLimitWriteBucketsEnvVar, invalidSetting)
+			t.Setenv(rateLimitWriteBucketsEnvVar, invalidSetting)
 		} else {
-			os.Setenv(rateLimitWriteBucketsEnvVar, fmt.Sprintf("%d", rateLimitWriteBuckets))
+			t.Setenv(rateLimitWriteBucketsEnvVar, fmt.Sprintf("%d", rateLimitWriteBuckets))
 		}
 
 		err := initializeCloudProviderRateLimitConfig(emptyConfig)
 
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
 		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
-
-		os.Unsetenv(rateLimitReadQPSEnvVar)
-		os.Unsetenv(rateLimitReadBucketsEnvVar)
-		os.Unsetenv(rateLimitWriteQPSEnvVar)
-		os.Unsetenv(rateLimitWriteBucketsEnvVar)
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -18,12 +18,12 @@ package azure
 
 import (
 	"fmt"
-	"os"
 	"reflect"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"strings"
 	"testing"
 	"time"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
@@ -421,180 +421,144 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 		},
 	}
 
-	os.Setenv("ARM_CLOUD", "AzurePublicCloud")
-	os.Setenv("LOCATION", "southeastasia")
-	os.Setenv("ARM_SUBSCRIPTION_ID", "subscriptionId")
-	os.Setenv("ARM_RESOURCE_GROUP", "resourceGroup")
-	os.Setenv("ARM_TENANT_ID", "tenantId")
-	os.Setenv("ARM_CLIENT_ID", "aadClientId")
-	os.Setenv("ARM_CLIENT_SECRET", "aadClientSecret")
-	os.Setenv("ARM_VM_TYPE", "vmss")
-	os.Setenv("ARM_CLIENT_CERT_PATH", "aadClientCertPath")
-	os.Setenv("ARM_CLIENT_CERT_PASSWORD", "aadClientCertPassword")
-	os.Setenv("ARM_DEPLOYMENT", "deployment")
-	os.Setenv("AZURE_CLUSTER_NAME", "clusterName")
-	os.Setenv("AZURE_NODE_RESOURCE_GROUP", "resourcegroup")
-	os.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "true")
-	os.Setenv("ARM_USER_ASSIGNED_IDENTITY_ID", "UserAssignedIdentityID")
-	os.Setenv("AZURE_VMSS_CACHE_TTL", "100")
-	os.Setenv("AZURE_VMSS_VMS_CACHE_TTL", "110")
-	os.Setenv("AZURE_VMSS_VMS_CACHE_JITTER", "90")
-	os.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "8")
-	os.Setenv("ENABLE_BACKOFF", "true")
-	os.Setenv("BACKOFF_RETRIES", "1")
-	os.Setenv("BACKOFF_EXPONENT", "1")
-	os.Setenv("BACKOFF_DURATION", "1")
-	os.Setenv("BACKOFF_JITTER", "1")
-	os.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "true")
+	t.Setenv("ARM_CLOUD", "AzurePublicCloud")
+	t.Setenv("LOCATION", "southeastasia")
+	t.Setenv("ARM_SUBSCRIPTION_ID", "subscriptionId")
+	t.Setenv("ARM_RESOURCE_GROUP", "resourceGroup")
+	t.Setenv("ARM_TENANT_ID", "tenantId")
+	t.Setenv("ARM_CLIENT_ID", "aadClientId")
+	t.Setenv("ARM_CLIENT_SECRET", "aadClientSecret")
+	t.Setenv("ARM_VM_TYPE", "vmss")
+	t.Setenv("ARM_CLIENT_CERT_PATH", "aadClientCertPath")
+	t.Setenv("ARM_CLIENT_CERT_PASSWORD", "aadClientCertPassword")
+	t.Setenv("ARM_DEPLOYMENT", "deployment")
+	t.Setenv("AZURE_CLUSTER_NAME", "clusterName")
+	t.Setenv("AZURE_NODE_RESOURCE_GROUP", "resourcegroup")
+	t.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "true")
+	t.Setenv("ARM_USER_ASSIGNED_IDENTITY_ID", "UserAssignedIdentityID")
+	t.Setenv("AZURE_VMSS_CACHE_TTL", "100")
+	t.Setenv("AZURE_VMSS_VMS_CACHE_TTL", "110")
+	t.Setenv("AZURE_VMSS_VMS_CACHE_JITTER", "90")
+	t.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "8")
+	t.Setenv("ENABLE_BACKOFF", "true")
+	t.Setenv("BACKOFF_RETRIES", "1")
+	t.Setenv("BACKOFF_EXPONENT", "1")
+	t.Setenv("BACKOFF_DURATION", "1")
+	t.Setenv("BACKOFF_JITTER", "1")
+	t.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "true")
 
-	manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, true, reflect.DeepEqual(*expectedConfig, *manager.config), "unexpected azure manager configuration")
+	t.Run("environment variables correctly set", func(t *testing.T) {
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, true, reflect.DeepEqual(*expectedConfig, *manager.config), "unexpected azure manager configuration")
+	})
 
-	// invalid bool for ARM_USE_MANAGED_IDENTITY_EXTENSION
-	os.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "invalidbool")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr0 := "strconv.ParseBool: parsing \"invalidbool\": invalid syntax"
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr0, err.Error(), "Return err does not match, expected: %v, actual: %v", expectedErr0, err.Error())
-	// revert back to good ARM_USE_MANAGED_IDENTITY_EXTENSION
-	os.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "true")
+	t.Run("invalid bool for ARM_USE_MANAGED_IDENTITY_EXTENSION", func(t *testing.T) {
+		t.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "invalidbool")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr0 := "strconv.ParseBool: parsing \"invalidbool\": invalid syntax"
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr0, err.Error(), "Return err does not match, expected: %v, actual: %v", expectedErr0, err.Error())
+	})
 
-	// invalid int for AZURE_VMSS_CACHE_TTL
-	os.Setenv("AZURE_VMSS_CACHE_TTL", "invalidint")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr := fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good AZURE_VMSS_CACHE_TTL
-	os.Setenv("AZURE_VMSS_CACHE_TTL", "100")
+	t.Run("invalid int for AZURE_VMSS_CACHE_TTL", func(t *testing.T) {
+		t.Setenv("AZURE_VMSS_CACHE_TTL", "invalidint")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// invalid int for AZURE_MAX_DEPLOYMENT_COUNT
-	os.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "invalidint")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse AZURE_MAX_DEPLOYMENT_COUNT \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good AZURE_MAX_DEPLOYMENT_COUNT
-	os.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "8")
+	t.Run("invalid int for AZURE_MAX_DEPLOYMENT_COUNT", func(t *testing.T) {
+		t.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "invalidint")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse AZURE_MAX_DEPLOYMENT_COUNT \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// zero AZURE_MAX_DEPLOYMENT_COUNT will use default value
-	os.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "0")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(defaultMaxDeploymentsCount), (*manager.config).MaxDeploymentsCount, "MaxDeploymentsCount does not match.")
-	// revert back to good AZURE_MAX_DEPLOYMENT_COUNT
-	os.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "8")
+	t.Run("zero AZURE_MAX_DEPLOYMENT_COUNT will use default value", func(t *testing.T) {
+		t.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "0")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(defaultMaxDeploymentsCount), (*manager.config).MaxDeploymentsCount, "MaxDeploymentsCount does not match.")
+	})
 
-	// invalid bool for ENABLE_BACKOFF
-	os.Setenv("ENABLE_BACKOFF", "invalidbool")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse ENABLE_BACKOFF \"invalidbool\": strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good ENABLE_BACKOFF
-	os.Setenv("ENABLE_BACKOFF", "true")
+	t.Run("invalid bool for ENABLE_BACKOFF", func(t *testing.T) {
+		t.Setenv("ENABLE_BACKOFF", "invalidbool")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse ENABLE_BACKOFF \"invalidbool\": strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// invalid int for BACKOFF_RETRIES
-	os.Setenv("BACKOFF_RETRIES", "invalidint")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse BACKOFF_RETRIES '\\x00': strconv.ParseInt: parsing \"invalidint\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good BACKOFF_RETRIES
-	os.Setenv("BACKOFF_RETRIES", "1")
+	t.Run("invalid int for BACKOFF_RETRIES", func(t *testing.T) {
+		t.Setenv("BACKOFF_RETRIES", "invalidint")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse BACKOFF_RETRIES '\\x00': strconv.ParseInt: parsing \"invalidint\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// empty BACKOFF_RETRIES will use default value
-	os.Setenv("BACKOFF_RETRIES", "")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, backoffRetriesDefault, (*manager.config).CloudProviderBackoffRetries, "CloudProviderBackoffRetries does not match.")
-	// revert back to good BACKOFF_RETRIES
-	os.Setenv("BACKOFF_RETRIES", "1")
+	t.Run("empty BACKOFF_RETRIES will use default value", func(t *testing.T) {
+		t.Setenv("BACKOFF_RETRIES", "")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, backoffRetriesDefault, (*manager.config).CloudProviderBackoffRetries, "CloudProviderBackoffRetries does not match.")
+	})
 
-	// invalid float for BACKOFF_EXPONENT
-	os.Setenv("BACKOFF_EXPONENT", "invalidfloat")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse BACKOFF_EXPONENT \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good BACKOFF_EXPONENT
-	os.Setenv("BACKOFF_EXPONENT", "1")
+	t.Run("invalid float for BACKOFF_EXPONENT", func(t *testing.T) {
+		t.Setenv("BACKOFF_EXPONENT", "invalidfloat")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse BACKOFF_EXPONENT \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// empty BACKOFF_EXPONENT will use default value
-	os.Setenv("BACKOFF_EXPONENT", "")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, backoffExponentDefault, (*manager.config).CloudProviderBackoffExponent, "CloudProviderBackoffExponent does not match.")
-	// revert back to good BACKOFF_EXPONENT
-	os.Setenv("BACKOFF_EXPONENT", "1")
+	t.Run("empty BACKOFF_EXPONENT will use default value", func(t *testing.T) {
+		t.Setenv("BACKOFF_EXPONENT", "")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, backoffExponentDefault, (*manager.config).CloudProviderBackoffExponent, "CloudProviderBackoffExponent does not match.")
+	})
 
-	// invalid int for BACKOFF_DURATION
-	os.Setenv("BACKOFF_DURATION", "invalidint")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse BACKOFF_DURATION \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good BACKOFF_DURATION
-	os.Setenv("BACKOFF_DURATION", "1")
+	t.Run("invalid int for BACKOFF_DURATION", func(t *testing.T) {
+		t.Setenv("BACKOFF_DURATION", "invalidint")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse BACKOFF_DURATION \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// empty BACKOFF_DURATION will use default value
-	os.Setenv("BACKOFF_DURATION", "")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, backoffDurationDefault, (*manager.config).CloudProviderBackoffDuration, "CloudProviderBackoffDuration does not match.")
-	// revert back to good BACKOFF_DURATION
-	os.Setenv("BACKOFF_DURATION", "1")
+	t.Run("empty BACKOFF_DURATION will use default value", func(t *testing.T) {
+		t.Setenv("BACKOFF_DURATION", "")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, backoffDurationDefault, (*manager.config).CloudProviderBackoffDuration, "CloudProviderBackoffDuration does not match.")
+	})
 
-	// invalid float for BACKOFF_JITTER
-	os.Setenv("BACKOFF_JITTER", "invalidfloat")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse BACKOFF_JITTER \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good BACKOFF_JITTER
-	os.Setenv("BACKOFF_JITTER", "1")
+	t.Run("invalid float for BACKOFF_JITTER", func(t *testing.T) {
+		t.Setenv("BACKOFF_JITTER", "invalidfloat")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse BACKOFF_JITTER \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 
-	// empty BACKOFF_JITTER will use default value
-	os.Setenv("BACKOFF_JITTER", "")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	assert.NoError(t, err)
-	assert.Equal(t, backoffJitterDefault, (*manager.config).CloudProviderBackoffJitter, "CloudProviderBackoffJitter does not match.")
-	// revert back to good BACKOFF_JITTER
-	os.Setenv("BACKOFF_JITTER", "1")
+	t.Run("empty BACKOFF_JITTER will use default value", func(t *testing.T) {
+		t.Setenv("BACKOFF_JITTER", "")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		assert.NoError(t, err)
+		assert.Equal(t, backoffJitterDefault, (*manager.config).CloudProviderBackoffJitter, "CloudProviderBackoffJitter does not match.")
+	})
 
-	// invalid bool for CLOUD_PROVIDER_RATE_LIMIT
-	os.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "invalidbool")
-	manager, err = createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
-	expectedErr = fmt.Errorf("failed to parse CLOUD_PROVIDER_RATE_LIMIT: \"invalidbool\", strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
-	assert.Nil(t, manager)
-	assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
-	// revert back to good CLOUD_PROVIDER_RATE_LIMIT
-	os.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "1")
-
-	os.Unsetenv("ARM_CLOUD")
-	os.Unsetenv("ARM_SUBSCRIPTION_ID")
-	os.Unsetenv("LOCATION")
-	os.Unsetenv("ARM_RESOURCE_GROUP")
-	os.Unsetenv("ARM_TENANT_ID")
-	os.Unsetenv("ARM_CLIENT_ID")
-	os.Unsetenv("ARM_CLIENT_SECRET")
-	os.Unsetenv("ARM_VM_TYPE")
-	os.Unsetenv("ARM_CLIENT_CERT_PATH")
-	os.Unsetenv("ARM_CLIENT_CERT_PASSWORD")
-	os.Unsetenv("ARM_DEPLOYMENT")
-	os.Unsetenv("AZURE_CLUSTER_NAME")
-	os.Unsetenv("AZURE_NODE_RESOURCE_GROUP")
-	os.Unsetenv("ARM_USE_MANAGED_IDENTITY_EXTENSION")
-	os.Unsetenv("ARM_USER_ASSIGNED_IDENTITY_ID")
-	os.Unsetenv("AZURE_VMSS_CACHE_TTL")
-	os.Unsetenv("AZURE_MAX_DEPLOYMENT_COUNT")
-	os.Unsetenv("ENABLE_BACKOFF")
-	os.Unsetenv("BACKOFF_RETRIES")
-	os.Unsetenv("BACKOFF_EXPONENT")
-	os.Unsetenv("BACKOFF_DURATION")
-	os.Unsetenv("BACKOFF_JITTER")
-	os.Unsetenv("CLOUD_PROVIDER_RATE_LIMIT")
+	t.Run("invalid bool for CLOUD_PROVIDER_RATE_LIMIT", func(t *testing.T) {
+		t.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "invalidbool")
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		expectedErr := fmt.Errorf("failed to parse CLOUD_PROVIDER_RATE_LIMIT: \"invalidbool\", strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
+		assert.Nil(t, manager)
+		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
+	})
 }
 
 func TestCreateAzureManagerInvalidConfig(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -18,7 +18,6 @@ package clusterapi
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -854,9 +853,7 @@ func Test_getKeyHelpers(t *testing.T) {
 	}
 
 	testgroup := "test.k8s.io"
-	if err := os.Setenv(CAPIGroupEnvVar, testgroup); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	t.Setenv(CAPIGroupEnvVar, testgroup)
 
 	for _, tc := range []struct {
 		name     string

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
@@ -19,7 +19,6 @@ package exoscale
 import (
 	"context"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -125,9 +124,9 @@ type cloudProviderTestSuite struct {
 }
 
 func (ts *cloudProviderTestSuite) SetupTest() {
-	_ = os.Setenv("EXOSCALE_ZONE", testZone)
-	_ = os.Setenv("EXOSCALE_API_KEY", "x")
-	_ = os.Setenv("EXOSCALE_API_SECRET", "x")
+	ts.T().Setenv("EXOSCALE_ZONE", testZone)
+	ts.T().Setenv("EXOSCALE_API_KEY", "x")
+	ts.T().Setenv("EXOSCALE_API_SECRET", "x")
 
 	manager, err := newManager()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_manager_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -109,8 +108,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			for key, value := range c.env {
-				os.Setenv(key, value)
-				defer os.Unsetenv(key)
+				t.Setenv(key, value)
 			}
 
 			cfg, err := LoadConfigFromEnv()
@@ -121,12 +119,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 }
 
 func TestCreateIonosCloudManager(t *testing.T) {
-	os.Setenv(envKeyClusterId, "test")
-	os.Setenv(envKeyToken, "token")
-	defer func() {
-		os.Unsetenv(envKeyClusterId)
-		os.Unsetenv(envKeyToken)
-	}()
+	t.Setenv(envKeyClusterId, "test")
+	t.Setenv(envKeyToken, "token")
 
 	manager, err := CreateIonosCloudManager(nil, "ua")
 	require.Nil(t, manager)


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
