### PR TITLE
Fix accessing index out of bonds

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 // NewCappingRecommendationProcessor constructs new RecommendationsProcessor that adjusts recommendation
@@ -255,14 +255,21 @@ func ApplyVPAPolicy(podRecommendation *vpa_types.RecommendedPodResources,
 	return &vpa_types.RecommendedPodResources{ContainerRecommendations: updatedRecommendations}, nil
 }
 
+func getRecommendationForContainer(containerName string, resources []vpa_types.RecommendedContainerResources) *vpa_types.RecommendedContainerResources {
+	for _, containerRec := range resources {
+		if containerRec.ContainerName == containerName {
+			return &containerRec
+		}
+	}
+	return nil
+}
+
 // GetRecommendationForContainer returns recommendation for given container name
 func GetRecommendationForContainer(containerName string, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedContainerResources {
 	if recommendation != nil {
-		for i, containerRec := range recommendation.ContainerRecommendations {
-			if containerRec.ContainerName == containerName {
-				recommendationCopy := recommendation.ContainerRecommendations[i]
-				return &recommendationCopy
-			}
+		if recommendationForContainer := getRecommendationForContainer(containerName, recommendation.ContainerRecommendations); recommendationForContainer != nil {
+			result := *recommendationForContainer
+			return &result
 		}
 	}
 	return nil
@@ -343,6 +350,20 @@ func getBoundaryRecommendation(recommendation apiv1.ResourceList, container apiv
 	}
 }
 
+type containerWithRecommendation struct {
+	container      *apiv1.Container
+	recommendation *vpa_types.RecommendedContainerResources
+}
+
+func zipContainersWithRecommendations(resources []vpa_types.RecommendedContainerResources, pod *apiv1.Pod) []containerWithRecommendation {
+	result := make([]containerWithRecommendation, 0)
+	for _, container := range pod.Spec.Containers {
+		recommendation := getRecommendationForContainer(container.Name, resources)
+		result = append(result, containerWithRecommendation{container: &container, recommendation: recommendation})
+	}
+	return result
+}
+
 func applyPodLimitRange(resources []vpa_types.RecommendedContainerResources,
 	pod *apiv1.Pod, limitRange apiv1.LimitRangeItem, resourceName apiv1.ResourceName,
 	fieldGetter func(vpa_types.RecommendedContainerResources) *apiv1.ResourceList) []vpa_types.RecommendedContainerResources {
@@ -350,34 +371,43 @@ func applyPodLimitRange(resources []vpa_types.RecommendedContainerResources,
 	maxLimit := limitRange.Max[resourceName]
 	defaultLimit := limitRange.Default[resourceName]
 
+	containersWithRecommendations := zipContainersWithRecommendations(resources, pod)
 	var sumLimit, sumRecommendation resource.Quantity
-	for i, container := range pod.Spec.Containers {
-		if i >= len(resources) {
-			continue
-		}
+	for _, containerWithRecommendation := range containersWithRecommendations {
+		container := containerWithRecommendation.container
 		limit := container.Resources.Limits[resourceName]
 		request := container.Resources.Requests[resourceName]
-		recommendation := (*fieldGetter(resources[i]))[resourceName]
+		var recommendation resource.Quantity
+		if containerWithRecommendation.recommendation == nil {
+			// No recommendation, don't change the container
+			recommendation = request
+		} else {
+			recommendation = (*fieldGetter(*containerWithRecommendation.recommendation))[resourceName]
+		}
 		containerLimit, _ := getProportionalResourceLimit(resourceName, &limit, &request, &recommendation, &defaultLimit)
 		if containerLimit != nil {
 			sumLimit.Add(*containerLimit)
 		}
 		sumRecommendation.Add(recommendation)
 	}
+
 	if minLimit.Cmp(sumLimit) <= 0 && minLimit.Cmp(sumRecommendation) <= 0 && (maxLimit.IsZero() || maxLimit.Cmp(sumLimit) >= 0) {
 		return resources
 	}
 
 	if minLimit.Cmp(sumRecommendation) > 0 && !sumLimit.IsZero() {
-		for i := range pod.Spec.Containers {
-			request := (*fieldGetter(resources[i]))[resourceName]
+		for _, containerWithRecommendation := range containersWithRecommendations {
+			if containerWithRecommendation.recommendation == nil {
+				continue
+			}
+			request := (*fieldGetter(*containerWithRecommendation.recommendation))[resourceName]
 			var cappedContainerRequest *resource.Quantity
 			if resourceName == apiv1.ResourceMemory {
 				cappedContainerRequest, _ = scaleQuantityProportionallyMem(&request, &sumRecommendation, &minLimit, roundUpToFullUnit)
 			} else {
 				cappedContainerRequest, _ = scaleQuantityProportionallyCPU(&request, &sumRecommendation, &minLimit, noRounding)
 			}
-			(*fieldGetter(resources[i]))[resourceName] = *cappedContainerRequest
+			(*fieldGetter(*containerWithRecommendation.recommendation))[resourceName] = *cappedContainerRequest
 		}
 		return resources
 	}
@@ -393,17 +423,53 @@ func applyPodLimitRange(resources []vpa_types.RecommendedContainerResources,
 	if !maxLimit.IsZero() && maxLimit.Cmp(sumLimit) < 0 {
 		targetTotalLimit = maxLimit
 	}
-	for i := range pod.Spec.Containers {
-		limit := (*fieldGetter(resources[i]))[resourceName]
+	for _, containerWithRecommendation := range containersWithRecommendations {
+		var limit resource.Quantity
+		if containerWithRecommendation.recommendation == nil {
+			// No recommendation, don't change the container
+			limit = containerWithRecommendation.container.Resources.Limits[resourceName]
+		} else {
+			limit = (*fieldGetter(*containerWithRecommendation.recommendation))[resourceName]
+		}
+
 		var cappedContainerRequest *resource.Quantity
 		if resourceName == apiv1.ResourceMemory {
 			cappedContainerRequest, _ = scaleQuantityProportionallyMem(&limit, &sumLimit, &targetTotalLimit, roundDownToFullUnit)
 		} else {
 			cappedContainerRequest, _ = scaleQuantityProportionallyCPU(&limit, &sumLimit, &targetTotalLimit, noRounding)
 		}
-		(*fieldGetter(resources[i]))[resourceName] = *cappedContainerRequest
+		(*fieldGetter(*containerWithRecommendation.recommendation))[resourceName] = *cappedContainerRequest
 	}
 	return resources
+}
+
+func recommendationForContainerExists(containerName string, containerRecommendations []vpa_types.RecommendedContainerResources) bool {
+	for _, recommendation := range containerRecommendations {
+		if containerName == recommendation.ContainerName {
+			return true
+		}
+	}
+	return false
+}
+
+func insertRequestsForMissingRecommendations(containerRecommendations []vpa_types.RecommendedContainerResources, pod *apiv1.Pod) []vpa_types.RecommendedContainerResources {
+	result := make([]vpa_types.RecommendedContainerResources, 0)
+	for _, r := range containerRecommendations {
+		result = append(result, *r.DeepCopy())
+	}
+	for _, container := range pod.Spec.Containers {
+		if recommendationForContainerExists(container.Name, containerRecommendations) {
+			continue
+		}
+		if len(container.Resources.Requests) == 0 {
+			continue
+		}
+		result = append(result, vpa_types.RecommendedContainerResources{
+			ContainerName: container.Name,
+			Target:        container.Resources.Requests.DeepCopy(),
+		})
+	}
+	return result
 }
 
 func (c *cappingRecommendationProcessor) capProportionallyToPodLimitRange(
@@ -419,6 +485,7 @@ func (c *cappingRecommendationProcessor) capProportionallyToPodLimitRange(
 	getUpper := func(rl vpa_types.RecommendedContainerResources) *apiv1.ResourceList { return &rl.UpperBound }
 	getLower := func(rl vpa_types.RecommendedContainerResources) *apiv1.ResourceList { return &rl.LowerBound }
 
+	containerRecommendations = insertRequestsForMissingRecommendations(containerRecommendations, pod)
 	containerRecommendations = applyPodLimitRange(containerRecommendations, pod, *podLimitRange, apiv1.ResourceCPU, getUpper)
 	containerRecommendations = applyPodLimitRange(containerRecommendations, pod, *podLimitRange, apiv1.ResourceMemory, getUpper)
 

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -414,6 +414,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
+							Name: "container1",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU: resource.MustParse("1"),
@@ -424,6 +425,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 							},
 						},
 						{
+							Name: "container2",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU: resource.MustParse("1"),
@@ -477,6 +479,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
+							Name: "container1",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU: resource.MustParse("1"),
@@ -487,6 +490,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 							},
 						},
 						{
+							Name: "container2",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceCPU: resource.MustParse("1"),
@@ -540,6 +544,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
+							Name: "container1",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: resource.MustParse("1"),
@@ -550,6 +555,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 							},
 						},
 						{
+							Name: "container2",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: resource.MustParse("1"),
@@ -603,6 +609,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
+							Name: "container1",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: resource.MustParse("1"),
@@ -613,6 +620,7 @@ func TestApplyPodLimitRange(t *testing.T) {
 							},
 						},
 						{
+							Name: "container2",
 							Resources: apiv1.ResourceRequirements{
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: resource.MustParse("1"),
@@ -650,6 +658,124 @@ func TestApplyPodLimitRange(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "cap mem request to pod min, only one container with recomendation",
+			resources: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "container1",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			pod: apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("1G"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("2G"),
+								},
+							},
+						},
+						{
+							Name: "container2",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("1G"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("2G"),
+								},
+							},
+						},
+					},
+				},
+			},
+			limitRange: apiv1.LimitRangeItem{
+				Type: apiv1.LimitTypePod,
+				Max: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("10G"),
+				},
+				Min: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("4G"),
+				},
+			},
+			resourceName: apiv1.ResourceMemory,
+			expect: []vpa_types.RecommendedContainerResources{
+				{
+					// TODO: This is incorrect; The pod will be rejected by limit range because sum of its
+					// pod requests is too small - it's 3Gi(2Gi for `container1` (from recommendation) and 1Gi
+					// for `container2` (unchanged incoming request)) and minimum is 4Gi.
+					ContainerName: "container1",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("2000000000"),
+					},
+				},
+			},
+		},
+		{
+			name: "cap mem request to pod min, extra recommendation",
+			resources: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "container1",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+				{
+					ContainerName: "container2",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+			},
+			pod: apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container2",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("1"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceMemory: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			limitRange: apiv1.LimitRangeItem{
+				Type: apiv1.LimitTypePod,
+				Max: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("10G"),
+				},
+				Min: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("4G"),
+				},
+			},
+			resourceName: apiv1.ResourceMemory,
+			expect: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "container1",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+				{
+					ContainerName: "container2",
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("4000000000"),
+					},
+				},
+			},
+		},
 	}
 	getTarget := func(rl vpa_types.RecommendedContainerResources) *apiv1.ResourceList { return &rl.Target }
 	for _, tc := range tests {
@@ -662,14 +788,16 @@ func TestApplyPodLimitRange(t *testing.T) {
 
 func TestApplyLimitRangeMinToRequest(t *testing.T) {
 	requestsOnly := vpa_types.ContainerControlledValuesRequestsOnly
+	requestAndLimit := vpa_types.ContainerControlledValuesRequestsAndLimits
 	tests := []struct {
-		name              string
-		resources         vpa_types.RecommendedPodResources
-		pod               apiv1.Pod
-		limitRange        apiv1.LimitRangeItem
-		policy            *vpa_types.PodResourcePolicy
-		expect            vpa_types.RecommendedPodResources
-		expectAnnotations []string
+		name                string
+		resources           vpa_types.RecommendedPodResources
+		pod                 apiv1.Pod
+		containerLimitRange apiv1.LimitRangeItem
+		podLimitRange       apiv1.LimitRangeItem
+		policy              *vpa_types.PodResourcePolicy
+		expect              vpa_types.RecommendedPodResources
+		expectAnnotations   map[string][]string
 	}{
 		{
 			name: "caps to min range if above container limit",
@@ -703,7 +831,7 @@ func TestApplyLimitRangeMinToRequest(t *testing.T) {
 					},
 				},
 			},
-			limitRange: apiv1.LimitRangeItem{
+			containerLimitRange: apiv1.LimitRangeItem{
 				Type: apiv1.LimitTypeContainer,
 				Min: apiv1.ResourceList{
 					apiv1.ResourceMemory: resource.MustParse("500M"),
@@ -720,10 +848,11 @@ func TestApplyLimitRangeMinToRequest(t *testing.T) {
 					},
 				},
 			},
-			expectAnnotations: []string{
-				"memory capped to fit Min in container LimitRange",
+			expectAnnotations: map[string][]string{
+				"container": {"memory capped to fit Min in container LimitRange"},
 			},
-		}, {
+		},
+		{
 			name: "caps to container limit if below container limit",
 			resources: vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -755,7 +884,7 @@ func TestApplyLimitRangeMinToRequest(t *testing.T) {
 					},
 				},
 			},
-			limitRange: apiv1.LimitRangeItem{
+			containerLimitRange: apiv1.LimitRangeItem{
 				Type: apiv1.LimitTypeContainer,
 				Min: apiv1.ResourceList{
 					apiv1.ResourceMemory: resource.MustParse("500M"),
@@ -778,21 +907,254 @@ func TestApplyLimitRangeMinToRequest(t *testing.T) {
 					},
 				},
 			},
-			expectAnnotations: []string{
-				"memory capped to fit Min in container LimitRange",
-				"memory capped to container limit",
+			expectAnnotations: map[string][]string{
+				"container": {
+					"memory capped to fit Min in container LimitRange",
+					"memory capped to container limit",
+				},
 			},
+		},
+		{
+			name: "caps to pod limit if below pod limit",
+			resources: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("200M"),
+						},
+					},
+				},
+			},
+			pod: apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("50M"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("100M"),
+								},
+							},
+						},
+					},
+				},
+			},
+			podLimitRange: apiv1.LimitRangeItem{
+				Type: apiv1.LimitTypePod,
+				Min: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("500M"),
+				},
+			},
+			policy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName:    vpa_types.DefaultContainerResourcePolicy,
+					ControlledValues: &requestsOnly,
+				}},
+			},
+			expect: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("100M"),
+						},
+					},
+				},
+			},
+			expectAnnotations: map[string][]string{
+				"container": {
+					"memory capped to container limit",
+				},
+			},
+		},
+		{
+			name: "caps to pod limit if below pod limit one container with recommendation and one without",
+			resources: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("200M"),
+						},
+					},
+				},
+			},
+			pod: apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("50M"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("100M"),
+								},
+							},
+						},
+						{
+							Name: "container2",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("50M"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("100M"),
+								},
+							},
+						},
+					},
+				},
+			},
+			podLimitRange: apiv1.LimitRangeItem{
+				Type: apiv1.LimitTypePod,
+				Min: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("500M"),
+				},
+			},
+			policy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName:    vpa_types.DefaultContainerResourcePolicy,
+					ControlledValues: &requestAndLimit,
+				}},
+			},
+			expect: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("400000000"),
+						},
+					},
+					{
+						ContainerName: "container2",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("100000000"),
+						},
+					},
+				},
+			},
+			expectAnnotations: map[string][]string{},
+		},
+		{
+			name: "caps to pod limit if below pod limit two containers with recommendation",
+			resources: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("200M"),
+						},
+					},
+					{
+						ContainerName: "container2",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("200M"),
+						},
+					},
+				},
+			},
+			pod: apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("50M"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("100M"),
+								},
+							},
+						},
+						{
+							Name: "container2",
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("50M"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("100M"),
+								},
+							},
+						},
+					},
+				},
+			},
+			podLimitRange: apiv1.LimitRangeItem{
+				Type: apiv1.LimitTypePod,
+				Min: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("500M"),
+				},
+			},
+			policy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName:    vpa_types.DefaultContainerResourcePolicy,
+					ControlledValues: &requestAndLimit,
+				}},
+			},
+			expect: vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container1",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("250000000"),
+						},
+					},
+					{
+						ContainerName: "container2",
+						Target: apiv1.ResourceList{
+							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory: resource.MustParse("250000000"),
+						},
+					},
+				},
+			},
+			expectAnnotations: map[string][]string{},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			calculator := fakeLimitRangeCalculator{containerLimitRange: tc.limitRange}
+			calculator := fakeLimitRangeCalculator{
+				containerLimitRange: tc.containerLimitRange,
+				podLimitRange:       tc.podLimitRange,
+			}
 			processor := NewCappingRecommendationProcessor(&calculator)
 			processedRecommendation, annotations, err := processor.Apply(&tc.resources, tc.policy, nil, &tc.pod)
 			assert.NoError(t, err)
-			assert.Contains(t, annotations, "container")
-			assert.ElementsMatch(t, tc.expectAnnotations, annotations["container"])
-			assert.Equal(t, tc.expect, *processedRecommendation)
+			for containerName, expectedAnnotations := range tc.expectAnnotations {
+				if assert.Contains(t, annotations, containerName) {
+					assert.ElementsMatch(t, expectedAnnotations, annotations[containerName], "for container '%s'", containerName)
+				}
+			}
+			assert.Equal(t, tc.expect, *processedRecommendation, "for container %s", containerName)
+			for containerName := range annotations {
+				assert.Contains(t, tc.expectAnnotations, containerName)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The function should match containers to their recommendations directly instead of hoping thier order will match,

See [this comment](https://github.com/kubernetes/autoscaler/issues/3966#issuecomment-1262159504)

Fixes #3966

#### Which component this PR applies to?

VPA admission controller

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #3966

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix bug in VPA admission controller. When:

- List of containers in pod is different than list of container in recommendation (for example as a result of a recent change to pod definition in its controller) and
- Pod was in a namespace with a `LimitRange`

VPA could crash or set container requests incorrectly. Now it sets correct limits and requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
