### PR TITLE
Add pods from node undergoing scale-down to unschedulable pods

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podlistprocessor
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+type currentlyDrainedNodesPodListProcessor struct {
+}
+
+// NewCurrentlyDrainedNodesPodListProcessor returns a new processor adding pods
+// from currently drained nodes to the unschedulable pods.
+func NewCurrentlyDrainedNodesPodListProcessor() *currentlyDrainedNodesPodListProcessor {
+	return &currentlyDrainedNodesPodListProcessor{}
+}
+
+// Process adds recreatable pods from currently drained nodes
+func (p *currentlyDrainedNodesPodListProcessor) Process(_ *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	return unschedulablePods, nil
+}
+
+func (p *currentlyDrainedNodesPodListProcessor) CleanUp() {
+}

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -19,6 +19,8 @@ package podlistprocessor
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
+	"k8s.io/klog/v2"
 )
 
 type currentlyDrainedNodesPodListProcessor struct {
@@ -31,9 +33,26 @@ func NewCurrentlyDrainedNodesPodListProcessor() *currentlyDrainedNodesPodListPro
 }
 
 // Process adds recreatable pods from currently drained nodes
-func (p *currentlyDrainedNodesPodListProcessor) Process(_ *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	return unschedulablePods, nil
+func (p *currentlyDrainedNodesPodListProcessor) Process(context *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	recreatablePods := pod_util.FilterRecreatablePods(currentlyDrainedPods(context))
+	return append(unschedulablePods, pod_util.ClearPodNodeNames(recreatablePods)...), nil
 }
 
 func (p *currentlyDrainedNodesPodListProcessor) CleanUp() {
+}
+
+func currentlyDrainedPods(context *context.AutoscalingContext) []*apiv1.Pod {
+	var pods []*apiv1.Pod
+	_, nodeNames := context.ScaleDownActuator.CheckStatus().DeletionsInProgress()
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := context.ClusterSnapshot.NodeInfos().Get(nodeName)
+		if err != nil {
+			klog.Warningf("Couldn't get node %v info, assuming the node got deleted already: %v", nodeName, err)
+			continue
+		}
+		for _, podInfo := range nodeInfo.Pods {
+			pods = append(pods, podInfo.Pod)
+		}
+	}
+	return pods
 }

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -15,3 +15,288 @@ limitations under the License.
 */
 
 package podlistprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestCurrentlyDrainedNodesPodListProcessor(t *testing.T) {
+	testCases := []struct {
+		name         string
+		drainedNodes []string
+		nodes        []*apiv1.Node
+		pods         []*apiv1.Pod
+
+		unschedulablePods []*apiv1.Pod
+		wantPods          []*apiv1.Pod
+	}{
+		{
+			name: "no nodes, no unschedulable pods",
+		},
+		{
+			name: "no nodes, some unschedulable pods",
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:         "single node undergoing deletion",
+			drainedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name:         "single empty node undergoing deletion",
+			drainedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+		},
+		{
+			name:         "single node undergoing deletion, unschedulable pods",
+			drainedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p3", 300, 1),
+				BuildTestPod("p4", 400, 1),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+				BuildTestPod("p3", 300, 1),
+				BuildTestPod("p4", 400, 1),
+			},
+		},
+		{
+			name: "single ready node",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+		},
+		{
+			name: "single ready node, unschedulable pods",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildScheduledTestPod("p2", 200, 1, "n"),
+			},
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p3", 300, 1),
+				BuildTestPod("p4", 400, 1),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p3", 300, 1),
+				BuildTestPod("p4", 400, 1),
+			},
+		},
+		{
+			name:         "multiple nodes, all undergoing deletion",
+			drainedNodes: []string{"n1", "n2"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				BuildScheduledTestPod("p3", 300, 1, "n2"),
+				BuildScheduledTestPod("p4", 400, 1, "n2"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+				BuildTestPod("p3", 300, 1),
+				BuildTestPod("p4", 400, 1),
+			},
+		},
+		{
+			name:         "multiple nodes, some undergoing deletion",
+			drainedNodes: []string{"n1"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				BuildScheduledTestPod("p3", 300, 1, "n2"),
+				BuildScheduledTestPod("p4", 400, 1, "n2"),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+			},
+		},
+		{
+			name: "multiple nodes, no undergoing deletion",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				BuildScheduledTestPod("p3", 300, 1, "n2"),
+				BuildScheduledTestPod("p4", 400, 1, "n2"),
+			},
+		},
+		{
+			name:         "single node, non-recreatable pods filtered out",
+			drainedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 200, 1, "n"), "rs"),
+				SetDSPodSpec(BuildScheduledTestPod("p3", 300, 1, "n")),
+				SetMirrorPodSpec(BuildScheduledTestPod("p4", 400, 1, "n")),
+				SetStaticPodSpec(BuildScheduledTestPod("p5", 500, 1, "n")),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				SetRSPodSpec(BuildTestPod("p2", 200, 1), "rs"),
+			},
+		},
+		{
+			name: "unschedulable pods, non-recreatable pods not filtered out",
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				SetRSPodSpec(BuildTestPod("p2", 200, 1), "rs"),
+				SetDSPodSpec(BuildTestPod("p3", 300, 1)),
+				SetMirrorPodSpec(BuildTestPod("p4", 400, 1)),
+				SetStaticPodSpec(BuildTestPod("p5", 500, 1)),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				SetRSPodSpec(BuildTestPod("p2", 200, 1), "rs"),
+				SetDSPodSpec(BuildTestPod("p3", 300, 1)),
+				SetMirrorPodSpec(BuildTestPod("p4", 400, 1)),
+				SetStaticPodSpec(BuildTestPod("p5", 500, 1)),
+			},
+		},
+		{
+			name:         "everything works together",
+			drainedNodes: []string{"n1", "n3", "n5"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 1000, 10),
+				BuildTestNode("n4", 1000, 10),
+				BuildTestNode("n5", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n1"),
+				BuildScheduledTestPod("p2", 200, 1, "n1"),
+				SetRSPodSpec(BuildScheduledTestPod("p3", 300, 1, "n1"), "rs"),
+				SetDSPodSpec(BuildScheduledTestPod("p4", 400, 1, "n1")),
+				BuildScheduledTestPod("p5", 500, 1, "n2"),
+				BuildScheduledTestPod("p6", 600, 1, "n2"),
+				BuildScheduledTestPod("p7", 700, 1, "n3"),
+				SetStaticPodSpec(BuildScheduledTestPod("p8", 800, 1, "n3")),
+				SetMirrorPodSpec(BuildScheduledTestPod("p9", 900, 1, "n3")),
+			},
+			unschedulablePods: []*apiv1.Pod{
+				BuildTestPod("p10", 1000, 1),
+				SetMirrorPodSpec(BuildTestPod("p11", 1100, 1)),
+				SetStaticPodSpec(BuildTestPod("p12", 1200, 1)),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+				BuildTestPod("p2", 200, 1),
+				SetRSPodSpec(BuildTestPod("p3", 300, 1), "rs"),
+				BuildTestPod("p7", 700, 1),
+				BuildTestPod("p10", 1000, 1),
+				SetMirrorPodSpec(BuildTestPod("p11", 1100, 1)),
+				SetStaticPodSpec(BuildTestPod("p12", 1200, 1)),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.AutoscalingContext{
+				ScaleDownActuator: &mockActuator{&mockActuationStatus{tc.drainedNodes}},
+				ClusterSnapshot:   clustersnapshot.NewBasicClusterSnapshot(),
+			}
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, ctx.ClusterSnapshot, tc.nodes, tc.pods)
+
+			processor := NewCurrentlyDrainedNodesPodListProcessor()
+			pods, err := processor.Process(&ctx, tc.unschedulablePods)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantPods, pods)
+		})
+	}
+}
+
+type mockActuator struct {
+	status *mockActuationStatus
+}
+
+func (m *mockActuator) StartDeletion(_, _ []*apiv1.Node, _ time.Time) (*status.ScaleDownStatus, errors.AutoscalerError) {
+	return nil, nil
+}
+
+func (m *mockActuator) CheckStatus() scaledown.ActuationStatus {
+	return m.status
+}
+
+func (m *mockActuator) ClearResultsNotNewerThan(time.Time) {
+
+}
+
+type mockActuationStatus struct {
+	drainedNodes []string
+}
+
+func (m *mockActuationStatus) RecentEvictions() []*apiv1.Pod {
+	return nil
+}
+
+func (m *mockActuationStatus) DeletionsInProgress() ([]string, []string) {
+	return nil, m.drainedNodes
+}
+
+func (m *mockActuationStatus) DeletionResults() (map[string]status.NodeDeleteResult, time.Time) {
+	return nil, time.Time{}
+}
+
+func (m *mockActuationStatus) DeletionsCount(_ string) int {
+	return 0
+}

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podlistprocessor

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filteroutschedulable
+package podlistprocessor
 
 import (
 	"sort"
@@ -43,9 +43,7 @@ func NewFilterOutSchedulablePodListProcessor(predicateChecker predicatechecker.P
 }
 
 // Process filters out pods which are schedulable from list of unschedulable pods.
-func (p *filterOutSchedulablePodListProcessor) Process(
-	context *context.AutoscalingContext,
-	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *filterOutSchedulablePodListProcessor) Process(context *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	// We need to check whether pods marked as unschedulable are actually unschedulable.
 	// It's likely we added a new node and the scheduler just haven't managed to put the
 	// pod on in yet. In this situation we don't want to trigger another scale-up.

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filteroutschedulable
+package podlistprocessor
 
 import (
 	"fmt"

--- a/cluster-autoscaler/core/podlistprocessor/pod_list_processor.go
+++ b/cluster-autoscaler/core/podlistprocessor/pod_list_processor.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podlistprocessor
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+type defaultPodListProcessor struct {
+	currentlyDrainedNodes *currentlyDrainedNodesPodListProcessor
+	filterOutSchedulable  *filterOutSchedulablePodListProcessor
+}
+
+// NewDefaultPodListProcessor returns a default implementation of the pod list
+// processor, which wraps and sequentially runs other sub-processors.
+func NewDefaultPodListProcessor(currentlyDrainedNodes *currentlyDrainedNodesPodListProcessor, filterOutSchedulable *filterOutSchedulablePodListProcessor) *defaultPodListProcessor {
+	return &defaultPodListProcessor{
+		currentlyDrainedNodes: currentlyDrainedNodes,
+		filterOutSchedulable:  filterOutSchedulable,
+	}
+}
+
+// Process runs sub-processors sequentially
+func (p *defaultPodListProcessor) Process(ctx *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	unschedulablePods, err := p.currentlyDrainedNodes.Process(ctx, unschedulablePods)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.filterOutSchedulable.Process(ctx, unschedulablePods)
+}
+
+func (p *defaultPodListProcessor) CleanUp() {
+	p.currentlyDrainedNodes.CleanUp()
+	p.filterOutSchedulable.CleanUp()
+}

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package planner
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -34,17 +37,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-
-	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
-
-var rSetLabels = map[string]string{
-	"app": "rs",
-}
 
 func TestUpdateClusterState(t *testing.T) {
 	testCases := []struct {
@@ -54,334 +48,386 @@ func TestUpdateClusterState(t *testing.T) {
 		actuationStatus *fakeActuationStatus
 		eligible        []string
 		wantUnneeded    []string
-		wantErr         bool
 		replicasSets    []*appsv1.ReplicaSet
 	}{
 		{
-			name: "all eligible",
+			name: "empty nodes, all eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
 				BuildTestNode("n2", 1000, 10),
 				BuildTestNode("n3", 1000, 10),
-				BuildTestNode("n4", 1000, 10),
 			},
-			eligible:        []string{"n1", "n2", "n3", "n4"},
 			actuationStatus: &fakeActuationStatus{},
-			wantUnneeded:    []string{"n1", "n2", "n3", "n4"},
+			eligible:        []string{"n1", "n2", "n3"},
+			wantUnneeded:    []string{"n1", "n2", "n3"},
 		},
 		{
-			name: "none eligible",
+			name: "empty nodes, some eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
 				BuildTestNode("n2", 1000, 10),
 				BuildTestNode("n3", 1000, 10),
-				BuildTestNode("n4", 1000, 10),
 			},
-			eligible:        []string{},
 			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{"n1", "n2"},
+		},
+		{
+			name: "empty nodes, none eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 1000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{},
 			wantUnneeded:    []string{},
 		},
 		{
-			name: "some eligible",
+			name: "single utilised node, not eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1"},
+			wantUnneeded:    []string{},
+		},
+		{
+			name: "pods cannot schedule on node undergoing deletion, not eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				nodeUndergoingDeletion("n2", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n1"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1"},
+			wantUnneeded:    []string{},
+		},
+		{
+			name: "pods can schedule on non-eligible node, eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
 				BuildTestNode("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				BuildTestNode("n4", 1000, 10),
 			},
-			eligible:        []string{"n1", "n3"},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n1"), "rs"),
+			},
 			actuationStatus: &fakeActuationStatus{},
-			wantUnneeded:    []string{"n1", "n3"},
+			eligible:        []string{"n1"},
+			wantUnneeded:    []string{"n1"},
 		},
 		{
-			name: "pods from already drained node can schedule elsewhere",
+			name: "pods can schedule on eligible node, eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 2000, 10),
+				BuildTestNode("n2", 1000, 10),
 			},
 			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n1"), "rs"),
 			},
-			eligible: []string{"n1"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2"},
-			},
-			wantUnneeded: []string{},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{"n1"},
 		},
 		{
-			name: "pods from already drained node can't schedule elsewhere",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 2000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
-				scheduledPod("p3", 500, 1, "n2", "rs"),
-			},
-			eligible: []string{"n1"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2"},
-			},
-			wantUnneeded: []string{},
-			wantErr:      true,
-		},
-		{
-			name: "pods from multiple drained nodes can schedule elsewhere",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 2000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 2000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
-				scheduledPod("p4", 500, 1, "n4", "rs"),
-				scheduledPod("p5", 500, 1, "n4", "rs"),
-			},
-			eligible: []string{"n1", "n3"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-			},
-			wantUnneeded: []string{},
-		},
-		{
-			name: "pods from multiple drained nodes can't schedule elsewhere",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 2000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 2000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
-				scheduledPod("p3", 500, 1, "n2", "rs"),
-				scheduledPod("p4", 500, 1, "n4", "rs"),
-				scheduledPod("p5", 500, 1, "n4", "rs"),
-			},
-			eligible: []string{"n1", "n3"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-			},
-			wantUnneeded: []string{},
-			wantErr:      true,
-		},
-		{
-			name: "multiple drained nodes but new candidates found",
+			name: "pods cannot schedule anywhere, not eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 2000, 10),
-				nodeUndergoingDeletion("n2", 2000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 500, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p3", 1000, 1, "n2"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{},
+		},
+		{
+			name: "all pods from multiple nodes can schedule elsewhere, all eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
 				BuildTestNode("n3", 2000, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p3", 500, 1, "n2"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p4", 500, 1, "n2"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{"n1", "n2"},
+		},
+		{
+			name: "some pods from multiple nodes can schedule elsewhere, some eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 2000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p3", 500, 1, "n2"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p4", 500, 1, "n2"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{"n2"},
+		},
+		{
+			name: "no pods from multiple nodes can schedule elsewhere, no eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 500, 10),
+			},
+			pods: []*apiv1.Pod{
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n1"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p3", 500, 1, "n2"), "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p4", 500, 1, "n2"), "rs"),
+			},
+			actuationStatus: &fakeActuationStatus{},
+			eligible:        []string{"n1", "n2"},
+			wantUnneeded:    []string{},
+		},
+		{
+			name: "recently evicted RS pod, not eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				nodeUndergoingDeletion("n2", 2000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n2"), "rs"),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{},
+		},
+		{
+			name: "recently evicted pod without owner, not eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					BuildTestPod("p1", 1000, 1),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{},
+		},
+		{
+			name: "recently evicted static pod, eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				nodeUndergoingDeletion("n2", 2000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetStaticPodSpec(BuildScheduledTestPod("p1", 500, 1, "n2")),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "recently evicted mirror pod, eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				nodeUndergoingDeletion("n2", 2000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetMirrorPodSpec(BuildScheduledTestPod("p1", 500, 1, "n2")),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "recently evicted DS pod, eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				nodeUndergoingDeletion("n2", 2000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetDSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n2")),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "recently evicted pod can schedule on non-eligible node, eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 1000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n3"), "rs"),
+				},
+			},
+			eligible:     []string{"n1"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "recently evicted pod can schedule on eligible node, eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 1000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n3"), "rs"),
+				},
+			},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "recently evicted pod too large to schedule anywhere, all eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 2000, 10),
+			},
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 2000, 1, "n3"), "rs"),
+				},
+			},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{"n1", "n2"},
+		},
+		{
+			name: "all recently evicted pod got rescheduled, all eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 2000, 10),
+			},
+			replicasSets: append(generateReplicaSetWithReplicas("rs1", 2, 2, nil), generateReplicaSets("rs", 5)...),
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n3"), "rs1"),
+					SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n3"), "rs1"),
+				},
+			},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{"n1", "n2"},
+		},
+		{
+			name: "some recently evicted pod got rescheduled, some eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 2000, 10),
+			},
+			replicasSets: append(generateReplicaSetWithReplicas("rs1", 2, 1, nil), generateReplicaSets("rs", 5)...),
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n3"), "rs1"),
+					SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n3"), "rs1"),
+				},
+			},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{"n1"},
+		},
+		{
+			name: "no recently evicted pod got rescheduled, no eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				nodeUndergoingDeletion("n3", 2000, 10),
+			},
+			replicasSets: append(generateReplicaSetWithReplicas("rs1", 2, 0, nil), generateReplicaSets("rs", 5)...),
+			actuationStatus: &fakeActuationStatus{
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n3"), "rs1"),
+					SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n3"), "rs1"),
+				},
+			},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{},
+		},
+		{
+			name: "all scheduled and recently evicted pods can schedule elsewhere, all eligible",
+			nodes: []*apiv1.Node{
+				BuildTestNode("n1", 1000, 10),
+				BuildTestNode("n2", 1000, 10),
+				BuildTestNode("n3", 1000, 10),
 				nodeUndergoingDeletion("n4", 2000, 10),
-				BuildTestNode("n5", 2000, 10),
 			},
 			pods: []*apiv1.Pod{
-				scheduledPod("p1", 400, 1, "n1", "rs"),
-				scheduledPod("p2", 400, 1, "n2", "rs"),
-				scheduledPod("p3", 400, 1, "n3", "rs"),
-				scheduledPod("p4", 400, 1, "n4", "rs"),
-				scheduledPod("p5", 400, 1, "n5", "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p1", 250, 1, "n1"), "rs"),
 			},
