### PR TITLE
cleanup unused constants in clusterapi provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -581,32 +581,32 @@ func deleteTestConfigs(t *testing.T, controller *machineController, testConfigs 
 
 func TestControllerFindMachine(t *testing.T) {
 	type testCase struct {
-		description             string
-		name                    string
-		namespace               string
-		useDeprecatedAnnotation bool
-		lookupSucceeds          bool
+		description    string
+		name           string
+		namespace      string
+		useAnnotation  bool
+		lookupSucceeds bool
 	}
 
 	var testCases = []testCase{{
-		description:             "lookup fails",
-		lookupSucceeds:          false,
-		useDeprecatedAnnotation: false,
-		name:                    "machine-does-not-exist",
-		namespace:               "namespace-does-not-exist",
+		description:    "lookup fails",
+		lookupSucceeds: false,
+		useAnnotation:  false,
+		name:           "machine-does-not-exist",
+		namespace:      "namespace-does-not-exist",
 	}, {
-		description:             "lookup fails in valid namespace",
-		lookupSucceeds:          false,
-		useDeprecatedAnnotation: false,
-		name:                    "machine-does-not-exist-in-existing-namespace",
+		description:    "lookup fails in valid namespace",
+		lookupSucceeds: false,
+		useAnnotation:  false,
+		name:           "machine-does-not-exist-in-existing-namespace",
 	}, {
-		description:             "lookup succeeds",
-		lookupSucceeds:          true,
-		useDeprecatedAnnotation: false,
+		description:    "lookup succeeds",
+		lookupSucceeds: true,
+		useAnnotation:  false,
 	}, {
-		description:             "lookup succeeds with deprecated annotation",
-		lookupSucceeds:          true,
-		useDeprecatedAnnotation: true,
+		description:    "lookup succeeds with annotation",
+		lookupSucceeds: true,
+		useAnnotation:  true,
 	}}
 
 	test := func(t *testing.T, tc testCase, testConfig *testConfig) {
@@ -644,7 +644,7 @@ func TestControllerFindMachine(t *testing.T) {
 			if tc.namespace == "" {
 				tc.namespace = testConfig.machines[0].GetNamespace()
 			}
-			if tc.useDeprecatedAnnotation {
+			if tc.useAnnotation {
 				for i := range testConfig.machines {
 					n := testConfig.nodes[i]
 					annotations := n.GetAnnotations()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -28,10 +28,6 @@ import (
 )
 
 const (
-	deprecatedNodeGroupMinSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
-	deprecatedNodeGroupMaxSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
-	deprecatedClusterNameLabel              = "cluster.k8s.io/cluster-name"
-
 	cpuKey      = "capacity.cluster-autoscaler.kubernetes.io/cpu"
 	memoryKey   = "capacity.cluster-autoscaler.kubernetes.io/memory"
 	gpuTypeKey  = "capacity.cluster-autoscaler.kubernetes.io/gpu-type"


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

this change removes some unused values and adjusts the names in the unit tests to better reflect usage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
