### PR TITLE
update clusterapi nodegroups processor

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups.go
@@ -25,7 +25,11 @@ import (
 // even if they have different infrastructure provider-specific labels.
 func CreateClusterAPINodeInfoComparator(extraIgnoredLabels []string) NodeInfoComparator {
 	capiIgnoredLabels := map[string]bool{
-		"topology.ebs.csi.aws.com/zone": true, // this is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity
+		"topology.ebs.csi.aws.com/zone":                 true, // this is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity
+		"topology.diskplugin.csi.alibabacloud.com/zone": true, // this is a label used by the Alibaba Cloud CSI driver as a target for Persistent Volume Node Affinity
+		"ibm-cloud.kubernetes.io/worker-id":             true, // this is a label used by the IBM Cloud Cloud Controler Manager
+		"vpc-block-csi-driver-labels":                   true, // this is a label used by the IBM Cloud CSI driver as a target for Persisten Volume Node Affinity
+
 	}
 
 	for k, v := range BasicIgnoredLabels {

--- a/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups_test.go
@@ -50,6 +50,27 @@ func TestIsClusterAPINodeInfoSimilar(t *testing.T) {
 			removeOneLabel: false,
 		},
 		{
+			description:    "topology.diskplugin.csi.alibabacloud.com/zone different values",
+			label:          "topology.diskplugin.csi.alibabacloud.com/zone",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
+			description:    "ibm-cloud.kubernetes.io/worker-id different values",
+			label:          "ibm-cloud.kubernetes.io/worker-id",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
+			description:    "vpc-block-csi-driver-labels different values",
+			label:          "vpc-block-csi-driver-labels",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
 			description:    "topology.ebs.csi.aws.com/zone one node labeled",
 			label:          "topology.ebs.csi.aws.com/zone",
 			value1:         "foo",


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

this change adds labels that are used on Alibaba Cloud and IBM Cloud for
CSI and CCM.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