-			eligible: []string{"n1", "n3", "n5"},
 			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
+				recentEvictions: []*apiv1.Pod{
+					SetRSPodSpec(BuildScheduledTestPod("p2", 250, 1, "n4"), "rs"),
+					SetRSPodSpec(BuildScheduledTestPod("p3", 250, 1, "n4"), "rs"),
+				},
 			},
-			wantUnneeded: []string{"n1", "n3"},
+			eligible:     []string{"n1", "n2"},
+			wantUnneeded: []string{"n1", "n2"},
 		},
 		{
-			name: "recently evicted pods can schedule elsewhere, node uneeded",
+			name: "some scheduled and recently evicted pods can schedule elsewhere, some eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
 				BuildTestNode("n2", 1000, 10),
 				BuildTestNode("n3", 1000, 10),
+				nodeUndergoingDeletion("n4", 2000, 10),
 			},
 			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p1", 500, 1, "n1"), "rs"),
 			},
-			eligible: []string{"n1", "n2"},
 			actuationStatus: &fakeActuationStatus{
 				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p3", 500, 1, "n4", "rs"),
+					SetRSPodSpec(BuildScheduledTestPod("p2", 500, 1, "n4"), "rs"),
+					SetRSPodSpec(BuildScheduledTestPod("p3", 500, 1, "n4"), "rs"),
 				},
 			},
