### PR TITLE
recommendation post processor for integer CPU

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -183,6 +183,7 @@ Name | Type | Description | Default
 `memory-aggregation-interval-count` | Int64 | The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count. | model.DefaultMemoryAggregationIntervalCount
 `memory-histogram-decay-half-life` | Duration | The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period. | model.DefaultMemoryHistogramDecayHalfLife
 `cpu-histogram-decay-half-life` | Duration | The amount of time it takes a historical CPU usage sample to lose half of its weight. | model.DefaultCPUHistogramDecayHalfLife
+`cpu-integer-post-processor-enabled` | Bool | Enable the CPU integer recommendation post processor | false
 
 ### What are the parameters to VPA updater?
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -19,6 +19,7 @@
   - [Capping to Limit Range](#capping-to-limit-range)
   - [Resource Policy Overriding Limit Range](#resource-policy-overriding-limit-range)
   - [Starting multiple recommenders](#starting-multiple-recommenders)
+  - [Using CPU management with static policy](#using-cpu-management-with-static-policy)
 - [Known limitations](#known-limitations)
 - [Related links](#related-links)
 
@@ -294,6 +295,17 @@ Please note the usage of the following arguments to override default names and p
 
 You can then choose which recommender to use by setting `recommenders` inside the `VerticalPodAutoscaler` spec.
 
+### Using CPU management with static policy
+
+If you are using the [CPU management with static policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) for some containers,
+you probably want the CPU recommendation to be an integer. A dedicated recommendation pre-processor can perform a round up on the CPU recommendation. Recommendation capping still applies after the round up.   
+To activate this feature, pass the flag `--cpu-integer-post-processor-enabled` when you start the recommender. 
+The pre-processor only acts on containers having a specific configuration. This configuration consists in an annotation on your VPA object for each impacted container.
+The annotation format is the following:
+```
+vpa-post-processor.kubernetes.io/{containerName}_integerCPU=true
+```
+ 
 # Known limitations
 
 * Whenever VPA updates the pod resources, the pod is recreated, which causes all

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -89,12 +89,13 @@ func main() {
 
 	useCheckpoints := *storage != "prometheus"
 
-	postProcessors := []routines.RecommendationPostProcessor{
-		&routines.CappingPostProcessor{},
-	}
+	var postProcessors []routines.RecommendationPostProcessor
 	if *postProcessorCPUasInteger {
 		postProcessors = append(postProcessors, &routines.IntegerCPUPostProcessor{})
 	}
+	// CappingPostProcessor, should always come in the last position for post-processing
+	postProcessors = append(postProcessors, &routines.CappingPostProcessor{})
+
 	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace, *recommenderName, postProcessors)
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -70,7 +70,7 @@ var (
 // Post processors flags
 var (
 	// CPU as integer to benefit for CPU management Static Policy ( https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy )
-	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. Only containers that specify it can have their CPU recommendation rounded up to an integer value.")
+	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental)")
 )
 
 func main() {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -67,6 +67,12 @@ var (
 	cpuHistogramDecayHalfLife      = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
 )
 
+// Post processors flags
+var (
+	// CPU as integer to benefit for CPU management Static Policy ( https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy )
+	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. Only containers that specify it can have their CPU recommendation rounded up to an integer value.")
+)
+
 func main() {
 	klog.InitFlags(nil)
 	kube_flag.InitFlags()
@@ -85,6 +91,9 @@ func main() {
 
 	postProcessors := []routines.RecommendationPostProcessor{
 		&routines.CappingPostProcessor{},
+	}
+	if *postProcessorCPUasInteger {
+		postProcessors = append(postProcessors, &routines.IntegerCPUPostProcessor{})
 	}
 	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace, *recommenderName, postProcessors)
 

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"math"
+	"strings"
+)
+
+// IntegerCPUPostProcessor ensures that the recommendation delivers an integer value for CPU
+// This is need for users who want to use CPU Management with static policy: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
+type IntegerCPUPostProcessor struct{}
+
+const (
+	// The user interface for that post processor is an annotation on the VPA object with the following format:
+	// vpa-post-processor.kubernetes.io/{containerName}_integerCPU=true
+	vpaPostProcessorPrefix           = "vpa-post-processor.kubernetes.io/"
+	vpaPostProcessorIntegerCPUSuffix = "_integerCPU"
+	vpaPostProcessorIntegerCPUValue  = "true"
+)
+
+var _ RecommendationPostProcessor = &IntegerCPUPostProcessor{}
+
+// Process apply the capping post-processing to the recommendation.
+// For this post processor the CPU value is rounded up to an integer
+func (p *IntegerCPUPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+
+	amendedRecommendation := recommendation.DeepCopy()
+
+	process := func(recommendation apiv1.ResourceList) {
+		for resourceName, recommended := range recommendation {
+			if resourceName != apiv1.ResourceCPU {
+				continue
+			}
+			v := float64(recommended.MilliValue()) / 1000
+			r := int64(math.Ceil(v))
+			recommended.Set(r)
+			recommendation[resourceName] = recommended
+		}
+	}
+
+	for key, value := range vpa.Annotations {
+		containerName := extractContainerName(key, vpaPostProcessorPrefix, vpaPostProcessorIntegerCPUSuffix)
+		if containerName == "" || value != vpaPostProcessorIntegerCPUValue {
+			continue
+		}
+
+		for _, r := range amendedRecommendation.ContainerRecommendations {
+			if r.ContainerName != containerName {
+				continue
+			}
+			process(r.Target)
+			process(r.LowerBound)
+			process(r.UpperBound)
+			process(r.UncappedTarget)
+		}
+	}
+	return amendedRecommendation
+}
+
+// extractContainerName return the container name for the feature based on annotation key
+// if the returned value is empty that means that the key does not match
+func extractContainerName(key, prefix, suffix string) string {
+	if !strings.HasPrefix(key, prefix) {
+		return ""
+	}
+	if !strings.HasSuffix(key, suffix) {
+		return ""
+	}
+
+	return key[len(prefix) : len(key)-len(suffix)]
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 )
 
-func Test_extractContainerName(t *testing.T) {
+func TestExtractContainerName(t *testing.T) {
 	tests := []struct {
 		name   string
 		key    string
@@ -70,7 +70,7 @@ func Test_extractContainerName(t *testing.T) {
 	}
 }
 
-func Test_integerCPUPostProcessor_Process(t *testing.T) {
+func TestIntegerCPUPostProcessor_Process(t *testing.T) {
 	tests := []struct {
 		name           string
 		vpa            *model.Vpa
@@ -80,7 +80,7 @@ func Test_integerCPUPostProcessor_Process(t *testing.T) {
 		{
 			name: "No containers match",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container-other" + vpaPostProcessorIntegerCPUSuffix: "true",
+				vpaPostProcessorPrefix + "container-other" + vpaPostProcessorIntegerCPUSuffix: vpaPostProcessorIntegerCPUValue,
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -98,7 +98,7 @@ func Test_integerCPUPostProcessor_Process(t *testing.T) {
 		{
 			name: "2 containers, 1 matching only",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: "true",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: vpaPostProcessorIntegerCPUValue,
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -116,8 +116,8 @@ func Test_integerCPUPostProcessor_Process(t *testing.T) {
 		{
 			name: "2 containers, 2 matching",
 			vpa: &model.Vpa{Annotations: map[string]string{
-				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: "true",
-				vpaPostProcessorPrefix + "container2" + vpaPostProcessorIntegerCPUSuffix: "true",
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: vpaPostProcessorIntegerCPUValue,
+				vpaPostProcessorPrefix + "container2" + vpaPostProcessorIntegerCPUSuffix: vpaPostProcessorIntegerCPUValue,
 			}},
 			recommendation: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
@@ -183,7 +183,7 @@ func equalResourceList(rla, rlb v1.ResourceList) bool {
 	return true
 }
 
-func Test_setIntegerCPURecommendation(t *testing.T) {
+func TestSetIntegerCPURecommendation(t *testing.T) {
 	tests := []struct {
 		name                   string
 		recommendation         v1.ResourceList

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	"testing"
+)
+
+func Test_extractContainerName(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		prefix string
+		suffix string
+		want   string
+	}{
+		{
+			name:   "empty",
+			key:    "",
+			prefix: "",
+			suffix: "",
+			want:   "",
+		},
+		{
+			name:   "no match",
+			key:    "abc",
+			prefix: "z",
+			suffix: "x",
+			want:   "",
+		},
+		{
+			name:   "match",
+			key:    "abc",
+			prefix: "a",
+			suffix: "c",
+			want:   "b",
+		},
+		{
+			name:   "real",
+			key:    vpaPostProcessorPrefix + "kafka" + vpaPostProcessorIntegerCPUSuffix,
+			prefix: vpaPostProcessorPrefix,
+			suffix: vpaPostProcessorIntegerCPUSuffix,
+			want:   "kafka",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, extractContainerName(tt.key, tt.prefix, tt.suffix), "extractContainerName(%v, %v, %v)", tt.key, tt.prefix, tt.suffix)
+		})
+	}
+}
+
+func Test_integerCPUPostProcessor_Process(t *testing.T) {
+	tests := []struct {
+		name           string
+		vpa            *model.Vpa
+		recommendation *vpa_types.RecommendedPodResources
+		want           *vpa_types.RecommendedPodResources
+	}{
+		{
+			name: "No containers match",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container-other" + vpaPostProcessorIntegerCPUSuffix: "true",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "2 containers, 1 matching only",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: "true",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("9", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("8.2", "300Mi").GetContainerResources(),
+				},
+			},
+		},
+		{
+			name: "2 containers, 2 matching",
+			vpa: &model.Vpa{Annotations: map[string]string{
+				vpaPostProcessorPrefix + "container1" + vpaPostProcessorIntegerCPUSuffix: "true",
+				vpaPostProcessorPrefix + "container2" + vpaPostProcessorIntegerCPUSuffix: "true",
+			}},
+			recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("8.6", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("5.2", "300Mi").GetContainerResources(),
+				},
+			},
+			want: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					test.Recommendation().WithContainer("container1").WithTarget("9", "200Mi").GetContainerResources(),
+					test.Recommendation().WithContainer("container2").WithTarget("6", "300Mi").GetContainerResources(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := IntegerCPUPostProcessor{}
+			got := c.Process(tt.vpa, tt.recommendation, nil)
+			assert.Equalf(t, reScale3(tt.want), reScale3(got), "Process(%v, %v, nil)", tt.vpa, tt.recommendation)
+		})
+	}
+}
+
+func reScale3(recommended *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
+
+	scale3 := func(rl v1.ResourceList) {
+		for k, v := range rl {
+			v.SetMilli(v.MilliValue())
+			rl[k] = v
+		}
+	}
+
+	for _, r := range recommended.ContainerRecommendations {
+		scale3(r.LowerBound)
+		scale3(r.Target)
+		scale3(r.UncappedTarget)
+		scale3(r.UpperBound)
+	}
+	return recommended
+}


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler/recommender

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It introduces a recommendation post processor that allows users to have a CPU integer as recommendation.
Thanks to that it is now possible to use VPA with applications using [CPU management with static policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy)

#### Which issue(s) this PR fixes:

Fixes #5236

#### Special notes for your reviewer:

As discussed during the SIG meeting the user interface is based on an annotations. This could be structured in the spec of the VPA once the feature will have gained maturity.

#### Does this PR introduce a user-facing change?

The "cpu integer post-processor" can be enabled using flag `--cpu-integer-post-processor-enabled=true` when starting the VPA recommender.
The post-processor would round-up CPU recommendation for containers referenced by a VPA annotation with this format:
`vpa-post-processor.kubernetes.io/{containerName}_integerCPU=true`

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This post processor is optional. To run it in the recommender the command-line flag should be set:
`--cpu-integer-post-processor-enabled=true`, then only the pods/containers that have the relevant annotation are affected.