### PR TITLE
API for KEP-4831: Control VPA eviction behavior based on scaling direction and resource

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -382,8 +382,8 @@ spec:
                   evictionRequirements:
                     description: EvictionRequirements is a list of EvictionRequirements
                       that need to evaluate to true in order for a Pod to be evicted.
-                      If more than one EvictionRequirement is specified, they are
-                      combined with AND.
+                      If more than one EvictionRequirement is specified, all of them
+                      need to be fulfilled to allow eviction.
                     items:
                       description: EvictionRequirement defines a single condition
                         which needs to be true in order to evict a Pod
@@ -400,7 +400,8 @@ spec:
                         resource:
                           description: Resources is a list of one or more resources
                             that the condition applies to. If more than one resource
-                            is given, they are combined with OR, not with AND.
+                            is given, the EvictionRequirement is fulfilled if at least
+                            one resource meets `changeRequirement`.
                           items:
                             description: ResourceName is the name identifying various
                               resources in a ResourceList.

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -364,7 +364,7 @@ spec:
                     description: API version of the referent
                     type: string
                   kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -379,6 +379,38 @@ spec:
                   pods. If not specified, all fields in the `PodUpdatePolicy` are
                   set to their default values.
                 properties:
+                  evictionRequirements:
+                    description: EvictionRequirements is a list of EvictionRequirements
+                      that need to evaluate to true in order for a Pod to be evicted.
+                      If more than one EvictionRequirement is specified, they are
+                      combined with AND.
+                    items:
+                      description: EvictionRequirement defines a single condition
+                        which needs to be true in order to evict a Pod
+                      properties:
+                        changeRequirement:
+                          description: EvictionChangeRequirement refers to the relationship
+                            between the new target recommendation for a Pod and its
+                            current requests, what kind of change is necessary for
+                            the Pod to be evicted
+                          enum:
+                          - TargetHigherThanRequests
+                          - TargetLowerThanRequests
+                          type: string
+                        resource:
+                          description: Resources is a list of one or more resources
+                            that the condition applies to. If more than one resource
+                            is given, they are combined with OR, not with AND.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                      required:
+                      - changeRequirement
+                      - resource
+                      type: object
+                    type: array
                   minReplicas:
                     description: Minimal number of replicas which need to be alive
                       for Updater to attempt pod eviction (pending other checks like
@@ -607,7 +639,7 @@ spec:
                     description: API version of the referent
                     type: string
                   kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -121,8 +121,8 @@ const (
 // order to evict a Pod
 type EvictionRequirement struct {
 	// Resources is a list of one or more resources that the condition applies
-	// to. If more than one resource is given, they are combined with OR, not
-	// with AND.
+	// to. If more than one resource is given, the EvictionRequirement is fulfilled
+	// if at least one resource meets `changeRequirement`.
 	Resources         []v1.ResourceName         `json:"resource" protobuf:"bytes,1,name=resources"`
 	ChangeRequirement EvictionChangeRequirement `json:"changeRequirement" protobuf:"bytes,2,name=changeRequirement"`
 }
@@ -142,7 +142,7 @@ type PodUpdatePolicy struct {
 
 	// EvictionRequirements is a list of EvictionRequirements that need to
 	// evaluate to true in order for a Pod to be evicted. If more than one
-	// EvictionRequirement is specified, they are combined with AND.
+	// EvictionRequirement is specified, all of them need to be fulfilled to allow eviction.
 	// +optional
 	EvictionRequirements []*EvictionRequirement `json:"evictionRequirements,omitempty" protobuf:"bytes,3,opt,name=evictionRequirements"`
 }

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -106,6 +106,27 @@ type VerticalPodAutoscalerSpec struct {
 	Recommenders []*VerticalPodAutoscalerRecommenderSelector `json:"recommenders,omitempty" protobuf:"bytes,4,opt,name=recommenders"`
 }
 
+// EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted
+// +kubebuilder:validation:Enum:=TargetHigherThanRequests;TargetLowerThanRequests
+type EvictionChangeRequirement string
+
+const (
+	// TargetHigherThanRequests means the new target recommendation for a Pod is higher than its current requests, i.e. the Pod is scaled up
+	TargetHigherThanRequests EvictionChangeRequirement = "TargetHigherThanRequests"
+	// TargetLowerThanRequests means the new target recommendation for a Pod is lower than its current requests, i.e. the Pod is scaled down
+	TargetLowerThanRequests EvictionChangeRequirement = "TargetLowerThanRequests"
+)
+
+// EvictionRequirement defines a single condition which needs to be true in
+// order to evict a Pod
+type EvictionRequirement struct {
+	// Resources is a list of one or more resources that the condition applies
+	// to. If more than one resource is given, they are combined with OR, not
+	// with AND.
+	Resources         []v1.ResourceName         `json:"resource" protobuf:"bytes,1,name=resources"`
+	ChangeRequirement EvictionChangeRequirement `json:"changeRequirement" protobuf:"bytes,2,name=changeRequirement"`
+}
+
 // PodUpdatePolicy describes the rules on how changes are applied to the pods.
 type PodUpdatePolicy struct {
 	// Controls when autoscaler applies changes to the pod resources.
@@ -118,6 +139,12 @@ type PodUpdatePolicy struct {
 	// allowed. Overrides global '--min-replicas' flag.
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
+
+	// EvictionRequirements is a list of EvictionRequirements that need to
+	// evaluate to true in order for a Pod to be evicted. If more than one
+	// EvictionRequirement is specified, they are combined with AND.
+	// +optional
+	EvictionRequirements []*EvictionRequirement `json:"evictionRequirements,omitempty" protobuf:"bytes,3,opt,name=evictionRequirements"`
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resources.


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
vertical-pod-autoscaler

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/kind api-change

#### What this PR does / why we need it
Implements KEP-4831: Control VPA eviction behavior based on scaling direction and resource

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
API for #4831
Implementation is done in #5599


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
