### PR TITLE
Support for DirectX Devices

### DIFF
--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -43,10 +43,11 @@ func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(context
 	for _, node := range readyNodes {
 		_, hasGpuLabel := node.Labels[context.CloudProvider.GPULabel()]
 		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[gpu.ResourceNvidiaGPU]
+		directXAllocatable, hasDirectXAllocatable := node.Status.Allocatable[gpu.ResourceDirectX]
 		// We expect node to have GPU based on label, but it doesn't show up
 		// on node object. Assume the node is still not fully started (installing
 		// GPU drivers).
-		if hasGpuLabel && (!hasGpuAllocatable || gpuAllocatable.IsZero()) {
+		if hasGpuLabel && ((!hasGpuAllocatable || gpuAllocatable.IsZero()) && (!hasDirectXAllocatable || directXAllocatable.IsZero())) {
 			klog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
 				node.Name)
 			nodesWithUnreadyGpu[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.ResourceUnready)

--- a/cluster-autoscaler/processors/customresources/gpu_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor_test.go
@@ -84,6 +84,38 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	nodeGpuUnready.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(0, resource.DecimalSI)
 	expectedReadiness[nodeGpuUnready.Name] = false
 
+	nodeDirectXReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeDirectXReady",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeDirectXReady.Status.Allocatable[gpu.ResourceDirectX] = *resource.NewQuantity(1, resource.DecimalSI)
+	nodeDirectXReady.Status.Capacity[gpu.ResourceDirectX] = *resource.NewQuantity(1, resource.DecimalSI)
+	expectedReadiness[nodeDirectXReady.Name] = true
+
+	nodeDirectXUnready := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeDirectXUnready",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeDirectXUnready.Status.Allocatable[gpu.ResourceDirectX] = *resource.NewQuantity(0, resource.DecimalSI)
+	nodeDirectXUnready.Status.Capacity[gpu.ResourceDirectX] = *resource.NewQuantity(0, resource.DecimalSI)
+	expectedReadiness[nodeDirectXUnready.Name] = false
+
 	nodeGpuUnready2 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "nodeGpuUnready2",
@@ -124,12 +156,16 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 		nodeGpuReady,
 		nodeGpuUnready,
 		nodeGpuUnready2,
+		nodeDirectXReady,
+		nodeDirectXUnready,
 		nodeNoGpuReady,
 	}
 	initialAllNodes := []*apiv1.Node{
 		nodeGpuReady,
 		nodeGpuUnready,
 		nodeGpuUnready2,
+		nodeDirectXReady,
+		nodeDirectXUnready,
 		nodeNoGpuReady,
 		nodeNoGpuUnready,
 	}

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -25,6 +25,8 @@ import (
 const (
 	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
 	ResourceNvidiaGPU = "nvidia.com/gpu"
+	// ResourceDirectX is the name of the DirectX resource on windows.
+	ResourceDirectX = "microsoft.com/directx"
 	// DefaultGPUType is the type of GPU used in NAP if the user
 	// don't specify what type of GPU his pod wants.
 	DefaultGPUType = "nvidia-tesla-k80"


### PR DESCRIPTION
#### Which component this PR applies to?

Under Windows the handling for GPU does currently not support ScaleDown since the Node is not treated as Ready.
Other than on Linux the Resource is named `microsoft.com/directx`

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows GPU accelerated windows nodes to scale down
