### PR TITLE
Support scaling down a particular node with graceful termination

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -289,6 +289,8 @@ type AutoscalingOptions struct {
 	BypassedSchedulers map[string]bool
 	// ProvisioningRequestEnabled tells if CA processes ProvisioningRequest.
 	ProvisioningRequestEnabled bool
+	// ForceScaleDownEnabled tells if CA processes the force-scale-down node taint.
+	ForceScaleDownEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/observers/loopstart/loopstart.go
+++ b/cluster-autoscaler/observers/loopstart/loopstart.go
@@ -34,6 +34,11 @@ func (l *ObserversList) Refresh() {
 	}
 }
 
+// Register appends observer to the observers list.
+func (l *ObserversList) Register(observer Observer) {
+	l.observers = append(l.observers, observer)
+}
+
 // NewObserversList return new ObserversList.
 func NewObserversList(observers []Observer) *ObserversList {
 	return &ObserversList{observers}

--- a/cluster-autoscaler/processors/forcescaledown/force_scale_down_node_taints_observer.go
+++ b/cluster-autoscaler/processors/forcescaledown/force_scale_down_node_taints_observer.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/client-go/informers"
+	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+// ForceScaleDownNodeTaintsObserver is an observer to handle force-scale-down taints.
+type ForceScaleDownNodeTaintsObserver struct {
+	kubeClient     kube_client.Interface
+	listerRegistry kube_util.ListerRegistry
+}
+
+// NewForceScaleDownNodeTaintsObserver returns a constructed ForceScaleDownNodeTaintsObserver struct.
+func NewForceScaleDownNodeTaintsObserver(kubeClient kube_client.Interface, informerFactory informers.SharedInformerFactory) *ForceScaleDownNodeTaintsObserver {
+	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(informerFactory)
+	return &ForceScaleDownNodeTaintsObserver{kubeClient, listerRegistry}
+}
+
+// Refresh starts to backfill empty TimeAdded for all force-scale-down taints.
+func (p *ForceScaleDownNodeTaintsObserver) Refresh() {
+	if err := p.backfillTaintTimeAddedIfEmtpy(context.Background()); err != nil {
+		klog.Warningf("Failed to backfill TimeAdded for force-scale-down taints: %v", err)
+	}
+}
+
+func (p *ForceScaleDownNodeTaintsObserver) backfillTaintTimeAddedIfEmtpy(ctx context.Context) error {
+	nodes, err := p.listerRegistry.AllNodeLister().List()
+	if err != nil {
+		return fmt.Errorf("failed to list all nodes: %w", err)
+	}
+	taintUpdater := func(node *apiv1.Node) {
+		for index := range node.Spec.Taints {
+			if node.Spec.Taints[index].Key != taints.ForceScaleDownTaint {
+				continue
+			}
+			if node.Spec.Taints[index].TimeAdded != nil && !node.Spec.Taints[index].TimeAdded.IsZero() {
+				continue
+			}
+			node.Spec.Taints[index].TimeAdded = &metav1.Time{Time: time.Now()}
+		}
+	}
+	nodesToUpdate := []*apiv1.Node{}
+	for _, node := range nodes {
+		copiedNode := node.DeepCopy()
+		taintUpdater(copiedNode)
+		if !reflect.DeepEqual(node, copiedNode) {
+			nodesToUpdate = append(nodesToUpdate, node)
+		}
+	}
+	for _, node := range nodesToUpdate {
+		klog.V(2).Infof("Backfilling TimeAdded for force-scale-down node taint %s: %+v", node.Name, node.Spec.Taints)
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			node, err := p.kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get node %s: %w", node, err)
+			}
+			taintUpdater(node)
+			if _, err := p.kubeClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("failed to update node %s: %w", node.Name, err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update %s node taint after retries: %w", node.Name, err)
+		}
+	}
+	return nil
+}

