### PR TITLE
Remove units for default boot disk size

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -49,8 +49,8 @@ const (
 	bootDiskTypeLabel             = "cloud.google.com/gke-boot-disk"
 )
 
-// DefaultBootDiskSize is 100 GB.
-const DefaultBootDiskSize = 100 * units.GB
+// DefaultBootDiskSizeGB is 100 GB.
+const DefaultBootDiskSizeGB = 100
 
 // NodePrice returns a price of running the given node for a given period of time.
 // All prices are in USD.
@@ -95,8 +95,8 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 		// Boot disk price
 		bootDiskSize, _ := strconv.ParseInt(node.Annotations[BootDiskSizeAnnotation], 10, 64)
 		if bootDiskSize == 0 {
-			klog.Errorf("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSize)
-			bootDiskSize = DefaultBootDiskSize
+			klog.Errorf("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSizeGB)
+			bootDiskSize = DefaultBootDiskSizeGB
 		}
 		bootDiskType := node.Annotations[BootDiskTypeAnnotation]
 		if val, ok := node.Labels[bootDiskTypeLabel]; ok {

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
@@ -213,6 +213,12 @@ func TestGetNodePrice(t *testing.T) {
 			priceComparisonCoefficient: 1,
 			expanderSupport:            true,
 		},
+		"node with default boot disk is cheaper that node with more expensive boot disk type": {
+			cheaperNode:                testNode(t, "cheapNode", "", 8000, 30*units.GiB, "", 0, false, false),
+			expensiveNode:              testNodeEphemeralStorage(t, "expensiveNode", false, 0, "pd-ssd", 100, false),
+			priceComparisonCoefficient: 1,
+			expanderSupport:            true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The disk size is converted to bytes and then this value is multiplied by the price for 1 GB, which makes the node price to have a wrong value.