### PR TITLE
CA - AWS - Update Docs all actions IAM policy

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -47,6 +47,7 @@ should be updated to restrict the resources/add conditionals:
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeLaunchTemplateVersions"
@@ -169,7 +170,7 @@ will find the ASGs that have at least all the given tags. Without the tags, the 
 to the ASG as it has not been discovered. In the example, a value is not given for the tags and in this case any value will be ignored and
 will be arbitrary - only the tag name matters. Optionally, the tag value can be set to be usable and custom tags can also be added. For example,
 `--node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled=foo,k8s.io/cluster-autoscaler/<cluster-name>=bar,my-custom-tag=custom-value`.
-Now the ASG tags must have the correct values as well as the custom tag to be successfully discovered by the Cluster Autoscaler. 
+Now the ASG tags must have the correct values as well as the custom tag to be successfully discovered by the Cluster Autoscaler.
 
 Example deployment:
 
@@ -196,9 +197,9 @@ Policies and Spot Instances](#Using-Mixed-Instances-Policies-and-Spot-Instances)
 for details.
 
 When scaling up from 0 nodes, the Cluster Autoscaler reads ASG tags to derive information about the specifications of the nodes
-i.e labels and taints in that ASG. Note that it does not actually apply these labels or taints - this is done by an AWS generated 
+i.e labels and taints in that ASG. Note that it does not actually apply these labels or taints - this is done by an AWS generated
 user data script. It gives the Cluster Autoscaler information about whether pending pods will be able to be scheduled should a new node
-be spun up for a particular ASG with the asumption the ASG tags accurately reflect the labels/taint actually applied. 
+be spun up for a particular ASG with the asumption the ASG tags accurately reflect the labels/taint actually applied.
 
 The following is only required if scaling up from 0 nodes. The Cluster Autoscaler will require the label tag
 on the ASG should a deployment have a NodeSelector, else no scaling will occur as the Cluster Autoscaler does not realise
@@ -252,8 +253,8 @@ Recommendations:
 - It is recommended to use a second tag like
   `k8s.io/cluster-autoscaler/<cluster-name>` when
   `k8s.io/cluster-autoscaler/enabled` is used across many clusters to prevent
-  ASGs from different clusters having conflicts. 
-  An ASG must contain at least all the tags specified and as such secondary tags can differentiate between different 
+  ASGs from different clusters having conflicts.
+  An ASG must contain at least all the tags specified and as such secondary tags can differentiate between different
   clusters ASGs.
 - To prevent conflicts, do not provide a `--nodes` argument if
   `--node-group-auto-discovery` is specified.
@@ -422,7 +423,7 @@ To refresh static list, please run `go run ec2_instance_types/gen.go` under
 
 ## Using the AWS SDK vendored in the AWS cloudprovider
 
-If you want to use a newer version of the AWS SDK than the version currently vendored as a direct dependency by Cluster Autoscaler, then you can use the version vendored under this AWS cloudprovider. 
+If you want to use a newer version of the AWS SDK than the version currently vendored as a direct dependency by Cluster Autoscaler, then you can use the version vendored under this AWS cloudprovider.
 
 The current version vendored is `v1.44.24`.
 
@@ -443,12 +444,12 @@ If you want to use custom AWS cloud config e.g. endpoint urls
 2. Add the following in your `values.yaml`:
     ```yaml
     cloudConfigPath: config/cloud.conf
-    
+
     extraVolumes:
       - name: cloud-config
         configMap:
           name: cloud-config
-    
+
     extraVolumeMounts:
       - name: cloud-config
         mountPath: config
@@ -461,7 +462,7 @@ Please note: it is also possible to mount the cloud config file from host:
       - name: cloud-config
         hostPath:
           path: /path/to/file/on/host
-    
+
     extraVolumeMounts:
       - name: cloud-config
         mountPath: config/cloud.conf


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
Cluster-autoscaler AWS cloudprovider IAM policy docs - adds an action from the minimal policy to the "all actions" policy. Note that this functionality actually fails silently if not added to the IAM permission so users may be unaware their CA is not using this functionality.

It's also pulled in some unrelated trailing whitespace trimming as I have the chart pre-commit hooks installed.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
