### PR TITLE
chore(cluster-autoscaler/rancher): parametize provider ID

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/README.md
+++ b/cluster-autoscaler/cloudprovider/rancher/README.md
@@ -72,3 +72,10 @@ spec:
         cluster.provisioning.cattle.io/autoscaler-resource-ephemeral-storage: 50Gi
         cluster.provisioning.cattle.io/autoscaler-resource-memory: 4Gi
 ```
+
+
+## Troubleshooting
+
+### Problem identifying node's nodegroups
+
+If you get `Nodegroup is nil for <prefix>:///<node-id>`, and `<prefix>` != `rke2`, you can set `providerIDPrefix: <prefix>` in the configuration file in order to identify correctly the nodes.

--- a/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
+++ b/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
@@ -7,3 +7,5 @@ clusterName: my-cluster
 clusterNamespace: fleet-default
 # optional, will be auto-discovered if not specified
 #clusterAPIVersion: v1alpha4
+# optional, default: rke2
+providerIDPrefix: rke2

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
@@ -29,6 +29,7 @@ type cloudConfig struct {
 	ClusterName       string `yaml:"clusterName"`
 	ClusterNamespace  string `yaml:"clusterNamespace"`
 	ClusterAPIVersion string `yaml:"clusterAPIVersion"`
+	ProviderIDPrefix  string `yaml:"providerIDPrefix"`
 }
 
 func newConfig(file string) (*cloudConfig, error) {
@@ -37,7 +38,7 @@ func newConfig(file string) (*cloudConfig, error) {
 		return nil, fmt.Errorf("unable to read cloud config file: %w", err)
 	}
 
-	config := &cloudConfig{}
+	config := &cloudConfig{ProviderIDPrefix: rke2ProviderID}
 	if err := yaml.Unmarshal(b, config); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal config file: %w", err)
 	}

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_config_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_config_test.go
@@ -39,4 +39,9 @@ func TestNewConfig(t *testing.T) {
 	if len(cfg.ClusterNamespace) == 0 {
 		t.Fatal("expected cluster namespace to be set")
 	}
+
+	if len(cfg.ProviderIDPrefix) == 0 {
+		// It is optional, but set in this context
+		t.Fatal("expected provider id to be set")
+	}
 }

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
@@ -494,6 +494,7 @@ func setup(machines []runtime.Object) (*RancherCloudProvider, error) {
 		ClusterName:       testCluster,
 		ClusterNamespace:  testNamespace,
 		ClusterAPIVersion: "v1alpha4",
+		ProviderIDPrefix:  rke2ProviderID,
 	}
 
 	machinePools := []provisioningv1.RKEMachinePool{

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
@@ -43,7 +43,7 @@ const (
 	// providerName is the cloud provider name for rancher
 	providerName = "rancher"
 
-	// rke2ProviderID identifies nodes that are using RKE2
+	// rke2ProviderID is the default Provider ID to identify nodes that are using RKE2
 	rke2ProviderID       = "rke2"
 	rke2ProviderIDPrefix = rke2ProviderID + "://"
 
@@ -146,8 +146,8 @@ func (provider *RancherCloudProvider) Pricing() (cloudprovider.PricingModel, aut
 
 // NodeGroupForNode returns the node group for the given node.
 func (provider *RancherCloudProvider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup, error) {
-	// skip nodes that are not managed by rke2.
-	if !strings.HasPrefix(node.Spec.ProviderID, rke2ProviderID) {
+	// skip nodes that are not managed by the defined providerID
+	if !strings.HasPrefix(node.Spec.ProviderID, provider.config.ProviderIDPrefix) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR parametrizes the Provider ID used in rancher autoscaler to attribute node group to existent nodes.

#### Which issue(s) this PR fixes:

Fixes #5140

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
