### PR TITLE
Extract scheduling hints to a dedicated object

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	processor_callbacks "k8s.io/autoscaler/cluster-autoscaler/processors/callbacks"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_record "k8s.io/client-go/tools/record"
@@ -42,9 +43,9 @@ type AutoscalingContext struct {
 	CloudProvider cloudprovider.CloudProvider
 	// TODO(kgolab) - move away too as it's not config
 	// PredicateChecker to check if a pod can fit into a node.
-	PredicateChecker simulator.PredicateChecker
+	PredicateChecker predicatechecker.PredicateChecker
 	// ClusterSnapshot denotes cluster snapshot used for predicate checking.
-	ClusterSnapshot simulator.ClusterSnapshot
+	ClusterSnapshot clustersnapshot.ClusterSnapshot
 	// ExpanderStrategy is the strategy used to choose which node group to expand when scaling up
 	ExpanderStrategy expander.Strategy
 	// EstimatorBuilder is the builder function for node count estimator to be used.
@@ -90,8 +91,8 @@ func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions)
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
 func NewAutoscalingContext(
 	options config.AutoscalingOptions,
-	predicateChecker simulator.PredicateChecker,
-	clusterSnapshot simulator.ClusterSnapshot,
+	predicateChecker predicatechecker.PredicateChecker,
+	clusterSnapshot clustersnapshot.ClusterSnapshot,
 	autoscalingKubeClients *AutoscalingKubeClients,
 	cloudProvider cloudprovider.CloudProvider,
 	expanderStrategy expander.Strategy,

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -29,7 +29,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_client "k8s.io/client-go/kubernetes"
@@ -42,8 +43,8 @@ type AutoscalerOptions struct {
 	EventsKubeClient       kube_client.Interface
 	AutoscalingKubeClients *context.AutoscalingKubeClients
 	CloudProvider          cloudprovider.CloudProvider
-	PredicateChecker       simulator.PredicateChecker
-	ClusterSnapshot        simulator.ClusterSnapshot
+	PredicateChecker       predicatechecker.PredicateChecker
+	ClusterSnapshot        clustersnapshot.ClusterSnapshot
 	ExpanderStrategy       expander.Strategy
 	EstimatorBuilder       estimator.EstimatorBuilder
 	Processors             *ca_processors.AutoscalingProcessors
@@ -91,14 +92,14 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 	}
 	if opts.PredicateChecker == nil {
 		predicateCheckerStopChannel := make(chan struct{})
-		predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(opts.KubeClient, predicateCheckerStopChannel)
+		predicateChecker, err := predicatechecker.NewSchedulerBasedPredicateChecker(opts.KubeClient, predicateCheckerStopChannel)
 		if err != nil {
 			return err
 		}
 		opts.PredicateChecker = predicateChecker
 	}
 	if opts.ClusterSnapshot == nil {
-		opts.ClusterSnapshot = simulator.NewBasicClusterSnapshot()
+		opts.ClusterSnapshot = clustersnapshot.NewBasicClusterSnapshot()
 	}
 	if opts.CloudProvider == nil {
 		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts.AutoscalingOptions)

--- a/cluster-autoscaler/core/filteroutschedulable/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/filteroutschedulable/filter_out_schedulable.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 
 	apiv1 "k8s.io/api/core/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
@@ -98,8 +99,8 @@ func (p *filterOutSchedulablePodListProcessor) CleanUp() {
 // and will be scheduled after lower priority pod preemption.
 func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(
 	unschedulableCandidates []*apiv1.Pod,
-	clusterSnapshot simulator.ClusterSnapshot,
-	predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {
+	clusterSnapshot clustersnapshot.ClusterSnapshot,
+	predicateChecker predicatechecker.PredicateChecker) ([]*apiv1.Pod, error) {
 	unschedulablePodsCache := utils.NewPodSchedulableMap()
 
 	// Sort unschedulable pods by importance

--- a/cluster-autoscaler/core/filteroutschedulable/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/filteroutschedulable/filter_out_schedulable_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -100,8 +101,8 @@ func TestFilterOutSchedulableByPacking(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			predicateChecker, err := simulator.NewTestPredicateChecker()
-			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
+			clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 
 			for _, node := range tt.nodes {
 				err := clusterSnapshot.AddNode(node)
@@ -215,9 +216,9 @@ func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
 			pendingPods:   12000,
 		},
 	}
-	snapshots := map[string]func() simulator.ClusterSnapshot{
-		"basic": func() simulator.ClusterSnapshot { return simulator.NewBasicClusterSnapshot() },
-		"delta": func() simulator.ClusterSnapshot { return simulator.NewDeltaClusterSnapshot() },
+	snapshots := map[string]func() clustersnapshot.ClusterSnapshot{
+		"basic": func() clustersnapshot.ClusterSnapshot { return clustersnapshot.NewBasicClusterSnapshot() },
+		"delta": func() clustersnapshot.ClusterSnapshot { return clustersnapshot.NewDeltaClusterSnapshot() },
 	}
 	for snapshotName, snapshotFactory := range snapshots {
 		for _, tc := range tests {
@@ -242,7 +243,7 @@ func BenchmarkFilterOutSchedulableByPacking(b *testing.B) {
 					}
 				}
 
-				predicateChecker, err := simulator.NewTestPredicateChecker()
+				predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 				assert.NoError(b, err)
 
 				clusterSnapshot := snapshotFactory()

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -367,9 +368,9 @@ func (a *Actuator) scheduleDeletion(nodeInfo *framework.NodeInfo, nodeGroupId st
 	}
 }
 
-func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (simulator.ClusterSnapshot, error) {
+func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (clustersnapshot.ClusterSnapshot, error) {
 	knownNodes := make(map[string]bool)
-	snapshot := simulator.NewBasicClusterSnapshot()
+	snapshot := clustersnapshot.NewBasicClusterSnapshot()
 
 	scheduledPods, err := a.ctx.ScheduledPodLister().List()
 	if err != nil {

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -40,7 +40,7 @@ import (
 	acontext "k8s.io/autoscaler/cluster-autoscaler/context"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -157,7 +157,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 			context, err := NewScaleTestAutoscalingContext(options, fakeClient, registry, provider, nil, nil)
 			assert.NoError(t, err)
 
-			simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, []*apiv1.Node{n1}, dsPods)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, []*apiv1.Node{n1}, dsPods)
 
 			evictor := Evictor{
 				DsEvictionEmptyNodeTimeout: scenario.dsEvictionTimeout,
@@ -572,7 +572,7 @@ func TestPodsToEvict(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
-			snapshot := simulator.NewBasicClusterSnapshot()
+			snapshot := clustersnapshot.NewBasicClusterSnapshot()
 			node := BuildTestNode("test-node", 1000, 1000)
 			err := snapshot.AddNodeWithPods(node, tc.pods)
 			if err != nil {

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unremovable"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
@@ -104,7 +104,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 				provider.AddNode("ng1", n)
 			}
 			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, nil, nil)
-			simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, tc.nodes, tc.pods)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, tc.nodes, tc.pods)
 			if err != nil {
 				t.Fatalf("Could not create autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -159,7 +159,6 @@ func TestFindUnneededNodes(t *testing.T) {
 	assert.True(t, sd.unneededNodes.Contains("n2"))
 	assert.True(t, sd.unneededNodes.Contains("n7"))
 	assert.True(t, sd.unneededNodes.Contains("n8"))
-	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
 	for _, n := range []string{"n1", "n2", "n3", "n4", "n7", "n8"} {
 		_, found := sd.nodeUtilizationMap[n]
 		assert.True(t, found, n)
@@ -289,8 +288,6 @@ func TestFindUnneededGPUNodes(t *testing.T) {
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
 	assert.True(t, sd.unneededNodes.Contains("n2"))
-
-	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
 	for _, n := range []string{"n1", "n2", "n3"} {
 		_, found := sd.nodeUtilizationMap[n]
 		assert.True(t, found, n)
@@ -489,8 +486,6 @@ func TestPodsWithPreemptionsFindUnneededNodes(t *testing.T) {
 	assert.Equal(t, 2, len(sd.unneededNodes.AsList()))
 	assert.True(t, sd.unneededNodes.Contains("n2"))
 	assert.True(t, sd.unneededNodes.Contains("n3"))
-	assert.Contains(t, sd.podLocationHints, p2.Namespace+"/"+p2.Name)
-	assert.Contains(t, sd.podLocationHints, p3.Namespace+"/"+p3.Name)
 	for _, n := range []string{"n1", "n2", "n3", "n4"} {
 		_, found := sd.nodeUtilizationMap[n]
 		assert.True(t, found, n)

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -1289,13 +1289,12 @@ func newWrapperForTesting(ctx *context.AutoscalingContext, clusterStateRegistry 
 	if ndt == nil {
 		ndt = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	}
-
 	deleteOptions := simulator.NodeDeleteOptions{
 		SkipNodesWithSystemPods:   true,
 		SkipNodesWithLocalStorage: true,
 		MinReplicaCount:           0,
 	}
-	sd := NewScaleDown(ctx, NewTestProcessors(), clusterStateRegistry, ndt, deleteOptions)
+	sd := NewScaleDown(ctx, NewTestProcessors(), ndt, deleteOptions)
 	actuator := actuation.NewActuator(ctx, clusterStateRegistry, ndt, deleteOptions)
 	return NewScaleDownWrapper(sd, actuator)
 }

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	autoscaler_errors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -150,7 +151,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	sd := wrapper.sd
 	allNodes := []*apiv1.Node{n1, n2, n3, n4, n5, n7, n8, n9}
 
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4, p5, p6})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4, p5, p6})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
@@ -171,7 +172,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	sd.unremovableNodes = unremovable.NewNodes()
 	sd.unneededNodes.Update([]simulator.NodeToBeRemoved{{Node: n1}, {Node: n2}, {Node: n3}, {Node: n4}}, time.Now())
 	allNodes = []*apiv1.Node{n1, n2, n3, n4}
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
@@ -188,7 +189,7 @@ func TestFindUnneededNodes(t *testing.T) {
 
 	sd.unremovableNodes = unremovable.NewNodes()
 	scaleDownCandidates := []*apiv1.Node{n1, n3, n4}
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
@@ -196,7 +197,7 @@ func TestFindUnneededNodes(t *testing.T) {
 
 	// Node n1 is unneeded, but should be skipped because it has just recently been found to be unremovable
 	allNodes = []*apiv1.Node{n1}
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 
@@ -205,7 +206,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	assert.Equal(t, 1, len(sd.unremovableNodes.AsList()))
 
 	// But it should be checked after timeout
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now().Add(context.UnremovableNodeRecheckTimeout+time.Second), nil)
 	assert.NoError(t, autoscalererr)
 
@@ -282,7 +283,7 @@ func TestFindUnneededGPUNodes(t *testing.T) {
 	sd := wrapper.sd
 	allNodes := []*apiv1.Node{n1, n2, n3}
 
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3})
 
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
@@ -397,7 +398,7 @@ func TestFindUnneededWithPerNodeGroupThresholds(t *testing.T) {
 			clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 			wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 			sd := wrapper.sd
-			simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, allPods)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, allPods)
 
 			ng1 := provider.GetNodeGroup("n1").(*testprovider.TestNodeGroup)
 			ng1.SetOptions(tc.n1opts)
@@ -482,7 +483,7 @@ func TestPodsWithPreemptionsFindUnneededNodes(t *testing.T) {
 	sd := wrapper.sd
 
 	allNodes := []*apiv1.Node{n1, n2, n3, n4}
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
 	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, 2, len(sd.unneededNodes.AsList()))
@@ -547,7 +548,7 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, numCandidates, len(sd.unneededNodes.AsList()))
@@ -570,7 +571,7 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 		}
 	}
 
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	// Check that the deleted node was replaced
@@ -631,7 +632,7 @@ func TestFindUnneededEmptyNodes(t *testing.T) {
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, numEmpty+numCandidates, len(sd.unneededNodes.AsList()))
@@ -687,7 +688,7 @@ func TestFindUnneededNodePool(t *testing.T) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
 	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
 	assert.NoError(t, autoscalererr)
 	assert.NotEmpty(t, sd.unneededNodes)
@@ -777,7 +778,7 @@ func TestScaleDown(t *testing.T) {
 
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
@@ -1034,7 +1035,7 @@ func simpleScaleDownEmpty(t *testing.T, config *ScaleTestConfig) {
 
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, config.NodeDeletionTracker)
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
@@ -1128,7 +1129,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	// N1 is unready so it requires a bigger unneeded time.
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
@@ -1152,7 +1153,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	// N1 has been unready for 2 hours, ok to delete.
 	context.CloudProvider = provider
 	wrapper = newWrapperForTesting(&context, clusterStateRegistry, nil)
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-2*time.Hour))
 	assert.NoError(t, autoscalererr)
 	empty, drain = wrapper.NodesToDelete(time.Now())
@@ -1242,7 +1243,7 @@ func TestScaleDownNoMove(t *testing.T) {
 
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
-	simulator.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -42,6 +42,8 @@ import (
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -121,8 +123,8 @@ func (callbacks *staticAutoscalerProcessorCallbacks) reset() {
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
 func NewStaticAutoscaler(
 	opts config.AutoscalingOptions,
-	predicateChecker simulator.PredicateChecker,
-	clusterSnapshot simulator.ClusterSnapshot,
+	predicateChecker predicatechecker.PredicateChecker,
+	clusterSnapshot clustersnapshot.ClusterSnapshot,
 	autoscalingKubeClients *context.AutoscalingKubeClients,
 	processors *ca_processors.AutoscalingProcessors,
 	cloudProvider cloudprovider.CloudProvider,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1507,7 +1507,7 @@ func newScaleDownPlannerAndActuator(t *testing.T, ctx *context.AutoscalingContex
 		MinReplicaCount:           0,
 	}
 	ndt := deletiontracker.NewNodeDeletionTracker(0 * time.Second)
-	sd := legacy.NewScaleDown(ctx, p, cs, ndt, deleteOptions)
+	sd := legacy.NewScaleDown(ctx, p, ndt, deleteOptions)
 	actuator := actuation.NewActuator(ctx, cs, ndt, deleteOptions)
 	wrapper := legacy.NewScaleDownWrapper(sd, actuator)
 	return wrapper, wrapper

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -46,7 +46,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
@@ -166,14 +167,14 @@ func NewScaleTestAutoscalingContext(
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
 	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0))
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	if err != nil {
 		return context.AutoscalingContext{}, err
 	}
 	if debuggingSnapshotter == nil {
 		debuggingSnapshotter = debuggingsnapshot.NewDebuggingSnapshotter(false)
 	}
-	clusterSnapshot := simulator.NewBasicClusterSnapshot()
+	clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 	return context.AutoscalingContext{
 		AutoscalingOptions: options,
 		AutoscalingKubeClients: context.AutoscalingKubeClients{

--- a/cluster-autoscaler/core/utils/pod_schedulable.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	pod_utils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
@@ -43,7 +43,7 @@ import (
 type PodSchedulableInfo struct {
 	spec            apiv1.PodSpec
 	labels          map[string]string
-	schedulingError *simulator.PredicateError
+	schedulingError *predicatechecker.PredicateError
 }
 
 const maxPodsPerOwnerRef = 10
@@ -68,7 +68,7 @@ func (psi *PodSchedulableInfo) Match(pod *apiv1.Pod) bool {
 }
 
 // Get returns scheduling info for given pod if matching one exists in PodSchedulableMap
-func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, bool) {
+func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*predicatechecker.PredicateError, bool) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
 		return nil, false
@@ -85,7 +85,7 @@ func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*simulator.PredicateError, bool)
 }
 
 // Set sets scheduling info for given pod in PodSchedulableMap
-func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *simulator.PredicateError) {
+func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *predicatechecker.PredicateError) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil || pod_utils.IsDaemonSetPod(pod) {
 		return

--- a/cluster-autoscaler/core/utils/pod_schedulable_test.go
+++ b/cluster-autoscaler/core/utils/pod_schedulable_test.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"fmt"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"testing"
 
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -65,7 +65,7 @@ func TestPodSchedulableMap(t *testing.T) {
 	assert.True(t, found)
 	assert.Nil(t, err)
 
-	cpuErr := simulator.GenericPredicateError()
+	cpuErr := predicatechecker.GenericPredicateError()
 
 	// Pod in different RC
 	_, found = pMap.Get(podInRc2)

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -37,7 +37,7 @@ import (
 )
 
 // GetNodeInfoFromTemplate returns NodeInfo object built base on TemplateNodeInfo returned by NodeGroup.TemplateNodeInfo().
-func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
+func GetNodeInfoFromTemplate(nodeGroup cloudprovider.NodeGroup, daemonsets []*appsv1.DaemonSet, predicateChecker predicatechecker.PredicateChecker, ignoredTaints taints.TaintKeySet) (*schedulerframework.NodeInfo, errors.AutoscalerError) {
 	id := nodeGroup.Id()
 	baseNodeInfo, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -23,7 +23,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	klog "k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -37,15 +38,15 @@ type podInfo struct {
 
 // BinpackingNodeEstimator estimates the number of needed nodes to handle the given amount of pods.
 type BinpackingNodeEstimator struct {
-	predicateChecker simulator.PredicateChecker
-	clusterSnapshot  simulator.ClusterSnapshot
+	predicateChecker predicatechecker.PredicateChecker
+	clusterSnapshot  clustersnapshot.ClusterSnapshot
 	limiter          EstimationLimiter
 }
 
 // NewBinpackingNodeEstimator builds a new BinpackingNodeEstimator.
 func NewBinpackingNodeEstimator(
-	predicateChecker simulator.PredicateChecker,
-	clusterSnapshot simulator.ClusterSnapshot,
+	predicateChecker predicatechecker.PredicateChecker,
+	clusterSnapshot clustersnapshot.ClusterSnapshot,
 	limiter EstimationLimiter) *BinpackingNodeEstimator {
 	return &BinpackingNodeEstimator{
 		predicateChecker: predicateChecker,

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -23,7 +23,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -166,11 +167,11 @@ func TestBinpackingEstimate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clusterSnapshot := simulator.NewBasicClusterSnapshot()
+			clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 			// Add one node in different zone to trigger topology spread constraints
 			clusterSnapshot.AddNode(makeNode(100, 100, "oldnode", "zone-jupiter"))
 
-			predicateChecker, err := simulator.NewTestPredicateChecker()
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 			assert.NoError(t, err)
 			limiter := NewThresholdBasedEstimationLimiter(tc.maxNodes, time.Duration(0))
 			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter)

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -21,7 +21,8 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -41,15 +42,15 @@ type Estimator interface {
 }
 
 // EstimatorBuilder creates a new estimator object.
-type EstimatorBuilder func(simulator.PredicateChecker, simulator.ClusterSnapshot) Estimator
+type EstimatorBuilder func(predicatechecker.PredicateChecker, clustersnapshot.ClusterSnapshot) Estimator
 
 // NewEstimatorBuilder creates a new estimator object from flag.
 func NewEstimatorBuilder(name string, limiter EstimationLimiter) (EstimatorBuilder, error) {
 	switch name {
 	case BinpackingEstimatorName:
 		return func(
-			predicateChecker simulator.PredicateChecker,
-			clusterSnapshot simulator.ClusterSnapshot) Estimator {
+			predicateChecker predicatechecker.PredicateChecker,
+			clusterSnapshot clustersnapshot.ClusterSnapshot) Estimator {
 			return NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter)
 		}, nil
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -48,7 +48,7 @@ import (
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
@@ -358,7 +358,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions:   autoscalingOptions,
-		ClusterSnapshot:      simulator.NewDeltaClusterSnapshot(),
+		ClusterSnapshot:      clustersnapshot.NewDeltaClusterSnapshot(),
 		KubeClient:           kubeClient,
 		EventsKubeClient:     eventsKubeClient,
 		DebuggingSnapshotter: debuggingSnapshotter,

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -22,7 +22,7 @@ import (
 
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
@@ -75,7 +75,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
 
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{
@@ -160,7 +160,7 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
 
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	assert.NoError(t, err)
 
 	// Fill cache
@@ -249,7 +249,7 @@ func TestGetNodeInfosCacheExpired(t *testing.T) {
 	provider := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil, nil, nil, nil, nil)
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -17,11 +17,11 @@ limitations under the License.
 package simulator
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -29,7 +29,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	klog "k8s.io/klog/v2"
 )
@@ -87,39 +86,36 @@ const (
 
 // RemovalSimulator is a helper object for simulating node removal scenarios.
 type RemovalSimulator struct {
-	listers          kube_util.ListerRegistry
-	clusterSnapshot  clustersnapshot.ClusterSnapshot
-	predicateChecker predicatechecker.PredicateChecker
-	usageTracker     *UsageTracker
-	canPersist       bool
-	deleteOptions    NodeDeleteOptions
+	listers             kube_util.ListerRegistry
+	clusterSnapshot     clustersnapshot.ClusterSnapshot
+	usageTracker        *UsageTracker
+	canPersist          bool
+	deleteOptions       NodeDeleteOptions
+	schedulingSimulator *scheduling.HintingSimulator
 }
 
 // NewRemovalSimulator returns a new RemovalSimulator.
 func NewRemovalSimulator(listers kube_util.ListerRegistry, clusterSnapshot clustersnapshot.ClusterSnapshot, predicateChecker predicatechecker.PredicateChecker,
 	usageTracker *UsageTracker, deleteOptions NodeDeleteOptions, persistSuccessfulSimulations bool) *RemovalSimulator {
 	return &RemovalSimulator{
-		listers:          listers,
-		clusterSnapshot:  clusterSnapshot,
-		predicateChecker: predicateChecker,
-		usageTracker:     usageTracker,
-		canPersist:       persistSuccessfulSimulations,
-		deleteOptions:    deleteOptions,
+		listers:             listers,
+		clusterSnapshot:     clusterSnapshot,
+		usageTracker:        usageTracker,
+		canPersist:          persistSuccessfulSimulations,
+		deleteOptions:       deleteOptions,
+		schedulingSimulator: scheduling.NewHintingSimulator(predicateChecker),
 	}
 }
 
-// FindNodesToRemove finds nodes that can be removed. Returns also an
-// information about good rescheduling location for each of the pods.
+// FindNodesToRemove finds nodes that can be removed.
 func (r *RemovalSimulator) FindNodesToRemove(
 	candidates []string,
 	destinations []string,
-	oldHints map[string]string,
 	timestamp time.Time,
 	pdbs []*policyv1.PodDisruptionBudget,
-) (nodesToRemove []NodeToBeRemoved, unremovableNodes []*UnremovableNode, podReschedulingHints map[string]string, finalError errors.AutoscalerError) {
+) (nodesToRemove []NodeToBeRemoved, unremovableNodes []*UnremovableNode, finalError errors.AutoscalerError) {
 	result := make([]NodeToBeRemoved, 0)
 	unremovable := make([]*UnremovableNode, 0)
-	newHints := make(map[string]string, len(oldHints))
 
 	destinationMap := make(map[string]bool, len(destinations))
 	for _, destination := range destinations {
@@ -127,14 +123,14 @@ func (r *RemovalSimulator) FindNodesToRemove(
 	}
 
 	for _, nodeName := range candidates {
-		rn, urn := r.CheckNodeRemoval(nodeName, destinationMap, oldHints, newHints, timestamp, pdbs)
+		rn, urn := r.CheckNodeRemoval(nodeName, destinationMap, timestamp, pdbs)
 		if rn != nil {
 			result = append(result, *rn)
 		} else if urn != nil {
 			unremovable = append(unremovable, urn)
 		}
 	}
-	return result, unremovable, newHints, nil
+	return result, unremovable, nil
 }
 
 // CheckNodeRemoval checks whether a specific node can be removed. Depending on
@@ -143,8 +139,6 @@ func (r *RemovalSimulator) FindNodesToRemove(
 func (r *RemovalSimulator) CheckNodeRemoval(
 	nodeName string,
 	destinationMap map[string]bool,
-	oldHints map[string]string,
-	newHints map[string]string,
 	timestamp time.Time,
 	pdbs []*policyv1.PodDisruptionBudget,
 ) (*NodeToBeRemoved, *UnremovableNode) {
@@ -169,7 +163,7 @@ func (r *RemovalSimulator) CheckNodeRemoval(
 	}
 
 	err = r.withForkedSnapshot(func() error {
-		return r.findPlaceFor(nodeName, podsToRemove, destinationMap, oldHints, newHints, timestamp)
+		return r.findPlaceFor(nodeName, podsToRemove, destinationMap, timestamp)
 	})
 	if err != nil {
 		klog.V(2).Infof("node %s is not suitable for removal: %v", nodeName, err)
@@ -222,12 +216,7 @@ func (r *RemovalSimulator) withForkedSnapshot(f func() error) (err error) {
 	return err
 }
 
-func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool,
-	oldHints map[string]string, newHints map[string]string, timestamp time.Time) error {
-	podKey := func(pod *apiv1.Pod) string {
-		return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-	}
-
+func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool, timestamp time.Time) error {
 	isCandidateNode := func(nodeName string) bool {
 		return nodeName != removedNode && nodes[nodeName]
 	}
@@ -242,45 +231,25 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 		}
 	}
 
+	newpods := make([]*apiv1.Pod, 0, len(pods))
 	for _, podptr := range pods {
 		newpod := *podptr
 		newpod.Spec.NodeName = ""
-		pod := &newpod
+		newpods = append(newpods, &newpod)
+	}
 
-		foundPlace := false
-		targetNode := ""
+	targetNodes, err := r.schedulingSimulator.TrySchedulePods(r.clusterSnapshot, newpods, isCandidateNode)
+	if err != nil {
+		return err
+	}
 
-		klog.V(5).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
-
-		if hintedNode, hasHint := oldHints[podKey(pod)]; hasHint && isCandidateNode(hintedNode) {
-			if err := r.predicateChecker.CheckPredicates(r.clusterSnapshot, pod, hintedNode); err == nil {
-				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, hintedNode)
-				if err := r.clusterSnapshot.AddPod(pod, hintedNode); err != nil {
-					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, hintedNode, err)
-				}
-				newHints[podKey(pod)] = hintedNode
-				foundPlace = true
-				targetNode = hintedNode
-			}
-		}
-
-		if !foundPlace {
-			newNodeName, err := r.predicateChecker.FitsAnyNodeMatching(r.clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
-				return isCandidateNode(nodeInfo.Node().Name)
-			})
-			if err == nil {
-				klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, newNodeName)
-				if err := r.clusterSnapshot.AddPod(pod, newNodeName); err != nil {
-					return fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, newNodeName, err)
-				}
-				newHints[podKey(pod)] = newNodeName
-				targetNode = newNodeName
-			} else {
-				return fmt.Errorf("failed to find place for %s", podKey(pod))
-			}
-		}
-
+	for _, targetNode := range targetNodes {
 		r.usageTracker.RegisterUsage(removedNode, targetNode, timestamp)
 	}
 	return nil
+}
+
+// DropOldHints drops old scheduling hints.
+func (r *RemovalSimulator) DropOldHints() {
+	r.schedulingSimulator.DropOldHints()
 }

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -86,15 +88,15 @@ const (
 // RemovalSimulator is a helper object for simulating node removal scenarios.
 type RemovalSimulator struct {
 	listers          kube_util.ListerRegistry
-	clusterSnapshot  ClusterSnapshot
-	predicateChecker PredicateChecker
+	clusterSnapshot  clustersnapshot.ClusterSnapshot
+	predicateChecker predicatechecker.PredicateChecker
 	usageTracker     *UsageTracker
 	canPersist       bool
 	deleteOptions    NodeDeleteOptions
 }
 
 // NewRemovalSimulator returns a new RemovalSimulator.
-func NewRemovalSimulator(listers kube_util.ListerRegistry, clusterSnapshot ClusterSnapshot, predicateChecker PredicateChecker,
+func NewRemovalSimulator(listers kube_util.ListerRegistry, clusterSnapshot clustersnapshot.ClusterSnapshot, predicateChecker predicatechecker.PredicateChecker,
 	usageTracker *UsageTracker, deleteOptions NodeDeleteOptions, persistSuccessfulSimulations bool) *RemovalSimulator {
 	return &RemovalSimulator{
 		listers:          listers,

--- a/cluster-autoscaler/simulator/clustersnapshot/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/basic.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"errors"

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot_benchmark_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/clustersnapshot/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/delta.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package clustersnapshot
 
 import (
 	"testing"
 
-	apiv1 "k8s.io/api/core/v1"
-
 	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
 )
 
 // InitializeClusterSnapshotOrDie clears cluster snapshot and then initializes it with given set of nodes and pods.

--- a/cluster-autoscaler/simulator/predicatechecker/delegating_shared_lister.go
+++ b/cluster-autoscaler/simulator/predicatechecker/delegating_shared_lister.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/predicatechecker/error.go
+++ b/cluster-autoscaler/simulator/predicatechecker/error.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
 	"fmt"

--- a/cluster-autoscaler/simulator/predicatechecker/interface.go
+++ b/cluster-autoscaler/simulator/predicatechecker/interface.go
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+
 	apiv1 "k8s.io/api/core/v1"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // PredicateChecker checks whether all required predicates pass for given Pod and Node.
 type PredicateChecker interface {
-	FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod) (string, error)
-	FitsAnyNodeMatching(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeMatches func(*schedulerframework.NodeInfo) bool) (string, error)
-	CheckPredicates(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError
+	FitsAnyNode(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod) (string, error)
+	FitsAnyNodeMatching(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeMatches func(*schedulerframework.NodeInfo) bool) (string, error)
+	CheckPredicates(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError
 }

--- a/cluster-autoscaler/simulator/predicatechecker/schedulerbased.go
+++ b/cluster-autoscaler/simulator/predicatechecker/schedulerbased.go
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
 	"context"
 	"fmt"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -78,14 +80,14 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-
 }
 
 // FitsAnyNode checks if the given pod can be placed on any of the given nodes.
-func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod) (string, error) {
+func (p *SchedulerBasedPredicateChecker) FitsAnyNode(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod) (string, error) {
 	return p.FitsAnyNodeMatching(clusterSnapshot, pod, func(*schedulerframework.NodeInfo) bool {
 		return true
 	})
 }
 
 // FitsAnyNodeMatching checks if the given pod can be placed on any of the given nodes matching the provided function.
-func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeMatches func(*schedulerframework.NodeInfo) bool) (string, error) {
+func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeMatches func(*schedulerframework.NodeInfo) bool) (string, error) {
 	if clusterSnapshot == nil {
 		return "", fmt.Errorf("ClusterSnapshot not provided")
 	}
@@ -141,7 +143,7 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot Clu
 }
 
 // CheckPredicates checks if the given pod can be placed on the given node.
-func (p *SchedulerBasedPredicateChecker) CheckPredicates(clusterSnapshot ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError {
+func (p *SchedulerBasedPredicateChecker) CheckPredicates(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError {
 	if clusterSnapshot == nil {
 		return NewPredicateError(InternalPredicateError, "", "ClusterSnapshot not provided", nil, emptyString)
 	}

--- a/cluster-autoscaler/simulator/predicatechecker/schedulerbased_test.go
+++ b/cluster-autoscaler/simulator/predicatechecker/schedulerbased_test.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
 	"testing"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestCheckPredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			predicateChecker, err := NewTestPredicateChecker()
-			clusterSnapshot := NewBasicClusterSnapshot()
+			clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 			err = clusterSnapshot.AddNodeWithPods(tt.node, tt.scheduledPods)
 			assert.NoError(t, err)
 
@@ -103,7 +104,7 @@ func TestFitsAnyNode(t *testing.T) {
 
 	var err error
 
-	clusterSnapshot := NewBasicClusterSnapshot()
+	clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 	err = clusterSnapshot.AddNode(n1000)
 	assert.NoError(t, err)
 	err = clusterSnapshot.AddNode(n2000)
@@ -144,7 +145,7 @@ func TestDebugInfo(t *testing.T) {
 	predicateChecker, err := NewTestPredicateChecker()
 	assert.NoError(t, err)
 
-	clusterSnapshot := NewBasicClusterSnapshot()
+	clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 
 	err = clusterSnapshot.AddNode(node1)
 	assert.NoError(t, err)

--- a/cluster-autoscaler/simulator/predicatechecker/testchecker.go
+++ b/cluster-autoscaler/simulator/predicatechecker/testchecker.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package simulator
+package predicatechecker
 
 import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"fmt"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// HintingSimulator is a helper object for simulating scheduler behavior.
+// TODO(x13n): Reuse this in filter_out_unschedulable.
+type HintingSimulator struct {
+	predicateChecker predicatechecker.PredicateChecker
+	hints            *Hints
+}
+
+// NewHintingSimulator returns a new HintingSimulator.
+func NewHintingSimulator(predicateChecker predicatechecker.PredicateChecker) *HintingSimulator {
+	return &HintingSimulator{
+		predicateChecker: predicateChecker,
+		hints:            NewHints(),
+	}
+}
+
+// TrySchedulePods attempts to schedule provided pods on any acceptable nodes.
+// Each node is considered acceptable iff isNodeAcceptable() returns true.
+// Returns a list of nodes that were chosen or an error if scheduling any of the pods failed.
+// Note: this function does not fork clusterSnapshot: this has to be done by the caller.
+func (s *HintingSimulator) TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, isNodeAcceptable func(string) bool) ([]string, error) {
+	var nodeNames []string
+	for _, pod := range pods {
+		klog.V(5).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
+		nodeName, err := s.findNodeWithHints(clusterSnapshot, pod, isNodeAcceptable)
+		if err != nil {
+			return nil, err
+		}
+		if nodeName == "" {
+			nodeName, err = s.schedulePod(clusterSnapshot, pod, isNodeAcceptable)
+			if err != nil {
+				return nil, err
+			}
+		}
+		nodeNames = append(nodeNames, nodeName)
+	}
+	return nodeNames, nil
+}
+
+func (s *HintingSimulator) findNodeWithHints(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, isNodeAcceptable func(string) bool) (string, error) {
+	hk := HintKeyFromPod(pod)
+	if hintedNode, hasHint := s.hints.Get(hk); hasHint && isNodeAcceptable(hintedNode) {
+		if err := s.predicateChecker.CheckPredicates(clusterSnapshot, pod, hintedNode); err == nil {
+			klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, hintedNode)
+			if err := clusterSnapshot.AddPod(pod, hintedNode); err != nil {
+				return "", fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, hintedNode, err)
+			}
+			s.hints.Set(hk, hintedNode)
+			return hintedNode, nil
+		}
+	}
+	return "", nil
+}
+
+func (s *HintingSimulator) schedulePod(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, isNodeAcceptable func(string) bool) (string, error) {
+	newNodeName, err := s.predicateChecker.FitsAnyNodeMatching(clusterSnapshot, pod, func(nodeInfo *schedulerframework.NodeInfo) bool {
+		return isNodeAcceptable(nodeInfo.Node().Name)
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to find place for %s/%s", pod.Namespace, pod.Name)
+	}
+	klog.V(4).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, newNodeName)
+	if err := clusterSnapshot.AddPod(pod, newNodeName); err != nil {
+		return "", fmt.Errorf("Simulating scheduling of %s/%s to %s return error; %v", pod.Namespace, pod.Name, newNodeName, err)
+	}
+	s.hints.Set(HintKeyFromPod(pod), newNodeName)
+	return newNodeName, nil
+}
+
+// DropOldHints drops old scheduling hints.
+func (s *HintingSimulator) DropOldHints() {
+	s.hints.DropOld()
+}
+
+// ScheduleAnywhere can be passed to TrySchedulePods when there are no extra restrictions on nodes to consider.
+func ScheduleAnywhere(_ string) bool {
+	return true
+}

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func TestTrySchedulePods(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		nodes           []*apiv1.Node
+		pods            []*apiv1.Pod
+		newPods         []*apiv1.Pod
+		acceptableNodes func(string) bool
+		wantErr         bool
+	}{
+		{
+			desc: "two new pods, two nodes",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+			},
+			pods: []*apiv1.Pod{
+				buildScheduledPod("p1", 300, 500000, "n1"),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p2", 600, 500000),
+				BuildTestPod("p3", 500, 500000),
+			},
+			acceptableNodes: ScheduleAnywhere,
+		},
+		{
+			desc: "three new pods, two nodes, no fit",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+			},
+			pods: []*apiv1.Pod{
+				buildScheduledPod("p1", 300, 500000, "n1"),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p2", 600, 500000),
+				BuildTestPod("p3", 500, 500000),
+				BuildTestPod("p4", 700, 500000),
+			},
+			acceptableNodes: ScheduleAnywhere,
+			wantErr:         true,
+		},
+		{
+			desc: "no new pods, two nodes",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+			},
+			pods: []*apiv1.Pod{
+				buildScheduledPod("p1", 300, 500000, "n1"),
+			},
+			newPods:         []*apiv1.Pod{},
+			acceptableNodes: ScheduleAnywhere,
+		},
+		{
+			desc: "two nodes, but only one acceptable",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+			},
+			pods: []*apiv1.Pod{
+				buildScheduledPod("p1", 300, 500000, "n1"),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p2", 500, 500000),
+				BuildTestPod("p3", 500, 500000),
+			},
+			acceptableNodes: singleNodeOk("n2"),
+		},
+		{
+			desc: "two nodes, but only one acceptable, no fit",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+			},
+			pods: []*apiv1.Pod{
+				buildScheduledPod("p1", 300, 500000, "n1"),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p2", 500, 500000),
+				BuildTestPod("p3", 500, 500000),
+			},
+			acceptableNodes: singleNodeOk("n1"),
+			wantErr:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
+			assert.NoError(t, err)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, clusterSnapshot, tc.nodes, tc.pods)
+			s := NewHintingSimulator(predicateChecker)
+			_, err = s.TrySchedulePods(clusterSnapshot, tc.newPods, tc.acceptableNodes)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				numScheduled := countPods(t, clusterSnapshot)
+				assert.Equal(t, len(tc.pods)+len(tc.newPods), numScheduled)
+				s.DropOldHints()
+				// Check if new hints match actually scheduled node names.
+				for _, np := range tc.newPods {
+					hintedNode, found := s.hints.Get(HintKeyFromPod(np))
+					assert.True(t, found)
+					actualNode := nodeNameForPod(t, clusterSnapshot, np.Name)
+					assert.Equal(t, hintedNode, actualNode)
+				}
+			}
+		})
+	}
+}
+
+func TestPodSchedulesOnHintedNode(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		nodeNames []string
+		podNodes  map[string]string
+	}{
+		{
+			desc:      "single hint",
+			nodeNames: []string{"n1", "n2", "n3"},
+			podNodes:  map[string]string{"p1": "n2"},
+		},
+		{
+			desc:      "all on one node",
+			nodeNames: []string{"n1", "n2", "n3"},
+			podNodes: map[string]string{
+				"p1": "n2",
+				"p2": "n2",
+				"p3": "n2",
+			},
+		},
+		{
+			desc:      "spread across nodes",
+			nodeNames: []string{"n1", "n2", "n3"},
+			podNodes: map[string]string{
+				"p1": "n1",
+				"p2": "n2",
+				"p3": "n3",
+			},
+		},
+		{
+			desc:      "lots of pods",
+			nodeNames: []string{"n1", "n2", "n3"},
+			podNodes: map[string]string{
+				"p1": "n1",
+				"p2": "n1",
+				"p3": "n1",
+				"p4": "n2",
+				"p5": "n2",
+				"p6": "n2",
+				"p7": "n3",
+				"p8": "n3",
+				"p9": "n3",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
+			assert.NoError(t, err)
+			nodes := make([]*apiv1.Node, 0, len(tc.nodeNames))
+			for _, n := range tc.nodeNames {
+				nodes = append(nodes, buildReadyNode(n, 9999, 9999))
+			}
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, clusterSnapshot, nodes, []*apiv1.Pod{})
+			pods := make([]*apiv1.Pod, 0, len(tc.podNodes))
+			s := NewHintingSimulator(predicateChecker)
+			for p, n := range tc.podNodes {
+				pod := BuildTestPod(p, 1, 1)
+				pods = append(pods, pod)
+				s.hints.Set(HintKeyFromPod(pod), n)
+			}
+			_, err = s.TrySchedulePods(clusterSnapshot, pods, ScheduleAnywhere)
+			assert.NoError(t, err)
+
+			for p, hinted := range tc.podNodes {
+				actual := nodeNameForPod(t, clusterSnapshot, p)
+				assert.Equal(t, hinted, actual)
+			}
+		})
+	}
+}
+
+func buildReadyNode(name string, cpu, mem int64) *apiv1.Node {
+	n := BuildTestNode(name, cpu, mem)
+	SetNodeReadyState(n, true, time.Time{})
+	return n
+}
+
+func buildScheduledPod(name string, cpu, mem int64, nodeName string) *apiv1.Pod {
+	p := BuildTestPod(name, cpu, mem)
+	p.Spec.NodeName = nodeName
+	return p
+}
+
+func countPods(t *testing.T, clusterSnapshot clustersnapshot.ClusterSnapshot) int {
+	t.Helper()
+	count := 0
+	nis, err := clusterSnapshot.NodeInfos().List()
+	assert.NoError(t, err)
+	for _, ni := range nis {
+		count += len(ni.Pods)
+	}
+	return count
+}
+
+func nodeNameForPod(t *testing.T, clusterSnapshot clustersnapshot.ClusterSnapshot, pod string) string {
+	t.Helper()
+	nis, err := clusterSnapshot.NodeInfos().List()
+	assert.NoError(t, err)
+	for _, ni := range nis {
+		for _, pi := range ni.Pods {
+			if pi.Pod.Name == pod {
+				return ni.Node().Name
+			}
+		}
+	}
+	return ""
+}
+
+func singleNodeOk(nodeName string) func(string) bool {
+	return func(otherNodeName string) bool {
+		return nodeName == otherNodeName
+	}
+}

--- a/cluster-autoscaler/simulator/scheduling/hints.go
+++ b/cluster-autoscaler/simulator/scheduling/hints.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// HintKey uniquely identifies a pod for the sake of scheduling hints.
+type HintKey string
+
+// HintKeyFromPod generates a HintKey for a given pod.
+func HintKeyFromPod(pod *apiv1.Pod) HintKey {
+	if pod.UID != "" {
+		return HintKey(pod.UID)
+	}
+	return HintKey(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+}
+
+// Hints can be used for tracking past scheduling decisions. It is
+// essentially equivalent to a map, with the ability to replace whole
+// generations of keys. See DropOld() for more information.
+type Hints struct {
+	current map[HintKey]string
+	old     map[HintKey]string
+}
+
+// NewHints returns a new Hints object.
+func NewHints() *Hints {
+	return &Hints{
+		current: make(map[HintKey]string),
+		old:     make(map[HintKey]string),
+	}
+}
+
+// Get retrieves a hinted node name for a given key.
+func (h *Hints) Get(hk HintKey) (string, bool) {
+	if v, ok := h.current[hk]; ok {
+		return v, ok
+	}
+	v, ok := h.old[hk]
+	return v, ok
+}
+
+// Set updates a hinted node name for a given key.
+func (h *Hints) Set(hk HintKey, nodeName string) {
+	h.current[hk] = nodeName
+}
+
+// DropOld cleans up old keys. All keys are considered old if they were added
+// before the previous call to DropOld().
+func (h *Hints) DropOld() {
+	oldHintsCount := len(h.old)
+	h.old = h.current
+	h.current = make(map[HintKey]string, oldHintsCount)
+}

--- a/cluster-autoscaler/simulator/scheduling/hints_test.go
+++ b/cluster-autoscaler/simulator/scheduling/hints_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestDropOld(t *testing.T) {
+	f := func(initial []string, final []string) bool {
+		all := chain(initial, final)
+		s := NewHints()
+		if incorrectKeys(s, []string{}, all) {
+			return false
+		}
+		for _, k := range initial {
+			s.Set(HintKey(k), k)
+		}
+		if incorrectKeys(s, initial, all) {
+			return false
+		}
+		s.DropOld()
+		if incorrectKeys(s, initial, all) {
+			return false
+		}
+		for _, k := range final {
+			s.Set(HintKey(k), k)
+		}
+		if incorrectKeys(s, all, all) {
+			return false
+		}
+		s.DropOld()
+		if incorrectKeys(s, final, all) {
+			return false
+		}
+		return true
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func chain(a, b []string) []string {
+	return append(append([]string{}, a...), b...)
+}
+
+func anyPresent(s *Hints, keys map[string]bool) bool {
+	for k := range keys {
+		if _, found := s.Get(HintKey(k)); found {
+			return true
+		}
+	}
+	return false
+}
+
+func allPresentAndCorrect(s *Hints, keys []string) bool {
+	for _, k := range keys {
+		v, found := s.Get(HintKey(k))
+		if !found {
+			return false
+		}
+		if k != v {
+			return false
+		}
+	}
+	return true
+}
+
+func incorrectKeys(s *Hints, want, all []string) bool {
+	dontWant := make(map[string]bool)
+	for _, k := range all {
+		dontWant[k] = true
+	}
+	for _, k := range want {
+		delete(dontWant, k)
+	}
+	if !allPresentAndCorrect(s, want) {
+		return true
+	}
+	return anyPresent(s, dontWant)
+}

--- a/cluster-autoscaler/utils/daemonset/daemonset.go
+++ b/cluster-autoscaler/utils/daemonset/daemonset.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"math/rand"
 
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -35,11 +36,11 @@ const (
 )
 
 // GetDaemonSetPodsForNode returns daemonset nodes for the given pod.
-func GetDaemonSetPodsForNode(nodeInfo *schedulerframework.NodeInfo, daemonsets []*appsv1.DaemonSet, predicateChecker simulator.PredicateChecker) ([]*apiv1.Pod, error) {
+func GetDaemonSetPodsForNode(nodeInfo *schedulerframework.NodeInfo, daemonsets []*appsv1.DaemonSet, predicateChecker predicatechecker.PredicateChecker) ([]*apiv1.Pod, error) {
 	result := make([]*apiv1.Pod, 0)
 
 	// here we can use empty snapshot
-	clusterSnapshot := simulator.NewBasicClusterSnapshot()
+	clusterSnapshot := clustersnapshot.NewBasicClusterSnapshot()
 
 	// add a node with pods - node info is created by cloud provider,
 	// we don't know whether it'll have pods or not.

--- a/cluster-autoscaler/utils/daemonset/daemonset_test.go
+++ b/cluster-autoscaler/utils/daemonset/daemonset_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,7 +39,7 @@ func TestGetDaemonSetPodsForNode(t *testing.T) {
 	nodeInfo := schedulerframework.NewNodeInfo()
 	nodeInfo.SetNode(node)
 
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	assert.NoError(t, err)
 	ds1 := newDaemonSet("ds1", "0.1", "100M", nil)
 	ds2 := newDaemonSet("ds2", "0.1", "100M", map[string]string{"foo": "bar"})


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

One more refactor of existing scale down code in order to make parallel scale down (https://github.com/kubernetes/autoscaler/issues/5079) possible.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is a follow-up to https://github.com/kubernetes/autoscaler/pull/5147. Only last 3 commits should be reviewed as a part of this PR. It will be on hold until the previous one is merged.

/hold

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @yaroslava-serdiuk 
/assign @MaciekPytel 