### PR TITLE
Re-sort on root level, add `hostNetwork` parameter

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.25.0
+version: 9.26.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -2,20 +2,20 @@
 
 Scales Kubernetes worker nodes within autoscaling groups.
 
-## TL;DR:
+## TL;DR
 
 ```console
 $ helm repo add autoscaler https://kubernetes.github.io/autoscaler
 
 # Method 1 - Using Autodiscovery
 $ helm install my-release autoscaler/cluster-autoscaler \
---set 'autoDiscovery.clusterName'=<CLUSTER NAME>
+    --set 'autoDiscovery.clusterName'=<CLUSTER NAME>
 
 # Method 2 - Specifying groups manually
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroups[0].name=your-asg-name" \
---set "autoscalingGroups[0].maxSize=10" \
---set "autoscalingGroups[0].minSize=1"
+    --set "autoscalingGroups[0].name=your-asg-name" \
+    --set "autoscalingGroups[0].maxSize=10" \
+    --set "autoscalingGroups[0].minSize=1"
 ```
 
 ## Introduction
@@ -68,10 +68,10 @@ Either:
 
 To create a valid configuration, follow instructions for your cloud provider:
 
-* [AWS](#aws---using-auto-discovery-of-tagged-instance-groups)
-* [GCE](#gce)
-* [Azure AKS](#azure-aks)
-* [OpenStack Magnum](#openstack-magnum)
+- [AWS](#aws---using-auto-discovery-of-tagged-instance-groups)
+- [GCE](#gce)
+- [Azure AKS](#azure-aks)
+- [OpenStack Magnum](#openstack-magnum)
 
 ### AWS - Using auto-discovery of tagged instance groups
 
@@ -84,13 +84,19 @@ Auto-discovery finds ASGs tags as below and automatically manages them based on 
 - Set (option) `awsAccessKeyID=<YOUR AWS KEY ID>` and `awsSecretAccessKey=<YOUR AWS SECRET KEY>` if you want to [use AWS credentials directly instead of an instance role](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials)
 
 ```console
-$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION>
+$ helm install my-release autoscaler/cluster-autoscaler \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set awsRegion=<YOUR AWS REGION>
 ```
 
 Alternatively with your own AWS credentials
 
 ```console
-$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION> --set awsAccessKeyID=<YOUR AWS KEY ID> --set awsSecretAccessKey=<YOUR AWS SECRET KEY>
+$ helm install my-release autoscaler/cluster-autoscaler \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set awsRegion=<YOUR AWS REGION> \
+    --set awsAccessKeyID=<YOUR AWS KEY ID> \
+    --set awsSecretAccessKey=<YOUR AWS SECRET KEY>
 ```
 
 #### Specifying groups manually
@@ -102,15 +108,14 @@ Without autodiscovery, specify an array of elements each containing ASG name, mi
 
 ```console
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroups[0].name=your-asg-name" \
---set "autoscalingGroups[0].maxSize=10" \
---set "autoscalingGroups[0].minSize=1"
+    --set "autoscalingGroups[0].name=your-asg-name" \
+    --set "autoscalingGroups[0].maxSize=10" \
+    --set "autoscalingGroups[0].minSize=1"
 ```
 
 #### Auto-discovery
 
-For auto-discovery of instances to work, they must be tagged with the keys in `.Values.autoDiscovery.tags`, which by default are
-`k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster-autoscaler/<ClusterName>`
+For auto-discovery of instances to work, they must be tagged with the keys in `.Values.autoDiscovery.tags`, which by default are `k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster-autoscaler/<ClusterName>`.
 
 The value of the tag does not matter, only the key.
 
@@ -147,7 +152,7 @@ spec:
 
 In this example you would need to `--set autoDiscovery.clusterName=my.cluster.internal` when installing.
 
-It is not recommended to try to mix this with setting `autoscalingGroups`
+It is not recommended to try to mix this with setting `autoscalingGroups`.
 
 See [autoscaler AWS documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup) for a more discussion of the setup.
 
@@ -163,9 +168,9 @@ To use Managed Instance Group (MIG) auto-discovery, provide a YAML file setting 
 
 ```console
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroupsnamePrefix[0].name=your-ig-prefix,autoscalingGroupsnamePrefix[0].maxSize=10,autoscalingGroupsnamePrefi[0].minSize=1" \
---set autoDiscovery.clusterName=<CLUSTER NAME> \
---set cloudProvider=gce
+    --set "autoscalingGroupsnamePrefix[0].name=your-ig-prefix,autoscalingGroupsnamePrefix[0].maxSize=10,autoscalingGroupsnamePrefi[0].minSize=1" \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set cloudProvider=gce
 ```
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
@@ -174,7 +179,7 @@ In the event you want to explicitly specify MIGs instead of using auto-discovery
 
 ```
 # where 'n' is the index, starting at 0
--- set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
+--set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
 ```
 
 ### Azure AKS
@@ -199,28 +204,31 @@ The following parameters are required:
 - `magnumClusterName=<cluster name or ID>` and `autoscalingGroups` with the names of node groups and min/max node counts
 - or `autoDiscovery.clusterName=<cluster name or ID>` with one or more `autoDiscovery.roles`.
 
-Additionally, `cloudConfigPath: "/etc/kubernetes/cloud-config"` must be set as this should be the location
-of the cloud-config file on the host.
+Additionally, `cloudConfigPath: "/etc/kubernetes/cloud-config"` must be set as this should be the location of the cloud-config file on the host.
 
 Example values files can be found [here](../../cluster-autoscaler/cloudprovider/magnum/examples).
 
 Install the chart with
 
-```
+```console
 $ helm install my-release autoscaler/cluster-autoscaler -f myvalues.yaml
 ```
+
 ### Cluster-API
 
 `cloudProvider: clusterapi` must be set, and then one or more of
+
 - `autoDiscovery.clusterName`
 - or `autoDiscovery.labels`
-See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details
+
+See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
 
 Additional config parameters available, see the `values.yaml` for more details
-`clusterAPIMode`
-`clusterAPIKubeconfigSecret`
-`clusterAPIWorkloadKubeconfigPath`
-`clusterAPICloudConfigPath`
+
+- `clusterAPIMode`
+- `clusterAPIKubeconfigSecret`
+- `clusterAPIWorkloadKubeconfigPath`
+- `clusterAPICloudConfigPath`
 
 ## Uninstalling the Chart
 
@@ -253,7 +261,9 @@ Once you have the IAM role configured, you would then need to `--set rbac.servic
 ### Azure - Using azure workload identity
 
 You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to used federated identity with Azure.
+
 You can also set the correct settings yourself instead of relying on this project.
+
 For example the following configuration will configure the Autoscaler to use your federated identity:
 
 ```yaml
@@ -280,8 +290,7 @@ extraVolumeMounts:
 
 ## Troubleshooting
 
-The chart will succeed even if the container arguments are incorrect. A few minutes after starting
-`kubectl logs -l "app=aws-cluster-autoscaler" --tail=50` should loop through something like
+The chart will succeed even if the container arguments are incorrect. A few minutes after starting `kubectl logs -l "app=aws-cluster-autoscaler" --tail=50` should loop through something like
 
 ```
 polling_autoscaler.go:111] Poll finished
@@ -355,6 +364,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | extraVolumeSecrets | object | `{}` | Additional volumes to mount from Secrets. |
 | extraVolumes | list | `[]` | Additional volumes. |
 | fullnameOverride | string | `""` | String to fully override `cluster-autoscaler.fullname` template. |
+| hostNetwork | bool | `false` | Whether to expose network interfaces of the host machine to pods. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"registry.k8s.io/autoscaling/cluster-autoscaler"` | Image repository |

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -2,20 +2,20 @@
 
 {{ template "chart.description" . }}
 
-## TL;DR:
+## TL;DR
 
 ```console
 $ helm repo add autoscaler https://kubernetes.github.io/autoscaler
 
 # Method 1 - Using Autodiscovery
 $ helm install my-release autoscaler/cluster-autoscaler \
---set 'autoDiscovery.clusterName'=<CLUSTER NAME>
+    --set 'autoDiscovery.clusterName'=<CLUSTER NAME>
 
 # Method 2 - Specifying groups manually
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroups[0].name=your-asg-name" \
---set "autoscalingGroups[0].maxSize=10" \
---set "autoscalingGroups[0].minSize=1"
+    --set "autoscalingGroups[0].name=your-asg-name" \
+    --set "autoscalingGroups[0].maxSize=10" \
+    --set "autoscalingGroups[0].minSize=1"
 ```
 
 ## Introduction
@@ -68,10 +68,10 @@ Either:
 
 To create a valid configuration, follow instructions for your cloud provider:
 
-* [AWS](#aws---using-auto-discovery-of-tagged-instance-groups)
-* [GCE](#gce)
-* [Azure AKS](#azure-aks)
-* [OpenStack Magnum](#openstack-magnum)
+- [AWS](#aws---using-auto-discovery-of-tagged-instance-groups)
+- [GCE](#gce)
+- [Azure AKS](#azure-aks)
+- [OpenStack Magnum](#openstack-magnum)
 
 ### AWS - Using auto-discovery of tagged instance groups
 
@@ -84,13 +84,19 @@ Auto-discovery finds ASGs tags as below and automatically manages them based on 
 - Set (option) `awsAccessKeyID=<YOUR AWS KEY ID>` and `awsSecretAccessKey=<YOUR AWS SECRET KEY>` if you want to [use AWS credentials directly instead of an instance role](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-aws-credentials)
 
 ```console
-$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION>
+$ helm install my-release autoscaler/cluster-autoscaler \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set awsRegion=<YOUR AWS REGION>
 ```
 
 Alternatively with your own AWS credentials
 
 ```console
-$ helm install my-release autoscaler/cluster-autoscaler --set autoDiscovery.clusterName=<CLUSTER NAME> --set awsRegion=<YOUR AWS REGION> --set awsAccessKeyID=<YOUR AWS KEY ID> --set awsSecretAccessKey=<YOUR AWS SECRET KEY>
+$ helm install my-release autoscaler/cluster-autoscaler \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set awsRegion=<YOUR AWS REGION> \
+    --set awsAccessKeyID=<YOUR AWS KEY ID> \
+    --set awsSecretAccessKey=<YOUR AWS SECRET KEY>
 ```
 
 #### Specifying groups manually
@@ -102,15 +108,14 @@ Without autodiscovery, specify an array of elements each containing ASG name, mi
 
 ```console
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroups[0].name=your-asg-name" \
---set "autoscalingGroups[0].maxSize=10" \
---set "autoscalingGroups[0].minSize=1"
+    --set "autoscalingGroups[0].name=your-asg-name" \
+    --set "autoscalingGroups[0].maxSize=10" \
+    --set "autoscalingGroups[0].minSize=1"
 ```
 
 #### Auto-discovery
 
-For auto-discovery of instances to work, they must be tagged with the keys in `.Values.autoDiscovery.tags`, which by default are
-`k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster-autoscaler/<ClusterName>`
+For auto-discovery of instances to work, they must be tagged with the keys in `.Values.autoDiscovery.tags`, which by default are `k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster-autoscaler/<ClusterName>`.
 
 The value of the tag does not matter, only the key.
 
@@ -147,7 +152,7 @@ spec:
 
 In this example you would need to `--set autoDiscovery.clusterName=my.cluster.internal` when installing.
 
-It is not recommended to try to mix this with setting `autoscalingGroups`
+It is not recommended to try to mix this with setting `autoscalingGroups`.
 
 See [autoscaler AWS documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup) for a more discussion of the setup.
 
@@ -163,9 +168,9 @@ To use Managed Instance Group (MIG) auto-discovery, provide a YAML file setting 
 
 ```console
 $ helm install my-release autoscaler/cluster-autoscaler \
---set "autoscalingGroupsnamePrefix[0].name=your-ig-prefix,autoscalingGroupsnamePrefix[0].maxSize=10,autoscalingGroupsnamePrefi[0].minSize=1" \
---set autoDiscovery.clusterName=<CLUSTER NAME> \
---set cloudProvider=gce
+    --set "autoscalingGroupsnamePrefix[0].name=your-ig-prefix,autoscalingGroupsnamePrefix[0].maxSize=10,autoscalingGroupsnamePrefi[0].minSize=1" \
+    --set autoDiscovery.clusterName=<CLUSTER NAME> \
+    --set cloudProvider=gce
 ```
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
@@ -174,7 +179,7 @@ In the event you want to explicitly specify MIGs instead of using auto-discovery
 
 ```
 # where 'n' is the index, starting at 0
--- set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
+--set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
 ```
 
 ### Azure AKS
@@ -199,29 +204,31 @@ The following parameters are required:
 - `magnumClusterName=<cluster name or ID>` and `autoscalingGroups` with the names of node groups and min/max node counts
 - or `autoDiscovery.clusterName=<cluster name or ID>` with one or more `autoDiscovery.roles`.
 
-Additionally, `cloudConfigPath: "/etc/kubernetes/cloud-config"` must be set as this should be the location
-of the cloud-config file on the host.
+Additionally, `cloudConfigPath: "/etc/kubernetes/cloud-config"` must be set as this should be the location of the cloud-config file on the host.
 
 Example values files can be found [here](../../cluster-autoscaler/cloudprovider/magnum/examples).
 
 Install the chart with
 
-```
+```console
 $ helm install my-release autoscaler/cluster-autoscaler -f myvalues.yaml
 ```
+
 ### Cluster-API
 
 `cloudProvider: clusterapi` must be set, and then one or more of
+
 - `autoDiscovery.clusterName`
 - or `autoDiscovery.labels`
-See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details
 
+See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
 
 Additional config parameters available, see the `values.yaml` for more details
-`clusterAPIMode`
-`clusterAPIKubeconfigSecret`
-`clusterAPIWorkloadKubeconfigPath`
-`clusterAPICloudConfigPath`
+
+- `clusterAPIMode`
+- `clusterAPIKubeconfigSecret`
+- `clusterAPIWorkloadKubeconfigPath`
+- `clusterAPICloudConfigPath`
 
 ## Uninstalling the Chart
 
@@ -254,7 +261,9 @@ Once you have the IAM role configured, you would then need to `--set rbac.servic
 ### Azure - Using azure workload identity
 
 You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to used federated identity with Azure.
+
 You can also set the correct settings yourself instead of relying on this project.
+
 For example the following configuration will configure the Autoscaler to use your federated identity:
 
 ```yaml
@@ -281,8 +290,7 @@ extraVolumeMounts:
 
 ## Troubleshooting
 
-The chart will succeed even if the container arguments are incorrect. A few minutes after starting
-`kubectl logs -l "app=aws-cluster-autoscaler" --tail=50` should loop through something like
+The chart will succeed even if the container arguments are incorrect. A few minutes after starting `kubectl logs -l "app=aws-cluster-autoscaler" --tail=50` should loop through something like
 
 ```
 polling_autoscaler.go:111] Poll finished

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: "{{ .Values.dnsPolicy }}"
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       containers:
         - name: {{ template "cluster-autoscaler.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/cluster-autoscaler/templates/podsecuritypolicy.yaml
+++ b/charts/cluster-autoscaler/templates/podsecuritypolicy.yaml
@@ -19,7 +19,7 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'downwardAPI'
-  hostNetwork: false
+  hostNetwork: {{ .Values.hostNetwork }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -2,6 +2,9 @@
 # affinity -- Affinity for pod assignment
 affinity: {}
 
+# additionalLabels -- Labels to add to each object of the chart.
+additionalLabels: {}
+
 autoDiscovery:
   # cloudProviders `aws`, `gce`, `azure`, `magnum` and `clusterapi` `oci-oke` are supported by auto-discovery at this time
   # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
@@ -72,6 +75,14 @@ azureClientID: ""
 # Required if `cloudProvider=azure`
 azureClientSecret: ""
 
+# azureClusterName -- Azure AKS cluster name.
+# Required if `cloudProvider=azure`
+azureClusterName: ""
+
+# azureNodeResourceGroup -- Azure resource group where the cluster's nodes are located, typically set as `MC_<cluster-resource-group-name>_<cluster-name>_<location>`.
+# Required if `cloudProvider=azure`
+azureNodeResourceGroup: ""
+
 # azureResourceGroup -- Azure resource group that the cluster is located.
 # Required if `cloudProvider=azure`
 azureResourceGroup: ""
@@ -84,48 +95,14 @@ azureSubscriptionID: ""
 # Required if `cloudProvider=azure`
 azureTenantID: ""
 
-# azureVMType -- Azure VM type.
-azureVMType: "AKS"
-
-# azureClusterName -- Azure AKS cluster name.
-# Required if `cloudProvider=azure`
-azureClusterName: ""
-
-# azureNodeResourceGroup -- Azure resource group where the cluster's nodes are located, typically set as `MC_<cluster-resource-group-name>_<cluster-name>_<location>`.
-# Required if `cloudProvider=azure`
-azureNodeResourceGroup: ""
+# azureUseManagedIdentityExtension -- Whether to use Azure's managed identity extension for credentials. If using MSI, ensure subscription ID, resource group, and azure AKS cluster name are set. You can only use one authentication method at a time, either azureUseWorkloadIdentityExtension or azureUseManagedIdentityExtension should be set.
+azureUseManagedIdentityExtension: false
 
 # azureUseWorkloadIdentityExtension -- Whether to use Azure's workload identity extension for credentials. See the project here: https://github.com/Azure/azure-workload-identity for more details. You can only use one authentication method at a time, either azureUseWorkloadIdentityExtension or azureUseManagedIdentityExtension should be set.
 azureUseWorkloadIdentityExtension: false
 
-# azureUseManagedIdentityExtension -- Whether to use Azure's managed identity extension for credentials. If using MSI, ensure subscription ID, resource group, and azure AKS cluster name are set. You can only use one authentication method at a time, either azureUseWorkloadIdentityExtension or azureUseManagedIdentityExtension should be set.
-azureUseManagedIdentityExtension: false
-
-# magnumClusterName -- Cluster name or ID in Magnum.
-# Required if `cloudProvider=magnum` and not setting `autoDiscovery.clusterName`.
-magnumClusterName: ""
-
-# magnumCABundlePath -- Path to the host's CA bundle, from `ca-file` in the cloud-config file.
-magnumCABundlePath: "/etc/kubernetes/ca-bundle.crt"
-
-# clusterAPIMode --  Cluster API mode, see https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters
-# Syntax: workloadClusterMode-ManagementClusterMode
-# for `kubeconfig-kubeconfig`, `incluster-kubeconfig` and `single-kubeconfig` you always must mount the external kubeconfig using either `extraVolumeSecrets` or `extraMounts` and `extraVolumes`
-# if you dont set `clusterAPIKubeconfigSecret`and thus use an in-cluster config or want to use a non capi generated kubeconfig you must do so for the workload kubeconfig as well
-clusterAPIMode: incluster-incluster  # incluster-incluster, incluster-kubeconfig, kubeconfig-incluster, kubeconfig-kubeconfig, single-kubeconfig
-
-# clusterAPIKubeconfigSecret -- Secret containing kubeconfig for connecting to Cluster API managed workloadcluster
-# Required if `cloudProvider=clusterapi` and `clusterAPIMode=kubeconfig-kubeconfig,kubeconfig-incluster or incluster-kubeconfig`
-clusterAPIKubeconfigSecret: ""
-
-# clusterAPIWorkloadKubeconfigPath -- Path to kubeconfig for connecting to Cluster API managed workloadcluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or kubeconfig-incluster`
-clusterAPIWorkloadKubeconfigPath: /etc/kubernetes/value
-
-# clusterAPICloudConfigPath -- Path to kubeconfig for connecting to Cluster API Management Cluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or incluster-kubeconfig`
-clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
-
-# clusterAPIConfigMapsNamespace -- Namespace on the workload cluster to store Leader election and status configmaps
-clusterAPIConfigMapsNamespace: ""
+# azureVMType -- Azure VM type.
+azureVMType: "AKS"
 
 # cloudConfigPath -- Configuration file for cloud provider.
 cloudConfigPath: ""
@@ -135,6 +112,25 @@ cloudConfigPath: ""
 # `aws` supported for AWS. `gce` for GCE. `azure` for Azure AKS.
 # `magnum` for OpenStack Magnum, `clusterapi` for Cluster API.
 cloudProvider: aws
+
+# clusterAPICloudConfigPath -- Path to kubeconfig for connecting to Cluster API Management Cluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or incluster-kubeconfig`
+clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
+
+# clusterAPIConfigMapsNamespace -- Namespace on the workload cluster to store Leader election and status configmaps
+clusterAPIConfigMapsNamespace: ""
+
+# clusterAPIKubeconfigSecret -- Secret containing kubeconfig for connecting to Cluster API managed workloadcluster
+# Required if `cloudProvider=clusterapi` and `clusterAPIMode=kubeconfig-kubeconfig,kubeconfig-incluster or incluster-kubeconfig`
+clusterAPIKubeconfigSecret: ""
+
+# clusterAPIMode --  Cluster API mode, see https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters
+# Syntax: workloadClusterMode-ManagementClusterMode
+# for `kubeconfig-kubeconfig`, `incluster-kubeconfig` and `single-kubeconfig` you always must mount the external kubeconfig using either `extraVolumeSecrets` or `extraMounts` and `extraVolumes`
+# if you dont set `clusterAPIKubeconfigSecret`and thus use an in-cluster config or want to use a non capi generated kubeconfig you must do so for the workload kubeconfig as well
+clusterAPIMode: incluster-incluster  # incluster-incluster, incluster-kubeconfig, kubeconfig-incluster, kubeconfig-kubeconfig, single-kubeconfig
+
+# clusterAPIWorkloadKubeconfigPath -- Path to kubeconfig for connecting to Cluster API managed workloadcluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or kubeconfig-incluster`
+clusterAPIWorkloadKubeconfigPath: /etc/kubernetes/value
 
 # containerSecurityContext -- [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 containerSecurityContext: {}
@@ -151,16 +147,17 @@ deployment:
 # If autoscaler does not depend on cluster DNS, recommended to set this to `Default`.
 dnsPolicy: ClusterFirst
 
+# envFromConfigMap -- ConfigMap name to use as envFrom.
+envFromConfigMap: ""
+
+# envFromSecret -- Secret name to use as envFrom.
+envFromSecret: ""
+
 ## Priorities Expander
 # expanderPriorities -- The expanderPriorities is used if `extraArgs.expander` contains `priority` and expanderPriorities is also set with the priorities.
 # If `extraArgs.expander` contains `priority`, then expanderPriorities is used to define cluster-autoscaler-priority-expander priorities.
 # See: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md
 expanderPriorities: {}
-
-# priorityConfigMapAnnotations -- Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap.
-priorityConfigMapAnnotations: {}
-  # key1: "value1"
-  # key2: "value2"
 
 # extraArgs -- Additional container arguments.
 # Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler
@@ -200,11 +197,17 @@ extraEnvConfigMaps: {}
 # extraEnvSecrets -- Additional container environment variables from Secrets.
 extraEnvSecrets: {}
 
-# envFromConfigMap -- ConfigMap name to use as envFrom.
-envFromConfigMap: ""
+# extraVolumeMounts -- Additional volumes to mount.
+extraVolumeMounts: []
+  # - name: ssl-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+  #   readOnly: true
 
-# envFromSecret -- Secret name to use as envFrom.
-envFromSecret: ""
+# extraVolumes -- Additional volumes.
+extraVolumes: []
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
 
 # extraVolumeSecrets -- Additional volumes to mount from Secrets.
 extraVolumeSecrets: {}
@@ -217,20 +220,11 @@ extraVolumeSecrets: {}
   #     - key: subkey
   #       path: mypath
 
-# extraVolumes -- Additional volumes.
-extraVolumes: []
-  # - name: ssl-certs
-  #   hostPath:
-  #     path: /etc/ssl/certs/ca-bundle.crt
-
-# extraVolumeMounts -- Additional volumes to mount.
-extraVolumeMounts: []
-  # - name: ssl-certs
-  #   mountPath: /etc/ssl/certs/ca-certificates.crt
-  #   readOnly: true
-
 # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
 fullnameOverride: ""
+
+# hostNetwork -- Whether to expose network interfaces of the host machine to pods.
+hostNetwork: false
 
 image:
   # image.repository -- Image repository
@@ -250,6 +244,13 @@ image:
 # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
 kubeTargetVersionOverride: ""
 
+# magnumCABundlePath -- Path to the host's CA bundle, from `ca-file` in the cloud-config file.
+magnumCABundlePath: "/etc/kubernetes/ca-bundle.crt"
+
+# magnumClusterName -- Cluster name or ID in Magnum.
+# Required if `cloudProvider=magnum` and not setting `autoDiscovery.clusterName`.
+magnumClusterName: ""
+
 # nameOverride -- String to partially override `cluster-autoscaler.fullname` template (will maintain the release name)
 nameOverride: ""
 
@@ -267,11 +268,28 @@ podDisruptionBudget:
 # podLabels -- Labels to add to each pod.
 podLabels: {}
 
-# additionalLabels -- Labels to add to each object of the chart.
-additionalLabels: {}
-
 # priorityClassName -- priorityClassName
 priorityClassName: "system-cluster-critical"
+
+# priorityConfigMapAnnotations -- Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap.
+priorityConfigMapAnnotations: {}
+  # key1: "value1"
+  # key2: "value2"
+
+## Custom PrometheusRule to be defined
+## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  # prometheusRule.enabled -- If true, creates a Prometheus Operator PrometheusRule.
+  enabled: false
+  # prometheusRule.additionalLabels -- Additional labels to be set in metadata.
+  additionalLabels: {}
+  # prometheusRule.namespace -- Namespace which Prometheus is running in.
+  namespace: monitoring
+  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
+  interval: null
+  # prometheusRule.rules -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
+  rules: []
 
 rbac:
   # rbac.create -- If `true`, create and use RBAC resources.
@@ -350,21 +368,6 @@ serviceMonitor:
   ## [RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig)
   # serviceMonitor.metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion.
   metricRelabelings: {}
-
-## Custom PrometheusRule to be defined
-## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
-prometheusRule:
-  # prometheusRule.enabled -- If true, creates a Prometheus Operator PrometheusRule.
-  enabled: false
-  # prometheusRule.additionalLabels -- Additional labels to be set in metadata.
-  additionalLabels: {}
-  # prometheusRule.namespace -- Namespace which Prometheus is running in.
-  namespace: monitoring
-  # prometheusRule.interval -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
-  interval: null
-  # prometheusRule.rules -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
-  rules: []
 
 # tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
 tolerations: []


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds the ability to configure the `hostNetwork` setting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Some context about `hostNetwork` is taken from here: https://alesnosek.com/blog/2017/02/14/accessing-kubernetes-pods-from-outside-of-the-cluster/

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `hostNetwork` parameter
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
