### PR TITLE
AWS: don't cache empty instance-types from stale LC names

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -101,8 +101,15 @@ func newASGCache(awsService *awsWrapper, explicitSpecs []string, autoDiscoverySp
 var getInstanceTypeForAsg = func(m *asgCache, group *asg) (string, error) {
 	if obj, found, _ := m.asgInstanceTypeCache.GetByKey(group.AwsRef.Name); found {
 		return obj.(instanceTypeCachedObject).instanceType, nil
-	} else if result, err := m.awsService.getInstanceTypesForAsgs([]*asg{group}); err == nil {
-		return result[group.AwsRef.Name], nil
+	}
+
+	result, err := m.awsService.getInstanceTypesForAsgs([]*asg{group})
+	if err != nil {
+		return "", fmt.Errorf("could not get instance type for %s: %w", group.AwsRef.Name, err)
+	}
+
+	if instanceType, ok := result[group.AwsRef.Name]; ok {
+		return instanceType, nil
 	}
 
 	return "", fmt.Errorf("could not find instance type for %s", group.AwsRef.Name)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -705,9 +705,13 @@ func (m *awsWrapper) getInstanceTypesForAsgs(asgs []*asg) (map[string]string, er
 	}
 
 	for asgName, cfgName := range launchConfigsToQuery {
+		if instanceType, ok := launchConfigs[cfgName]; !ok || instanceType == "" {
+			klog.Warningf("Could not fetch %q launch configuration for ASG %q", cfgName, asgName)
+			continue
+		}
 		results[asgName] = launchConfigs[cfgName]
 	}
-	klog.V(4).Infof("Successfully queried %d launch configurations", len(launchConfigsToQuery))
+	klog.V(4).Infof("Successfully queried %d launch configurations", len(launchConfigs))
 
 	// Have to query LaunchTemplates one-at-a-time, since there's no way to query <lt, version> pairs in bulk
 	for asgName, lt := range launchTemplatesToQuery {


### PR DESCRIPTION
There's a small time window between the moment the cluster's ASG list is refreshed (happens at main loop start, cached for 1mn), and the moment when expired (or new) per ASG instance-types cache entries are fetched again from ASG's LaunchConfigurations.

An ASG's LauchConfiguration might have been replaced during that window; in which case attempts to refresh that ASG instance-type would use the stale -possibly deleted- LC name we got when we last listed ASGs, which is probably acceptable as long as we're converging at next ASG refresh deadline (at most 1mn in the future).

AWS DescribeLaunchConfigurations API would not fail if some of the provided LaunchConfigurationNames are missing from the result set (eg. because it was replaced and deleted after we last refreshed ASGs definitions). That's useful as we cache everything we could retrieve, and we'll get any missing entry once we retry with a refreshed ASG list, avoiding collecting everything again (expansive API calls).

The issue is getInstanceTypesForAsgs() will return entries for each ASGs, irrespective of what it got by calling getInstanceTypeByLaunchConfigNames() (our DescribeLaunchConfigurations wrapper), so we can end up caching empty ("") instance types names. This causes getAsgTemplate failures ('ASG %q uses the unknown EC2 instance type ""') and degenerates to the cluster-autoscaler aborting its main loop cycle for as long as the bogus entries remains in instance-types cache (up to 20mn depending on jitter).

Tested on several large clusters having more than 200 ASGs+LCs attached, where a high LC churn was previously inhibiting all cluster-autoscaler activity for a long time.

Unrelated: updated getInstanceTypeForAsg which was swallowing getInstanceTypesForAsgs error message, to help with diagnostics.

#### What type of PR is this?
/kind bug

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```