### PR TITLE
Add note regarding GPU label for the CAPI provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -322,3 +322,17 @@ spec:
 **Warning**: If the Autoscaler is enabled **and** the replicas field is set for a `MachineDeployment` or `MachineSet` the Cluster may enter a broken state where replicas become unpredictable.
 
 If the replica field is unset in the Cluster definition Autoscaling can be enabled [as described above](#enabling-autoscaling)
+
+## Special note on GPU instances
+
+As with other providers, if the device plugin on nodes that provides GPU
+resources takes some time to advertise the GPU resource to the cluster, this
+may cause Cluster Autoscaler to unnecessarily scale out multiple times.
+
+To avoid this, you can configure `kubelet` on your GPU nodes to label the node
+before it joins the cluster by passing it the `--node-labels` flag. For the
+CAPI cloudprovider, the label format is as follows:
+
+`cluster-api/accelerator=<gpu-type>`
+
+`<gpu-type>` is arbitrary.


### PR DESCRIPTION


#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

cluster-autoscaler takes into consideration the time that a node takes to initialise a GPU resource on a node, as long as a particular label is in place.  This label differs from provider to provider, and is documented in some cases but not for CAPI.

This commit adds a note with the specific label that should be applied when a node is instantiated.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
