### PR TITLE
Export metric_server_response like other VPA recommender metrics

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -18,35 +18,16 @@ package metrics
 
 import (
 	"context"
-	"strconv"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	k8sapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
+	recommender_metrics "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 	klog "k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
-
-const (
-	metricsNamespace = metrics.TopMetricsNamespace + "metrics-server-client"
-)
-
-var metricServerResponses = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Name:      "metric_server_responses",
-		Help:      "Count of responses to queries to metrics server",
-	}, []string{"is_error"},
-)
-
-// Register initializes all VPA metrics for metrics server client
-func Register() {
-	prometheus.MustRegister(metricServerResponses)
-}
 
 // ContainerMetricsSnapshot contains information about usage of certain container within defined time window.
 type ContainerMetricsSnapshot struct {
@@ -87,8 +68,8 @@ func (c *metricsClient) GetContainersMetrics() ([]*ContainerMetricsSnapshot, err
 
 	podMetricsInterface := c.metricsGetter.PodMetricses(c.namespace)
 	podMetricsList, err := podMetricsInterface.List(context.TODO(), metav1.ListOptions{})
+	recommender_metrics.RecordMetricsServerResponse(err)
 	if err != nil {
-		metricServerResponses.WithLabelValues(strconv.FormatBool(true)).Inc()
 		return nil, err
 	}
 	klog.V(3).Infof("%v podMetrics retrieved for all namespaces", len(podMetricsList.Items))
@@ -96,7 +77,6 @@ func (c *metricsClient) GetContainersMetrics() ([]*ContainerMetricsSnapshot, err
 		metricsSnapshotsForPod := createContainerMetricsSnapshots(podMetrics)
 		metricsSnapshots = append(metricsSnapshots, metricsSnapshotsForPod...)
 	}
-	metricServerResponses.WithLabelValues(strconv.FormatBool(false)).Inc()
 	return metricsSnapshots, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -51,15 +51,17 @@ type MetricsClient interface {
 type metricsClient struct {
 	metricsGetter resourceclient.PodMetricsesGetter
 	namespace     string
+	clientName    string
 }
 
 // NewMetricsClient creates new instance of MetricsClient, which is used by recommender.
 // It requires an instance of PodMetricsesGetter, which is used for underlying communication with metrics server.
 // namespace limits queries to particular namespace, use k8sapiv1.NamespaceAll to select all namespaces.
-func NewMetricsClient(metricsGetter resourceclient.PodMetricsesGetter, namespace string) MetricsClient {
+func NewMetricsClient(metricsGetter resourceclient.PodMetricsesGetter, namespace, clientName string) MetricsClient {
 	return &metricsClient{
 		metricsGetter: metricsGetter,
 		namespace:     namespace,
+		clientName:    clientName,
 	}
 }
 
@@ -68,7 +70,7 @@ func (c *metricsClient) GetContainersMetrics() ([]*ContainerMetricsSnapshot, err
 
 	podMetricsInterface := c.metricsGetter.PodMetricses(c.namespace)
 	podMetricsList, err := podMetricsInterface.List(context.TODO(), metav1.ListOptions{})
-	recommender_metrics.RecordMetricsServerResponse(err)
+	recommender_metrics.RecordMetricsServerResponse(err, c.clientName)
 	if err != nil {
 		return nil, err
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -84,7 +84,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "")
+	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -23,7 +23,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
-	vpa_metrics_client "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
@@ -82,7 +81,6 @@ func main() {
 	metrics.Initialize(*address, healthCheck)
 	metrics_recommender.Register()
 	metrics_quality.Register()
-	vpa_metrics_client.Register()
 
 	useCheckpoints := *storage != "prometheus"
 	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace)

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -261,7 +261,7 @@ func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, us
 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 	return RecommenderFactory{
 		ClusterState:           clusterState,
-		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState, *memorySaver, namespace),
+		ClusterStateFeeder:     input.NewClusterStateFeeder(config, clusterState, *memorySaver, namespace, "default-metrics-client"),
 		ControllerFetcher:      controllerFetcher,
 		CheckpointWriter:       checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
 		VpaClient:              vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
@@ -19,6 +19,7 @@ package recommender
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -71,6 +72,14 @@ var (
 			Help:      "Number of aggregate container states being tracked by the recommender",
 		},
 	)
+
+	metricServerResponses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "metric_server_responses",
+			Help:      "Count of responses to queries to metrics server",
+		}, []string{"is_error"},
+	)
 )
 
 type objectCounterKey struct {
@@ -88,7 +97,7 @@ type ObjectCounter struct {
 
 // Register initializes all metrics for VPA Recommender
 func Register() {
-	prometheus.MustRegister(vpaObjectCount, recommendationLatency, functionLatency, aggregateContainerStatesCount)
+	prometheus.MustRegister(vpaObjectCount, recommendationLatency, functionLatency, aggregateContainerStatesCount, metricServerResponses)
 }
 
 // NewExecutionTimer provides a timer for Recommender's RunOnce execution
@@ -104,6 +113,11 @@ func ObserveRecommendationLatency(created time.Time) {
 // RecordAggregateContainerStatesCount records the number of containers being tracked by the recommender
 func RecordAggregateContainerStatesCount(statesCount int) {
 	aggregateContainerStatesCount.Set(float64(statesCount))
+}
+
+// RecordMetricsServerResponse records result of a query to metrics server
+func RecordMetricsServerResponse(err error) {
+	metricServerResponses.WithLabelValues(strconv.FormatBool(err != nil)).Inc()
 }
 
 // NewObjectCounter creates a new helper to split VPA objects into buckets

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
@@ -78,7 +78,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "metric_server_responses",
 			Help:      "Count of responses to queries to metrics server",
-		}, []string{"is_error"},
+		}, []string{"is_error", "client_name"},
 	)
 )
 
@@ -116,8 +116,8 @@ func RecordAggregateContainerStatesCount(statesCount int) {
 }
 
 // RecordMetricsServerResponse records result of a query to metrics server
-func RecordMetricsServerResponse(err error) {
-	metricServerResponses.WithLabelValues(strconv.FormatBool(err != nil)).Inc()
+func RecordMetricsServerResponse(err error, clientName string) {
+	metricServerResponses.WithLabelValues(strconv.FormatBool(err != nil), clientName).Inc()
 }
 
 // NewObjectCounter creates a new helper to split VPA objects into buckets


### PR DESCRIPTION
There is no reason for the metric to be exported differently than other metrics

Hyphens in name of the metric caused prometheus errors

#### Which component this PR applies to?

VPA recommmender

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

VPA recommender fails to initialize because we call MustRegister on a metric with an invalid name and the registration fails.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