+			eligible:     []string{"n1", "n2"},
 			wantUnneeded: []string{"n1"},
 		},
 		{
-			name: "recently evicted pods can schedule elsewhere, no unneeded",
+			name: "scheduled and recently evicted pods take all capacity, no eligible",
 			nodes: []*apiv1.Node{
 				BuildTestNode("n1", 1000, 10),
 				BuildTestNode("n2", 1000, 10),
 				BuildTestNode("n3", 1000, 10),
+				nodeUndergoingDeletion("n4", 2000, 10),
 			},
 			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n2", "rs"),
-				scheduledPod("p2", 500, 1, "n2", "rs"),
+				SetRSPodSpec(BuildScheduledTestPod("p1", 1000, 1, "n1"), "rs"),
 			},
-			eligible: []string{"n1", "n2"},
 			actuationStatus: &fakeActuationStatus{
 				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p3", 500, 1, "n4", "rs"),
-					scheduledPod("p4", 500, 1, "n4", "rs"),
-					scheduledPod("p5", 500, 1, "n4", "rs"),
+					SetRSPodSpec(BuildScheduledTestPod("p2", 1000, 1, "n4"), "rs"),
+					SetRSPodSpec(BuildScheduledTestPod("p3", 1000, 1, "n4"), "rs"),
 				},
 			},