--- a/cluster-autoscaler/processors/forcescaledown/force_scale_down_node_taints_observer_test.go
+++ b/cluster-autoscaler/processors/forcescaledown/force_scale_down_node_taints_observer_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestBackfillTaintTimeAddedIfEmtpy(t *testing.T) {
+	defaultTimeAdded := &metav1.Time{Time: time.Date(2024, time.March, 9, 0, 0, 0, 0, time.UTC)}
+	testCases := []struct {
+		name               string
+		nodes              []*apiv1.Node
+		nodesWithTimeAdded []string
+	}{
+		{
+			name: "no nodes to process",
+		},
+		{
+			name: "all nodes already have taint with TimeAdded",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+			},
+			nodesWithTimeAdded: []string{"n1"},
+		},
+		{
+			name: "1 out of 2 nodes need to be backfilled",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			nodesWithTimeAdded: []string{"n1"},
+		},
+	}
+
+	for index := range testCases {
+		tc := testCases[index]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			backfilledNodeNames := map[string]bool{}
+			for _, name := range tc.nodesWithTimeAdded {
+				backfilledNodeNames[name] = true
+			}
+			for index := range tc.nodes {
+				if backfilledNodeNames[tc.nodes[index].Name] {
+					taint := apiv1.Taint{
+						Key:       taints.ForceScaleDownTaint,
+						Effect:    apiv1.TaintEffectNoSchedule,
+						TimeAdded: defaultTimeAdded,
+					}
+					tc.nodes[index].Spec.Taints = append(tc.nodes[index].Spec.Taints, taint)
+				}
+			}
+
+			fakeClient := fake.NewSimpleClientset()
+			for index := range tc.nodes {
+				_, err := fakeClient.CoreV1().Nodes().Create(context.TODO(), tc.nodes[index], metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			stop := make(chan struct{})
+			informerFactory.Start(stop)
+
+			processor := NewForceScaleDownNodeTaintsObserver(fakeClient, informerFactory)
+			err := processor.backfillTaintTimeAddedIfEmtpy(context.TODO())
+			assert.NoError(t, err)
+			nodeList, err := fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.nodes), len(nodeList.Items))
+			for _, node := range nodeList.Items {
+				for _, taint := range node.Spec.Taints {
+					assert.NotNil(t, taint.TimeAdded, "Node %s taint %s should have non-nil TimeAdded", node.Name, taint.Key)
+				}
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_comparer.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_comparer.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/klog/v2"
+)
+
+// ScaleDownCandidateNodesCompare is sorting scale down candidates so that force-scale-down nodes appear first.
+type ScaleDownCandidateNodesCompare struct{}
+
+// NewScaleDownCandidateNodesCompare return ScaleDownCandidateNodesCompare struct.
+func NewScaleDownCandidateNodesCompare() *ScaleDownCandidateNodesCompare {
+	return &ScaleDownCandidateNodesCompare{}
+}
+
+// ScaleDownEarlierThan return true if node1 has force-scale-down taint and node2 doesn't.
+func (p *ScaleDownCandidateNodesCompare) ScaleDownEarlierThan(node1, node2 *apiv1.Node) bool {
+	if taints.HasForceScaleDownTaint(node1) && !taints.HasForceScaleDownTaint(node2) {
+		klog.V(4).Infof("Prioritizing node %s over %s, because only %s has the force-scale-down taint", node1.Name, node2.Name, node1.Name)
+		return true
+	}
+	return false
+}

--- a/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_comparer_test.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_comparer_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestScaleDownEarlierThan(t *testing.T) {
+	taint := apiv1.Taint{
+		Key:    taints.ForceScaleDownTaint,
+		Effect: apiv1.TaintEffectNoSchedule,
+	}
+	candidate1 := BuildTestNode("candidate1", 100, 0)
+	candidate1.Spec.Taints = []apiv1.Taint{taint}
+	candidate2 := BuildTestNode("candidate2", 100, 0)
+	candidate2.Spec.Taints = []apiv1.Taint{taint}
+	nonCandidate1 := BuildTestNode("non-candidate1", 100, 0)
+	nonCandidate2 := BuildTestNode("non-candidate2", 100, 0)
+
+	processor := NewScaleDownCandidateNodesCompare()
+	testCases := []struct {
+		name  string
+		node1 *apiv1.Node
+		node2 *apiv1.Node
+		want  bool
+	}{
+		{
+			name:  "Compare two candidates",
+			node1: candidate1,
+			node2: candidate2,
+			want:  false,
+		},
+		{
+			name:  "Compare two non-candidates",
+			node1: nonCandidate1,
+			node2: nonCandidate2,
+			want:  false,
+		},
+		{
+			name:  "Compare candidate and non-candidate",
+			node1: candidate1,
+			node2: nonCandidate2,
+			want:  true,
+		},
+		{
+			name:  "Compare non-candidate and candidate",
+			node1: nonCandidate1,
+			node2: candidate2,
+			want:  false,
+		},
+	}
+	for index := range testCases {
+		tc := testCases[index]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := processor.ScaleDownEarlierThan(tc.node1, tc.node2)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_processor.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_processor.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+)
+
+// ScaleDownCandidateNodesProcessor is a processor to handle pod destination candidates and scale down candidates.
+type ScaleDownCandidateNodesProcessor struct{}
+
+// NewScaleDownCandidateNodesProcessor returns a new ScaleDownCandidateNodesProcessor struct.
+func NewScaleDownCandidateNodesProcessor() *ScaleDownCandidateNodesProcessor {
+	return &ScaleDownCandidateNodesProcessor{}
+}
+
+// GetPodDestinationCandidates returns nodes that potentially could act as destinations for pods
+// that would become unscheduled after a scale down.
+func (p *ScaleDownCandidateNodesProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext, nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	result := []*apiv1.Node{}
+	for _, node := range nodes {
+		if !taints.HasForceScaleDownTaint(node) {
+			result = append(result, node)
+		}
+	}
+	return result, nil
+}
+
+// GetScaleDownCandidates returns the scale down candidate nodes from the input.
+func (p *ScaleDownCandidateNodesProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext, nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	return nodes, nil
+}
+
+// CleanUp is called at CA termination.
+func (p *ScaleDownCandidateNodesProcessor) CleanUp() {}

--- a/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_processor_test.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_down_candidate_nodes_processor_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestGetPodDestinationCandidates(t *testing.T) {
+	testCases := []struct {
+		name       string
+		nodes      []*apiv1.Node
+		forcedNods []string
+		wantNodes  []*apiv1.Node
+	}{
+		{
+			name: "no nodes and no pod destination candidates",
+		},
+		{
+			name: "force-scale-down nodes should not be returned",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			forcedNods: []string{"n1"},
+			wantNodes: []*apiv1.Node{
+				BuildTestNode("n2", 1000, 10),
+			},
+		},
+	}
+
+	for index := range testCases {
+		tc := testCases[index]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			forcedNodeNames := map[string]bool{}
+			for _, name := range tc.forcedNods {
+				forcedNodeNames[name] = true
+			}
+			for index := range tc.nodes {
+				if forcedNodeNames[tc.nodes[index].Name] {
+					taint := apiv1.Taint{Key: taints.ForceScaleDownTaint, Effect: apiv1.TaintEffectNoSchedule}
+					tc.nodes[index].Spec.Taints = append(tc.nodes[index].Spec.Taints, taint)
+				}
+			}
+			ctx := &context.AutoscalingContext{}
+			processor := NewScaleDownCandidateNodesProcessor()
+			result, err := processor.GetPodDestinationCandidates(ctx, tc.nodes)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantNodes, result)
+		})
+	}
+}

