### PR TITLE
feat: wip check only controller ref to decide if a pod is replicated

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/client-go/dynamic"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_record "k8s.io/client-go/tools/record"
 	klog "k8s.io/klog/v2"
@@ -116,9 +117,9 @@ func NewAutoscalingContext(
 }
 
 // NewAutoscalingKubeClients builds AutoscalingKubeClients out of basic client.
-func NewAutoscalingKubeClients(opts config.AutoscalingOptions, kubeClient, eventsKubeClient kube_client.Interface) *AutoscalingKubeClients {
+func NewAutoscalingKubeClients(opts config.AutoscalingOptions, dynamicClient *dynamic.DynamicClient, kubeClient, eventsKubeClient kube_client.Interface) *AutoscalingKubeClients {
 	listerRegistryStopChannel := make(chan struct{})
-	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(kubeClient, listerRegistryStopChannel)
+	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(kubeClient, dynamicClient, listerRegistryStopChannel)
 	kubeEventRecorder := kube_util.CreateEventRecorder(eventsKubeClient, opts.RecordDuplicatedEvents)
 	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap, opts.StatusConfigMapName)
 	if err != nil {

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/client-go/dynamic"
 	kube_client "k8s.io/client-go/kubernetes"
 )
 
@@ -40,6 +41,7 @@ import (
 type AutoscalerOptions struct {
 	config.AutoscalingOptions
 	KubeClient             kube_client.Interface
+	DynamicClient          *dynamic.DynamicClient
 	EventsKubeClient       kube_client.Interface
 	AutoscalingKubeClients *context.AutoscalingKubeClients
 	CloudProvider          cloudprovider.CloudProvider
@@ -88,7 +90,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.Processors = ca_processors.DefaultProcessors()
 	}
 	if opts.AutoscalingKubeClients == nil {
-		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient, opts.EventsKubeClient)
+		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.DynamicClient, opts.KubeClient, opts.EventsKubeClient)
 	}
 	if opts.ClusterSnapshot == nil {
 		opts.ClusterSnapshot = clustersnapshot.NewBasicClusterSnapshot()

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -381,7 +381,8 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	kubeClientConfig.Burst = autoscalingOptions.KubeClientBurst
 	kubeClientConfig.QPS = float32(autoscalingOptions.KubeClientQPS)
 	kubeClient := createKubeClient(kubeClientConfig)
-	dynamicClient := dynamic.NewForConfigOrDie(kubeClientConfig)
+	// re-use kubeClient's REST client
+	dynamicClient := dynamic.New(kubeClient.Discovery().RESTClient())
 
 	eventsKubeClient := createKubeClient(getKubeConfig())
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -54,6 +54,7 @@ import (
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
+	"k8s.io/client-go/dynamic"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -380,6 +381,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	kubeClientConfig.Burst = autoscalingOptions.KubeClientBurst
 	kubeClientConfig.QPS = float32(autoscalingOptions.KubeClientQPS)
 	kubeClient := createKubeClient(kubeClientConfig)
+	dynamicClient := dynamic.NewForConfigOrDie(kubeClientConfig)
 
 	eventsKubeClient := createKubeClient(getKubeConfig())
 
@@ -395,6 +397,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 		EventsKubeClient:     eventsKubeClient,
 		DebuggingSnapshotter: debuggingSnapshotter,
 		PredicateChecker:     predicateChecker,
+		DynamicClient:        dynamicClient,
 	}
 
 	opts.Processors = ca_processors.DefaultProcessors()

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -133,7 +133,7 @@ func GetPodsForDeletionOnNodeDrain(
 			if _, err := l.Get(controllerRef.Name); err == nil {
 				replicated = true
 			} else {
-				return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("%s controller for %s/%s is not available, err: %v", strings.ToLower(refKind), pod.Namespace, pod.Name, err)
+				return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("owner %s for %s/%s is not available, err: %v", refKind, pod.Namespace, pod.Name, err)
 			}
 		}
 

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -131,10 +131,10 @@ func GetPodsForDeletionOnNodeDrain(
 			// The assumption in the code below is that the controllerRef/owner of
 			// a pod resource will always be in the same namespace
 			// TODO: find a better way to handle this
-			l := listers.GenericListerFactory().GetLister(schema.GroupVersionResource{
-				Group:    gv.Group,
-				Version:  gv.Version,
-				Resource: controllerRef.Kind,
+			l := listers.GenericListerFactory().GetLister(schema.GroupVersionKind{
+				Group:   gv.Group,
+				Version: gv.Version,
+				Kind:    controllerRef.Kind,
 			}, pod.GetNamespace())
 
 			if _, err := l.Get(controllerRef.Name); err == nil {

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -83,7 +83,6 @@ func GetPodsForDeletionOnNodeDrain(
 
 	pods = []*apiv1.Pod{}
 	daemonSetPods = []*apiv1.Pod{}
-	checkReferences := listers != nil
 	// filter kube-system PDBs to avoid doing it for every kube-system pod
 	kubeSystemPDBs := make([]*policyv1.PodDisruptionBudget, 0)
 	for _, pdb := range pdbs {

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -121,25 +121,7 @@ func GetPodsForDeletionOnNodeDrain(
 		// so OwnerReference doesn't have its own Namespace field
 		controllerNamespace := pod.Namespace
 
-		if refKind == "ReplicationController" {
-			if checkReferences {
-				rc, err := listers.ReplicationControllerLister().ReplicationControllers(controllerNamespace).Get(controllerRef.Name)
-				// Assume a reason for an error is because the RC is either
-				// gone/missing or that the rc has too few replicas configured.
-				// TODO: replace the minReplica check with pod disruption budget.
-				if err == nil && rc != nil {
-					if rc.Spec.Replicas != nil && *rc.Spec.Replicas < minReplica {
-						return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: MinReplicasReached}, fmt.Errorf("replication controller for %s/%s has too few replicas spec: %d min: %d",
-							pod.Namespace, pod.Name, rc.Spec.Replicas, minReplica)
-					}
-					replicated = true
-				} else {
-					return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("replication controller for %s/%s is not available, err: %v", pod.Namespace, pod.Name, err)
-				}
-			} else {
-				replicated = true
-			}
-		} else if pod_util.IsDaemonSetPod(pod) {
+		if pod_util.IsDaemonSetPod(pod) {
 			isDaemonSetPod = true
 			// don't have listener for other DaemonSet kind
 			// TODO: we should use a generic client for checking the reference.
@@ -150,55 +132,6 @@ func GetPodsForDeletionOnNodeDrain(
 				} else if err != nil {
 					return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: UnexpectedError}, fmt.Errorf("error when trying to get daemonset for %s/%s , err: %v", pod.Namespace, pod.Name, err)
 				}
-			}
-		} else if refKind == "Job" {
-			if checkReferences {
-				job, err := listers.JobLister().Jobs(controllerNamespace).Get(controllerRef.Name)
-
-				// Assume the only reason for an error is because the Job is
-				// gone/missing, not for any other cause.  TODO(mml): something more
-				// sophisticated than this
-				if err == nil && job != nil {
-					replicated = true
-				} else {
-					return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("job for %s/%s is not available: err: %v", pod.Namespace, pod.Name, err)
-				}
-			} else {
-				replicated = true
-			}
-		} else if refKind == "ReplicaSet" {
-			if checkReferences {
-				rs, err := listers.ReplicaSetLister().ReplicaSets(controllerNamespace).Get(controllerRef.Name)
-
-				// Assume the only reason for an error is because the RS is
-				// gone/missing, not for any other cause.  TODO(mml): something more
-				// sophisticated than this
-				if err == nil && rs != nil {
-					if rs.Spec.Replicas != nil && *rs.Spec.Replicas < minReplica {
-						return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: MinReplicasReached}, fmt.Errorf("replication controller for %s/%s has too few replicas spec: %d min: %d",
-							pod.Namespace, pod.Name, rs.Spec.Replicas, minReplica)
-					}
-					replicated = true
-				} else {
-					return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("replication controller for %s/%s is not available, err: %v", pod.Namespace, pod.Name, err)
-				}
-			} else {
-				replicated = true
-			}
-		} else if refKind == "StatefulSet" {
-			if checkReferences {
-				ss, err := listers.StatefulSetLister().StatefulSets(controllerNamespace).Get(controllerRef.Name)
-
-				// Assume the only reason for an error is because the StatefulSet is
-				// gone/missing, not for any other cause.  TODO(mml): something more
-				// sophisticated than this
-				if err == nil && ss != nil {
-					replicated = true
-				} else {
-					return []*apiv1.Pod{}, []*apiv1.Pod{}, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("statefulset for %s/%s is not available: err: %v", pod.Namespace, pod.Name, err)
-				}
-			} else {
-				replicated = true
 			}
 		}
 		if isDaemonSetPod {

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -60,6 +60,8 @@ type ListerRegistry interface {
 	GenericListerFactory() *GenericListerFactory
 }
 
+// GenericListerFactory is a factory for creating
+// listers for a new GVRs identified during runtime
 type GenericListerFactory struct {
 	stopCh        <-chan struct{}
 	listersMap    map[string]dynamiclister.Lister
@@ -82,7 +84,7 @@ type listerRegistryImpl struct {
 	dynamicClient               *dynamic.DynamicClient
 }
 
-// GetDynamicLister returns the lister for a particular GVR
+// GetLister returns the lister for a particular GVR
 func (g *GenericListerFactory) GetLister(gvr schema.GroupVersionResource, namespace string) dynamiclister.Lister {
 	key := fmt.Sprintf("%s_%s_%s_%s", gvr.Group, gvr.Version, gvr.Resource, namespace)
 	if g.listersMap[key] != nil {


### PR DESCRIPTION
**This PR is still WIP. I will mention the reviewers here once I am done. Although it might not be in the best shape as a WIP PR but if the reviewers have any feedback, I would love to have it. :pray:** 

Signed-off-by: vadasambar <surajrbanakar@gmail.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- scale down [is blocked](https://github.com/kubernetes/autoscaler/blob/73d02f1d641a38314e93077d375d80e03468ad60/cluster-autoscaler/utils/drain/drain.go#L210-L211) on the pods where the controller reference is not understood by the CA ([CA as of now only understands controller refs for Daemonsets, ReplicaSets, Jobs, ReplicationControllers, Deployments and StatefulSets](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/utils/drain/drain.go#L124-L203)). This is because CA treats pods with non-understood controller references as non-replicated and hence deems scale-down as not-safe. 
- this PR introduces a change where all pods with ownerReference `controller: true` are treated as replicated and scale-down is not blocked
#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/5387

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
All pods with controller reference of any sort are treated as replicated. This means cluster-autoscaler would not block scale down on these pods unless `cluster-autoscaler.kubernetes.io/safe-to-evict: false` or `cluster-autoscaler.kubernetes.io/daemonset-pod: true` annotation is set on them. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
TBD
```docs

```
