### PR TITLE
`skipped_scale_events_count` cluster-autoscaler metric add new reason and node_group label

### DIFF
--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -410,6 +410,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		if currentTargetSize >= nodeGroup.MaxSize() {
 			klog.V(4).Infof("Skipping node group %s - max size reached", nodeGroup.Id())
 			skippedNodeGroups[nodeGroup.Id()] = maxLimitReachedReason
+			metrics.RegisterSkippedScaleUpNodeGroupMaxSize()
 			continue
 		}
 

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -410,7 +410,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		if currentTargetSize >= nodeGroup.MaxSize() {
 			klog.V(4).Infof("Skipping node group %s - max size reached", nodeGroup.Id())
 			skippedNodeGroups[nodeGroup.Id()] = maxLimitReachedReason
-			metrics.RegisterSkippedScaleUpNodeGroupMaxSize()
+			metrics.RegisterSkippedScaleUpNodeGroupMaxSize(nodeGroup.Id())
 			continue
 		}
 
@@ -434,9 +434,9 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			for _, resource := range checkResult.exceededResources {
 				switch resource {
 				case cloudprovider.ResourceNameCores:
-					metrics.RegisterSkippedScaleUpCPU()
+					metrics.RegisterSkippedScaleUpCPU(nodeGroup.Id())
 				case cloudprovider.ResourceNameMemory:
-					metrics.RegisterSkippedScaleUpMemory()
+					metrics.RegisterSkippedScaleUpMemory(nodeGroup.Id())
 				default:
 					continue
 				}

--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -692,6 +692,7 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		if size-deletionsInProgress <= nodeGroup.MinSize() {
 			klog.V(1).Infof("Skipping %s - node group min size reached", node.Name)
 			sd.unremovableNodes.AddReason(node, simulator.NodeGroupMinSizeReached)
+			metrics.RegisterSkippedScaleDownNodeGroupMinSize()
 			continue
 		}
 

--- a/cluster-autoscaler/core/scaledown/legacy/legacy.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy.go
@@ -692,7 +692,7 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 		if size-deletionsInProgress <= nodeGroup.MinSize() {
 			klog.V(1).Infof("Skipping %s - node group min size reached", node.Name)
 			sd.unremovableNodes.AddReason(node, simulator.NodeGroupMinSizeReached)
-			metrics.RegisterSkippedScaleDownNodeGroupMinSize()
+			metrics.RegisterSkippedScaleDownNodeGroupMinSize(nodeGroup.Id())
 			continue
 		}
 
@@ -710,9 +710,9 @@ func (sd *ScaleDown) NodesToDelete(currentTime time.Time, pdbs []*policyv1.PodDi
 			for _, resource := range checkResult.exceededResources {
 				switch resource {
 				case cloudprovider.ResourceNameCores:
-					metrics.RegisterSkippedScaleDownCPU()
+					metrics.RegisterSkippedScaleDownCPU(nodeGroup.Id())
 				case cloudprovider.ResourceNameMemory:
-					metrics.RegisterSkippedScaleDownMemory()
+					metrics.RegisterSkippedScaleDownMemory(nodeGroup.Id())
 				default:
 					continue
 				}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -330,7 +330,7 @@ var (
 			Name:      "skipped_scale_events_count",
 			Help:      "Count of scaling events that the CA has chosen to skip.",
 		},
-		[]string{"direction", "reason"},
+		[]string{"direction", "reason", "node_group"},
 	)
 
 	/**** Metrics related to NodeAutoprovisioning ****/
@@ -571,33 +571,33 @@ func UpdateOverflowingControllers(count int) {
 }
 
 // RegisterSkippedScaleDownCPU increases the count of skipped scale outs because of CPU resource limits
-func RegisterSkippedScaleDownCPU() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, CpuResourceLimit).Add(1.0)
+func RegisterSkippedScaleDownCPU(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, CpuResourceLimit, nodeGroup).Add(1.0)
 }
 
 // RegisterSkippedScaleDownMemory increases the count of skipped scale outs because of Memory resource limits
-func RegisterSkippedScaleDownMemory() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, MemoryResourceLimit).Add(1.0)
+func RegisterSkippedScaleDownMemory(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, MemoryResourceLimit, nodeGroup).Add(1.0)
 }
 
 // RegisterSkippedScaleUpCPU increases the count of skipped scale outs because of CPU resource limits
