### PR TITLE
Corrected the links for Priority in k8s API and Pod Preemption in k8s.

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -224,8 +224,8 @@ priority pod preemption.
 Older versions of CA won't take priorities into account.
 
 More about Pod Priority and Preemption:
- * [Priority in Kubernetes API](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-priority-api.md),
- * [Pod Preemption in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-preemption.md),
+ * [Priority in Kubernetes API](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/pod-priority-api.md),
+ * [Pod Preemption in Kubernetes](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/pod-preemption.md),
  * [Pod Priority and Preemption tutorial](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
 
 ### How does Cluster Autoscaler remove nodes?


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler,

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
`Priority in Kubernetes API` and `Pod Preemption in Kubernetes` under [How does Cluster Autoscaler work with Pod Priority and Preemption?](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption) in CA [FAQ ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md)  gives 404 error, so this PR has fixed the hyperlinks for both of them.

#### Does this PR introduce a user-facing change?

```
NONE
```