### PR TITLE
add optional key for deployment configMapRef

### DIFF
--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -201,6 +201,7 @@ spec:
           {{- if .Values.envFromConfigMap }}
             - configMapRef:
                 name: {{ .Values.envFromConfigMap }}
+                optional: {{ .Values.envFromConfigMapOptional }}
           {{- end }}
           {{- end }}
           livenessProbe:

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -199,6 +199,7 @@ extraEnvSecrets: {}
 
 # envFromConfigMap -- ConfigMap name to use as envFrom.
 envFromConfigMap: ""
+envFromConfigMapOptional: true
 
 # envFromSecret -- Secret name to use as envFrom.
 envFromSecret: ""


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
cluster-autoscaler
-->

#### What type of PR is this? /

<!--
/kind feature
-->

#### What this PR does / why we need it:
This PR adds the `optional` property for the configMapRef in the `deployment.yaml` chart so that users can easily specify it in their `values.yaml` file.
#### Which issue(s) this PR fixes:
<!--
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
-->
```release-note
Added the optional property to the configMapRef in the deployment spec for cluster-autoscaler. The value can be specified using the envFromConfigMapOptional variable in the values file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
-->
```docs

```