+			eligible:     []string{"n1", "n2"},
 			wantUnneeded: []string{},
-		},
-		{
-			name: "recently evicted pods can't schedule elsewhere",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				BuildTestNode("n2", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 500, 1, "n1", "rs"),
-				scheduledPod("p2", 500, 1, "n1", "rs"),
-			},
-			eligible: []string{"n1", "n2"},
-			actuationStatus: &fakeActuationStatus{
-				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p3", 500, 1, "n3", "rs"),
-					scheduledPod("p4", 500, 1, "n3", "rs"),
-					scheduledPod("p5", 500, 1, "n3", "rs"),
-				},
-			},
-			wantUnneeded: []string{},
-			wantErr:      true,
-		},
-		{
-			name: "multiple drained nodes and recent evictions, no unneeded",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 1000, 10),
-				BuildTestNode("n5", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 200, 1, "n1", "rs"),
-				scheduledPod("p2", 200, 1, "n2", "rs"),
-				scheduledPod("p3", 200, 1, "n3", "rs"),
-				scheduledPod("p4", 200, 1, "n4", "rs"),
-				scheduledPod("p5", 200, 1, "n5", "rs"),
-			},
-			eligible: []string{"n1", "n3", "n5"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p6", 600, 1, "n6", "rs"),
-					scheduledPod("p7", 600, 1, "n6", "rs"),
-				},
-			},
-			wantUnneeded: []string{},
-		},
-		{
-			name: "multiple drained nodes and recent evictions, one unneeded",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 1000, 10),
-				BuildTestNode("n5", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 200, 1, "n1", "rs"),
-				scheduledPod("p2", 200, 1, "n2", "rs"),
-				scheduledPod("p3", 200, 1, "n3", "rs"),
-				scheduledPod("p4", 200, 1, "n4", "rs"),
-				scheduledPod("p5", 200, 1, "n5", "rs"),
-			},
-			eligible: []string{"n1", "n3", "n5"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p6", 600, 1, "n6", "rs"),
-				},
-			},
-			wantUnneeded: []string{"n1"},
-		},
-		{
-			name: "multiple drained nodes and recent evictions, replicas rescheduled, two nodes unneeded",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 1000, 10),
-				BuildTestNode("n5", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 200, 1, "n1", "rs"),
-				scheduledPod("p2", 200, 1, "n2", "rs"),
-				scheduledPod("p3", 200, 1, "n3", "rs"),
-				scheduledPod("p4", 200, 1, "n4", "rs"),
-				scheduledPod("p5", 200, 1, "n5", "rs"),
-			},
-			eligible: []string{"n1", "n3", "n5"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p6", 600, 1, "n1", "rs1"),
-					scheduledPod("p7", 600, 1, "n3", "rs1"),
-				},
-			},
-			replicasSets: append(generateReplicaSetWithReplicas("rs1", 2, 2, rSetLabels), generateReplicaSets("rs", 5)...),
-			wantUnneeded: []string{"n1", "n3"},
-		},
-		{
-			name: "multiple drained nodes and recent evictions, some replicas rescheduled, one node unneeded",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 1000, 10),
-				BuildTestNode("n5", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 200, 1, "n1", "rs"),
-				scheduledPod("p2", 200, 1, "n2", "rs"),
-				scheduledPod("p3", 200, 1, "n3", "rs"),
-				scheduledPod("p4", 200, 1, "n4", "rs"),
-				scheduledPod("p5", 200, 1, "n5", "rs"),
-			},
-			eligible: []string{"n1", "n3", "n5"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-				recentEvictions: []*apiv1.Pod{
-					scheduledPod("p6", 600, 1, "n1", "rs1"),
-					scheduledPod("p7", 600, 1, "n3", "rs1"),
-				},
-			},
-			replicasSets: append(generateReplicaSetWithReplicas("rs1", 2, 1, rSetLabels), generateReplicaSets("rs", 5)...),
-			wantUnneeded: []string{"n1"},
-		},
-		{
-			name: "multiple drained nodes and recent evictions, pods belonging to ds",
-			nodes: []*apiv1.Node{
-				BuildTestNode("n1", 1000, 10),
-				nodeUndergoingDeletion("n2", 1000, 10),
-				BuildTestNode("n3", 1000, 10),
-				nodeUndergoingDeletion("n4", 1000, 10),
-				BuildTestNode("n5", 1000, 10),
-			},
-			pods: []*apiv1.Pod{
-				scheduledPod("p1", 200, 1, "n1", "rs"),
-				scheduledPod("p2", 200, 1, "n2", "rs"),
-				scheduledPod("p3", 200, 1, "n3", "rs"),
-				scheduledPod("p4", 200, 1, "n4", "rs"),
-				scheduledPod("p5", 200, 1, "n5", "rs"),
-			},
-			eligible: []string{"n1", "n3", "n5"},
-			actuationStatus: &fakeActuationStatus{
-				currentlyDrained: []string{"n2", "n4"},
-				recentEvictions: []*apiv1.Pod{
-					scheduledDSPod("p6", 600, 1, "n1"),
-					scheduledDSPod("p7", 600, 1, "n3"),
-				},
-			},
-			wantUnneeded: []string{"n1", "n3"},
 		},
 	}
 	for _, tc := range testCases {
@@ -402,19 +448,10 @@ func TestUpdateClusterState(t *testing.T) {
 			p := New(&context, NewTestProcessors(&context), deleteOptions)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(tc.eligible)}
 			// TODO(x13n): test subsets of nodes passed as podDestinations/scaleDownCandidates.
-			aErr := p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, nil, time.Now())
-			if tc.wantErr {
-				assert.Error(t, aErr)
-			} else {
-				assert.NoError(t, aErr)
-			}
+			assert.NoError(t, p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, nil, time.Now()))
 			wantUnneeded := asMap(tc.wantUnneeded)
 			for _, n := range tc.nodes {
-				if wantUnneeded[n.Name] {
-					assert.True(t, p.unneededNodes.Contains(n.Name), n.Name)
-				} else {
-					assert.False(t, p.unneededNodes.Contains(n.Name), n.Name)
-				}
+				assert.Equal(t, wantUnneeded[n.Name], p.unneededNodes.Contains(n.Name), n.Name)
 			}
 		})
 	}
