### PR TITLE
Don't depend on IsNodeBeingDeleted implementation

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -108,9 +108,6 @@ func (c *Checker) FilterOutUnremovable(context *context.AutoscalingContext, scal
 func (c *Checker) unremovableReasonAndNodeUtilization(context *context.AutoscalingContext, timestamp time.Time, nodeInfo *schedulerframework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {
 	node := nodeInfo.Node()
 
-	// Skip nodes marked to be deleted, if they were marked recently.
-	// Old-time marked nodes are again eligible for deletion - something went wrong with them
-	// and they have not been deleted.
 	if actuation.IsNodeBeingDeleted(node, timestamp) {
 		klog.V(1).Infof("Skipping %s from delete consideration - the node is currently being deleted", node.Name)
 		return simulator.CurrentlyBeingDeleted, nil

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -46,10 +46,6 @@ func TestFilterOutUnremovable(t *testing.T) {
 	justDeletedNode.Spec.Taints = []apiv1.Taint{{Key: deletetaint.ToBeDeletedTaint, Value: strconv.FormatInt(now.Unix()-30, 10)}}
 	SetNodeReadyState(justDeletedNode, true, time.Time{})
 
-	tooOldDeletedNode := BuildTestNode("tooOldDeleted", 1000, 10)
-	tooOldDeletedNode.Spec.Taints = []apiv1.Taint{{Key: deletetaint.ToBeDeletedTaint, Value: strconv.FormatInt(now.Unix()-301, 10)}}
-	SetNodeReadyState(tooOldDeletedNode, true, time.Time{})
-
 	noScaleDownNode := BuildTestNode("noScaleDown", 1000, 10)
 	noScaleDownNode.Annotations = map[string]string{ScaleDownDisabledKey: "true"}
 	SetNodeReadyState(noScaleDownNode, true, time.Time{})
@@ -75,11 +71,6 @@ func TestFilterOutUnremovable(t *testing.T) {
 			desc:  "recently deleted node is filtered out",
 			nodes: []*apiv1.Node{regularNode, justDeletedNode},
 			want:  []string{"regular"},
-		},
-		{
-			desc:  "deleted long time ago stays",
-			nodes: []*apiv1.Node{regularNode, tooOldDeletedNode},
-			want:  []string{"regular", "tooOldDeleted"},
 		},
 		{
 			desc:  "marked no scale down is filtered out",


### PR DESCRIPTION
The fact that it only considers nodes as deleted only until a certain timeout is of no concern to the eligibility.Checker.

#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow up to comments on https://github.com/kubernetes/autoscaler/pull/5118

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @MaciekPytel 