-func RegisterSkippedScaleUpCPU() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, CpuResourceLimit).Add(1.0)
+func RegisterSkippedScaleUpCPU(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, CpuResourceLimit, nodeGroup).Add(1.0)
 }
 
 // RegisterSkippedScaleUpMemory increases the count of skipped scale outs because of Memory resource limits
-func RegisterSkippedScaleUpMemory() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, MemoryResourceLimit).Add(1.0)
+func RegisterSkippedScaleUpMemory(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, MemoryResourceLimit, nodeGroup).Add(1.0)
 }
 
 // RegisterSkippedScaleUpNodeGroupMaxSize increases the count of skipped scale outs
 // because the node group has reached its maximum configured size
-func RegisterSkippedScaleUpNodeGroupMaxSize() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, NodeGroupLimit).Add(1.0)
+func RegisterSkippedScaleUpNodeGroupMaxSize(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, NodeGroupLimit, nodeGroup).Add(1.0)
 }
 
 // RegisterSkippedScaleDownNodeGroupMinSize increases the count of skipped scale outs
 // because the node group has reached its minimum configured size
-func RegisterSkippedScaleDownNodeGroupMinSize() {
-	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, NodeGroupLimit).Add(1.0)
+func RegisterSkippedScaleDownNodeGroupMinSize(nodeGroup string) {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, NodeGroupLimit, nodeGroup).Add(1.0)
 }

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -75,6 +75,8 @@ const (
 	CpuResourceLimit string = "CpuResourceLimit"
 	// MemoryResourceLimit minimum or maximum reached, check the direction label to determine min or max
 	MemoryResourceLimit string = "MemoryResourceLimit"
+	// NodeGroupLimit the minimum or maxium node group limit reached, check the direction label to determine min or max
+	NodeGroupLimit string = "NodeGroupLimit"
 
 	// autoscaledGroup is managed by CA
 	autoscaledGroup NodeGroupType = "autoscaled"
@@ -586,4 +588,16 @@ func RegisterSkippedScaleUpCPU() {
 // RegisterSkippedScaleUpMemory increases the count of skipped scale outs because of Memory resource limits
 func RegisterSkippedScaleUpMemory() {
 	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, MemoryResourceLimit).Add(1.0)
+}
+
+// RegisterSkippedScaleUpNodeGroupMaxSize increases the count of skipped scale outs
+// because the node group has reached its maximum configured size
+func RegisterSkippedScaleUpNodeGroupMaxSize() {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, NodeGroupLimit).Add(1.0)
+}
+
+// RegisterSkippedScaleDownNodeGroupMinSize increases the count of skipped scale outs
+// because the node group has reached its minimum configured size
+func RegisterSkippedScaleDownNodeGroupMinSize() {
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, NodeGroupLimit).Add(1.0)
 }

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -124,7 +124,7 @@ scale down reasons are `empty`, `underutilized`, `unready`.
 * `skipped_scale_events_count` counts the number of times that the
   autoscaler has declined to scale a node group because of a resource limit being reached or
   similar internal event. Scale direction can be either `up` or `down`, and the reason explains
-  why the scaling was skipped (eg `CPULimitReached`, `MemoryLimitReached`). This is
+  why the scaling was skipped (eg `CPULimitReached`, `MemoryLimitReached`, `NodeGroupLimit`). This is
   different than failed scaling events in that the autoscaler is choosing not to perform
   a scaling action.
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR addresses issue #5122. It adds an additional reason `NodeGroupLimit` to the metric `skipped_scale_events_count`. This is helpful for creating alerts as a k8s cluster admin/operator that new nodes in a node group can't be scaled in because the max node group size has been reached or that the node group can't be further scaled down because the min node group size has been reached. To get this information today, you must monitor the node group metrics from the cloud provider itself. Simply monitoring the `unschedulable_pods_count` is not enough because there are several reasons that a pod could be unschedulable outside of max node size reached (wrong toleration or nonexistent nodeSelector).

This PR also adds the `node_group` label to the `skipped_scale_events_count` since the metric is closely tied to a specific node group(s), I figured it would be useful to know which it applies to.

#### Which issue(s) this PR fixes:

Fixes #5122.

#### Special notes for your reviewer:

I'm not sure if we want to drop the `node_group` label from the metric or add any special logic to only emit that label when the `emitPerNodeGroupMetrics` flag is true.

#### Does this PR introduce a user-facing change?

```release-note
Adds `NodeGroupLimit` as a reason to the metric `skipped_scale_events_count`. This allows you to track if the cluster-autoscaler skip a scale up or down event due to the node group already having reached its maximum or minimum size. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