@@ -426,7 +463,7 @@ func generateReplicaSets(name string, replicas int32) []*appsv1.ReplicaSet {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
-				UID:       rSetUID(name),
+				UID:       types.UID(name),
 			},
 			Spec: appsv1.ReplicaSetSpec{
 				Replicas: &replicas,
@@ -436,12 +473,16 @@ func generateReplicaSets(name string, replicas int32) []*appsv1.ReplicaSet {
 }
 
 func generateReplicaSetWithReplicas(name string, specReplicas, statusReplicas int32, labels map[string]string) []*appsv1.ReplicaSet {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["app"] = "rs"
 	return []*appsv1.ReplicaSet{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
-				UID:       rSetUID(name),
+				UID:       types.UID(name),
 			},
 			Spec: appsv1.ReplicaSetSpec{
 				Replicas: &specReplicas,
@@ -454,28 +495,6 @@ func generateReplicaSetWithReplicas(name string, specReplicas, statusReplicas in
 	}
 }
 
-func rSetUID(name string) types.UID {
-	return types.UID(fmt.Sprintf("api/v1/namespaces/default/replicasets/%s", name))
-}
-
-func scheduledDSPod(name string, cpu, memory int64, nodeName string) *apiv1.Pod {
-	p := BuildTestPod(name, cpu, memory)
-	p.OwnerReferences = GenerateOwnerReferences("ds", "DaemonSet", "extensions/v1beta1", "api/v1/namespaces/default/daemonsets/ds")
-	p.Spec.NodeName = nodeName
-	p.Namespace = "default"
-	p.Labels = rSetLabels
-	return p
-}
-
-func scheduledPod(name string, cpu, memory int64, nodeName, rSetName string) *apiv1.Pod {
-	p := BuildTestPod(name, cpu, memory)
-	p.OwnerReferences = GenerateOwnerReferences(rSetName, "ReplicaSet", "extensions/v1beta1", rSetUID(rSetName))
-	p.Spec.NodeName = nodeName
-	p.Namespace = "default"
-	p.Labels = rSetLabels
-	return p
-}
-
 func nodeUndergoingDeletion(name string, cpu, memory int64) *apiv1.Node {
 	n := BuildTestNode(name, cpu, memory)
 	toBeDeletedTaint := apiv1.Taint{Key: deletetaint.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
@@ -484,8 +503,7 @@ func nodeUndergoingDeletion(name string, cpu, memory int64) *apiv1.Node {
 }
 
 type fakeActuationStatus struct {
-	recentEvictions  []*apiv1.Pod
-	currentlyDrained []string
+	recentEvictions []*apiv1.Pod
 }
 
 func (f *fakeActuationStatus) RecentEvictions() []*apiv1.Pod {
@@ -493,7 +511,7 @@ func (f *fakeActuationStatus) RecentEvictions() []*apiv1.Pod {
 }
 
 func (f *fakeActuationStatus) DeletionsInProgress() ([]string, []string) {
-	return nil, f.currentlyDrained
+	return nil, nil
 }
 
 func (f *fakeActuationStatus) DeletionResults() (map[string]status.NodeDeleteResult, time.Time) {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -143,6 +143,15 @@ func (m *onNodeGroupDeleteMock) Delete(id string) error {
 	return args.Error(0)
 }
 
+func setUpScaleDownActuator(ctx *context.AutoscalingContext, options config.AutoscalingOptions) {
+	deleteOptions := simulator.NodeDeleteOptions{
+		SkipNodesWithSystemPods:   options.SkipNodesWithSystemPods,
+		SkipNodesWithLocalStorage: options.SkipNodesWithLocalStorage,
+		MinReplicaCount:           options.MinReplicaCount,
+	}
+	ctx.ScaleDownActuator = actuation.NewActuator(ctx, nil, deletiontracker.NewNodeDeletionTracker(0*time.Second), deleteOptions)
+}
+
 func TestStaticAutoscalerRunOnce(t *testing.T) {
 	readyNodeLister := kubernetes.NewTestNodeLister(nil)
 	allNodeLister := kubernetes.NewTestNodeLister(nil)
@@ -203,6 +212,8 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
+
+	setUpScaleDownActuator(&context, options)
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
@@ -413,6 +424,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
 
+	setUpScaleDownActuator(&context, options)
+
 	processors := NewTestProcessors(&context)
 	processors.NodeGroupManager = nodeGroupManager
 	processors.NodeGroupListProcessor = nodeGroupListProcessor
@@ -555,6 +568,8 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
+
+	setUpScaleDownActuator(&context, options)
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
@@ -710,6 +725,8 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
 
+	setUpScaleDownActuator(&context, options)
+
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
 		nil, nil, nil, nil)
@@ -839,6 +856,8 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
 
+	setUpScaleDownActuator(&context, options)
+
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,
 		nil, nil, nil, nil)
@@ -935,6 +954,8 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
 	assert.NoError(t, err)
+
+	setUpScaleDownActuator(&context, options)
 
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, scheduledPodMock,
 		unschedulablePodMock, podDisruptionBudgetListerMock, daemonSetListerMock,

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/core/filteroutschedulable"
+	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
@@ -135,7 +135,10 @@ func ExtractPodNames(pods []*apiv1.Pod) []string {
 // NewTestProcessors returns a set of simple processors for use in tests.
 func NewTestProcessors(context *context.AutoscalingContext) *processors.AutoscalingProcessors {
 	return &processors.AutoscalingProcessors{
-		PodListProcessor:       filteroutschedulable.NewFilterOutSchedulablePodListProcessor(context.PredicateChecker),
+		PodListProcessor: podlistprocessor.NewDefaultPodListProcessor(
+			podlistprocessor.NewCurrentlyDrainedNodesPodListProcessor(),
+			podlistprocessor.NewFilterOutSchedulablePodListProcessor(context.PredicateChecker),
+		),
 		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{},
 		NodeGroupSetProcessor:  nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}),
 		ScaleDownSetProcessor:  nodes.NewPostFilteringScaleDownNodeProcessor(),

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -41,7 +41,7 @@ import (
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
-	"k8s.io/autoscaler/cluster-autoscaler/core/filteroutschedulable"
+	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -375,7 +375,10 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 
 	opts.Processors = ca_processors.DefaultProcessors()
 	opts.Processors.TemplateNodeInfoProvider = nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nodeInfoCacheExpireTime)
-	opts.Processors.PodListProcessor = filteroutschedulable.NewFilterOutSchedulablePodListProcessor(opts.PredicateChecker)
+	opts.Processors.PodListProcessor = podlistprocessor.NewDefaultPodListProcessor(
+		podlistprocessor.NewCurrentlyDrainedNodesPodListProcessor(),
+		podlistprocessor.NewFilterOutSchedulablePodListProcessor(opts.PredicateChecker),
+	)
 
 	var nodeInfoComparator nodegroupset.NodeInfoComparator
 	if len(autoscalingOptions.BalancingLabels) > 0 {

--- a/cluster-autoscaler/utils/pod/pod.go
+++ b/cluster-autoscaler/utils/pod/pod.go
@@ -60,3 +60,26 @@ func IsStaticPod(pod *apiv1.Pod) bool {
 	}
 	return false
 }
+
+// FilterRecreatablePods filters pods that will be recreated by their controllers
+func FilterRecreatablePods(pods []*apiv1.Pod) []*apiv1.Pod {
+	filtered := make([]*apiv1.Pod, 0, len(pods))
+	for _, p := range pods {
+		if IsStaticPod(p) || IsMirrorPod(p) || IsDaemonSetPod(p) {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}
+
+// ClearPodNodeNames removes node name from pods
+func ClearPodNodeNames(pods []*apiv1.Pod) []*apiv1.Pod {
+	newPods := make([]*apiv1.Pod, 0, len(pods))
+	for _, podPtr := range pods {
+		newPod := *podPtr
+		newPod.Spec.NodeName = ""
+		newPods = append(newPods, &newPod)
+	}
+	return newPods
+}

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kube_types "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // BuildTestPod creates a pod with specified resources.
@@ -100,6 +101,37 @@ func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage in
 		pod.Spec.Containers[0].Resources.Requests[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(ephemeralStorage, resource.DecimalSI)
 	}
 
+	return pod
+}
+
+// BuildScheduledTestPod builds a scheduled test pod with a given spec
+func BuildScheduledTestPod(name string, cpu, memory int64, nodeName string) *apiv1.Pod {
+	p := BuildTestPod(name, cpu, memory)
+	p.Spec.NodeName = nodeName
+	return p
+}
+
+// SetStaticPodSpec sets pod spec to make it a static pod
+func SetStaticPodSpec(pod *apiv1.Pod) *apiv1.Pod {
+	pod.Annotations[kube_types.ConfigSourceAnnotationKey] = kube_types.FileSource
+	return pod
+}
+
+// SetMirrorPodSpec sets pod spec to make it a mirror pod
+func SetMirrorPodSpec(pod *apiv1.Pod) *apiv1.Pod {
+	pod.ObjectMeta.Annotations[kube_types.ConfigMirrorAnnotationKey] = "mirror"
+	return pod
+}
+
+// SetDSPodSpec sets pod spec to make it a DS pod
+func SetDSPodSpec(pod *apiv1.Pod) *apiv1.Pod {
+	pod.OwnerReferences = GenerateOwnerReferences("ds", "DaemonSet", "apps/v1", "api/v1/namespaces/default/daemonsets/ds")
+	return pod
+}
+
+// SetRSPodSpec sets pod spec to make it a RS pod
+func SetRSPodSpec(pod *apiv1.Pod, rsName string) *apiv1.Pod {
+	pod.OwnerReferences = GenerateOwnerReferences(rsName, "ReplicaSet", "extensions/v1beta1", types.UID(rsName))
 	return pod
 }
 


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds pods from nodes undergoing scale-down to unschedulable pods. Thanks to that we can quickly detect if these pods can schedule on exisiting nodes in the cluster and trigger scale-up as needed.

This PR additionally removed similar logic from the scale-down to avoid pod duplication.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