--- a/cluster-autoscaler/processors/forcescaledown/scale_up_unschedulable_pods_processor.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_up_unschedulable_pods_processor.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
+	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/klog/v2"
+)
+
+// ScaleUpUnschedulablePodsProcessor is a processor to handle unschedulable pods on force-scale-down nodes.
+type ScaleUpUnschedulablePodsProcessor struct{}
+
+// NewScaleUpUnschedulablePodsProcessor returns a new processor adding pods
+// from currently force-scale-down nodes to the unschedulable pods.
+func NewScaleUpUnschedulablePodsProcessor() *ScaleUpUnschedulablePodsProcessor {
+	return &ScaleUpUnschedulablePodsProcessor{}
+}
+
+// Process adds recreatable and unschedulable pods from currently force-scale-down nodes
+func (p *ScaleUpUnschedulablePodsProcessor) Process(context *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	klog.V(4).Infof("Processing currently force-scale-down nodes and pods")
+	forceScaleDownPods, err := getCurrentlyForceScaleDownPods(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get currently force-scale-down pods: %w", err)
+	}
+	forceScaleDownPods = pod_util.ClearPodNodeNames(forceScaleDownPods)
+	recreatablePods := pod_util.FilterRecreatablePods(forceScaleDownPods)
+	unschedulableForceScaleDownPods, err := filterOutSchedulablePodsToAvoidNodeChurn(context, recreatablePods)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter out schedulable force-scale-down pods: %w", err)
+	}
+	allUnschedulablePods := appendAdditionalPods(unschedulablePods, unschedulableForceScaleDownPods)
+	klog.V(4).Infof("Pod count summary: all unschedulable %d, initial unschedulable %d, all force-scale-down %d, recreatable force-scale-down %d, unschedulable force-scale-down %d",
+		len(allUnschedulablePods), len(unschedulablePods), len(forceScaleDownPods), len(recreatablePods), len(unschedulableForceScaleDownPods))
+	return allUnschedulablePods, nil
+}
+
+// CleanUp cleans up the processor's internal structures.
+func (p *ScaleUpUnschedulablePodsProcessor) CleanUp() {}
+
+func getCurrentlyForceScaleDownPods(context *context.AutoscalingContext) ([]*apiv1.Pod, error) {
+	var pods []*apiv1.Pod
+	nodes, err := context.AllNodeLister().List()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all nodes when getting force-scale-down nodes: %w", err)
+	}
+	for _, node := range nodes {
+		if !taints.HasForceScaleDownTaint(node) {
+			continue
+		}
+		nodeInfo, err := context.ClusterSnapshot.NodeInfos().Get(node.Name)
+		if err != nil {
+			klog.Warningf("Couldn't get node %s info, assuming the node got deleted already: %v", node.Name, err)
+			continue
+		}
+		klog.V(2).Infof("Found %d pods on force-scale-down node %s", len(nodeInfo.Pods), node.Name)
+		for _, podInfo := range nodeInfo.Pods {
+			if podInfo.Pod.DeletionTimestamp == nil {
+				pods = append(pods, podInfo.Pod)
+			}
+		}
+	}
+	return pods, nil
+}
+
+func filterOutSchedulablePodsToAvoidNodeChurn(context *context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	context.ClusterSnapshot.Fork()
+	defer context.ClusterSnapshot.Revert()
+	simulator := scheduling.NewHintingSimulator(context.PredicateChecker)
+	statuses, _, err := simulator.TrySchedulePods(context.ClusterSnapshot, pods, scheduling.ScheduleAnywhere, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to simulate scheduling force-scale-down pods: %w", err)
+	}
+	scheduledPodUIDs := map[types.UID]bool{}
+	for _, status := range statuses {
+		scheduledPodUIDs[status.Pod.UID] = true
+	}
+	unschedulablePods := []*apiv1.Pod{}
+	for _, pod := range pods {
+		if scheduledPodUIDs[pod.UID] {
+			continue
+		}
+		unschedulablePods = append(unschedulablePods, pod)
+	}
+	return unschedulablePods, nil
+}
+
+func appendAdditionalPods(existingPods, additionalPods []*apiv1.Pod) []*apiv1.Pod {
+	result := []*apiv1.Pod{}
+	result = append(result, existingPods...)
+	existingPodUIDs := map[types.UID]bool{}
+	for _, pod := range existingPods {
+		existingPodUIDs[pod.UID] = true
+	}
+	for _, pod := range additionalPods {
+		if existingPodUIDs[pod.UID] {
+			continue
+		}
+		result = append(result, pod)
+	}
+	return result
+}

