### PR TITLE
Support policy/v1 for PodSecurityPolicy for v1.21+ 

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.21.0
+version: 9.21.1

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -70,8 +70,11 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if semverCompare "<1.10-0" $kubeTargetVersion -}}
 {{- print "extensions/v1beta1" -}}
+{{- if semverCompare ">1.21-0" $kubeTargetVersion -}}
+{{- print "policy/v1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Remove warning of policy/v1beta1 deprecation
```
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodSecurityPolicy
```

Reference:
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v116
