### PR TITLE
Cluster Autoscaler 1.26.1

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.26.0"
+const ClusterAutoscalerVersion = "1.26.1"


### PR DESCRIPTION
Bump CA version for a new 1.26 patch release.