### PR TITLE
Set MaxNodesTotal to maximum number of nodes in all node groups

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -57,6 +57,8 @@ type AutoscalingContext struct {
 	DebuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	// ScaleDownActuator is the interface for draining and deleting nodes
 	ScaleDownActuator scaledown.Actuator
+	// MaxNodes the maximum number of nodes in the whole cluster when MaxNodesTotal is zero
+	MaxNodes int
 }
 
 // AutoscalingKubeClients contains all Kubernetes API clients,

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -148,10 +148,10 @@ func isNodeGroupResourceExceeded(ctx *context.AutoscalingContext, resourceManage
 }
 
 func getCappedNewNodeCount(context *context.AutoscalingContext, newNodeCount, currentNodeCount int) (int, errors.AutoscalerError) {
-	if context.MaxNodesTotal > 0 && newNodeCount+currentNodeCount > context.MaxNodesTotal {
-		klog.V(1).Infof("Capping size to max cluster total size (%d)", context.MaxNodesTotal)
-		newNodeCount = context.MaxNodesTotal - currentNodeCount
-		context.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached", "Max total nodes in cluster reached: %v", context.MaxNodesTotal)
+	if context.MaxNodes > 0 && newNodeCount+currentNodeCount > context.MaxNodes {
+		klog.V(1).Infof("Capping size to max cluster total size (%d)", context.MaxNodes)
+		newNodeCount = context.MaxNodes - currentNodeCount
+		context.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached", "Max total nodes in cluster reached: %v", context.MaxNodes)
 		if newNodeCount < 1 {
 			return newNodeCount, errors.NewAutoscalerError(errors.TransientError, "max node total count already reached")
 		}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -321,11 +321,14 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		metrics.UpdateNodeGroupMax(nodeGroup.Id(), nodeGroup.MaxSize())
 		maxNodesCount += nodeGroup.MaxSize()
 	}
+
 	if a.MaxNodesTotal > 0 {
-		metrics.UpdateMaxNodesCount(integer.IntMin(a.MaxNodesTotal, maxNodesCount))
+		a.MaxNodesTotal = integer.IntMin(a.MaxNodesTotal, maxNodesCount)
 	} else {
-		metrics.UpdateMaxNodesCount(maxNodesCount)
+		a.MaxNodesTotal = maxNodesCount
 	}
+	metrics.UpdateMaxNodesCount(a.MaxNodesTotal)
+
 	nonExpendableScheduledPods := core_utils.FilterOutExpendablePods(originalScheduledPods, a.ExpendablePodsPriorityCutoff)
 	// Initialize cluster state to ClusterSnapshot
 	if typedErr := a.initializeClusterSnapshot(allNodes, nonExpendableScheduledPods); typedErr != nil {

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -321,14 +321,12 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		metrics.UpdateNodeGroupMax(nodeGroup.Id(), nodeGroup.MaxSize())
 		maxNodesCount += nodeGroup.MaxSize()
 	}
-
 	if a.MaxNodesTotal > 0 {
-		a.MaxNodesTotal = integer.IntMin(a.MaxNodesTotal, maxNodesCount)
+		a.MaxNodes = integer.IntMin(a.MaxNodesTotal, maxNodesCount)
 	} else {
-		a.MaxNodesTotal = maxNodesCount
+		a.MaxNodes = maxNodesCount
 	}
-	metrics.UpdateMaxNodesCount(a.MaxNodesTotal)
-
+	metrics.UpdateMaxNodesCount(a.MaxNodes)
 	nonExpendableScheduledPods := core_utils.FilterOutExpendablePods(originalScheduledPods, a.ExpendablePodsPriorityCutoff)
 	// Initialize cluster state to ClusterSnapshot
 	if typedErr := a.initializeClusterSnapshot(allNodes, nonExpendableScheduledPods); typedErr != nil {
@@ -512,7 +510,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 	if len(unschedulablePodsToHelp) == 0 {
 		scaleUpStatus.Result = status.ScaleUpNotNeeded
 		klog.V(1).Info("No unschedulable pods")
-	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
+	} else if a.MaxNodes > 0 && len(readyNodes) >= a.MaxNodes {
 		scaleUpStatus.Result = status.ScaleUpNoOptionsAvailable
 		klog.V(1).Info("Max total nodes in cluster reached")
 	} else if allPodsAreNew(unschedulablePodsToHelp, currentTime) {


### PR DESCRIPTION
Signed-off-by: yasinlachiny <yourlachiny@gmail.com>

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->
cluster-autoscaler
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
bug
#### What this PR does / why we need it:
static_autoscaler doesn't show 

>  "Max total nodes in cluster reached"

because this [this condition](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/core/static_autoscaler.go#L512) check  `a.MaxNodesTotal > 0` and it's zero by default we also have this condition in other place [like](https://github.com/kubernetes/autoscaler/blob/01389b01e66ae2b3ccedc6781ac2411e3e934cea/cluster-autoscaler/core/scale_up.go#L150). By this PR we can show the proper log when the cluster is full when we haven't set `MaxNodesTotal` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
No
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
