### PR TITLE
Use scheduling package in filterOutSchedulable processor

### DIFF
--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -543,7 +543,7 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleTestConfig) *ScaleTestResul
 		extraPods[i] = pod
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	resourceManager := scaleup.NewResourceManager(processors.CustomResourcesProcessor)
 	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, resourceManager, extraPods, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 	processors.ScaleUpStatusProcessor.Process(&context, scaleUpStatus)
@@ -699,7 +699,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 	p3 := BuildTestPod("p-new", 550, 0)
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	resourceManager := scaleup.NewResourceManager(processors.CustomResourcesProcessor)
 	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, resourceManager, []*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 
@@ -741,7 +741,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 	p3 := BuildTestPod("p-new", 500, 0)
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	resourceManager := scaleup.NewResourceManager(processors.CustomResourcesProcessor)
 	scaleUpStatus, err := ScaleUp(&context, processors, clusterState, resourceManager, []*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 	processors.ScaleUpStatusProcessor.Process(&context, scaleUpStatus)
@@ -813,7 +813,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 		pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	resourceManager := scaleup.NewResourceManager(processors.CustomResourcesProcessor)
 	scaleUpStatus, typedErr := ScaleUp(&context, processors, clusterState, resourceManager, pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, nil)
 
@@ -868,7 +868,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	processors.NodeGroupListProcessor = &MockAutoprovisioningNodeGroupListProcessor{t}
 	processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{t, 0}
 
@@ -922,7 +922,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	processors.NodeGroupListProcessor = &MockAutoprovisioningNodeGroupListProcessor{t}
 	processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{t, 2}
 
@@ -979,7 +979,7 @@ func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {
 
 	nodes := []*apiv1.Node{n1, n2}
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil).Process(&context, nodes, []*appsv1.DaemonSet{}, nil, time.Now())
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -1290,7 +1290,7 @@ func newWrapperForTesting(ctx *context.AutoscalingContext, clusterStateRegistry 
 		SkipNodesWithLocalStorage: true,
 		MinReplicaCount:           0,
 	}
-	sd := NewScaleDown(ctx, NewTestProcessors(), ndt, deleteOptions)
+	sd := NewScaleDown(ctx, NewTestProcessors(ctx), ndt, deleteOptions)
 	actuator := actuation.NewActuator(ctx, clusterStateRegistry, ndt, deleteOptions)
 	return NewScaleDownWrapper(sd, actuator)
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -212,9 +212,12 @@ func (p *Planner) injectPods(pods []*apiv1.Pod) error {
 	pods = clearNodeName(pods)
 	// Note: We're using ScheduleAnywhere, but the pods won't schedule back
 	// on the drained nodes due to taints.
-	_, err := p.actuationInjector.TrySchedulePods(p.context.ClusterSnapshot, pods, scheduling.ScheduleAnywhere)
+	statuses, _, err := p.actuationInjector.TrySchedulePods(p.context.ClusterSnapshot, pods, scheduling.ScheduleAnywhere, true)
 	if err != nil {
-		return fmt.Errorf("cannot scale down, no place to reschedule pods from ongoing deletions: %v", err)
+		return fmt.Errorf("cannot scale down, an unexpected error occurred: %v", err)
+	}
+	if len(statuses) != len(pods) {
+		return fmt.Errorf("cannot scale down, can reschedule only %d out of %d pods from ongoing deletions", len(statuses), len(pods))
 	}
 	return nil
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -309,7 +309,7 @@ func TestUpdateClusterState(t *testing.T) {
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, tc.nodes, tc.pods)
 			deleteOptions := simulator.NodeDeleteOptions{}
-			p := New(&context, NewTestProcessors(), deleteOptions)
+			p := New(&context, NewTestProcessors(&context), deleteOptions)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(tc.eligible)}
 			// TODO(x13n): test subsets of nodes passed as podDestinations/scaleDownCandidates.
 			aErr := p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, nil, time.Now())

