### PR TITLE
Export validateVPA to use in other places

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -83,7 +83,7 @@ func (h *resourceHandler) GetPatches(ar *v1.AdmissionRequest) ([]resource.PatchR
 		return nil, err
 	}
 
-	err = validateVPA(vpa, isCreate)
+	err = ValidateVPA(vpa, isCreate)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,8 @@ func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
 	return &vpa, nil
 }
 
-func validateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
+// ValidateVPA checks the correctness of VPA Spec and returns an error if there is a problem.
+func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	if vpa.Spec.UpdatePolicy != nil {
 		mode := vpa.Spec.UpdatePolicy.UpdateMode
 		if mode == nil {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -281,7 +281,7 @@ func TestValidateVPA(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
-			err := validateVPA(&tc.vpa, tc.isCreate)
+			err := ValidateVPA(&tc.vpa, tc.isCreate)
 			if tc.expectError == nil {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
#### Which component this PR applies to?

VPA admission-controller

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`validateVPA` is a common function that can be used outside of the `admission-controller/resource/vpa/handler.go`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE