### PR TITLE
Azure: support node label keys having underscores

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -37,13 +37,13 @@ If you are using `nodeSelector`, you need to tag the VMSS  with a node-template 
 
 To add the label of `foo=bar` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_label_foo: bar`.
 
-You can also use forward slashes in the labels by setting them as an underscore in the tag name. For example to add the label of `k8s.io/foo=bar` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_label_k8s.io_foo: bar`
+You can also use forward slashes in the labels by setting them as an underscore in the tag name. For example to add the label of `k8s.io/foo=bar` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_label_k8s.io_foo: bar`. To encode a tag name containing an underscore, use "~2" (eg. "cpu~2arch" gives "cpu_arch").
 
 #### Taints
 
 To add the taint of `foo=bar:NoSchedule` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_taint_foo: bar:NoSchedule`.
 
-You can also use forward slashes in taints by setting them as an underscore in the tag name. For example to add the taint of `k8s.io/foo=bar:NoSchedule` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_taint_k8s.io_foo: bar:NoSchedule`
+You can also use forward slashes in taints by setting them as an underscore in the tag name. For example to add the taint of `k8s.io/foo=bar:NoSchedule` to a node from a VMSS pool, you would add the following tag to the VMSS `k8s.io_cluster-autoscaler_node-template_taint_k8s.io_foo: bar:NoSchedule`. To encode a taint name containing an underscore, use "~2".
 
 #### Resources
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -166,6 +166,7 @@ func extractLabelsFromScaleSet(tags map[string]*string) map[string]string {
 		splits := strings.Split(tagName, nodeLabelTagName)
 		if len(splits) > 1 {
 			label := strings.Replace(splits[1], "_", "/", -1)
+			label = strings.Replace(label, "~2", "_", -1)
 			if label != "" {
 				result[label] = *tagValue
 			}
@@ -188,6 +189,7 @@ func extractTaintsFromScaleSet(tags map[string]*string) []apiv1.Taint {
 				values := strings.SplitN(*tagValue, ":", 2)
 				if len(values) > 1 {
 					taintKey := strings.Replace(splits[1], "_", "/", -1)
+					taintKey = strings.Replace(taintKey, "~2", "_", -1)
 					taints = append(taints, apiv1.Taint{
 						Key:    taintKey,
 						Value:  values[0],
@@ -258,6 +260,7 @@ func extractAllocatableResourcesFromScaleSet(tags map[string]*string) map[string
 		}
 
 		normalizedResourceName := strings.Replace(resourceName[1], "_", "/", -1)
+		normalizedResourceName = strings.Replace(normalizedResourceName, "~2", "/", -1)
 		quantity, err := resource.ParseQuantity(*tagValue)
 		if err != nil {
 			continue

--- a/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
@@ -31,15 +31,27 @@ func TestExtractLabelsFromScaleSet(t *testing.T) {
 	extraNodeLabelValue := "buzz"
 	blankString := ""
 
+	escapedSlashNodeLabelKey := "spam_egg"
+	escapedSlashNodeLabelValue := "foo"
+	expectedSlashEscapedNodeLabelKey := "spam/egg"
+
+	escapedUnderscoreNodeLabelKey := "foo~2bar"
+	escapedUnderscoreNodeLabelValue := "egg"
+	expectedUnderscoreEscapedNodeLabelKey := "foo_bar"
+
 	tags := map[string]*string{
 		fmt.Sprintf("%s%s", nodeLabelTagName, expectedNodeLabelKey): &expectedNodeLabelValue,
 		"fizz": &extraNodeLabelValue,
 		"bip":  &blankString,
+		fmt.Sprintf("%s%s", nodeLabelTagName, escapedSlashNodeLabelKey):      &escapedSlashNodeLabelValue,
+		fmt.Sprintf("%s%s", nodeLabelTagName, escapedUnderscoreNodeLabelKey): &escapedUnderscoreNodeLabelValue,
 	}
 
 	labels := extractLabelsFromScaleSet(tags)
-	assert.Len(t, labels, 1)
+	assert.Len(t, labels, 3)
 	assert.Equal(t, expectedNodeLabelValue, labels[expectedNodeLabelKey])
+	assert.Equal(t, escapedSlashNodeLabelValue, labels[expectedSlashEscapedNodeLabelKey])
+	assert.Equal(t, escapedUnderscoreNodeLabelValue, labels[expectedUnderscoreEscapedNodeLabelKey])
 }
 
 func TestExtractTaintsFromScaleSet(t *testing.T) {


### PR DESCRIPTION
Azure VMSS tags allowed character set isn't the exact same as the Kubernetes labels' character set. In particular "/" aren't supported as VMSS tags, but are allowed for Kubernetes labels. To support reflecting label values containing "/" to VMSS tags, the cluster-autoscaler evaluates underscores ("_") in VMSS tags keys as slashes ("/") in nodes labels keys.

But due to that substitution, a node label containing "_" (also a valid character for a k8s label) can't be reflected to VMSS tags (as it will be mis-read as a "/").

This PR takes inspiration from rfc6901's JSON escaping (rather hideous, but possibly familiar as it's used by kubectl-patch), by using ("~2") as a replacement for "_".

The tilde (`~`) character isn't allowed in k8s labels (and taints) keys so there's no possible ambiguities or regressions (a VMSS tag key having a "`~`" is currently evaluated to an impossible k8s label).

Labels and taints supported character sets:
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
