### PR TITLE
Check owner reference in scale down planner to avoid double-counting

### DIFF
--- a/cluster-autoscaler/core/scaledown/planner/controller.go
+++ b/cluster-autoscaler/core/scaledown/planner/controller.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planner
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+)
+
+type controllerCalculatorImpl struct {
+	listers kubernetes.ListerRegistry
+}
+
+func newControllerReplicasCalculator(listers kubernetes.ListerRegistry) controllerReplicasCalculator {
+	return &controllerCalculatorImpl{listers: listers}
+}
+
+func (c *controllerCalculatorImpl) getReplicas(ownerRef metav1.OwnerReference, namespace string) (*replicasInfo, error) {
+	result := &replicasInfo{}
+	switch ownerRef.Kind {
+	case "StatefulSet":
+		sSet, err := c.listers.StatefulSetLister().StatefulSets(namespace).Get(ownerRef.Name)
+		if err != nil {
+			return nil, err
+		}
+		result.currentReplicas = sSet.Status.CurrentReplicas
+		if sSet.Spec.Replicas != nil {
+			result.targetReplicas = *sSet.Spec.Replicas
+		} else {
+			result.targetReplicas = 1
+		}
+	case "ReplicaSet":
+		rSet, err := c.listers.ReplicaSetLister().ReplicaSets(namespace).Get(ownerRef.Name)
+		if err != nil {
+			return nil, err
+		}
+		result.currentReplicas = rSet.Status.Replicas
+		if rSet.Spec.Replicas != nil {
+			result.targetReplicas = *rSet.Spec.Replicas
+		} else {
+			result.targetReplicas = 1
+		}
+	case "ReplicationController":
+		rController, err := c.listers.ReplicationControllerLister().ReplicationControllers(namespace).Get(ownerRef.Name)
+		if err != nil {
+			return nil, err
+		}
+		result.currentReplicas = rController.Status.Replicas
+		if rController.Spec.Replicas != nil {
+			result.targetReplicas = *rController.Spec.Replicas
+		} else {
+			result.targetReplicas = 1
+		}
+	case "Job":
+		job, err := c.listers.JobLister().Jobs(namespace).Get(ownerRef.Name)
+		if err != nil {
+			return nil, err
+		}
+		result.currentReplicas = job.Status.Active
+		if job.Spec.Parallelism != nil {
+			result.targetReplicas = *job.Spec.Parallelism
+		} else {
+			result.targetReplicas = 1
+		}
+		if job.Spec.Completions != nil && *job.Spec.Completions-job.Status.Succeeded < result.targetReplicas {
+			result.targetReplicas = *job.Spec.Completions - job.Status.Succeeded
+		}
+	default:
+		return nil, fmt.Errorf("unhandled controller type: %s", ownerRef.Kind)
+	}
+	return result, nil
+}

