### PR TITLE
Rephrase error messages specific for GPUs.

### DIFF
--- a/cluster-autoscaler/core/scaledown/resource/limits.go
+++ b/cluster-autoscaler/core/scaledown/resource/limits.go
@@ -128,7 +128,7 @@ func (lf *LimitsFinder) customResourcesTotal(context *context.AutoscalingContext
 		}
 		nodeGroup, err := context.CloudProvider.NodeGroupForNode(node)
 		if err != nil {
-			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("can not get node group for node %v when calculating cluster gpu usage", node.Name)
+			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get node group for node %v when calculating cluster custom resource usage", node.Name)
 		}
 		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
 			// We do not trust cloud providers to return properly constructed nil for interface type - hence the reflection check.
@@ -146,7 +146,7 @@ func (lf *LimitsFinder) customResourcesTotal(context *context.AutoscalingContext
 		if !cacheHit {
 			resourceTargets, err = lf.crp.GetNodeResourceTargets(context, node, nodeGroup)
 			if err != nil {
-				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("can not get gpu count for node %v when calculating cluster gpu usage")
+				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get custom resource count for node %v when calculating cluster custom resource usage")
 			}
 			if nodeGroup != nil {
 				ngCache[nodeGroup.Id()] = resourceTargets

--- a/cluster-autoscaler/core/scaleup/resource_manager.go
+++ b/cluster-autoscaler/core/scaleup/resource_manager.go
@@ -249,7 +249,7 @@ func (m *ResourceManager) customResourcesTotal(ctx *context.AutoscalingContext, 
 		if currentSize > 0 {
 			resourceTargets, err := m.crp.GetNodeResourceTargets(ctx, nodeInfo.Node(), nodeGroup)
 			if err != nil {
-				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get target gpu for node group %v: ", nodeGroup.Id())
+				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get custom resource target for node group %v: ", nodeGroup.Id())
 			}
 
 			for _, resourceTarget := range resourceTargets {
@@ -264,7 +264,7 @@ func (m *ResourceManager) customResourcesTotal(ctx *context.AutoscalingContext, 
 	for _, node := range nodesFromNotAutoscaledGroups {
 		resourceTargets, err := m.crp.GetNodeResourceTargets(ctx, node, nil)
 		if err != nil {
-			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get target gpu for node gpus count for node %v: ", node.Name)
+			return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get custom resource target for node %v: ", node.Name)
 		}
 
 		for _, resourceTarget := range resourceTargets {


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Some error messages related to custom resources assumes that the custom resource is always GPU. Rephrasing these error messages to clear up any confusion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
