### PR TITLE
huawei-cloudprovider: enable taints resolve for as, modify the example yaml to accelerate node scale-down

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/examples/cluster-autoscaler-deployment.yaml
@@ -31,6 +31,9 @@ spec:
             - --scale-down-delay-after-add=1m0s
             - --scale-down-unneeded-time=1m0s
             - --expander=random
+            - --max-empty-bulk-delete=100
+            - --max-scale-down-parallelism=100
+            - --node-deletion-batcher-interval=10s
           volumeMounts:
             - name: cloud-config
               mountPath: /config

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package huaweicloud
+
+import (
+	"reflect"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+func Test_extractTaintsFromTags(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]string
+		want []apiv1.Taint
+	}{
+		{
+			name: "tag in right format",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "bar:NoSchedule",
+			},
+			want: []apiv1.Taint{
+				{Key: "foo", Value: "bar", Effect: apiv1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "empty taint key should be ignored",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_": "bar:NoSchedule",
+			},
+			want: []apiv1.Taint{},
+		},
+		{
+			name: "invalid tag key should be ignored",
+			args: map[string]string{
+				"invalidTagKey": "bar:NoSchedule",
+			},
+			want: []apiv1.Taint{},
+		},
+		{
+			name: "invalid taint effect should be ignored",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "bar:InvalidEffect",
+			},
+			want: []apiv1.Taint{},
+		},
+		{
+			name: "empty taint value",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": ":NoSchedule",
+			},
+			want: []apiv1.Taint{
+				{Key: "foo", Value: "", Effect: apiv1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "one tag with valid tag, one tag with invalid key, ignore the invalid one",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "bar:NoSchedule",
+				"invalidTagKey": ":NoSchedule",
+			},
+			want: []apiv1.Taint{
+				{Key: "foo", Value: "bar", Effect: apiv1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "one tag with valid key/value, one tag with invalid value, ignore the invalid one",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "bar:NoSchedule",
+				"k8s.io_cluster-autoscaler_node-template_taint_bar": "invalidTagValue",
+			},
+			want: []apiv1.Taint{
+				{Key: "foo", Value: "bar", Effect: apiv1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "one tag with valid key/value, one tag with invalid value length, ignore the invalid one",
+			args: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "bar:NoSchedule",
+				"k8s.io_cluster-autoscaler_node-template_taint_bar": "foo:NoSchedule:more",
+			},
+			want: []apiv1.Taint{
+				{Key: "foo", Value: "bar", Effect: apiv1.TaintEffectNoSchedule},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractTaintsFromTags(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractTaintsFromTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildGenericLabels(t *testing.T) {
+	template := &asgTemplate{
+		name:   "foo",
+		region: "foo",
+		zone:   "foo",
+	}
+	tests := []struct {
+		name string
+		tags map[string]string
+		want map[string]string
+	}{
+		{
+			name: "tags contain taints key, ignore it when extract labels",
+			tags: map[string]string{
+				"k8s.io_cluster-autoscaler_node-template_taint_foo": "true:PreferNoSchedule",
+				"foo": "bar",
+			},
+			want: map[string]string{
+				apiv1.LabelArchStable:         cloudprovider.DefaultArch,
+				apiv1.LabelOSStable:           cloudprovider.DefaultOS,
+				apiv1.LabelInstanceTypeStable: template.name,
+				apiv1.LabelTopologyRegion:     template.region,
+				apiv1.LabelTopologyZone:       template.zone,
+				apiv1.LabelHostname:           "foo",
+				"foo":                         "bar",
+			},
+		},
+		{
+			name: "tags don't contain taints key",
+			tags: map[string]string{
+				"foo": "bar",
+			},
+			want: map[string]string{
+				apiv1.LabelArchStable:         cloudprovider.DefaultArch,
+				apiv1.LabelOSStable:           cloudprovider.DefaultOS,
+				apiv1.LabelInstanceTypeStable: template.name,
+				apiv1.LabelTopologyRegion:     template.region,
+				apiv1.LabelTopologyZone:       template.zone,
+				apiv1.LabelHostname:           "foo",
+				"foo":                         "bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			template.tags = tt.tags
+			if got := buildGenericLabels(template, "foo"); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildGenericLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

#### Which component this PR applies to?
cluster-autoscaler

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
huawei-cloudprovider: enable taints resolve for as, modify the example yaml to accelerate node scale-down

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes none

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
