### PR TITLE
Fix: add missing RBAC permissions to magnum examples

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-svcaccount.yaml
@@ -39,7 +39,7 @@ rules:
     resources: ["daemonsets", "replicasets", "statefulsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["watch", "list", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]


### PR DESCRIPTION
Similar change was done in https://github.com/kubernetes/autoscaler/pull/4154

Without these RBAC permissions seeing below in the pod logs:

```
E1024 14:31:11.976758       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: csidrivers.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-account" cannot list resource "csidrivers" in API group "storage.k8s.io" at the cluster scope
E1024 14:31:29.198925       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: csistoragecapacities.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-account" cannot list resource "csistoragecapacities" in API group "storage.k8s.io" at the cluster scope
```