### PR TITLE
OCI OKE autoscaller requires Updated Set of permissions. 

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml
+++ b/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml
@@ -15,6 +15,9 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidriver", "csistoragecapacities"]
+    verbs: ["watch", "list"]
   - apiGroups: [""]
     resources: ["events", "endpoints"]
     verbs: ["create", "patch"]
@@ -25,15 +28,15 @@ rules:
     resources: ["pods/status"]
     verbs: ["update"]
   - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["endpoints"]
     resourceNames: ["cluster-autoscaler"]
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["watch", "list", "get", "update"]
-  - apiGroups: [""]
-    resources: ["namepaces"]
-    verbs: ["list"]
+    verbs: ["watch", "list", "get", "patch", "update"]
   - apiGroups: [""]
     resources:
       - "pods"
@@ -53,10 +56,10 @@ rules:
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
     verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
@@ -64,10 +67,6 @@ rules:
     resourceNames: ["cluster-autoscaler"]
     resources: ["leases"]
     verbs: ["get", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers", "csistoragecapacities"]
-    verbs: ["get", "list"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-principals.yaml
+++ b/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-principals.yaml
@@ -15,6 +15,9 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidriver", "csistoragecapacities"]
+    verbs: ["watch", "list"]
   - apiGroups: [""]
     resources: ["events", "endpoints"]
     verbs: ["create", "patch"]
@@ -25,15 +28,15 @@ rules:
     resources: ["pods/status"]
     verbs: ["update"]
   - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["endpoints"]
     resourceNames: ["cluster-autoscaler"]
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["watch", "list", "get", "update"]
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["list"]
+    verbs: ["watch", "list", "get", "patch", "update"]
   - apiGroups: [""]
     resources:
       - "pods"
@@ -53,10 +56,10 @@ rules:
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
     verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
@@ -64,10 +67,6 @@ rules:
     resourceNames: ["cluster-autoscaler"]
     resources: ["leases"]
     verbs: ["get", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers", "csistoragecapacities"]
-    verbs: ["get", "list"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
OCI OKE auto scaler requires an updated set of permissions. 

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

This PR changes the default permissions needed to run OCI OKE auto scaler examples. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
