### PR TITLE
Update go version to 1.18.5

### DIFF
--- a/vertical-pod-autoscaler/builder/Dockerfile
+++ b/vertical-pod-autoscaler/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.12
+FROM golang:1.18.5
 LABEL maintainer="Beata Skiba	<bskiba@google.com>"
 
 ENV GOPATH /gopath/
@@ -22,6 +22,6 @@ ARG GOARCH
 ARG LDFLAGS
 
 RUN go version
-RUN go get github.com/tools/godep
+RUN go install github.com/tools/godep@latest
 RUN godep version
 CMD ["/bin/bash"]


### PR DESCRIPTION
#### Which component this PR applies to?
vertical-pod-autoscaler

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Update go version to 1.18.5 to stay in sync with k8s 1.25: https://github.com/kubernetes/release/issues/2625
* Switch from `go get` to `go install`, as `go get` no longer installs binaries

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bump go version to 1.18.5
```
