### PR TITLE
Mark VPA KEP 4902 as deprecated in favor of using PDB feature

### DIFF
--- a/vertical-pod-autoscaler/enhancements/4902-delete-oom-pods/README.md
+++ b/vertical-pod-autoscaler/enhancements/4902-delete-oom-pods/README.md
@@ -1,3 +1,7 @@
+**WARNING**
+:warning: We no longer intend to implemnt this KEP. Instead we recommend using
+[Unhealthy Pod Eviction Policy for PDBs](https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/3017-pod-healthy-policy-for-pdb/README.md).
+
 # KEP-4902: Delete OOM Pods
 
 <!-- toc -->


### PR DESCRIPTION
/kind cleanup
/kind documentation
/kind feature
/kind deprecation

Discussed on SIG meeting on 2022-11-21 and 2022-11-21, see [meeting notes](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit#heading=h.bymi5lfbsup2).