### PR TITLE
CA: GCE: fix custom machine type parsing

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
@@ -30,11 +30,18 @@ func TestNewCustomMachineType(t *testing.T) {
 	testCases := []struct {
 		name         string
 		expectCustom bool
+		expectErr    bool
 		expectCPU    int64
 		expectMemory int64
 	}{
 		{
 			name:         "custom-2-2816",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2816 * units.MiB,
+		},
+		{
+			name:         "custom-2-2816-ext",
 			expectCustom: true,
 			expectCPU:    2,
 			expectMemory: 2816 * units.MiB,
@@ -46,13 +53,58 @@ func TestNewCustomMachineType(t *testing.T) {
 			expectMemory: 2816 * units.MiB,
 		},
 		{
-			name: "other-a2-2816",
+			name:         "n2-custom-2-2816-ext",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2816 * units.MiB,
 		},
 		{
-			name: "other-2-2816",
+			name:         "e2-custom-medium-2816",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2816 * units.MiB,
 		},
 		{
-			name: "n1-standard-8",
+			name:         "e2-custom-micro-2048",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2048 * units.MiB,
+		},
+		{
+			name:         "e2-custom-small-2048",
+			expectCustom: true,
+			expectCPU:    2,
+			expectMemory: 2048 * units.MiB,
+		},
+		{
+			name:         "e2-custom",
+			expectCustom: true,
+			expectErr:    true,
+		},
+		{
+			name:         "e2-custom-8",
+			expectCustom: true,
+			expectErr:    true,
+		},
+		{
+			name:         "e2-custom-abc-2048",
+			expectCustom: true,
+			expectErr:    true,
+		},
+		{
+			name:         "other-a2-2816",
+			expectCustom: false,
+			expectErr:    true,
+		},
+		{
+			name:         "other-2-2816",
+			expectCustom: false,
+			expectErr:    true,
+		},
+		{
+			name:         "n1-standard-8",
+			expectCustom: false,
+			expectErr:    true,
 		},
 	}
 
@@ -60,12 +112,12 @@ func TestNewCustomMachineType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectCustom, IsCustomMachine(tc.name))
 			m, err := NewCustomMachineType(tc.name)
-			if tc.expectCustom {
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectCPU, m.CPU)
 				assert.Equal(t, tc.expectMemory, m.Memory)
-			} else {
-				assert.Error(t, err)
 			}
 		})
 	}
@@ -89,9 +141,29 @@ func TestGetMachineFamily(t *testing.T) {
 			machineType: "n2-custom-2-2816",
 			wantFamily:  "n2",
 		},
+		"custom machine type with family prefix and ext suffix": {
+			machineType: "n2-custom-2-2816-ext",
+			wantFamily:  "n2",
+		},
 		"custom machine type without family prefix": {
 			machineType: "custom-2-2816",
 			wantFamily:  "n1",
+		},
+		"custom machine type without family prefix with ext suffix": {
+			machineType: "custom-2-2816-ext",
+			wantFamily:  "n1",
+		},
+		"e2 custom medium type": {
+			machineType: "e2-custom-medium-2816",
+			wantFamily:  "e2",
+		},
+		"e2 custom small type": {
+			machineType: "e2-custom-small-2048",
+			wantFamily:  "e2",
+		},
+		"e2 custom micro type": {
+			machineType: "e2-custom-micro-2048",
+			wantFamily:  "e2",
 		},
 		"invalid machine type": {
 			machineType: "nodashes",


### PR DESCRIPTION
The previous implementation didn't handle machine types with the
"-ext" suffix, or E2 shared-core custom machine types.