### PR TITLE
Increase timeout for VPA `v1` e2e tests

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -48,7 +48,7 @@ case ${SUITE} in
   recommender|updater|admission-controller|actuation|full-vpa)
     export KUBECONFIG=$HOME/.kube/config
     pushd ${SCRIPT_ROOT}/e2e
-    go test -mod vendor ./v1beta2/*go -v --test.timeout=60m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
+    go test -mod vendor ./v1beta2/*go -v --test.timeout=90m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
     V1BETA2_RESULT=$?
     go test -mod vendor ./v1/*go -v --test.timeout=90m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=/workspace/_artifacts --disable-log-dump
     V1_RESULT=$?


### PR DESCRIPTION
With switch to ginkgo v2 timeout are counted differently[1]. With Ginkgo v1
timeout was per-test-suite. Now its for the whole test run. As a result
`actuation` [2] tests for `v1` API are timing out. They take a little more than
60 minutes. For example passing run [3] logs first '[v1]' at 19:30:23.701
and the last one at 20:33:44.510.

[1] https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior
[2] https://k8s-testgrid.appspot.com/sig-autoscaling-vpa#autoscaling-vpa-actuation
[3] https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-autoscaling-vpa-actuation/1564683608667459584/build-log.txt

#### Which component this PR applies to?

VPA

#### What type of PR is this?


/kind bug
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