--- a/cluster-autoscaler/core/scaledown/planner/controller_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/controller_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+var podLabels = map[string]string{
+	"app": "test",
+}
+
+func TestReplicasCounter(t *testing.T) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job",
+			Namespace: "default",
+			UID:       types.UID("batch/v1/namespaces/default/jobs/job"),
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism: proto.Int32(3),
+			Selector:    metav1.SetAsLabelSelector(podLabels),
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+	unsetJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unset_job",
+			Namespace: "default",
+			UID:       types.UID("batch/v1/namespaces/default/jobs/unset_job"),
+		},
+	}
+	jobWithSucceededReplicas := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "succeeded_job",
+			Namespace: "default",
+			UID:       types.UID("batch/v1/namespaces/default/jobs/succeeded_job"),
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism: proto.Int32(3),
+			Completions: proto.Int32(3),
+			Selector:    metav1.SetAsLabelSelector(podLabels),
+		},
+		Status: batchv1.JobStatus{
+			Active:    1,
+			Succeeded: 2,
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs",
+			Namespace: "default",
+			UID:       types.UID("apps/v1/namespaces/default/replicasets/rs"),
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: proto.Int32(1),
+			Selector: metav1.SetAsLabelSelector(podLabels),
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas: 1,
+		},
+	}
+	unsetRs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unset_rs",
+			Namespace: "default",
+			UID:       types.UID("apps/v1/namespaces/default/replicasets/unset_rs"),
+		},
+	}
+	rC := &apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+			UID:       types.UID("core/v1/namespaces/default/replicationcontrollers/rc"),
+		},
+		Spec: apiv1.ReplicationControllerSpec{
+			Replicas: proto.Int32(1),
+			Selector: podLabels,
+		},
+		Status: apiv1.ReplicationControllerStatus{
+			Replicas: 0,
+		},
+	}
+	sS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sset",
+			Namespace: "default",
+			UID:       types.UID("apps/v1/namespaces/default/statefulsets/sset"),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: proto.Int32(3),
+			Selector: metav1.SetAsLabelSelector(podLabels),
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas: 1,
+		},
+	}
+	rcLister, _ := kube_util.NewTestReplicationControllerLister([]*apiv1.ReplicationController{rC})
+	jobLister, _ := kube_util.NewTestJobLister([]*batchv1.Job{job, unsetJob, jobWithSucceededReplicas})
+	rsLister, _ := kube_util.NewTestReplicaSetLister([]*appsv1.ReplicaSet{rs, unsetRs})
+	ssLister, _ := kube_util.NewTestStatefulSetLister([]*appsv1.StatefulSet{sS})
+	listers := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, rcLister, jobLister, rsLister, ssLister)
+	testCases := []struct {
+		name         string
+		ownerRef     metav1.OwnerReference
+		wantReplicas replicasInfo
+		expectErr    bool
+	}{
+		{
+			name:     "job owner reference",
+			ownerRef: ownerRef("Job", job.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 1,
+				targetReplicas:  3,
+			},
+		},
+		{
+			name:     "job without parallelism owner reference",
+			ownerRef: ownerRef("Job", unsetJob.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 0,
+				targetReplicas:  1,
+			},
+		},
+		{
+			name:     "job with succeeded replicas owner reference",
+			ownerRef: ownerRef("Job", jobWithSucceededReplicas.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 1,
+				targetReplicas:  1,
+			},
+		},
+		{
+			name:     "replica set owner reference",
+			ownerRef: ownerRef("ReplicaSet", rs.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 1,
+				targetReplicas:  1,
+			},
+		},
+		{
+			name:     "replica set without replicas spec specified owner reference",
+			ownerRef: ownerRef("ReplicaSet", unsetRs.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 0,
+				targetReplicas:  1,
+			},
+		},
+		{
+			name:     "replica controller owner reference",
+			ownerRef: ownerRef("ReplicationController", rC.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 0,
+				targetReplicas:  1,
+			},
+		},
+		{
+			name:     "stateful set owner reference",
+			ownerRef: ownerRef("StatefulSet", sS.Name),
+			wantReplicas: replicasInfo{
+				currentReplicas: 0,
+				targetReplicas:  3,
+			},
+		},
+		{
+			name:      "not existing job owner ref",
+			ownerRef:  ownerRef("Job", "j"),
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newControllerReplicasCalculator(listers)
+			res, err := c.getReplicas(tc.ownerRef, "default")
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				if diff := cmp.Diff(tc.wantReplicas, *res, cmp.AllowUnexported(replicasInfo{})); diff != "" {
+					t.Errorf("getReplicas() diff (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func ownerRef(ownerType, ownerName string) metav1.OwnerReference {
+	api := ""
+	strType := ""
+	switch ownerType {
+	case "ReplicaSet":
+		api = "apps/v1"
+		strType = "replicasets"
+	case "StatefulSet":
+		api = "apps/v1"
+		strType = "statefulsets"
+	case "ReplicationController":
+		api = "core/v1"
+		strType = "replicationcontrollers"
+	case "Job":
+		api = "batch/v1"
+		strType = "jobs"
+	}
+	return test.GenerateOwnerReferences(ownerName, ownerType, api, types.UID(fmt.Sprintf("%s/namespaces/default/%s/%s", api, strType, ownerName)))[0]
+}

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
@@ -49,6 +50,15 @@ type removalSimulator interface {
 	SimulateNodeRemoval(node string, podDestinations map[string]bool, timestamp time.Time, pdbs []*policyv1.PodDisruptionBudget) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode)
 }
 
+// controllerReplicasCalculator calculates a number of target and expected replicas for a given controller.
+type controllerReplicasCalculator interface {
+	getReplicas(metav1.OwnerReference, string) (*replicasInfo, error)
+}
+
+type replicasInfo struct {
+	targetReplicas, currentReplicas int32
+}
+
 // Planner is responsible for deciding which nodes should be deleted during scale down.
 type Planner struct {
 	context              *context.AutoscalingContext
@@ -61,6 +71,7 @@ type Planner struct {
 	nodeUtilizationMap   map[string]utilization.Info
 	actuationStatus      scaledown.ActuationStatus
 	resourceLimitsFinder *resource.LimitsFinder
+	cc                   controllerReplicasCalculator
 }
 
 // New creates a new Planner object.
@@ -75,6 +86,7 @@ func New(context *context.AutoscalingContext, processors *processors.Autoscaling
 		eligibilityChecker:   eligibility.NewChecker(processors.NodeGroupConfigProcessor),
 		nodeUtilizationMap:   make(map[string]utilization.Info),
 		resourceLimitsFinder: resourceLimitsFinder,
+		cc:                   newControllerReplicasCalculator(context.ListerRegistry),
 	}
 }
 
@@ -165,19 +177,42 @@ func (p *Planner) NodeUtilizationMap() map[string]utilization.Info {
 //   - pods which were recently evicted (it is up to ActuationStatus to decide
 //     what "recently" means in this case).
 //
-// It is entirely possible for some external controller to have already created
-// a replacement pod for such recent evictions, in which case the subsequent
-// simulation will count them twice. This is ok: it is much safer to disrupt
-// the scale down because of double-counting some pods than it is to scale down
-// too aggressively.
+// For pods that are controlled by controller known by CA, it will check whether
+// they have been recreated and will inject only not yet recreated pods.
 func (p *Planner) injectOngoingActuation() error {
-	err := p.injectPods(currentlyDrainedPods(p.context.ClusterSnapshot.NodeInfos(), p.actuationStatus))
+	currentlyDrainedRecreatablePods := filterRecreatable(currentlyDrainedPods(p.context.ClusterSnapshot.NodeInfos(), p.actuationStatus))
+	recentlyEvictedRecreatablePods := filterRecreatable(p.actuationStatus.RecentEvictions())
+	err := p.injectPods(currentlyDrainedRecreatablePods)
 	if err != nil {
 		return err
 	}
-	// TODO(x13n): Check owner references to avoid double-counting already
-	// recreated pods.
-	return p.injectPods(p.actuationStatus.RecentEvictions())
+	return p.injectPods(filterOutRecreatedPods(recentlyEvictedRecreatablePods, p.cc))
+}
+
+func filterOutRecreatedPods(pods []*apiv1.Pod, cc controllerReplicasCalculator) []*apiv1.Pod {
+	var podsToInject []*apiv1.Pod
+	addedReplicas := make(map[string]int32)
+	for _, pod := range pods {
+		ownerRef := getKnownOwnerRef(pod.GetOwnerReferences())
+		// in case of unknown ownerRef (i.e. not recognized by CA) we still inject
+		// the pod, to be on the safe side in case there is some custom controller
+		// that will recreate the pod.
+		if ownerRef == nil {
+			podsToInject = append(podsToInject, pod)
+			continue
+		}
+		rep, err := cc.getReplicas(*ownerRef, pod.Namespace)
+		if err != nil {
+			podsToInject = append(podsToInject, pod)
+			continue
+		}
+		ownerUID := string(ownerRef.UID)
+		if rep.targetReplicas > rep.currentReplicas && addedReplicas[ownerUID] < rep.targetReplicas-rep.currentReplicas {
+			podsToInject = append(podsToInject, pod)
+			addedReplicas[ownerUID] += 1
+		}
+	}
+	return podsToInject
 }
 
 func currentlyDrainedPods(niLister framework.NodeInfoLister, as scaledown.ActuationStatus) []*apiv1.Pod {
@@ -208,7 +243,6 @@ func filterRecreatable(pods []*apiv1.Pod) []*apiv1.Pod {
 }
 
 func (p *Planner) injectPods(pods []*apiv1.Pod) error {
-	pods = filterRecreatable(pods)
 	pods = clearNodeName(pods)
 	// Note: We're using ScheduleAnywhere, but the pods won't schedule back
 	// on the drained nodes due to taints.
@@ -250,6 +284,17 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	if unremovableCount > 0 {
 		klog.V(1).Infof("%v nodes found to be unremovable in simulation, will re-check them at %v", unremovableCount, unremovableTimeout)
 	}
+}
+
+// getKnownOwnerRef returns ownerRef that is known by CA and CA knows the logic of how this controller recreates pods.
+func getKnownOwnerRef(ownerRefs []metav1.OwnerReference) *metav1.OwnerReference {
+	for _, ownerRef := range ownerRefs {
+		switch ownerRef.Kind {
+		case "StatefulSet", "Job", "ReplicaSet", "ReplicationController":
+			return &ownerRef
+		}
+	}
+	return nil
 }
 
 func merged(a, b []string) []string {


### PR DESCRIPTION
Check owner reference in scale down planner to avoid double-counting already deleted and recreated pods.

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
cluster-autoscaler
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR makes sure that in scale down planner we do not account twice for the pods that have been evicted and already recreated by its higher level controller.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
