### PR TITLE
clusterapi: track upcoming unprovisioned machines with a temporary providerID to enable detection of exhausted nodegroups

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1292,9 +1292,16 @@ func TestControllerMachineSetNodeNamesWithoutLinkage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	nodeCount := 0
+	for _, node := range nodeNames {
+		if !isPendingMachineProviderID(normalizedProviderString(node.Id)) {
+			nodeCount++
+		}
+	}
+
 	// We removed all linkage - so we should get 0 nodes back.
-	if len(nodeNames) != 0 {
-		t.Fatalf("expected len=0, got len=%v", len(nodeNames))
+	if nodeCount != 0 {
+		t.Fatalf("expected len=0, got len=%v", nodeCount)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Returns a temporary fake provider ID for Machines which have not been fulfilled by the backing cloud provider. Without an ID the nodes confuse the cluster autoscaler, it believes they can fit pods, but it does not account for the node as part of the nodegroup. This change allows the cluster state registry in the cluster autoscaler to correctly track these unprovisioned nodes and detect if they become "long unregistered" and back off the nodegroup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5417

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
