### PR TITLE
Use annotations to set labels and taints for clusterapi nodegroups

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -255,10 +255,22 @@ rules:
 
 #### Pre-defined labels and taints on nodes scaled from zero
 
-The Cluster API provider currently does not support the addition of pre-defined
-labels and taints for node groups that are scaling from zero. This work is on-going
-and will be included in a future release once the API for specifying those
-labels and taints has been accepted by the community.
+To provide labels or taint information for scale from zero, the optional
+capacity annotations may be supplied as a comma separated list, as 
+demonstrated in the example below:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  annotations:
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
+    capacity.cluster-autoscaler.kubernetes.io/memory: "128G"
+    capacity.cluster-autoscaler.kubernetes.io/cpu: "16"
+    capacity.cluster-autoscaler.kubernetes.io/labels: "key1=value1,key2=value2"
+    capacity.cluster-autoscaler.kubernetes.io/taints: "key1=value1:NoSchedule,key2=value2:NoExecute"
+```
 
 ## Specifying a Custom Resource Group
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	klog "k8s.io/klog/v2"
 )
 
@@ -169,15 +170,36 @@ func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructur
 }
 
 func (r unstructuredScalableResource) Labels() map[string]string {
-	// TODO implement this once the community has decided how they will handle labels
-	// this issue is related, https://github.com/kubernetes-sigs/cluster-api/issues/7006
-
+	annotations := r.unstructured.GetAnnotations()
+	// annotation value of the form "key1=value1,key2=value2"
+	if val, found := annotations[labelsKey]; found {
+		labels := strings.Split(val, ",")
+		kv := make(map[string]string, len(labels))
+		for _, label := range labels {
+			split := strings.SplitN(label, "=", 2)
+			if len(split) == 2 {
+				kv[split[0]] = split[1]
+			}
+		}
+		return kv
+	}
 	return nil
 }
 
 func (r unstructuredScalableResource) Taints() []apiv1.Taint {
-	// TODO implement this once the community has decided how they will handle taints
-
+	annotations := r.unstructured.GetAnnotations()
+	// annotation value the form of "key1=value1:condition,key2=value2:condition"
+	if val, found := annotations[taintsKey]; found {
+		taints := strings.Split(val, ",")
+		ret := make([]apiv1.Taint, 0, len(taints))
+		for _, taintStr := range taints {
+			taint, err := parseTaint(taintStr)
+			if err == nil {
+				ret = append(ret, taint)
+			}
+		}
+		return ret
+	}
 	return nil
 }
 
@@ -358,4 +380,45 @@ func resourceCapacityFromInfrastructureObject(infraobj *unstructured.Unstructure
 	}
 
 	return capacity
+}
+
+// adapted from https://github.com/kubernetes/kubernetes/blob/release-1.25/pkg/util/taints/taints.go#L39
+func parseTaint(st string) (apiv1.Taint, error) {
+	var taint apiv1.Taint
+
+	var key string
+	var value string
+	var effect apiv1.TaintEffect
+
+	parts := strings.Split(st, ":")
+	switch len(parts) {
+	case 1:
+		key = parts[0]
+	case 2:
+		effect = apiv1.TaintEffect(parts[1])
+
+		partsKV := strings.Split(parts[0], "=")
+		if len(partsKV) > 2 {
+			return taint, fmt.Errorf("invalid taint spec: %v", st)
+		}
+		key = partsKV[0]
+		if len(partsKV) == 2 {
+			value = partsKV[1]
+			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+				return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+			}
+		}
+	default:
+		return taint, fmt.Errorf("invalid taint spec: %v", st)
+	}
+
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
+	}
+
+	taint.Key = key
+	taint.Value = value
+	taint.Effect = effect
+
+	return taint, nil
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -34,6 +34,8 @@ const (
 	gpuTypeKey      = "capacity.cluster-autoscaler.kubernetes.io/gpu-type"
 	gpuCountKey     = "capacity.cluster-autoscaler.kubernetes.io/gpu-count"
 	maxPodsKey      = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
+	taintsKey       = "capacity.cluster-autoscaler.kubernetes.io/taints"
+	labelsKey       = "capacity.cluster-autoscaler.kubernetes.io/labels"
 )
 
 var (


### PR DESCRIPTION
#### Which component this PR applies to?

cluster-autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Updates the clusterapi provider to use label or taint capacity annotations on MachineDeployments to supply information about the nodegroup shape when the nodegroup replicas are scaled to zero. 

Currently, the clusterapi provider does not support nodegroup shapes with labels or taints and scaling up from zero replicas, which can cause nodegroups to be skipped in evaluation and fail to scale up. This scenario occurs when a pod is created that tolerates the nodegroup's taints and has a node selector that can only be satisfied by those nodegroups. The cluster-autoscaler needs the taint and label information about a nodegroup to correctly match such a pod to the nodegroup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for supplying labels and taints when scaling to and from zero nodes for the cluster autoscaler's Cluster API provider. Enabling this feature will require changes by the user, for instruction please see the Cluster API (clusterapi) provider README file in the autoscaler repository.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
