### PR TITLE
Add support for extended resource definition in GCE MIG template

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -72,7 +72,7 @@ func (t *GceTemplateBuilder) getAcceleratorCount(accelerators []*gce.Accelerator
 
 // BuildCapacity builds a list of resource capacities given list of hardware.
 func (t *GceTemplateBuilder) BuildCapacity(cpu int64, mem int64, accelerators []*gce.AcceleratorConfig, os OperatingSystem, osDistribution OperatingSystemDistribution, arch SystemArchitecture,
-	ephemeralStorage int64, ephemeralStorageLocalSSDCount int64, pods *int64, version string, r OsReservedCalculator) (apiv1.ResourceList, error) {
+	ephemeralStorage int64, ephemeralStorageLocalSSDCount int64, pods *int64, version string, r OsReservedCalculator, extendedResources apiv1.ResourceList) (apiv1.ResourceList, error) {
 	capacity := apiv1.ResourceList{}
 	if pods == nil {
 		capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
@@ -96,6 +96,12 @@ func (t *GceTemplateBuilder) BuildCapacity(cpu int64, mem int64, accelerators []
 			storageTotal = ephemeralStorage - r.CalculateOSReservedEphemeralStorage(ephemeralStorage, os, osDistribution, arch, version)
 		}
 		capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(math.Max(float64(storageTotal), 0)), resource.DecimalSI)
+	}
+
+	if extendedResources != nil && len(extendedResources) > 0 {
+		for resourceName, quantity := range extendedResources {
+			capacity[resourceName] = quantity
+		}
 	}
 
 	return capacity, nil
@@ -215,10 +221,16 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, template *gce.Instan
 		return nil, fmt.Errorf("could not fetch ephemeral storage from instance template: %v", err)
 	}
 
-	capacity, err := t.BuildCapacity(cpu, mem, template.Properties.GuestAccelerators, os, osDistribution, arch, ephemeralStorage, ephemeralStorageLocalSsdCount, pods, mig.Version(), reserved)
+	extendedResources, err := extractExtendedResourcesFromKubeEnv(kubeEnvValue)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch extended resources from instance template: %v", err)
+	}
+
+	capacity, err := t.BuildCapacity(cpu, mem, template.Properties.GuestAccelerators, os, osDistribution, arch, ephemeralStorage, ephemeralStorageLocalSsdCount, pods, mig.Version(), reserved, extendedResources)
 	if err != nil {
 		return nil, err
 	}
+
 	node.Status = apiv1.NodeStatus{
 		Capacity: capacity,
 	}
@@ -460,6 +472,33 @@ func extractKubeReservedFromKubeEnv(kubeEnv string) (string, error) {
 		return "", fmt.Errorf("kube-reserved not in kubelet args in kube-env: %q", kubeletArgs)
 	}
 	return kubeReserved, nil
+}
+
+func extractExtendedResourcesFromKubeEnv(kubeEnvValue string) (apiv1.ResourceList, error) {
+	extendedResourcesAsString, found, err := extractAutoscalerVarFromKubeEnv(kubeEnvValue, "extended_resources")
+	if err != nil {
+		klog.Warning("error while obtaining extended_resources from AUTOSCALER_ENV_VARS; %v", err)
+		return nil, err
+	}
+
+	if !found {
+		return apiv1.ResourceList{}, nil
+	}
+
+	extendedResourcesMap, err := parseKeyValueListToMap(extendedResourcesAsString)
+	if err != nil {
+		return apiv1.ResourceList{}, err
+	}
+
+	extendedResources := apiv1.ResourceList{}
+	for name, quantity := range extendedResourcesMap {
+		if q, err := resource.ParseQuantity(quantity); err == nil && q.Sign() >= 0 {
+			extendedResources[apiv1.ResourceName(name)] = q
+		} else if err != nil {
+			klog.Warning("ignoring invalid value in extended_resources defined in AUTOSCALER_ENV_VARS; %v", err)
+		}
+	}
+	return extendedResources, nil
 }
 
 // OperatingSystem denotes operating system used by nodes coming from node group

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -98,10 +98,8 @@ func (t *GceTemplateBuilder) BuildCapacity(cpu int64, mem int64, accelerators []
 		capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(math.Max(float64(storageTotal), 0)), resource.DecimalSI)
 	}
 
