### PR TITLE
Make prometheusRule.interval default to 1m

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.21.0
+version: 9.22.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -342,7 +342,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | priorityConfigMapAnnotations | object | `{}` | Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap. |
 | prometheusRule.additionalLabels | object | `{}` | Additional labels to be set in metadata. |
 | prometheusRule.enabled | bool | `false` | If true, creates a Prometheus Operator PrometheusRule. |
-| prometheusRule.interval | string | `nil` | How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set). |
+| prometheusRule.interval | string | `"1m"` | How often rules in the group are evaluated (falls back to the default value of `global.evaluation_interval` (which is 1m) if not set). |
 | prometheusRule.namespace | string | `"monitoring"` | Namespace which Prometheus is running in. |
 | prometheusRule.rules | list | `[]` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). |
 | rbac.clusterScoped | bool | `true` | if set to false will only provision RBAC to alter resources in the current namespace. Most useful for Cluster-API |

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -342,7 +342,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | priorityConfigMapAnnotations | object | `{}` | Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap. |
 | prometheusRule.additionalLabels | object | `{}` | Additional labels to be set in metadata. |
 | prometheusRule.enabled | bool | `false` | If true, creates a Prometheus Operator PrometheusRule. |
-| prometheusRule.interval | string | `"1m"` | How often rules in the group are evaluated (falls back to the default value of `global.evaluation_interval` (which is 1m) if not set). |
+| prometheusRule.interval | string | `"nil"` | How often rules in the group are evaluated (falls back to the Prometheus level value of `global.evaluation_interval` if not set). |
 | prometheusRule.namespace | string | `"monitoring"` | Namespace which Prometheus is running in. |
 | prometheusRule.rules | list | `[]` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). |
 | rbac.clusterScoped | bool | `true` | if set to false will only provision RBAC to alter resources in the current namespace. Most useful for Cluster-API |

--- a/charts/cluster-autoscaler/templates/prometheusrule.yaml
+++ b/charts/cluster-autoscaler/templates/prometheusrule.yaml
@@ -12,8 +12,6 @@ spec:
     - name: {{ include "cluster-autoscaler.fullname" . }}
       {{- if .Values.prometheusRule.interval }}
       interval: {{ .Values.prometheusRule.interval }}
-      {{- else }}
-      interval: 1m
       {{- end }}
       rules: {{- tpl (toYaml .Values.prometheusRule.rules) . | nindent 8 }}
 {{- end }}

--- a/charts/cluster-autoscaler/templates/prometheusrule.yaml
+++ b/charts/cluster-autoscaler/templates/prometheusrule.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   groups:
     - name: {{ include "cluster-autoscaler.fullname" . }}
+      {{- if .Values.prometheusRule.interval }}
       interval: {{ .Values.prometheusRule.interval }}
+      {{- else }}
+      interval: 1m
+      {{- end }}
       rules: {{- tpl (toYaml .Values.prometheusRule.rules) . | nindent 8 }}
 {{- end }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -358,8 +358,8 @@ prometheusRule:
   additionalLabels: {}
   # prometheusRule.namespace -- Namespace which Prometheus is running in.
   namespace: monitoring
-  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to the default value of `global.evaluation_interval` (which is 1m) if not set).
-  interval: 1m
+  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to the Prometheus level value of `global.evaluation_interval` if not set).
+  interval: nil
   # prometheusRule.rules -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
   rules: []
 

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -358,8 +358,8 @@ prometheusRule:
   additionalLabels: {}
   # prometheusRule.namespace -- Namespace which Prometheus is running in.
   namespace: monitoring
-  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
-  interval: null
+  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to the default value of `global.evaluation_interval` (which is 1m) if not set).
+  interval: 1m
   # prometheusRule.rules -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
   rules: []
 


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
helm-charts

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
What: Set default `prometheusRule.interval` to `1m` instead of `global. evaluation_interval` (which has a default value of `1m`)
Why: Helm release was failing since `prometheusRule.interval` was defaulting to `nil` when not explicitly set

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Please close if necessary

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
