### PR TITLE
Deprecate v1beta1 2

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -5,6 +5,7 @@
 - [Intro](#intro)
 - [Installation](#installation)
   - [Compatibility](#compatibility)
+  - [Notice on deprecation of v1beta2 version (>=0.13.0)](#notice-on-deprecation-of-v1beta2-version-0130)
   - [Notice on removal of v1beta1 version (>=0.5.0)](#notice-on-removal-of-v1beta1-version-050)
   - [Prerequisites](#prerequisites)
   - [Install command](#install-command)
@@ -59,6 +60,14 @@ The current default version is Vertical Pod Autoscaler 0.12.0
 | 0.8             | 1.13+              |
 | 0.4 to 0.7      | 1.11+              |
 | 0.3.X and lower | 1.7+               |
+
+### Notice on deprecation of v1beta2 version (>=0.13.0)
+**NOTE:** In 0.13.0 we deprecate `autoscaling.k8s.io/v1beta2` API. We plan to
+remove this API version. While for now you can continue to use `v1beta2` API we
+recommend using `autoscaling.k8s.io/v1` instead. `v1` and `v1beta2` APIs are
+almost identical (`v1` API has some fields which are not present in `v1beta2)
+so simply chaning which API version you're calling should be enough in almost
+all cases.
 
 ### Notice on removal of v1beta1 version (>=0.5.0)
 

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -514,7 +514,9 @@ spec:
     served: true
     storage: true
     subresources: {}
-  - name: v1beta2
+  - deprecated: true
+    deprecationWarning: autoscaling.k8s.io/v1beta2 API is deprecated
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VerticalPodAutoscaler is the configuration for a vertical pod

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -39,10 +39,15 @@ type VerticalPodAutoscalerList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=vpa
+// +k8s:prerelease-lifecycle-gen=true
 
 // VerticalPodAutoscaler is the configuration for a vertical pod
 // autoscaler, which automatically manages pod resources based on historical and
 // real time resource utilization.
+// +k8s:prerelease-lifecycle-gen:introduced=0.4.0
+// +k8s:prerelease-lifecycle-gen:deprecated=0.13.0
+// +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v1,VerticalPodAutoscaler
+// +kubebuilder:deprecatedversion:warning=autoscaling.k8s.io/v1beta2 API is deprecated
 type VerticalPodAutoscaler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`


### PR DESCRIPTION
#### Which component this PR applies to?

VPA

#### What type of PR is this?

/kind cleanup
/kind api-change
/kind deprecation
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #4969

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
autoscaling v1beta2 API is now deprecated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
