### PR TITLE
cluster-autoscaler: allow setting kuberentes client burst and qps to avoid rate limiting

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -168,6 +168,10 @@ type AutoscalingOptions struct {
 	ConcurrentGceRefreshes int
 	// Path to kube configuration if available
 	KubeConfigPath string
+	// Burst setting for kubernetes client
+	KubeClientBurst int
+	// QPS setting for kubernetes client
+	KubeClientQPS float64
 	// ClusterAPICloudConfigAuthoritative tells the Cluster API provider to treat the CloudConfig option as authoritative and
 	// not use KubeConfigPath as a fallback when it is not provided.
 	ClusterAPICloudConfigAuthoritative bool

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -90,6 +90,8 @@ var (
 	address                 = flag.String("address", ":8085", "The address to expose prometheus metrics.")
 	kubernetes              = flag.String("kubernetes", "", "Kubernetes master location. Leave blank for default")
 	kubeConfigFile          = flag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
+	kubeClientBurst         = flag.Int("kube-client-burst", rest.DefaultBurst, "Burst value for kubernetes client.")
+	kubeClientQPS           = flag.Float64("kube-client-qps", float64(rest.DefaultQPS), "QPS value for kubernetes client.")
 	cloudConfig             = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
 	enforceNodeGroupMinSize = flag.Bool("enforce-node-group-min-size", false, "Should CA scale up the node group to the configured min size if needed.")
@@ -290,6 +292,8 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		BalancingExtraIgnoredLabels:        *balancingIgnoreLabelsFlag,
 		BalancingLabels:                    *balancingLabelsFlag,
 		KubeConfigPath:                     *kubeConfigFile,
+		KubeClientBurst:                    *kubeClientBurst,
+		KubeClientQPS:                      *kubeClientQPS,
 		NodeDeletionDelayTimeout:           *nodeDeletionDelayTimeout,
 		AWSUseStaticInstanceList:           *awsUseStaticInstanceList,
 		ConcurrentGceRefreshes:             *concurrentGceRefreshes,
@@ -362,7 +366,12 @@ func registerSignalHandlers(autoscaler core.Autoscaler) {
 func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter) (core.Autoscaler, error) {
 	// Create basic config from flags.
 	autoscalingOptions := createAutoscalingOptions()
-	kubeClient := createKubeClient(getKubeConfig())
+
+	kubeClientConfig := getKubeConfig()
+	kubeClientConfig.Burst = autoscalingOptions.KubeClientBurst
+	kubeClientConfig.QPS = float32(autoscalingOptions.KubeClientQPS)
+	kubeClient := createKubeClient(kubeClientConfig)
+
 	eventsKubeClient := createKubeClient(getKubeConfig())
 
 	opts := core.AutoscalerOptions{


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

```
CA Waited for 191.285161ms due to client-side throttling, not priority and fairness, request: POST:[https://172.29.4.1:443/api/v1/namespaces/kube-system/events
```

- we currently see lots of rate limiting from the kubernetes client of CA, we'd like to give it more QPS to avoid that
- users might want to reduce the number of queries that CA does against their cluster

#### Does this PR introduce a user-facing change?
```release-note
- add `--kube-client-burst` and `--kube-client-qps` to control how many requests CA can do against kubernetes
```
