### PR TITLE
Clean up stale OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 approvers:
 - mwielgus
 - maciekpytel
-- bskiba
 - gjtempleton
 reviewers:
 - mwielgus
 - maciekpytel
-- bskiba
 - gjtempleton
+emeritus_approvers:
+- bskiba # 2022-09-30

--- a/addon-resizer/OWNERS
+++ b/addon-resizer/OWNERS
@@ -1,8 +1,7 @@
 approvers:
-- bskiba
-- wojtek-t
 - jbartosik
 reviewers:
-- bskiba
-- wojtek-t
 - jbartosik
+emeritus_approvers:
+- bskiba # 2022-09-30
+- wojtek-t # 2022-09-30

--- a/builder/OWNERS
+++ b/builder/OWNERS
@@ -1,10 +1,9 @@
 approvers:
-- aleksandra-malinowska
-- losipiuk
 - maciekpytel
 - mwielgus
 reviewers:
-- aleksandra-malinowska
-- losipiuk
 - maciekpytel
 - mwielgus
+emeritus_approvers:
+- aleksandra-malinowska # 2022-09-30
+- losipiuk # 2022-09-30

--- a/cluster-autoscaler/OWNERS
+++ b/cluster-autoscaler/OWNERS
@@ -1,9 +1,8 @@
 approvers:
-- aleksandra-malinowska
 - feiskyer
 - towca
 reviewers:
-- aleksandra-malinowska
 - feiskyer
-- Jeffwan
 - x13n
+emeritus_approvers:
+- aleksandra-malinowska # 2022-09-30

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,14 +1,10 @@
 approvers:
-- piosz
-- aleksandra-malinowska
-- losipiuk
-- schylek
 - kgolab
 reviewers:
 - feiskyer
-- piosz
-- aleksandra-malinowska
-- losipiuk
-- schylek
 - kgolab
-
+emeritus_approvers:
+- piosz # 2022-09-30
+- aleksandra-malinowska # 2022-09-30
+- losipiuk # 2022-09-30
+- schylek # 2022-09-30

--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -1,10 +1,10 @@
 approvers:
-- schylek
 - kgolab
 - jbartosik
 - krzysied
 reviewers:
-- schylek
 - kgolab
 - jbartosik
 - krzysied
+emeritus_approvers:
+- schylek # 2022-09-30


### PR DESCRIPTION
#### Which component this PR applies to?

Entire repository.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Inactive reviewers/approvers keep on being mentioned by k8s bot, which ends up discouraging external contributors trying to add improvements. This PR cleans up all OWNERS files according to [Kubernetes guideline](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#cleanup). The only exception is Cluster Autoscaler OWNERS for specific cloud providers: executing the guidlines now would mean removing all people from most of them completely and we are introducing a dedicated policy in https://github.com/kubernetes/autoscaler/pull/5198 already.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is the list of removed people and their respective Developer Activity counts in kubernetes/autoscaler repository over last year (taken from [this dashboard](https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-repo_name=kubernetes%2Fautoscaler&var-country_name=All)):
- aleksandra-malinowska (no activity)
- bskiba (5)
- Jeffwan (7)
- losipiuk (no activity)
- piosz (no activity)
- schylek (no activity)
- wojtek-t (1)

(Per the guideline, "inactive" is defined as having score of less than 10 over last year.)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Assigning to top level approvers:
/assign @mwielgus @gjtempleton @MaciekPytel

Notifying all affected members: 
/cc @aleksandra-malinowska @bskiba @Jeffwan @losipiuk @piosz @schylek @wojtek-t 

Putting the PR on hold for 2 weeks to let everyone raise their concerns, if any.
/hold