### PR TITLE
VPA: Fix typo, move service accounts to RBAC

### DIFF
--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-recommender
-  namespace: kube-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-updater
-  namespace: kube-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -214,7 +214,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-evictionter-binding
+  name: system:vpa-evictioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -229,6 +229,18 @@ kind: ServiceAccount
 metadata:
   name: vpa-admission-controller
   namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-recommender
+  namespace: openshift-vertical-pod-autoscaler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-updater
+  namespace: openshift-vertical-pod-autoscaler
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
+++ b/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
@@ -53,4 +53,5 @@ resources:
 commonAnnotations:
   "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
 EOF
-kubectl kustomize . > ${OUTPUT}
+echo --- > ${OUTPUT}
+kubectl kustomize . >> ${OUTPUT}


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This moves updater and recommender service accounts to the RBAC manifests where the admission controller's is.  That keeps the deployments separate from the RBAC needed for the deployments to work.  Also fixes a small harmless typo in the name of a role binding.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The VPA ClusterRoleBinding `system:vpa-evictionter-binding` has been renamed `system:vpa-evictioner-binding`. After applying the new RBAC manifest, the old one can be removed with `kubectl delete clusterrolebinding system:vpa-evictionter-binding`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