--- a/cluster-autoscaler/processors/forcescaledown/scale_up_unschedulable_pods_processor_test.go
+++ b/cluster-autoscaler/processors/forcescaledown/scale_up_unschedulable_pods_processor_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestScaleUpUnschedulablePodsProcessor(t *testing.T) {
+	testCases := []struct {
+		name         string
+		forcedNodes  []string
+		nodes        []*apiv1.Node
+		pods         []*apiv1.Pod
+		deletingPods []string
+
+		unschedulablePods []*apiv1.Pod
+		wantPods          []*apiv1.Pod
+	}{
+		{
+			name: "no nodes, no unschedulable pods",
+		},
+		{
+			name: "no nodes, some unschedulable pods",
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:        "single node has force-scale-down taint",
+			forcedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:        "single node does not have force-scale-down taint",
+			forcedNodes: []string{},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+			wantPods: []*apiv1.Pod{},
+		},
+		{
+			name:        "n1 has force-scale-down taint, and n2 does not have enough capacity",
+			forcedNodes: []string{"n1"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 350, 10),
+				BuildTestNode("n2", 350, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				BuildScheduledTestPod("p3", 100, 1, "n2"),
+				BuildScheduledTestPod("p4", 200, 1, "n2"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:        "n1 has force-scale-down taint, but n2 has enough capacity",
+			forcedNodes: []string{"n1"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				BuildScheduledTestPod("p3", 100, 1, "n2"),
+				BuildScheduledTestPod("p4", 200, 1, "n2"),
+			},
+			wantPods: []*apiv1.Pod{},
+		},
+		{
+			name:        "3 nodes have force-scale-down taint",
+			forcedNodes: []string{"n1", "n2", "n3"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n2"),
+				BuildScheduledTestPod("p3", 100, 1, "n3"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+				BuildTestPod("p3", 100, 1),
+			},
+		},
+		{
+			name:        "function input and force-scale-down nodes have duplicated pods",
+			forcedNodes: []string{"n2"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n2"),
+			},
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p2", 200, 1),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:        "force-scale-down pod is being deleted",
+			forcedNodes: []string{"n1", "n2"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 100, 1, "n2"),
+			},
+			deletingPods: []string{"p1"},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p2", 100, 1),
+			},
+		},
+		{
+			name:        "pod is force-scale-down but reschedulable",
+			forcedNodes: []string{"n1"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 100, 1, "n2"),
+			},
+			wantPods: []*apiv1.Pod{},
+		},
+	}
+
+	for index := range testCases {
+		tc := testCases[index]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			forcedNodeNames := map[string]bool{}
+			for _, name := range tc.forcedNodes {
+				forcedNodeNames[name] = true
+			}
+			for index := range tc.nodes {
+				if !forcedNodeNames[tc.nodes[index].Name] {
+					continue
+				}
+				taint := apiv1.Taint{
+					Key:    taints.ForceScaleDownTaint,
+					Effect: apiv1.TaintEffectNoSchedule,
+				}
+				tc.nodes[index].Spec.Taints = append(tc.nodes[index].Spec.Taints, taint)
+			}
+			deletingPodNames := map[string]bool{}
+			for _, name := range tc.deletingPods {
+				deletingPodNames[name] = true
+			}
+			for index := range tc.pods {
+				if deletingPodNames[tc.pods[index].Name] {
+					tc.pods[index].DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				}
+			}
+
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
+			assert.NoError(t, err)
+			ctx := context.AutoscalingContext{
+				ClusterSnapshot:  clustersnapshot.NewBasicClusterSnapshot(),
+				PredicateChecker: predicateChecker,
+				AutoscalingKubeClients: context.AutoscalingKubeClients{
+					ListerRegistry: newMockListerRegistry(tc.nodes),
+				},
+			}
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, ctx.ClusterSnapshot, tc.nodes, tc.pods)
+
+			processor := NewScaleUpUnschedulablePodsProcessor()
+			pods, err := processor.Process(&ctx, tc.unschedulablePods)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantPods, pods)
+		})
+	}
+}
+
+type mockListerRegistry struct {
+	kube_util.ListerRegistry
+	nodes []*apiv1.Node
+}
+
+func newMockListerRegistry(nodes []*apiv1.Node) *mockListerRegistry {
+	return &mockListerRegistry{
+		nodes: nodes,
+	}
+}
+
+func (mlr mockListerRegistry) AllNodeLister() kube_util.NodeLister {
+	return &mockNodeLister{nodes: mlr.nodes}
+}
+
+type mockNodeLister struct {
+	nodes []*apiv1.Node
+}
+
+func (mnl *mockNodeLister) List() ([]*apiv1.Node, error) {
+	return mnl.nodes, nil
+}
+func (mnl *mockNodeLister) Get(name string) (*apiv1.Node, error) {
+	return nil, fmt.Errorf("Unsupported operation")
+}

