### PR TITLE
Magnum provider: switch UUID dependency from satori to gofrs

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -46,7 +46,12 @@ func (m *magnumManagerDiscoveryMock) autoDiscoverNodeGroups(cfgs []magnumAutoDis
 	ngs := []*nodegroups.NodeGroup{}
 	two := 2
 	for i := 0; i < rand.Intn(20); i++ {
-		ngs = append(ngs, &nodegroups.NodeGroup{Name: uuid.NewV4().String(), NodeCount: 1, MinNodeCount: 1, MaxNodeCount: &two})
+		newUUID, err := uuid.NewV4()
+		if err != nil {
+			return nil, fmt.Errorf("failed to produce a random UUID: %v", err)
+		}
+		newUUIDStr := newUUID.String()
+		ngs = append(ngs, &nodegroups.NodeGroup{Name: newUUIDStr, NodeCount: 1, MinNodeCount: 1, MaxNodeCount: &two})
 	}
 	return ngs, nil
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager_impl.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager_impl.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 
 	apiv1 "k8s.io/api/core/v1"
 


### PR DESCRIPTION
Addresses issue #5218, that the satori UUID package is unmaintained and has security vulnerabilities
affecting generating random UUIDs.

In the magnum cloud provider, this package was only used to check whether a string matches a UUIDv4 or not, so the vulnerability with generating UUIDs could not have been exploited. (Generating UUIDs is only done in the unit tests).

The gofrs/uuid package is currenly at version 4.0.0 in go.mod, well past point at which it was forked and the vulnerability was fixed. It is a drop in replacement for verifying a UUID, and only a small change was needed in the testing code to handle a new returned error when generating a random UUID.

#### Which component this PR applies to?

Cluster autoscaler magnum cloud provider

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Removes a dependency with vulnerabilities from the magnum cloud provider code.

#### Which issue(s) this PR fixes:

Don't want to automatically close the issue as it covers multiple cloud providers.
The issue is #5218.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
