### PR TITLE
Stop filtering aggregatedContainerStates without samples

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "40000"}
+	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "50000"}
 )
 
 var (

--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "8000"}
+	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "40000"}
 )
 
 var (
@@ -443,8 +443,8 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 		Timeout:     timeoutRC,
 		Replicas:    replicas,
 		Annotations: make(map[string]string),
-		MemRequest:  1024 * 1024 * 1024,
-		MemLimit:    1024 * 1024 * 1024,
+		MemRequest:  1024 * 1024 * 300,
+		MemLimit:    1024 * 1024 * 500,
 	}
 
 	dpConfig := testutils.DeploymentConfig{

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -43,7 +43,7 @@ const (
 	// the initial values should be outside minimal bounds
 	initialCPU     = int64(10) // mCPU
 	initialMemory  = int64(10) // MB
-	oomTestTimeout = 8 * time.Minute
+	oomTestTimeout = 12 * time.Minute
 )
 
 var _ = FullVpaE2eDescribe("Pods under VPA", func() {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/vpa.go
@@ -31,7 +31,7 @@ func GetContainerNameToAggregateStateMap(vpa *model.Vpa) model.ContainerNameToAg
 		containerResourcePolicy := api_utils.GetContainerResourcePolicy(containerName, vpa.ResourcePolicy)
 		autoscalingDisabled := containerResourcePolicy != nil && containerResourcePolicy.Mode != nil &&
 			*containerResourcePolicy.Mode == vpa_types.ContainerScalingModeOff
-		if !autoscalingDisabled && aggregatedContainerState.TotalSamplesCount > 0 {
+		if !autoscalingDisabled {
 			aggregatedContainerState.UpdateFromPolicy(containerResourcePolicy)
 			filteredContainerNameToAggregateStateMap[containerName] = aggregatedContainerState
 		}


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
vertical-pod-autoscaler

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Stop filtering `aggregatedContainerState`s with `TotalSampleCount==0`. These `aggregateContainerState`s *can* contain OOMSamples, which don't increase the `TotalSampleCount` but make it possible to give a better memory recommendation. This change also increases the timeout for the OOMKill e2e test as it takes ~10 minutes for the recommendations to reach the expected range.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4981 

#### Special notes for your reviewer:
I'm not entirely sure if there is a good reason why `aggregateContainerStates` without PodMetric samples were ignored besides trying to optimize. Maybe someone else has context if there's an additional reason behind it why we shouldn't be removing this condition?

I looked at other options to solve this, but they seem much more complicated. 

##### Alternative A: Adding separate `SampleCounts` for CPU and memory
The VPA is built with the assumption that a sample contains both, CPU and memory data, therefore only a single `TotalSampleCount` exists in `aggregateContainerState`. We could move this further down and give each resource its own counter, *but* confidence is computed based on `TotalSampleCount`: therefore this would mean that CPU and memory can have different confidence and therefore different upper and lower bounds. This seems way too intrusive.

##### Alternative B: Increase `TotalSampleCount` when an OOMSample is added
Do something similar to the quick hack I discussed in #4981, but only for OOMSamples, not all memory samples.

```
diff --git a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
index 3facbe37e..7accd072e 100644
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -184,6 +184,7 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
        case ResourceCPU:
                a.addCPUSample(sample)
        case ResourceMemory:
+               a.TotalSamplesCount++
                a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
        default:
                panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
```

Downside: When many OOMSamples are recorded in a short period (e.g. when a Pod suddenly spikes in memory or has waaaaayyyyy too low intial resources defined), the confidence for CPU recommendations increases as well – which is the opposite of what's happening: In a situation like this we *don't* get PodMetrics and therefore no CPU metrics, so this also seems incorrect.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug which could lead to the recommender not giving any recommendations for Pods in OOMKill CrashLoopBackoff
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
