### PR TITLE
Make expander factory logic more pluggable

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -104,8 +104,9 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts.AutoscalingOptions)
 	}
 	if opts.ExpanderStrategy == nil {
-		expanderStrategy, err := factory.ExpanderStrategyFromStrings(strings.Split(opts.ExpanderNames, ","), opts.CloudProvider,
-			opts.AutoscalingKubeClients, opts.KubeClient, opts.ConfigNamespace, opts.GRPCExpanderCert, opts.GRPCExpanderURL)
+		expanderFactory := factory.NewFactory()
+		expanderFactory.RegisterDefaultExpanders(opts.CloudProvider, opts.AutoscalingKubeClients, opts.KubeClient, opts.ConfigNamespace, opts.GRPCExpanderCert, opts.GRPCExpanderURL)
+		expanderStrategy, err := expanderFactory.Build(strings.Split(opts.ExpanderNames, ","))
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/expander/factory/expander_factory.go
+++ b/cluster-autoscaler/expander/factory/expander_factory.go
@@ -28,54 +28,72 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander/waste"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+
 	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
-// ExpanderStrategyFromStrings creates an expander.Strategy according to the names of the expanders passed in
-// take in whole opts and access stuff here
-func ExpanderStrategyFromStrings(expanderFlags []string, cloudProvider cloudprovider.CloudProvider,
-	autoscalingKubeClients *context.AutoscalingKubeClients, kubeClient kube_client.Interface,
-	configNamespace string, GRPCExpanderCert string, GRPCExpanderURL string) (expander.Strategy, errors.AutoscalerError) {
+// Factory can create expander.Strategy based on provided expander names.
+type Factory struct {
+	createFunc map[string]func() expander.Filter
+}
+
+// NewFactory returns a new Factory.
+func NewFactory() *Factory {
+	return &Factory{
+		createFunc: make(map[string]func() expander.Filter),
+	}
+}
+
+// RegisterFilter registers a function that can provision a new expander.Filter under the specified name.
+func (f *Factory) RegisterFilter(name string, createFunc func() expander.Filter) {
+	f.createFunc[name] = createFunc
+}
+
+// Build creates a new expander.Strategy based on a list of expander.Filter names.
+func (f *Factory) Build(names []string) (expander.Strategy, errors.AutoscalerError) {
 	var filters []expander.Filter
 	seenExpanders := map[string]struct{}{}
 	strategySeen := false
-	for i, expanderFlag := range expanderFlags {
-		if _, ok := seenExpanders[expanderFlag]; ok {
-			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s was specified multiple times, each expander must not be specified more than once", expanderFlag)
+	for i, name := range names {
+		if _, ok := seenExpanders[name]; ok {
+			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s was specified multiple times, each expander must not be specified more than once", name)
 		}
 		if strategySeen {
-			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s came after an expander %s that will always return only one result, this is not allowed since %s will never be used", expanderFlag, expanderFlags[i-1], expanderFlag)
+			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s came after an expander %s that will always return only one result, this is not allowed since %s will never be used", name, names[i-1], name)
 		}
-		seenExpanders[expanderFlag] = struct{}{}
+		seenExpanders[name] = struct{}{}
 
-		switch expanderFlag {
-		case expander.RandomExpanderName:
-			filters = append(filters, random.NewFilter())
-		case expander.MostPodsExpanderName:
-			filters = append(filters, mostpods.NewFilter())
-		case expander.LeastWasteExpanderName:
-			filters = append(filters, waste.NewFilter())
-		case expander.PriceBasedExpanderName:
-			if _, err := cloudProvider.Pricing(); err != nil {
-				return nil, err
-			}
-			filters = append(filters, price.NewFilter(cloudProvider,
-				price.NewSimplePreferredNodeProvider(autoscalingKubeClients.AllNodeLister()),
-				price.SimpleNodeUnfitness))
-		case expander.PriorityBasedExpanderName:
-			// It seems other listers do the same here - they never receive the termination msg on the ch.
-			// This should be currently OK.
-			stopChannel := make(chan struct{})
-			lister := kubernetes.NewConfigMapListerForNamespace(kubeClient, stopChannel, configNamespace)
-			filters = append(filters, priority.NewFilter(lister.ConfigMaps(configNamespace), autoscalingKubeClients.Recorder))
-		case expander.GRPCExpanderName:
-			filters = append(filters, grpcplugin.NewFilter(GRPCExpanderCert, GRPCExpanderURL))
-		default:
-			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s not supported", expanderFlag)
+		create, known := f.createFunc[name]
+		if known {
+			filters = append(filters, create())
+		} else {
+			return nil, errors.NewAutoscalerError(errors.InternalError, "Expander %s not supported", name)
 		}
 		if _, ok := filters[len(filters)-1].(expander.Strategy); ok {
 			strategySeen = true
 		}
 	}
 	return newChainStrategy(filters, random.NewStrategy()), nil
+}
+
+// RegisterDefaultExpanders is a convenience function, registering all known expanders in the Factory.
+func (f *Factory) RegisterDefaultExpanders(cloudProvider cloudprovider.CloudProvider, autoscalingKubeClients *context.AutoscalingKubeClients, kubeClient kube_client.Interface, configNamespace string, GRPCExpanderCert string, GRPCExpanderURL string) {
+	f.RegisterFilter(expander.RandomExpanderName, random.NewFilter)
+	f.RegisterFilter(expander.MostPodsExpanderName, mostpods.NewFilter)
+	f.RegisterFilter(expander.LeastWasteExpanderName, waste.NewFilter)
+	f.RegisterFilter(expander.PriceBasedExpanderName, func() expander.Filter {
+		if _, err := cloudProvider.Pricing(); err != nil {
+			klog.Fatalf("Couldn't access cloud provider pricing for %s expander: %v", expander.PriceBasedExpanderName, err)
+		}
+		return price.NewFilter(cloudProvider, price.NewSimplePreferredNodeProvider(autoscalingKubeClients.AllNodeLister()), price.SimpleNodeUnfitness)
+	})
+	f.RegisterFilter(expander.PriorityBasedExpanderName, func() expander.Filter {
+		// It seems other listers do the same here - they never receive the termination msg on the ch.
+		// This should be currently OK.
+		stopChannel := make(chan struct{})
+		lister := kubernetes.NewConfigMapListerForNamespace(kubeClient, stopChannel, configNamespace)
+		return priority.NewFilter(lister.ConfigMaps(configNamespace), autoscalingKubeClients.Recorder)
+	})
+	f.RegisterFilter(expander.GRPCExpanderName, func() expander.Filter { return grpcplugin.NewFilter(GRPCExpanderCert, GRPCExpanderURL) })
 }


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR refactors expander factory code to make it reusable. There are no functional changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
