### PR TITLE
remove unsupported functionality from cluster-api provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -228,6 +228,13 @@ rules:
     - list
 ```
 
+#### Pre-defined labels and taints on nodes scaled from zero
+
+The Cluster API provider currently does not support the addition of pre-defined
+labels and taints for node groups that are scaling from zero. This work is on-going
+and will be included in a future release once the API for specifying those
+labels and taints has been accepted by the community.
+
 ## Specifying a Custom Resource Group
 
 By default all Kubernetes resources consumed by the Cluster API provider will

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -169,28 +169,16 @@ func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructur
 }
 
 func (r unstructuredScalableResource) Labels() map[string]string {
-	labels, found, err := unstructured.NestedStringMap(r.unstructured.Object, "spec", "template", "spec", "metadata", "labels")
-	if !found || err != nil {
-		return nil
-	}
-	return labels
+	// TODO implement this once the community has decided how they will handle labels
+	// this issue is related, https://github.com/kubernetes-sigs/cluster-api/issues/7006
+
+	return nil
 }
 
 func (r unstructuredScalableResource) Taints() []apiv1.Taint {
-	taints, found, err := unstructured.NestedSlice(r.unstructured.Object, "spec", "template", "spec", "taints")
-	if !found || err != nil {
-		return nil
-	}
-	ret := make([]apiv1.Taint, len(taints))
-	for i, t := range taints {
-		if v, ok := t.(apiv1.Taint); ok {
-			ret[i] = v
-		} else {
-			// if we cannot convert the interface to a Taint, return early with zero value
-			return nil
-		}
-	}
-	return ret
+	// TODO implement this once the community has decided how they will handle taints
+
+	return nil
 }
 
 // A node group can scale from zero if it can inform about the CPU and memory


### PR DESCRIPTION


#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

this change removes the code for the `Labels` and `Taints` interface functions of the clusterapi provider when scaling from zero. The body of these functions was added erronesouly and the Cluster API community is still deciding on how these values will be expose to the autoscaler.

also updates the tests and readme to be more clear about the usage of labels and taints when scaling from zero.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
