### PR TITLE
Fix VPA deployment

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -234,13 +234,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-recommender
-  namespace: openshift-vertical-pod-autoscaler
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-updater
-  namespace: openshift-vertical-pod-autoscaler
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Fixes #5298

Use namespace `kube-system` for VPA Service Accounts like it did before #5268
