### PR TITLE
Fix error logging when waiting for GCE operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -234,7 +234,11 @@ func (client *autoscalingGceClientV1) waitForOp(operation *gce.Operation, projec
 			klog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
 			if op.Status == "DONE" {
 				if op.Error != nil {
-					return fmt.Errorf("error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
+					errBytes, err := op.Error.MarshalJSON()
+					if err != nil {
+						errBytes = []byte(fmt.Sprintf("operation failed, but error couldn't be recovered: %v", err))
+					}
+					return fmt.Errorf("error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, errBytes)
 				}
 
 				return nil


### PR DESCRIPTION
`err` was always `nil` here, and the real error was not retained at all.

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Minor error logging improvement in GCE cloud provider.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