--- a/cluster-autoscaler/simulator/drainability/rules/forcescaledown/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/forcescaledown/rule.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/klog/v2"
+)
+
+// Rule is a drainability rule on how to handle pods on scale-down-requested nodes.
+type Rule struct{}
+
+// New creates a new Rule.
+func New() *Rule {
+	return &Rule{}
+}
+
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "FoceScaleDown"
+}
+
+// Drainable decides what to do with force-scale-down pods on node drain.
+func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
+	podDesc := fmt.Sprintf("pod %s/%s on node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	if drainCtx.Listers == nil || drainCtx.Listers.AllNodeLister() == nil {
+		return drainability.NewUndefinedStatus()
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		klog.V(6).Infof("Skipped force-scale-down drainable check for %s, because the pod does not have a node yet", podDesc)
+		return drainability.NewUndefinedStatus()
+	}
+	node, err := drainCtx.Listers.AllNodeLister().Get(pod.Spec.NodeName)
+	if err != nil {
+		klog.Warningf("Skipped force-scale-down drainable check for %s, because failed to get node: %v", podDesc, err)
+		return drainability.NewUndefinedStatus()
+	}
+	if !taints.HasForceScaleDownTaint(node) {
+		klog.V(6).Infof("Skipped force-scale-down drainable check for %s, because the node does not have force-scale-down taint", podDesc)
+		return drainability.NewUndefinedStatus()
+	}
+	deadline := taints.GetForceScaleDownDeadline(node)
+	if deadline == nil {
+		klog.V(2).Infof("Marking %s as drainable, because the tainted node does not have a force-scale-down deadline", podDesc)
+		return drainability.NewDrainableStatus()
+	}
+	if drainCtx.Timestamp.Before(*deadline) {
+		klog.V(2).Infof("Marking %s as drainable, because the node has force-scale-down taint, and it is before the deadline %v", podDesc, *deadline)
+		return drainability.NewDrainableStatus()
+	}
+	klog.V(2).Infof("Marking %s as drain skip, because the node has force-scale-down taint, and it exceeded the deadline %v", podDesc, *deadline)
+	return drainability.NewSkipStatus()
+}

