### PR TITLE
correct label query

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -22,9 +22,9 @@ import (
 	"sort"
 	"strings"
 	"time"
-	
-	"k8s.io/klog/v2"
 
+	"k8s.io/klog/v2"
+        
 	promapi "github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	prommodel "github.com/prometheus/common/model"

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	
+	"k8s.io/klog/v2"
 
 	promapi "github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -158,9 +158,7 @@ func TestGetEmptyClusterHistory(t *testing.T) {
 		config:           getDefaultPrometheusHistoryProviderConfigForTest(),
 		prometheusClient: &mockClient,
 	}
-	mockClient.On("Query", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Times(1).Return(
-		prommodel.Matrix{}, nil)
-	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(2).Return(
+	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(3).Return(
 		prommodel.Matrix{}, nil)
 	tss, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
@@ -204,7 +202,7 @@ func TestGetCPUSamples(t *testing.T) {
 		},
 		nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, labelsQuery, mock.AnythingOfType("v1.Range")).Return(prommodel.Matrix{}, nil)
 	podID := model.PodID{Namespace: "default", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -242,7 +240,7 @@ func TestGetMemorySamples(t *testing.T) {
 				},
 			},
 		}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, labelsQuery, mock.AnythingOfType("v1.Range")).Return(prommodel.Matrix{}, nil)
 	podID := model.PodID{Namespace: "default", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -283,7 +281,7 @@ func TestGetNamespacedMemorySamples(t *testing.T) {
 				},
 			},
 		}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, labelsQuery, mock.AnythingOfType("v1.Rang")).Return(prommodel.Matrix{}, nil)
 	podID := model.PodID{Namespace: "kube-system", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -306,7 +304,7 @@ func TestGetLabels(t *testing.T) {
 	}
 	mockClient.On("QueryRange", mock.Anything, cpuQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(
+	mockClient.On("QueryRange", mock.Anything, labelsQuery, mock.AnythingOfType("v1.Range")).Return(
 		prommodel.Matrix{
 			{
 				Metric: map[prommodel.LabelName]prommodel.LabelValue{


### PR DESCRIPTION
Signed-off-by: zounengren <zouyee1989@gmail.com>

#### Which component this PR applies to?
vpa
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If we use query interface with `up{job="kubernetes-pods"}`, the returned result would be vector, but expected to get matric type, and we need the label of the pod corresponding to the ResourceHistory query, not the most recent label of the pod, so that we can get the label of the extinct pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