-	if extendedResources != nil && len(extendedResources) > 0 {
-		for resourceName, quantity := range extendedResources {
-			capacity[resourceName] = quantity
-		}
+	for resourceName, quantity := range extendedResources {
+		capacity[resourceName] = quantity
 	}
 
 	return capacity, nil
@@ -223,7 +221,8 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, template *gce.Instan
 
 	extendedResources, err := extractExtendedResourcesFromKubeEnv(kubeEnvValue)
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch extended resources from instance template: %v", err)
+		// External Resources are optional and should not break the template creation
+		klog.Errorf("could not fetch extended resources from instance template: %v", err)
 	}
 
 	capacity, err := t.BuildCapacity(cpu, mem, template.Properties.GuestAccelerators, os, osDistribution, arch, ephemeralStorage, ephemeralStorageLocalSsdCount, pods, mig.Version(), reserved, extendedResources)

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -204,6 +204,20 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 				apiv1.ResourceName("anotherResource"): *resource.NewQuantity(1*units.GB, resource.DecimalSI),
 			},
 		},
+		{
+			scenario:                      "malformed extended_resources in kube-env",
+			kubeEnv:                       "AUTOSCALER_ENV_VARS: kube_reserved=cpu=0,memory=0,ephemeral-storage=10Gi;os_distribution=cos;os=linux;ephemeral_storage_local_ssd_count=2;extended_resources=someResource\n",
+			physicalCpu:                   8,
+			physicalMemory:                200 * units.MiB,
+			ephemeralStorageLocalSSDCount: 2,
+			kubeReserved:                  true,
+			reservedCpu:                   "0m",
+			reservedMemory:                fmt.Sprintf("%v", 0*units.MiB),
+			reservedEphemeralStorage:      "10Gi",
+			attachedLocalSSDCount:         4,
+			expectedErr:                   false,
+			extendedResources:             apiv1.ResourceList{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.scenario, func(t *testing.T) {
@@ -1144,6 +1158,112 @@ func TestExtractOperatingSystemDistributionFromKubeEnv(t *testing.T) {
 			assert.Equal(t, tc.expectedOperatingSystemDistribution, actualOperatingSystem)
 		})
 	}
+}
+
+func TestExtractExtendedResourcesFromKubeEnv(t *testing.T) {
+	type testCase struct {
+		name                      string
+		kubeEnv                   string
+		expectedExtendedResources apiv1.ResourceList
+		expectedErr               bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "numeric value",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=10",
+			expectedExtendedResources: apiv1.ResourceList{
+				apiv1.ResourceName("foo"): *resource.NewQuantity(10, resource.DecimalSI),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "numeric value with quantity suffix",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=10G",
+			expectedExtendedResources: apiv1.ResourceList{
+				apiv1.ResourceName("foo"): *resource.NewQuantity(10*units.GB, resource.DecimalSI),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "multiple extended_resources definition",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=10G,bar=230",
+			expectedExtendedResources: apiv1.ResourceList{
+				apiv1.ResourceName("foo"): *resource.NewQuantity(10*units.GB, resource.DecimalSI),
+				apiv1.ResourceName("bar"): *resource.NewQuantity(230, resource.DecimalSI),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid value",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=bar",
+			expectedExtendedResources: apiv1.ResourceList{},
+			expectedErr:               false,
+		},
+		{
+			name: "both valid and invalid values",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=bar,baz=10G",
+			expectedExtendedResources: apiv1.ResourceList{
+				apiv1.ResourceName("baz"): *resource.NewQuantity(10*units.GB, resource.DecimalSI),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid quantity suffix",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo=10Wi",
+			expectedExtendedResources: apiv1.ResourceList{},
+			expectedErr:               false,
+		},
+		{
+			name: "malformed extended_resources map",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources=foo",
+			expectedExtendedResources: apiv1.ResourceList{},
+			expectedErr:               true,
+		},
+		{
+			name: "malformed extended_resources definition",
+			kubeEnv: "AUTOSCALER_ENV_VARS: node_labels=a=b,c=d,cloud.google.com/gke-nodepool=pool-3,cloud.google.com/gke-preemptible=true;" +
+				"node_taints='dedicated=ml:NoSchedule,test=dev:PreferNoSchedule,a=b:c';" +
+				"kube_reserved=cpu=1000m,memory=300000Mi;" +
+				"extended_resources/",
+			expectedExtendedResources: apiv1.ResourceList{},
+			expectedErr:               true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			extendedResources, err := extractExtendedResourcesFromKubeEnv(tc.kubeEnv)
+			assertEqualResourceLists(t, "Resources", tc.expectedExtendedResources, extendedResources)
+			if tc.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
 }
 
 func TestParseKubeReserved(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -63,6 +63,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 		reservedEphemeralStorage      string
 		isEphemeralStorageBlocked     bool
 		ephemeralStorageLocalSSDCount int64
+		extendedResources             apiv1.ResourceList
 		// test outputs
 		expectedErr bool
 	}
@@ -186,6 +187,23 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			attachedLocalSSDCount:         4,
 			expectedErr:                   false,
 		},
+		{
+			scenario:                      "extended_resources present in kube-env",
+			kubeEnv:                       "AUTOSCALER_ENV_VARS: kube_reserved=cpu=0,memory=0,ephemeral-storage=10Gi;os_distribution=cos;os=linux;ephemeral_storage_local_ssd_count=2;extended_resources=someResource=2,anotherResource=1G\n",
+			physicalCpu:                   8,
+			physicalMemory:                200 * units.MiB,
+			ephemeralStorageLocalSSDCount: 2,
+			kubeReserved:                  true,
+			reservedCpu:                   "0m",
+			reservedMemory:                fmt.Sprintf("%v", 0*units.MiB),
+			reservedEphemeralStorage:      "10Gi",
+			attachedLocalSSDCount:         4,
+			expectedErr:                   false,
+			extendedResources: apiv1.ResourceList{
+				apiv1.ResourceName("someResource"):    *resource.NewQuantity(2, resource.DecimalSI),
+				apiv1.ResourceName("anotherResource"): *resource.NewQuantity(1*units.GB, resource.DecimalSI),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.scenario, func(t *testing.T) {
@@ -254,7 +272,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 				} else if tc.isEphemeralStorageBlocked {
 					physicalEphemeralStorageGiB = 0
 				}
-				capacity, err := tb.BuildCapacity(tc.physicalCpu, tc.physicalMemory, tc.accelerators, OperatingSystemLinux, OperatingSystemDistributionCOS, "", physicalEphemeralStorageGiB*units.GiB, tc.ephemeralStorageLocalSSDCount, tc.pods, "", &GceReserved{})
+				capacity, err := tb.BuildCapacity(tc.physicalCpu, tc.physicalMemory, tc.accelerators, OperatingSystemLinux, OperatingSystemDistributionCOS, "", physicalEphemeralStorageGiB*units.GiB, tc.ephemeralStorageLocalSSDCount, tc.pods, "", &GceReserved{}, tc.extendedResources)
 				assert.NoError(t, err)
 				assertEqualResourceLists(t, "Capacity", capacity, node.Status.Capacity)
 				if !tc.kubeReserved {
@@ -561,7 +579,7 @@ func TestBuildCapacityMemory(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", idx), func(t *testing.T) {
 			tb := GceTemplateBuilder{}
 			noAccelerators := make([]*gce.AcceleratorConfig, 0)
-			buildCapacity, err := tb.BuildCapacity(tc.physicalCpu, tc.physicalMemory, noAccelerators, tc.os, OperatingSystemDistributionCOS, "", -1, 0, nil, "", &GceReserved{})
+			buildCapacity, err := tb.BuildCapacity(tc.physicalCpu, tc.physicalMemory, noAccelerators, tc.os, OperatingSystemDistributionCOS, "", -1, 0, nil, "", &GceReserved{}, apiv1.ResourceList{})
 			assert.NoError(t, err)
 			expectedCapacity, err := makeResourceList2(tc.physicalCpu, tc.expectedCapacityMemory, 0, 110)
 			assert.NoError(t, err)


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for extended resources in GCE MIG template. 

Today, the `cluster-autoscaler` on GCE only supports scaling decisions based the following resources: CPU, Memory, EphemeralStorage and GPU. However, Kubernetes allows defining an arbitrary number of resources through the [Extended Resource API](https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node/). This can be useful when your instances have special resources that you want to share between your pods. One example that I can think of is `network bandwidth`, which cannot be requested by pods except through extended resources.
Some other implementations of the `CloudProvider` interface, like AWS or Azure, already support scaling decisions based on extended resources.

This PR adds the possibility to define extended resources for a node group on GCE, so that the cluster-autoscaler can account for them when taking scaling decisions. This is done through the `extended_resources` key inside the AUTOSCALER_ENV_VARS variable set on a MIG template. 

Example:
```
AUTOSCALER_ENV_VARS: kube_reserved=<...>;<...>;extended_resources=foo=10,bar=1M,foobar=2G
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

