### PR TITLE
cluster-autoscaler aws: remove duplicated permissions

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -58,7 +58,6 @@ should be updated to restrict the resources/add conditionals:
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "ec2:DescribeImages",
-        "ec2:DescribeInstanceTypes",
         "ec2:GetInstanceTypesFromInstanceRequirements",
         "eks:DescribeNodegroup"
       ],


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

remove a duplicated permission in the docs (already in the first block, no need in the second block)

```release-note
NONE
```
