### PR TITLE
cluster autoscaler: kamatera cloud provider - change uuid dependency

### DIFF
--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
@@ -18,9 +18,8 @@ package kamatera
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
 	"k8s.io/klog/v2"
 	"strings"
@@ -266,5 +265,5 @@ func kamateraServerName(namePrefix string) string {
 	if len(namePrefix) > 0 {
 		namePrefix = fmt.Sprintf("%s-", namePrefix)
 	}
-	return fmt.Sprintf("%s%s", namePrefix, hex.EncodeToString(uuid.NewV4().Bytes()))
+	return fmt.Sprintf("%s%s", namePrefix, strings.ReplaceAll(uuid.New().String(), "-", ""))
 }

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_utils_test.go
@@ -18,14 +18,13 @@ package kamatera
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
+	"strings"
 )
 
 func mockKamateraServerName() string {
-	return fmt.Sprintf("%s", hex.EncodeToString(uuid.NewV4().Bytes()))
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
 func mockServerConfig(namePrefix string, tags []string) ServerConfig {


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler (kamatera cloudprovider)

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

it changes the dependency used to generate uuid to a more maintained and secure alternative which is already included in the dependencies (`google/uuid`)

#### Which issue(s) this PR fixes:

Fixes #5218

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