--- a/cluster-autoscaler/simulator/drainability/rules/forcescaledown/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/forcescaledown/rule_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forcescaledown
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+)
+
+func TestDrainable(t *testing.T) {
+	testTime := time.Date(2024, time.March, 9, 0, 0, 0, 0, time.UTC)
+	testCases := map[string]struct {
+		pod   *apiv1.Pod
+		nodes []*apiv1.Node
+		want  drainability.Status
+	}{
+		"regular pod": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+			},
+			want: drainability.NewUndefinedStatus(),
+		},
+		"pod on non force-scale-down node": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+			nodes: []*apiv1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+					},
+					Spec: apiv1.NodeSpec{
+						Taints: []apiv1.Taint{},
+					},
+				},
+			},
+			want: drainability.NewUndefinedStatus(),
+		},
+		"pod on force-scale-down node without deadline": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+			nodes: []*apiv1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+					},
+					Spec: apiv1.NodeSpec{
+						Taints: []apiv1.Taint{
+							{
+								Key:    taints.ForceScaleDownTaint,
+								Effect: apiv1.TaintEffectNoSchedule,
+							},
+						},
+					},
+				},
+			},
+			want: drainability.NewDrainableStatus(),
+		},
+		"pod on force-scale-down node before deadline": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+			nodes: []*apiv1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+					},
+					Spec: apiv1.NodeSpec{
+						Taints: []apiv1.Taint{
+							{
+								Key:       taints.ForceScaleDownTaint,
+								Effect:    apiv1.TaintEffectNoSchedule,
+								Value:     "30",
+								TimeAdded: &metav1.Time{Time: testTime},
+							},
+						},
+					},
+				},
+			},
+			want: drainability.NewDrainableStatus(),
+		},
+		"pod on force-scale-down node after deadline": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+			nodes: []*apiv1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+					},
+					Spec: apiv1.NodeSpec{
+						Taints: []apiv1.Taint{
+							{
+								Key:       taints.ForceScaleDownTaint,
+								Effect:    apiv1.TaintEffectNoSchedule,
+								Value:     "30",
+								TimeAdded: &metav1.Time{Time: testTime.Add(-60 * time.Minute)},
+							},
+						},
+					},
+				},
+			},
+			want: drainability.NewSkipStatus(),
+		},
+	}
+
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+			ctx := drainability.DrainContext{
+				Listers:   newMockListerRegistry(tc.nodes),
+				Timestamp: testTime,
+			}
+			got := New().Drainable(&ctx, tc.pod)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
+			}
+		})
+	}
+}
+
+type mockListerRegistry struct {
+	kube_util.ListerRegistry
+	nodes []*apiv1.Node
+}
+
+func newMockListerRegistry(nodes []*apiv1.Node) *mockListerRegistry {
+	return &mockListerRegistry{
+		nodes: nodes,
+	}
+}
+
+func (mlr mockListerRegistry) AllNodeLister() kube_util.NodeLister {
+	return &mockNodeLister{nodes: mlr.nodes}
+}
+
+type mockNodeLister struct {
+	nodes []*apiv1.Node
+}
+
+func (mnl *mockNodeLister) List() ([]*apiv1.Node, error) {
+	return mnl.nodes, nil
+}
+func (mnl *mockNodeLister) Get(name string) (*apiv1.Node, error) {
+	for _, node := range mnl.nodes {
+		if node.Name == name {
+			return node, nil
+		}
+	}
+	return nil, fmt.Errorf("node %s not found", name)
+}