--- a/cluster-autoscaler/core/scaleup/resource_manager_test.go
+++ b/cluster-autoscaler/core/scaleup/resource_manager_test.go
@@ -64,7 +64,7 @@ func TestDeltaForNode(t *testing.T) {
 	for _, testCase := range testCases {
 		cp := testprovider.NewTestCloudProvider(nil, nil)
 		ctx := newContext(t, cp)
-		processors := test.NewTestProcessors()
+		processors := test.NewTestProcessors(&ctx)
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
@@ -105,7 +105,7 @@ func TestResourcesLeft(t *testing.T) {
 	for _, testCase := range testCases {
 		cp := newCloudProvider(t, 1000, 1000)
 		ctx := newContext(t, cp)
-		processors := test.NewTestProcessors()
+		processors := test.NewTestProcessors(&ctx)
 
 		ng := testCase.nodeGroupConfig
 		_, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
@@ -156,7 +156,7 @@ func TestApplyResourcesLimits(t *testing.T) {
 	for _, testCase := range testCases {
 		cp := testprovider.NewTestCloudProvider(nil, nil)
 		ctx := newContext(t, cp)
-		processors := test.NewTestProcessors()
+		processors := test.NewTestProcessors(&ctx)
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
@@ -214,7 +214,7 @@ func TestResourceManagerWithGpuResource(t *testing.T) {
 	provider.SetResourceLimiter(resourceLimiter)
 
 	context := newContext(t, provider)
-	processors := test.NewTestProcessors()
+	processors := test.NewTestProcessors(&context)
 
 	n1 := newNode(t, "n1", 8, 16)
 	utils_test.AddGpusToNode(n1, 4)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -214,7 +214,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 		MaxNodeProvisionTime: 10 * time.Second,
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
 	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(t, &context, processors, clusterState)
 
@@ -393,10 +393,6 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	provider.AddNode("ng1,", n1)
 	assert.NotNil(t, provider)
 
-	processors := NewTestProcessors()
-	processors.NodeGroupManager = nodeGroupManager
-	processors.NodeGroupListProcessor = nodeGroupListProcessor
-
 	// Create context with mocked lister registry.
 	options := config.AutoscalingOptions{
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
@@ -416,6 +412,10 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
+
+	processors := NewTestProcessors(&context)
+	processors.NodeGroupManager = nodeGroupManager
+	processors.NodeGroupListProcessor = nodeGroupListProcessor
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
@@ -575,7 +575,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	// broken node failed to register in time
 	clusterState.UpdateNodes(nodes, nil, later)
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 
 	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(t, &context, processors, clusterState)
 
@@ -720,7 +720,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 		MaxNodeProvisionTime: 10 * time.Second,
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
 	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(t, &context, processors, clusterState)
 
@@ -849,7 +849,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 		MaxNodeProvisionTime: 10 * time.Second,
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
 	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(t, &context, processors, clusterState)
 
@@ -946,7 +946,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 		MaxNodeProvisionTime: 10 * time.Second,
 	}
 
-	processors := NewTestProcessors()
+	processors := NewTestProcessors(&context)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff())
 	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(t, &context, processors, clusterState)
 

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -133,9 +133,9 @@ func ExtractPodNames(pods []*apiv1.Pod) []string {
 }
 
 // NewTestProcessors returns a set of simple processors for use in tests.
-func NewTestProcessors() *processors.AutoscalingProcessors {
+func NewTestProcessors(context *context.AutoscalingContext) *processors.AutoscalingProcessors {
 	return &processors.AutoscalingProcessors{
-		PodListProcessor:       filteroutschedulable.NewFilterOutSchedulablePodListProcessor(),
+		PodListProcessor:       filteroutschedulable.NewFilterOutSchedulablePodListProcessor(context.PredicateChecker),
 		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{},
 		NodeGroupSetProcessor:  nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}),
 		ScaleDownSetProcessor:  nodes.NewPostFilteringScaleDownNodeProcessor(),

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -368,7 +368,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 
 	opts.Processors = ca_processors.DefaultProcessors()
 	opts.Processors.TemplateNodeInfoProvider = nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nodeInfoCacheExpireTime)
-	opts.Processors.PodListProcessor = filteroutschedulable.NewFilterOutSchedulablePodListProcessor()
+	opts.Processors.PodListProcessor = filteroutschedulable.NewFilterOutSchedulablePodListProcessor(opts.PredicateChecker)
 
 	var nodeInfoComparator nodegroupset.NodeInfoComparator
 	if len(autoscalingOptions.BalancingLabels) > 0 {

--- a/cluster-autoscaler/simulator/scheduling/similar_pods.go
+++ b/cluster-autoscaler/simulator/scheduling/similar_pods.go
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package scheduling
 
 import (
-	"k8s.io/autoscaler/cluster-autoscaler/utils"
 	"reflect"
 
+	"k8s.io/autoscaler/cluster-autoscaler/utils"
+
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	pod_utils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
 
-// PodSchedulableInfo data structure is used to avoid running predicates #pending_pods * #nodes
+// SimilarPodsSchedulingInfo data structure is used to avoid running predicates #pending_pods * #nodes
 // times (which turned out to be very expensive if there are thousands of pending pods).
 // This optimization is based on the assumption that if there are that many pods they're
 // likely created by controllers (deployment, replication controller, ...).
@@ -36,56 +36,55 @@ import (
 // calculated.
 // To decide if two pods are similar enough we check if they have identical label
 // and spec and are owned by the same controller. The problem is the whole
-// PodSchedulableInfo struct is not hashable and keeping a list and running deep
+// SimilarPodsSchedulingInfo struct is not hashable and keeping a list and running deep
 // equality checks would likely also be expensive. So instead we use controller
 // UID as a key in initial lookup and only run full comparison on a set of
-// podSchedulableInfos created for pods owned by this controller.
-type PodSchedulableInfo struct {
-	spec            apiv1.PodSpec
-	labels          map[string]string
-	schedulingError *predicatechecker.PredicateError
+// SimilarPodsSchedulingInfo created for pods owned by this controller.
+type SimilarPodsSchedulingInfo struct {
+	spec   apiv1.PodSpec
+	labels map[string]string
+}
+
+// Match tests if given pod matches SimilarPodsSchedulingInfo
+func (psi *SimilarPodsSchedulingInfo) Match(pod *apiv1.Pod) bool {
+	return reflect.DeepEqual(pod.Labels, psi.labels) && utils.PodSpecSemanticallyEqual(pod.Spec, psi.spec)
 }
 
 const maxPodsPerOwnerRef = 10
 
-// PodSchedulableMap stores mapping from controller ref to PodSchedulableInfo
-type PodSchedulableMap struct {
-	items                  map[string][]PodSchedulableInfo
+// SimilarPodsScheduling stores mapping from controller ref to SimilarPodsSchedulingInfo
+type SimilarPodsScheduling struct {
+	items                  map[string][]SimilarPodsSchedulingInfo
 	overflowingControllers map[string]bool
 }
 
-// NewPodSchedulableMap creates a new PodSchedulableMap
-func NewPodSchedulableMap() PodSchedulableMap {
-	return PodSchedulableMap{
-		items:                  make(map[string][]PodSchedulableInfo),
+// NewSimilarPodsScheduling creates a new SimilarPodsScheduling
+func NewSimilarPodsScheduling() *SimilarPodsScheduling {
+	return &SimilarPodsScheduling{
+		items:                  make(map[string][]SimilarPodsSchedulingInfo),
 		overflowingControllers: make(map[string]bool),
 	}
 }
 
-// Match tests if given pod matches PodSchedulableInfo
-func (psi *PodSchedulableInfo) Match(pod *apiv1.Pod) bool {
-	return reflect.DeepEqual(pod.Labels, psi.labels) && utils.PodSpecSemanticallyEqual(pod.Spec, psi.spec)
-}
-
-// Get returns scheduling info for given pod if matching one exists in PodSchedulableMap
-func (p PodSchedulableMap) Get(pod *apiv1.Pod) (*predicatechecker.PredicateError, bool) {
+// IsSimilarUnschedulable returns scheduling info for given pod if matching one exists in SimilarPodsScheduling
+func (p *SimilarPodsScheduling) IsSimilarUnschedulable(pod *apiv1.Pod) bool {
 	ref := drain.ControllerRef(pod)
 	if ref == nil {
-		return nil, false
+		return false
 	}
 	uid := string(ref.UID)
 	if infos, found := p.items[uid]; found {
 		for _, info := range infos {
 			if info.Match(pod) {
-				return info.schedulingError, true
+				return true
 			}
 		}
 	}
-	return nil, false
+	return false
 }
 
-// Set sets scheduling info for given pod in PodSchedulableMap
-func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *predicatechecker.PredicateError) {
+// SetUnschedulable sets scheduling info for given pod in SimilarPodsScheduling
+func (p *SimilarPodsScheduling) SetUnschedulable(pod *apiv1.Pod) {
 	ref := drain.ControllerRef(pod)
 	if ref == nil || pod_utils.IsDaemonSetPod(pod) {
 		return
@@ -99,15 +98,14 @@ func (p PodSchedulableMap) Set(pod *apiv1.Pod, err *predicatechecker.PredicateEr
 		p.overflowingControllers[uid] = true
 		return
 	}
-	p.items[uid] = append(pm, PodSchedulableInfo{
-		spec:            pod.Spec,
-		labels:          pod.Labels,
-		schedulingError: err,
+	p.items[uid] = append(pm, SimilarPodsSchedulingInfo{
+		spec:   pod.Spec,
+		labels: pod.Labels,
 	})
 }
 
 // OverflowingControllerCount returns the number of controllers that had too
 // many different pods to be effectively cached.
-func (p PodSchedulableMap) OverflowingControllerCount() int {
+func (p *SimilarPodsScheduling) OverflowingControllerCount() int {
 	return len(p.overflowingControllers)
 }


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR separates the binpacking logic from the filterOutSchedulablePodsListProcessor. This enables reausability of this code and allows other places in CA to use it.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE