### PR TITLE
clusterapi: Add ephemeral disk capacity annotation for scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -183,9 +183,9 @@ you must specify the CPU and memory annotations, these annotations should
 match the expected capacity of the nodes created from the infrastructure.
 
 For example, if my MachineDeployment will create nodes that have "16000m" CPU,
-"128G" memory, 2 NVidia GPUs, and can support 200 max pods, the folllowing
-annotations will instruct the autoscaler how to expand the node group from
-zero replicas:
+"128G" memory, "100Gi" ephemeral disk storage, 2 NVidia GPUs, and can support
+200 max pods, the following annotations will instruct the autoscaler how to
+expand the node group from zero replicas:
 
 ```yaml
 apiVersion: cluster.x-k8s.io/v1alpha4
@@ -196,6 +196,7 @@ metadata:
     cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
     capacity.cluster-autoscaler.kubernetes.io/memory: "128G"
     capacity.cluster-autoscaler.kubernetes.io/cpu: "16"
+    capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk: "100Gi"
     capacity.cluster-autoscaler.kubernetes.io/gpu-type: "nvidia.com/gpu"
     capacity.cluster-autoscaler.kubernetes.io/gpu-count: "2"
     capacity.cluster-autoscaler.kubernetes.io/maxPods: "200"

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -219,6 +219,14 @@ func (r unstructuredScalableResource) InstanceCapacity() (map[corev1.ResourceNam
 		capacityAnnotations[corev1.ResourceMemory] = mem
 	}
 
+	disk, err := r.InstanceEphemeralDiskCapacityAnnotation()
+	if err != nil {
+		return nil, err
+	}
+	if !disk.IsZero() {
+		capacityAnnotations[corev1.ResourceEphemeralStorage] = disk
+	}
+
 	gpuCount, err := r.InstanceGPUCapacityAnnotation()
 	if err != nil {
 		return nil, err
@@ -262,6 +270,10 @@ func (r unstructuredScalableResource) InstanceCapacity() (map[corev1.ResourceNam
 	}
 
 	return capacity, nil
+}
+
+func (r unstructuredScalableResource) InstanceEphemeralDiskCapacityAnnotation() (resource.Quantity, error) {
+	return parseEphemeralDiskCapacity(r.unstructured.GetAnnotations())
 }
 
 func (r unstructuredScalableResource) InstanceCPUCapacityAnnotation() (resource.Quantity, error) {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -284,13 +284,15 @@ func TestSetSizeAndReplicas(t *testing.T) {
 func TestAnnotations(t *testing.T) {
 	cpuQuantity := resource.MustParse("2")
 	memQuantity := resource.MustParse("1024Mi")
+	diskQuantity := resource.MustParse("100Gi")
 	gpuQuantity := resource.MustParse("1")
 	maxPodsQuantity := resource.MustParse("42")
 	annotations := map[string]string{
-		cpuKey:      cpuQuantity.String(),
-		memoryKey:   memQuantity.String(),
-		gpuCountKey: gpuQuantity.String(),
-		maxPodsKey:  maxPodsQuantity.String(),
+		cpuKey:          cpuQuantity.String(),
+		memoryKey:       memQuantity.String(),
+		diskCapacityKey: diskQuantity.String(),
+		gpuCountKey:     gpuQuantity.String(),
+		maxPodsKey:      maxPodsQuantity.String(),
 	}
 
 	test := func(t *testing.T, testConfig *testConfig, testResource *unstructured.Unstructured) {
@@ -312,6 +314,12 @@ func TestAnnotations(t *testing.T) {
 			t.Fatal(err)
 		} else if memQuantity.Cmp(mem) != 0 {
 			t.Errorf("expected %v, got %v", memQuantity, mem)
+		}
+
+		if disk, err := sr.InstanceEphemeralDiskCapacityAnnotation(); err != nil {
+			t.Fatal(err)
+		} else if diskQuantity.Cmp(disk) != 0 {
+			t.Errorf("expected %v, got %v", diskQuantity, disk)
 		}
 
 		if gpu, err := sr.InstanceGPUCapacityAnnotation(); err != nil {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -28,11 +28,12 @@ import (
 )
 
 const (
-	cpuKey      = "capacity.cluster-autoscaler.kubernetes.io/cpu"
-	memoryKey   = "capacity.cluster-autoscaler.kubernetes.io/memory"
-	gpuTypeKey  = "capacity.cluster-autoscaler.kubernetes.io/gpu-type"
-	gpuCountKey = "capacity.cluster-autoscaler.kubernetes.io/gpu-count"
-	maxPodsKey  = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
+	cpuKey          = "capacity.cluster-autoscaler.kubernetes.io/cpu"
+	memoryKey       = "capacity.cluster-autoscaler.kubernetes.io/memory"
+	diskCapacityKey = "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk"
+	gpuTypeKey      = "capacity.cluster-autoscaler.kubernetes.io/gpu-type"
+	gpuCountKey     = "capacity.cluster-autoscaler.kubernetes.io/gpu-count"
+	maxPodsKey      = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
 )
 
 var (
@@ -201,6 +202,10 @@ func parseCPUCapacity(annotations map[string]string) (resource.Quantity, error) 
 
 func parseMemoryCapacity(annotations map[string]string) (resource.Quantity, error) {
 	return parseKey(annotations, memoryKey)
+}
+
+func parseEphemeralDiskCapacity(annotations map[string]string) (resource.Quantity, error) {
+	return parseKey(annotations, diskCapacityKey)
 }
 
 func parseGPUCount(annotations map[string]string) (resource.Quantity, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Updates the clusterapi provider to support an additional capacity annotation for ephemeral disk capacity on MachineDeployments to supply information about the nodegroup shape.

Without an ephemeral disk capacity supplied, workloads that request ephemeral disk will not trigger a scale up of nodegroups with zero replicas as the ephemeral disk capacity defaults to zero bytes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for supplying ephemeral disk capacity when scaling to and from zero nodes for the cluster autoscaler's Cluster API provider. Enabling this feature will require changes by the user, for instruction please see the Cluster API (clusterapi) provider README file in the autoscaler repository.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