--- a/cluster-autoscaler/simulator/drainability/rules/rules.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/daemonset"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/forcescaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/localstorage"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/longterminating"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/mirror"
@@ -61,6 +62,7 @@ func Default(deleteOptions options.NodeDeleteOptions) Rules {
 		{rule: daemonset.New()},
 		{rule: safetoevict.New()},
 		{rule: terminal.New()},
+		{rule: forcescaledown.New(), skip: !deleteOptions.ForceScaleDownEnabled},
 
 		// Blocking checks
 		{rule: replicated.New(deleteOptions.SkipNodesWithCustomControllerPods)},

--- a/cluster-autoscaler/simulator/options/nodedelete.go
+++ b/cluster-autoscaler/simulator/options/nodedelete.go
@@ -35,6 +35,10 @@ type NodeDeleteOptions struct {
 	// set or replication controller should have to allow pod deletion during
 	// scale down.
 	MinReplicaCount int
+	// ForceScaleDownEnabled determines whether nodes with force-scale-down taint
+	// should be handled separately, either always drainable or skip drain, based
+	// on the pod eviction deadline.
+	ForceScaleDownEnabled bool
 }
 
 // NewNodeDeleteOptions returns new node delete options extracted from autoscaling options.
@@ -44,5 +48,6 @@ func NewNodeDeleteOptions(opts config.AutoscalingOptions) NodeDeleteOptions {
 		SkipNodesWithLocalStorage:         opts.SkipNodesWithLocalStorage,
 		SkipNodesWithCustomControllerPods: opts.SkipNodesWithCustomControllerPods,
 		MinReplicaCount:                   opts.MinReplicaCount,
+		ForceScaleDownEnabled:             opts.ForceScaleDownEnabled,
 	}
 }

--- a/cluster-autoscaler/simulator/predicatechecker/schedulerbased.go
+++ b/cluster-autoscaler/simulator/predicatechecker/schedulerbased.go
@@ -130,6 +130,9 @@ func (p *SchedulerBasedPredicateChecker) FitsAnyNodeMatching(clusterSnapshot clu
 			p.lastIndex = (p.lastIndex + i + 1) % len(nodeInfosList)
 			return nodeInfo.Node().Name, nil
 		}
+		if filterStatus != nil {
+			klog.V(6).Infof("Pod %s/%s cannot be scheduled on node %s: %+v", pod.Namespace, pod.Name, nodeInfo.Node().Name, *filterStatus)
+		}
 	}
 	return "", fmt.Errorf("cannot put pod %s on any node", pod.Name)
 }


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new feature to support scaling down a particular node. As described in #5109, some nodes could become non-functional for some reason specific to the cloud provider. With this change, users can tag a node explicitly by running `kubectl annotate node <nodename> cluster-autoscaler.kubernetes.io/scale-down-requested=true`. Cluster-Autoscaler will perform all required safe checks, evict hosted pods and delete the node.

This PR also introduces the feature to scale up the cluster if the current node group size is smaller than the configured min size. This feature is disabled by default, and users need to pass in the bool flag `scale-up-to-meet-node-group-min-size-enabled` to enable it.

The first feature is slightly depend on the second feature. For example, the min size of a node group is 3, and it has exactly 3 nodes at this moment. If we tag a node to scale down, it wouldn't work because the node group is already at the min size, and the cluster could only be scaled up if it has unschedulable pods to help. Therefore, we need this change to take the `scale-down-requested` annotation into account and scale up the node group a bit if it's needed.

#### Which issue(s) this PR fixes:

Fixes #5109

#### Special notes for your reviewer:

Besides unit tests, this PR has been fully validated in an Azure K8s cluster. I will share more details about my experiments in a separate comment of this PR.

#### Does this PR introduce a user-facing change?

```release-note
Support scaling down a particular node if it has `cluster-autoscaler.kubernetes.io/scale-down-requested=true` annotation.
Support scaling up the cluster if the current node group size is smaller than the configured min size (disabled by default).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [FAQ How can I request Clsuter Autoscaler to scale down a particular node?]: https://github.com/liuxintong/autoscaler/blob/7fe865bc03b2e9feab9254227744da97049716fb/cluster-autoscaler/FAQ.md#how-can-i-request-clsuter-autoscaler-to-scale-down-a-particular-node
- [FAQ My cluster is below minimum / above maximum number of nodes, but CA did not fix that! Why?]: https://github.com/liuxintong/autoscaler/blob/7fe865bc03b2e9feab9254227744da97049716fb/cluster-autoscaler/FAQ.md#my-cluster-is-below-minimum--above-maximum-number-of-nodes-but-ca-did-not-fix-that-why
- [FAQ What are the parameters to CA?]: https://github.com/liuxintong/autoscaler/blob/7fe865bc03b2e9feab9254227744da97049716fb/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca
```
