### PR TITLE
cluster-autoscaler: terminating an instance does not mean there will be less desired instances

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -309,9 +309,6 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 				return err
 			}
 			klog.V(4).Infof(*resp.Activity.Description)
-
-			// Proactively decrement the size so autoscaler makes better decisions
-			commonAsg.curSize--
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

while working on https://github.com/kubernetes/autoscaler/pull/5411 to fix https://github.com/kubernetes/autoscaler/issues/4095 I realized that the core bug is that we decrement the currentSize (aka asg desired size) when terminating an instance
... but that's now how aws works, terminating an instance does not decreases the desired size, it only makes a new instance come up

(https://github.com/kubernetes/autoscaler/pull/5411 is still useful since it reduces api call overhead and log spam)

partially reverts https://github.com/kubernetes/autoscaler/pull/1378

/cc @alam0rt  @johanneswuerbach @aleksandra-malinowska

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/4095

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
