### PR TITLE
Add HTTP health-check to Addon Resizer 1.8

### DIFF
--- a/addon-resizer/healthcheck/healthcheck.go
+++ b/addon-resizer/healthcheck/healthcheck.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// HealthCheck contains information about last activity time of the monitored component.
+// NOTE: This started as a simplified version of VPA's HealthCheck.
+type HealthCheck struct {
+	// configuration
+	address         string
+	activityTimeout time.Duration
+	// current state
+	mutex        sync.Mutex
+	lastActivity time.Time
+}
+
+// NewHealthCheck builds new HealthCheck object with given timeout.
+func NewHealthCheck(address string, activityTimeout time.Duration) *HealthCheck {
+	return &HealthCheck{
+		address:         address,
+		activityTimeout: activityTimeout,
+		mutex:           sync.Mutex{},
+		lastActivity:    time.Now(),
+	}
+}
+
+// Serve sets up healthCheck handler on the given address
+func (hc *HealthCheck) Serve() {
+	go func() {
+		http.Handle("/health-check", hc)
+		err := http.ListenAndServe(hc.address, nil)
+		glog.Fatalf("Failed to start health check: %v", err)
+	}()
+}
+
+// checkLastActivity returns true if the last activity was too long ago, with duration from it.
+func (hc *HealthCheck) checkLastActivity() (bool, time.Duration) {
+	hc.mutex.Lock()
+	defer hc.mutex.Unlock()
+
+	now := time.Now()
+	lastActivity := hc.lastActivity
+	timedOut := now.After(lastActivity.Add(hc.activityTimeout))
+
+	return timedOut, now.Sub(lastActivity)
+}
+
+// ServeHTTP implements http.Handler interface to provide a health-check endpoint.
+func (hc *HealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if timedOut, ago := hc.checkLastActivity(); timedOut {
+		http.Error(w, fmt.Sprintf("Error: last activity more than %v ago (threshold is %v)", ago, hc.activityTimeout), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(200)
+	_, err := w.Write([]byte("OK"))
+	if err != nil {
+		glog.Fatalf("Failed to write response message: %v", err)
+	}
+}
+
+// UpdateLastActivity updates last time of activity to now
+func (hc *HealthCheck) UpdateLastActivity() {
+	hc.mutex.Lock()
+	defer hc.mutex.Unlock()
+
+	hc.lastActivity = time.Now()
+}

--- a/addon-resizer/nanny/nanny_lib.go
+++ b/addon-resizer/nanny/nanny_lib.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/golang/glog"
 	inf "gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/addon-resizer/healthcheck"
 )
 
 type operation int
@@ -99,7 +100,7 @@ type ResourceEstimator interface {
 // PollAPIServer periodically counts the number of nodes, estimates the expected
 // ResourceRequirements, compares them to the actual ResourceRequirements, and
 // updates the deployment with the expected ResourceRequirements if necessary.
-func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scaleDownDelay, scaleUpDelay time.Duration, threshold uint64) {
+func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, hc *healthcheck.HealthCheck, pollPeriod, scaleDownDelay, scaleUpDelay time.Duration, threshold uint64) {
 	lastChange := time.Now()
 	lastResult := noChange
 
@@ -112,6 +113,7 @@ func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scal
 		if lastResult = updateResources(k8s, est, time.Now(), lastChange, scaleDownDelay, scaleUpDelay, threshold, lastResult); lastResult == overwrite {
 			lastChange = time.Now()
 		}
+		hc.UpdateLastActivity()
 	}
 }
 


### PR DESCRIPTION
#### Which component this PR applies to?

addon-resizer

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a handler for HTTP-based health-check in Addon Resizer 1.8.

NOTE: The healthcheck.go is based on VPA code and simplified to fit Addon Resizer better.

By default the handler listens on port 8080, this can be changed with `healthcheck-address` flag (e.g. be setting it to `:8443`).

This allows to set up a liveness probe for the addon-resizer container, for example by adding following section to its yaml:
```
          livenessProbe:
            httpGet:
              path: /health-check
              port: 8080
            initialDelaySeconds: 10
            periodSeconds: 10
```

Should the binary get stuck (or at least 5 times slower than configured), it would be restarted by kubelet.

#### Special notes for your reviewer:

I'm not sure if this change should also be introduced on master - README says the recommended version is 1.8 but it seems a waste not to have this on master as well.
If yes - I will create a separate PR since some files moved between master and 1.8 branch.

#### Does this PR introduce a user-facing change?

```release-note
Added health check handler to allow configuring liveness Probe.

Added a new flag `healthcheck-address`, defaulting to ":8080".

No user action required.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
Addon Resizer provides an HTTP-based health-check, by default on port 8080, under `/health-check` path.

The port (and IP the health-check handler binds to) can be configured with `healthcheck-address`. If not set it defaults to ":8080".

The check fails if the main reconciliation loop lasts 5 times the configured period (`poll-period` flag).

Using the health-check handler, a liveness probe can be configured for Addon Resizer, for example by adding the following section to container definition:
-- cut here --
          livenessProbe:
            httpGet:
              path: /health-check
              port: 8080
            initialDelaySeconds: 10
            periodSeconds: 10
-- cut here --
```
