### PR TITLE
Extract criteria for removing unneded nodes to a separate package

### DIFF
--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -323,8 +323,6 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 	}
 
 	candidateNames := make([]string, 0)
-	readinessMap := make(map[string]bool)
-	candidateNodeGroups := make(map[string]cloudprovider.NodeGroup)
 
 	resourceLimiter, errCP := sd.context.CloudProvider.GetResourceLimiter()
 	if errCP != nil {
@@ -354,7 +352,6 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		}
 
 		ready, _, _ := kube_util.GetReadinessState(node)
-		readinessMap[node.Name] = ready
 
 		nodeGroup, err := sd.context.CloudProvider.NodeGroupForNode(node)
 		if err != nil {
@@ -431,7 +428,6 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		}
 
 		candidateNames = append(candidateNames, node.Name)
-		candidateNodeGroups[node.Name] = nodeGroup
 	}
 
 	if len(candidateNames) == 0 {

--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -27,15 +27,14 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unneeded"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unremovable"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
-	"k8s.io/autoscaler/cluster-autoscaler/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -48,9 +47,8 @@ type ScaleDown struct {
 	context              *context.AutoscalingContext
 	processors           *processors.AutoscalingProcessors
 	clusterStateRegistry *clusterstate.ClusterStateRegistry
-	unneededNodes        map[string]time.Time
-	unneededNodesList    []*apiv1.Node
 	unremovableNodes     *unremovable.Nodes
+	unneededNodes        *unneeded.Nodes
 	podLocationHints     map[string]string
 	nodeUtilizationMap   map[string]utilization.Info
 	usageTracker         *simulator.UsageTracker
@@ -65,20 +63,20 @@ func NewScaleDown(context *context.AutoscalingContext, processors *processors.Au
 	usageTracker := simulator.NewUsageTracker()
 	removalSimulator := simulator.NewRemovalSimulator(context.ListerRegistry, context.ClusterSnapshot, context.PredicateChecker, usageTracker, false)
 	unremovableNodes := unremovable.NewNodes()
+	resourceLimitsFinder := resource.NewLimitsFinder(processors.CustomResourcesProcessor)
 	return &ScaleDown{
 		context:              context,
 		processors:           processors,
 		clusterStateRegistry: clusterStateRegistry,
-		unneededNodes:        make(map[string]time.Time),
 		unremovableNodes:     unremovableNodes,
+		unneededNodes:        unneeded.NewNodes(processors.NodeGroupConfigProcessor, resourceLimitsFinder),
 		podLocationHints:     make(map[string]string),
 		nodeUtilizationMap:   make(map[string]utilization.Info),
 		usageTracker:         usageTracker,
-		unneededNodesList:    make([]*apiv1.Node, 0),
 		nodeDeletionTracker:  ndt,
 		removalSimulator:     removalSimulator,
 		eligibilityChecker:   eligibility.NewChecker(processors.NodeGroupConfigProcessor),
-		resourceLimitsFinder: resource.NewLimitsFinder(processors.CustomResourcesProcessor),
+		resourceLimitsFinder: resourceLimitsFinder,
 	}
 }
 
@@ -91,17 +89,16 @@ func (sd *ScaleDown) CleanUp(timestamp time.Time) {
 
 // CleanUpUnneededNodes clears the list of unneeded nodes.
 func (sd *ScaleDown) CleanUpUnneededNodes() {
-	sd.unneededNodesList = make([]*apiv1.Node, 0)
-	sd.unneededNodes = make(map[string]time.Time)
+	sd.unneededNodes.Clear()
 }
 
 // UnneededNodes returns a list of nodes that can potentially be scaled down.
 func (sd *ScaleDown) UnneededNodes() []*apiv1.Node {
-	return sd.unneededNodesList
+	return sd.unneededNodes.AsList()
 }
 
 // UpdateUnneededNodes calculates which nodes are not needed, i.e. all pods can be scheduled somewhere else,
-// and updates unneededNodes map accordingly. It also computes information where pods can be rescheduled and
+// and updates unneededNodes accordingly. It also computes information where pods can be rescheduled and
 // node utilization level. The computations are made only for the nodes managed by CA.
 // * destinationNodes are the nodes that can potentially take in any pods that are evicted because of a scale down.
 // * scaleDownCandidates are the nodes that are being considered for scale down.
@@ -199,17 +196,7 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	}
 
 	// Update the timestamp map.
-	result := make(map[string]time.Time)
-	unneededNodesList := make([]*apiv1.Node, 0, len(nodesToRemove))
-	for _, node := range nodesToRemove {
-		name := node.Node.Name
-		unneededNodesList = append(unneededNodesList, node.Node)
-		if val, found := sd.unneededNodes[name]; !found {
-			result[name] = timestamp
-		} else {
-			result[name] = val
-		}
-	}
+	sd.unneededNodes.Update(nodesToRemove, timestamp)
 
 	// Add nodes to unremovable map
 	if len(unremovable) > 0 {
@@ -223,24 +210,18 @@ func (sd *ScaleDown) UpdateUnneededNodes(
 	// This method won't always check all nodes, so let's give a generic reason for all nodes that weren't checked.
 	for _, node := range scaleDownCandidates {
 		unremovableReasonProvided := sd.unremovableNodes.HasReason(node.Name)
-		_, unneeded := result[node.Name]
+		unneeded := sd.unneededNodes.Contains(node.Name)
 		if !unneeded && !unremovableReasonProvided {
 			sd.unremovableNodes.AddReason(node, simulator.NotUnneededOtherReason)
 		}
 	}
 
 	// Update state and metrics
-	sd.unneededNodesList = unneededNodesList
-	sd.unneededNodes = result
 	sd.podLocationHints = newHints
 	sd.nodeUtilizationMap = utilizationMap
-	sd.clusterStateRegistry.UpdateScaleDownCandidates(sd.unneededNodesList, timestamp)
-	metrics.UpdateUnneededNodesCount(len(sd.unneededNodesList))
-	if klog.V(4).Enabled() {
-		for key, val := range sd.unneededNodes {
-			klog.Infof("%s is unneeded since %s duration %s", key, val.String(), timestamp.Sub(val).String())
-		}
-	}
+	unneededNodesList := sd.unneededNodes.AsList()
+	sd.clusterStateRegistry.UpdateScaleDownCandidates(unneededNodesList, timestamp)
+	metrics.UpdateUnneededNodesCount(len(unneededNodesList))
 	return nil
 }
 
@@ -260,10 +241,9 @@ func (sd *ScaleDown) UnremovableNodes() []*simulator.UnremovableNode {
 func (sd *ScaleDown) markSimulationError(simulatorErr errors.AutoscalerError,
 	timestamp time.Time) errors.AutoscalerError {
 	klog.Errorf("Error while simulating node drains: %v", simulatorErr)
-	sd.unneededNodesList = make([]*apiv1.Node, 0)
-	sd.unneededNodes = make(map[string]time.Time)
+	sd.unneededNodes.Clear()
 	sd.nodeUtilizationMap = make(map[string]utilization.Info)
-	sd.clusterStateRegistry.UpdateScaleDownCandidates(sd.unneededNodesList, timestamp)
+	sd.clusterStateRegistry.UpdateScaleDownCandidates(nil, timestamp)
 	return simulatorErr.AddPrefix("error while simulating node drains: ")
 }
 
@@ -277,7 +257,7 @@ func (sd *ScaleDown) chooseCandidates(nodes []string) (candidates []string, nonC
 		return nodes, nil
 	}
 	for _, node := range nodes {
-		if _, found := sd.unneededNodes[node]; found {
+		if sd.unneededNodes.Contains(node) {
 			candidates = append(candidates, node)
 		} else {
 			nonCandidates = append(nonCandidates, node)
@@ -322,112 +302,22 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		allNodeNames = append(allNodeNames, ni.Node().Name)
 	}
 
-	candidateNames := make([]string, 0)
-
 	resourceLimiter, errCP := sd.context.CloudProvider.GetResourceLimiter()
 	if errCP != nil {
 		return nil, nil, status.ScaleDownError, errors.ToAutoscalerError(errors.CloudProviderError, errCP)
 	}
 
 	scaleDownResourcesLeft := sd.resourceLimitsFinder.LimitsLeft(sd.context, allNodes, resourceLimiter, currentTime)
-
-	nodeGroupSize := utils.GetNodeGroupSizeMap(sd.context.CloudProvider)
-	resourcesWithLimits := resourceLimiter.GetResources()
-	for nodeName, unneededSince := range sd.unneededNodes {
-		klog.V(2).Infof("%s was unneeded for %s", nodeName, currentTime.Sub(unneededSince).String())
-
-		nodeInfo, err := sd.context.ClusterSnapshot.NodeInfos().Get(nodeName)
-		if err != nil {
-			klog.Errorf("Can't retrieve unneeded node %s from snapshot, err: %v", nodeName, err)
-			continue
-		}
-
-		node := nodeInfo.Node()
-
-		// Check if node is marked with no scale down annotation.
-		if eligibility.HasNoScaleDownAnnotation(node) {
-			klog.V(4).Infof("Skipping %s - scale down disabled annotation found", node.Name)
-			sd.unremovableNodes.AddReason(node, simulator.ScaleDownDisabledAnnotation)
-			continue
-		}
-
-		ready, _, _ := kube_util.GetReadinessState(node)
-
-		nodeGroup, err := sd.context.CloudProvider.NodeGroupForNode(node)
-		if err != nil {
-			klog.Errorf("Error while checking node group for %s: %v", node.Name, err)
-			sd.unremovableNodes.AddReason(node, simulator.UnexpectedError)
-			continue
-		}
-		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
-			klog.V(4).Infof("Skipping %s - no node group config", node.Name)
-			sd.unremovableNodes.AddReason(node, simulator.NotAutoscaled)
-			continue
-		}
-
-		if ready {
-			// Check how long a ready node was underutilized.
-			unneededTime, err := sd.processors.NodeGroupConfigProcessor.GetScaleDownUnneededTime(sd.context, nodeGroup)
-			if err != nil {
-				klog.Errorf("Error trying to get ScaleDownUnneededTime for node %s (in group: %s)", node.Name, nodeGroup.Id())
-				continue
-			}
-			if !unneededSince.Add(unneededTime).Before(currentTime) {
-				sd.unremovableNodes.AddReason(node, simulator.NotUnneededLongEnough)
-				continue
-			}
-		} else {
-			// Unready nodes may be deleted after a different time than underutilized nodes.
-			unreadyTime, err := sd.processors.NodeGroupConfigProcessor.GetScaleDownUnreadyTime(sd.context, nodeGroup)
-			if err != nil {
-				klog.Errorf("Error trying to get ScaleDownUnreadyTime for node %s (in group: %s)", node.Name, nodeGroup.Id())
-				continue
-			}
-			if !unneededSince.Add(unreadyTime).Before(currentTime) {
-				sd.unremovableNodes.AddReason(node, simulator.NotUnreadyLongEnough)
-				continue
-			}
-		}
-
-		size, found := nodeGroupSize[nodeGroup.Id()]
-		if !found {
-			klog.Errorf("Error while checking node group size %s: group size not found in cache", nodeGroup.Id())
-			sd.unremovableNodes.AddReason(node, simulator.UnexpectedError)
-			continue
-		}
-
-		deletionsInProgress := sd.nodeDeletionTracker.DeletionsCount(nodeGroup.Id())
-		if size-deletionsInProgress <= nodeGroup.MinSize() {
-			klog.V(1).Infof("Skipping %s - node group min size reached", node.Name)
-			sd.unremovableNodes.AddReason(node, simulator.NodeGroupMinSizeReached)
-			continue
-		}
-
-		scaleDownResourcesDelta, err := sd.resourceLimitsFinder.DeltaForNode(sd.context, node, nodeGroup, resourcesWithLimits)
-		if err != nil {
-			klog.Errorf("Error getting node resources: %v", err)
-			sd.unremovableNodes.AddReason(node, simulator.UnexpectedError)
-			continue
-		}
-
-		checkResult := scaleDownResourcesLeft.CheckDeltaWithinLimits(scaleDownResourcesDelta)
-		if checkResult.Exceeded() {
-			klog.V(4).Infof("Skipping %s - minimal limit exceeded for %v", node.Name, checkResult.ExceededResources)
-			sd.unremovableNodes.AddReason(node, simulator.MinimalResourceLimitExceeded)
-			for _, resource := range checkResult.ExceededResources {
-				switch resource {
-				case cloudprovider.ResourceNameCores:
-					metrics.RegisterSkippedScaleDownCPU()
-				case cloudprovider.ResourceNameMemory:
-					metrics.RegisterSkippedScaleDownMemory()
-				default:
-					continue
-				}
-			}
-			continue
-		}
-
-		candidateNames = append(candidateNames, node.Name)
+	empty, nonEmpty, unremovable := sd.unneededNodes.RemovableAt(sd.context, currentTime, scaleDownResourcesLeft, resourceLimiter.GetResources(), sd.nodeDeletionTracker)
+	for _, u := range unremovable {
+		sd.unremovableNodes.Add(u)
+	}
+	candidateNames := make([]string, 0, len(empty)+len(nonEmpty))
+	for _, n := range empty {
+		candidateNames = append(candidateNames, n.Name)
+	}
+	for _, n := range nonEmpty {
+		candidateNames = append(candidateNames, n.Name)
 	}
 
 	if len(candidateNames) == 0 {
@@ -444,7 +334,7 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		var nodes []*apiv1.Node
 		for _, node := range emptyNodesToRemove {
 			// Nothing super-bad should happen if the node is removed from tracker prematurely.
-			simulator.RemoveNodeFromTracker(sd.usageTracker, node.Node.Name, sd.unneededNodes)
+			sd.removeNodeFromTracker(node.Node.Name)
 			nodes = append(nodes, node.Node)
 		}
 		return nodes, nil, status.ScaleDownNodeDeleteStarted, nil
@@ -474,8 +364,19 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 	}
 	toRemove := nodesToRemove[0]
 	// Nothing super-bad should happen if the node is removed from tracker prematurely.
-	simulator.RemoveNodeFromTracker(sd.usageTracker, toRemove.Node.Name, sd.unneededNodes)
+	sd.removeNodeFromTracker(toRemove.Node.Name)
 	return nil, []*apiv1.Node{toRemove.Node}, status.ScaleDownNodeDeleteStarted, nil
+}
+
+func (sd *ScaleDown) removeNodeFromTracker(node string) {
+	unneeded := make([]string, 0, len(sd.unneededNodes.AsList()))
+	for _, n := range sd.unneededNodes.AsList() {
+		unneeded = append(unneeded, n.Name)
+	}
+	toRemove := simulator.RemoveNodeFromTracker(sd.usageTracker, node, unneeded)
+	for _, n := range toRemove {
+		sd.unneededNodes.Drop(n)
+	}
 }
 
 // updateScaleDownMetrics registers duration of different parts of scale down.

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	klog "k8s.io/klog/v2"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
@@ -151,13 +150,10 @@ func TestFindUnneededNodes(t *testing.T) {
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
-	assert.Equal(t, 3, len(sd.unneededNodes))
-	_, found := sd.unneededNodes["n2"]
-	assert.True(t, found)
-	_, found = sd.unneededNodes["n7"]
-	assert.True(t, found)
-	addTime, found := sd.unneededNodes["n8"]
-	assert.True(t, found)
+	assert.Equal(t, 3, len(sd.unneededNodes.AsList()))
+	assert.True(t, sd.unneededNodes.Contains("n2"))
+	assert.True(t, sd.unneededNodes.Contains("n7"))
+	assert.True(t, sd.unneededNodes.Contains("n8"))
 	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
 	for _, n := range []string{"n1", "n2", "n3", "n4", "n7", "n8"} {
 		_, found := sd.nodeUtilizationMap[n]
@@ -169,16 +165,14 @@ func TestFindUnneededNodes(t *testing.T) {
 	}
 
 	sd.unremovableNodes = unremovable.NewNodes()
-	sd.unneededNodes["n1"] = time.Now()
+	sd.unneededNodes.Update([]simulator.NodeToBeRemoved{{Node: n1}, {Node: n2}, {Node: n3}, {Node: n4}}, time.Now())
 	allNodes = []*apiv1.Node{n1, n2, n3, n4}
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
-	assert.Equal(t, 1, len(sd.unneededNodes))
-	addTime2, found := sd.unneededNodes["n2"]
-	assert.True(t, found)
-	assert.Equal(t, addTime, addTime2)
+	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
+	assert.True(t, sd.unneededNodes.Contains("n2"))
 	for _, n := range []string{"n1", "n2", "n3", "n4"} {
 		_, found := sd.nodeUtilizationMap[n]
 		assert.True(t, found, n)
@@ -194,7 +188,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
-	assert.Equal(t, 0, len(sd.unneededNodes))
+	assert.Equal(t, 0, len(sd.unneededNodes.AsList()))
 
 	// Node n1 is unneeded, but should be skipped because it has just recently been found to be unremovable
 	allNodes = []*apiv1.Node{n1}
@@ -202,7 +196,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
-	assert.Equal(t, 0, len(sd.unneededNodes))
+	assert.Equal(t, 0, len(sd.unneededNodes.AsList()))
 	// Verify that no other nodes are in unremovable map.
 	assert.Equal(t, 1, len(sd.unremovableNodes.AsList()))
 
@@ -211,7 +205,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now().Add(context.UnremovableNodeRecheckTimeout+time.Second), nil)
 	assert.NoError(t, autoscalererr)
 
-	assert.Equal(t, 1, len(sd.unneededNodes))
+	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
 	// Verify that nodes that are no longer unremovable are removed.
 	assert.Equal(t, 0, len(sd.unremovableNodes.AsList()))
 }
@@ -285,9 +279,8 @@ func TestFindUnneededGPUNodes(t *testing.T) {
 
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
-	assert.Equal(t, 1, len(sd.unneededNodes))
-	_, found := sd.unneededNodes["n2"]
-	assert.True(t, found)
+	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
+	assert.True(t, sd.unneededNodes.Contains("n2"))
 
 	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
 	for _, n := range []string{"n1", "n2", "n3"} {
@@ -403,11 +396,9 @@ func TestFindUnneededWithPerNodeGroupThresholds(t *testing.T) {
 
 			autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now(), nil)
 			assert.NoError(t, autoscalererr)
-			klog.Infof("[%s] Unneeded nodes %v", tn, sd.unneededNodes)
-			assert.Equal(t, len(tc.wantUnneeded), len(sd.unneededNodes))
+			assert.Equal(t, len(tc.wantUnneeded), len(sd.unneededNodes.AsList()))
 			for _, node := range tc.wantUnneeded {
-				_, found := sd.unneededNodes[node]
-				assert.True(t, found)
+				assert.True(t, sd.unneededNodes.Contains(node))
 			}
 		})
 	}
@@ -481,12 +472,9 @@ func TestPodsWithPreemptionsFindUnneededNodes(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
-	assert.Equal(t, 2, len(sd.unneededNodes))
-	klog.Warningf("Unneeded nodes %v", sd.unneededNodes)
-	_, found := sd.unneededNodes["n2"]
-	assert.True(t, found)
-	_, found = sd.unneededNodes["n3"]
-	assert.True(t, found)
+	assert.Equal(t, 2, len(sd.unneededNodes.AsList()))
+	assert.True(t, sd.unneededNodes.Contains("n2"))
+	assert.True(t, sd.unneededNodes.Contains("n3"))
 	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
 	assert.Contains(t, sd.podLocationHints, p3.Namespace+"/"+p3.Name)
 	for _, n := range []string{"n1", "n2", "n3", "n4"} {
@@ -546,9 +534,9 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
-	assert.Equal(t, numCandidates, len(sd.unneededNodes))
+	assert.Equal(t, numCandidates, len(sd.unneededNodes.AsList()))
 	// Simulate one of the unneeded nodes got deleted
-	deleted := sd.unneededNodesList[len(sd.unneededNodesList)-1]
+	deleted := sd.unneededNodes.AsList()[len(sd.unneededNodes.AsList())-1]
 	for i, node := range nodes {
 		if node.Name == deleted.Name {
 			// Move pod away from the node
@@ -570,8 +558,8 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	// Check that the deleted node was replaced
-	assert.Equal(t, numCandidates, len(sd.unneededNodes))
-	assert.NotContains(t, sd.unneededNodes, deleted)
+	assert.Equal(t, numCandidates, len(sd.unneededNodes.AsList()))
+	assert.False(t, sd.unneededNodes.Contains(deleted.Name))
 }
 
 func TestFindUnneededEmptyNodes(t *testing.T) {
@@ -627,10 +615,7 @@ func TestFindUnneededEmptyNodes(t *testing.T) {
 	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
-	for _, node := range sd.unneededNodesList {
-		t.Log(node.Name)
-	}
-	assert.Equal(t, numEmpty+numCandidates, len(sd.unneededNodes))
+	assert.Equal(t, numEmpty+numCandidates, len(sd.unneededNodes.AsList()))
 }
 
 func TestFindUnneededNodePool(t *testing.T) {

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unneeded
+
+import (
+	"reflect"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+)
+
+// Nodes tracks the state of cluster nodes that are not needed.
+type Nodes struct {
+	sdtg         scaleDownTimeGetter
+	limitsFinder *resource.LimitsFinder
+	cachedList   []*apiv1.Node
+	byName       map[string]*node
+}
+
+type node struct {
+	ntbr  simulator.NodeToBeRemoved
+	since time.Time
+}
+
+type scaleDownTimeGetter interface {
+	// GetScaleDownUnneededTime returns ScaleDownUnneededTime value that should be used for a given NodeGroup.
+	GetScaleDownUnneededTime(context *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup) (time.Duration, error)
+	// GetScaleDownUnreadyTime returns ScaleDownUnreadyTime value that should be used for a given NodeGroup.
+	GetScaleDownUnreadyTime(context *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup) (time.Duration, error)
+}
+
+// NewNodes returns a new initialized Nodes object.
+func NewNodes(sdtg scaleDownTimeGetter, limitsFinder *resource.LimitsFinder) *Nodes {
+	return &Nodes{
+		sdtg:         sdtg,
+		limitsFinder: limitsFinder,
+	}
+}
+
+// Update stores nodes along with a time at which they were found to be
+// unneeded. Previously existing timestamps are preserved.
+func (n *Nodes) Update(nodes []simulator.NodeToBeRemoved, ts time.Time) {
+	updated := make(map[string]*node, len(nodes))
+	for _, nn := range nodes {
+		name := nn.Node.Name
+		updated[name] = &node{
+			ntbr: nn,
+		}
+		if val, found := n.byName[name]; found {
+			updated[name].since = val.since
+		} else {
+			updated[name].since = ts
+		}
+	}
+	n.byName = updated
+	n.cachedList = nil
+	if klog.V(4).Enabled() {
+		for k, v := range n.byName {
+			klog.Infof("%s is unneeded since %s duration %s", k, v.since, ts.Sub(v.since))
+		}
+	}
+}
+
+// Clear resets the internal state, dropping information about all tracked nodes.
+func (n *Nodes) Clear() {
+	n.Update(nil, time.Time{})
+}
+
+// Contains returns true iff a given node is unneeded.
+func (n *Nodes) Contains(nodeName string) bool {
+	_, found := n.byName[nodeName]
+	return found
+}
+
+// AsList returns a slice of unneeded Node objects.
+func (n *Nodes) AsList() []*apiv1.Node {
+	if n.cachedList == nil {
+		n.cachedList = make([]*apiv1.Node, 0, len(n.byName))
+		for _, v := range n.byName {
+			n.cachedList = append(n.cachedList, v.ntbr.Node)
+		}
+	}
+	return n.cachedList
+}
+
+// Drop stops tracking a specified node.
+func (n *Nodes) Drop(node string) {
+	delete(n.byName, node)
+	n.cachedList = nil
+}
+
+// RemovableAt returns all nodes that can be removed at a given time, divided
+// into empty and non-empty node lists, as well as a list of nodes that were
+// unneeded, but are not removable, annotated by reason.
+func (n *Nodes) RemovableAt(context *context.AutoscalingContext, ts time.Time, resourcesLeft resource.Limits, resourcesWithLimits []string, as scaledown.ActuationStatus) (empty, needDrain []*apiv1.Node, unremovable []*simulator.UnremovableNode) {
+	nodeGroupSize := utils.GetNodeGroupSizeMap(context.CloudProvider)
+	for nodeName, v := range n.byName {
+		klog.V(2).Infof("%s was unneeded for %s", nodeName, ts.Sub(v.since).String())
+		node := v.ntbr.Node
+
+		if r := n.unremovableReason(context, v, ts, nodeGroupSize, resourcesLeft, resourcesWithLimits, as); r != simulator.NoReason {
+			unremovable = append(unremovable, &simulator.UnremovableNode{Node: node, Reason: r})
+			continue
+		}
+
+		if len(v.ntbr.PodsToReschedule) > 0 {
+			needDrain = append(needDrain, node)
+		} else {
+			empty = append(empty, node)
+		}
+	}
+	return
+}
+
+func (n *Nodes) unremovableReason(context *context.AutoscalingContext, v *node, ts time.Time, nodeGroupSize map[string]int, resourcesLeft resource.Limits, resourcesWithLimits []string, as scaledown.ActuationStatus) simulator.UnremovableReason {
+	node := v.ntbr.Node
+	// Check if node is marked with no scale down annotation.
+	if eligibility.HasNoScaleDownAnnotation(node) {
+		klog.V(4).Infof("Skipping %s - scale down disabled annotation found", node.Name)
+		return simulator.ScaleDownDisabledAnnotation
+	}
+	ready, _, _ := kube_util.GetReadinessState(node)
+
+	nodeGroup, err := context.CloudProvider.NodeGroupForNode(node)
+	if err != nil {
+		klog.Errorf("Error while checking node group for %s: %v", node.Name, err)
+		return simulator.UnexpectedError
+	}
+	if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
+		klog.V(4).Infof("Skipping %s - no node group config", node.Name)
+		return simulator.NotAutoscaled
+	}
+
+	if ready {
+		// Check how long a ready node was underutilized.
+		unneededTime, err := n.sdtg.GetScaleDownUnneededTime(context, nodeGroup)
+		if err != nil {
+			klog.Errorf("Error trying to get ScaleDownUnneededTime for node %s (in group: %s)", node.Name, nodeGroup.Id())
+			return simulator.UnexpectedError
+		}
+		if !v.since.Add(unneededTime).Before(ts) {
+			return simulator.NotUnneededLongEnough
+		}
+	} else {
+		// Unready nodes may be deleted after a different time than underutilized nodes.
+		unreadyTime, err := n.sdtg.GetScaleDownUnreadyTime(context, nodeGroup)
+		if err != nil {
+			klog.Errorf("Error trying to get ScaleDownUnreadyTime for node %s (in group: %s)", node.Name, nodeGroup.Id())
+			return simulator.UnexpectedError
+		}
+		if !v.since.Add(unreadyTime).Before(ts) {
+			return simulator.NotUnreadyLongEnough
+		}
+	}
+
+	size, found := nodeGroupSize[nodeGroup.Id()]
+	if !found {
+		klog.Errorf("Error while checking node group size %s: group size not found in cache", nodeGroup.Id())
+		return simulator.UnexpectedError
+	}
+
+	deletionsInProgress := as.DeletionsCount(nodeGroup.Id())
+	if size-deletionsInProgress <= nodeGroup.MinSize() {
+		klog.V(1).Infof("Skipping %s - node group min size reached", node.Name)
+		return simulator.NodeGroupMinSizeReached
+	}
+
+	resourceDelta, err := n.limitsFinder.DeltaForNode(context, node, nodeGroup, resourcesWithLimits)
+	if err != nil {
+		klog.Errorf("Error getting node resources: %v", err)
+		return simulator.UnexpectedError
+	}
+
+	checkResult := resourcesLeft.CheckDeltaWithinLimits(resourceDelta)
+	if checkResult.Exceeded() {
+		klog.V(4).Infof("Skipping %s - minimal limit exceeded for %v", node.Name, checkResult.ExceededResources)
+		for _, resource := range checkResult.ExceededResources {
+			switch resource {
+			case cloudprovider.ResourceNameCores:
+				metrics.RegisterSkippedScaleDownCPU()
+			case cloudprovider.ResourceNameMemory:
+				metrics.RegisterSkippedScaleDownMemory()
+			default:
+				continue
+			}
+		}
+		return simulator.MinimalResourceLimitExceeded
+	}
+
+	return simulator.NoReason
+}

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unneeded
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdate(t *testing.T) {
+	initialTimestamp := time.Now()
+	finalTimestamp := initialTimestamp.Add(1 * time.Minute)
+	testCases := []struct {
+		desc           string
+		initialNodes   []simulator.NodeToBeRemoved
+		finalNodes     []simulator.NodeToBeRemoved
+		wantTimestamps map[string]time.Time
+		wantVersions   map[string]string
+	}{
+		{
+			desc: "added then deleted",
+			initialNodes: []simulator.NodeToBeRemoved{
+				makeNode("n1", "v1"),
+				makeNode("n2", "v1"),
+				makeNode("n3", "v1"),
+			},
+			finalNodes: []simulator.NodeToBeRemoved{},
+		},
+		{
+			desc:         "added in last call",
+			initialNodes: []simulator.NodeToBeRemoved{},
+			finalNodes: []simulator.NodeToBeRemoved{
+				makeNode("n1", "v1"),
+				makeNode("n2", "v1"),
+				makeNode("n3", "v1"),
+			},
+			wantTimestamps: map[string]time.Time{"n1": finalTimestamp, "n2": finalTimestamp, "n3": finalTimestamp},
+			wantVersions:   map[string]string{"n1": "v1", "n2": "v1", "n3": "v1"},
+		},
+		{
+			desc: "single one remaining",
+			initialNodes: []simulator.NodeToBeRemoved{
+				makeNode("n1", "v1"),
+				makeNode("n2", "v1"),
+				makeNode("n3", "v1"),
+			},
+			finalNodes: []simulator.NodeToBeRemoved{
+				makeNode("n2", "v2"),
+			},
+			wantTimestamps: map[string]time.Time{"n2": initialTimestamp},
+			wantVersions:   map[string]string{"n2": "v2"},
+		},
+		{
+			desc: "single one older",
+			initialNodes: []simulator.NodeToBeRemoved{
+				makeNode("n2", "v1"),
+			},
+			finalNodes: []simulator.NodeToBeRemoved{
+				makeNode("n1", "v2"),
+				makeNode("n2", "v2"),
+				makeNode("n3", "v2"),
+			},
+			wantTimestamps: map[string]time.Time{"n1": finalTimestamp, "n2": initialTimestamp, "n3": finalTimestamp},
+			wantVersions:   map[string]string{"n1": "v2", "n2": "v2", "n3": "v2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			nodes := NewNodes(nil, nil)
+			nodes.Update(tc.initialNodes, initialTimestamp)
+			nodes.Update(tc.finalNodes, finalTimestamp)
+			wantNodes := len(tc.wantTimestamps)
+			assert.Equal(t, wantNodes, len(nodes.AsList()))
+			assert.Equal(t, wantNodes, len(nodes.byName))
+			for _, n := range nodes.AsList() {
+				nn, found := nodes.byName[n.Name]
+				assert.True(t, found)
+				assert.Equal(t, tc.wantTimestamps[n.Name], nn.since)
+				assert.Equal(t, tc.wantVersions[n.Name], version(nn.ntbr))
+			}
+		})
+	}
+}
+
+const testVersion = "testVersion"
+
+func makeNode(name, version string) simulator.NodeToBeRemoved {
+	n := BuildTestNode(name, 1000, 10)
+	n.Annotations = map[string]string{testVersion: version}
+	return simulator.NodeToBeRemoved{Node: n}
+}
+
+func version(n simulator.NodeToBeRemoved) string {
+	return n.Node.Annotations[testVersion]
+}

--- a/cluster-autoscaler/simulator/tracker_test.go
+++ b/cluster-autoscaler/simulator/tracker_test.go
@@ -83,14 +83,11 @@ func TestRemove(t *testing.T) {
 	tracker.RegisterUsage("C", "Z", now)
 	tracker.RegisterUsage("M", "N", now)
 
-	utilization := map[string]time.Time{
-		"A": now,
-		"C": now,
-		"X": now,
-		"M": now,
-	}
+	unneededNodes := []string{"A", "C", "X", "M"}
 
-	RemoveNodeFromTracker(tracker, "A", utilization)
+	dropped := RemoveNodeFromTracker(tracker, "A", unneededNodes)
+
+	assert.Equal(t, []string{"A", "X"}, dropped)
 
 	_, foundA := tracker.Get("A")
 	C, foundC := tracker.Get("C")
@@ -101,12 +98,4 @@ func TestRemove(t *testing.T) {
 	assert.True(t, foundX)
 	assert.NotContains(t, C.usedBy, "A")
 	assert.Contains(t, C.usedBy, "X")
-
-	_, foundA = utilization["A"]
-	_, foundC = utilization["C"]
-	_, foundX = utilization["X"]
-
-	assert.False(t, foundA)
-	assert.True(t, foundC)
-	assert.False(t, foundX)
 }


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

One more refactor of existing scale down code in order to make parallel scale down (https://github.com/kubernetes/autoscaler/issues/5079) possible.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is a follow-up to https://github.com/kubernetes/autoscaler/pull/5133. Only last 2 commits should be reviewed as a part of this PR. It will be on hold until the previous one is merged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
