### PR TITLE
Fix scaledown:nodedeletion metric calculation

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -269,7 +269,7 @@ type mockActuator struct {
 	status *mockActuationStatus
 }
 
-func (m *mockActuator) StartDeletion(_, _ []*apiv1.Node, _ time.Time) (*status.ScaleDownStatus, errors.AutoscalerError) {
+func (m *mockActuator) StartDeletion(_, _ []*apiv1.Node) (*status.ScaleDownStatus, errors.AutoscalerError) {
 	return nil, nil
 }
 

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -80,8 +80,10 @@ func (a *Actuator) ClearResultsNotNewerThan(t time.Time) {
 }
 
 // StartDeletion triggers a new deletion process.
-func (a *Actuator) StartDeletion(empty, drain []*apiv1.Node, currentTime time.Time) (*status.ScaleDownStatus, errors.AutoscalerError) {
-	defer func() { metrics.UpdateDuration(metrics.ScaleDownNodeDeletion, time.Now().Sub(currentTime)) }()
+func (a *Actuator) StartDeletion(empty, drain []*apiv1.Node) (*status.ScaleDownStatus, errors.AutoscalerError) {
+	deletionStartTime := time.Now()
+	defer func() { metrics.UpdateDuration(metrics.ScaleDownNodeDeletion, time.Now().Sub(deletionStartTime)) }()
+
 	results, ts := a.nodeDeletionTracker.DeletionResults()
 	scaleDownStatus := &status.ScaleDownStatus{NodeDeleteResults: results, NodeDeleteResultsAsOf: ts}
 

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -853,7 +853,7 @@ func TestStartDeletion(t *testing.T) {
 				nodeDeletionBatcher: NewNodeDeletionBatcher(&ctx, csr, ndt, 0*time.Second),
 				evictor:             Evictor{EvictionRetryTime: 0, DsEvictionRetryTime: 0, DsEvictionEmptyNodeTimeout: 0, PodEvictionHeadroom: DefaultPodEvictionHeadroom},
 			}
-			gotStatus, gotErr := actuator.StartDeletion(tc.emptyNodes, tc.drainNodes, time.Now())
+			gotStatus, gotErr := actuator.StartDeletion(tc.emptyNodes, tc.drainNodes)
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("StartDeletion error diff (-want +got):\n%s", diff)
 			}
@@ -932,7 +932,7 @@ func TestStartDeletion(t *testing.T) {
 
 			// Run StartDeletion again to gather node deletion results for deletions started in the previous call, and verify
 			// that they look as expected.
-			gotNextStatus, gotNextErr := actuator.StartDeletion(nil, nil, time.Now())
+			gotNextStatus, gotNextErr := actuator.StartDeletion(nil, nil)
 			if gotNextErr != nil {
 				t.Errorf("StartDeletion unexpected error: %v", gotNextErr)
 			}
@@ -1086,7 +1086,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			}
 
 			for _, nodes := range deleteNodes {
-				actuator.StartDeletion(nodes, []*apiv1.Node{}, time.Now())
+				actuator.StartDeletion(nodes, []*apiv1.Node{})
 				time.Sleep(deleteInterval)
 			}
 			wantDeletedNodes := 0

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -777,7 +777,7 @@ func TestScaleDown(t *testing.T) {
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
-	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
+	scaleDownStatus, err := wrapper.StartDeletion(empty, drain)
 	waitForDeleteToFinish(t, wrapper)
 	assert.NoError(t, err)
 	assert.Equal(t, status.ScaleDownNodeDeleteStarted, scaleDownStatus.Result)
@@ -1034,7 +1034,7 @@ func simpleScaleDownEmpty(t *testing.T, config *ScaleTestConfig) {
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
-	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
+	scaleDownStatus, err := wrapper.StartDeletion(empty, drain)
 
 	assert.NoError(t, err)
 	var expectedScaleDownResult status.ScaleDownResult
@@ -1128,7 +1128,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
-	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
+	scaleDownStatus, err := wrapper.StartDeletion(empty, drain)
 	waitForDeleteToFinish(t, wrapper)
 
 	assert.NoError(t, err)
@@ -1152,7 +1152,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-2*time.Hour))
 	assert.NoError(t, autoscalererr)
 	empty, drain = wrapper.NodesToDelete(time.Now())
-	scaleDownStatus, err = wrapper.StartDeletion(empty, drain, time.Now())
+	scaleDownStatus, err = wrapper.StartDeletion(empty, drain)
 	waitForDeleteToFinish(t, wrapper)
 
 	assert.NoError(t, err)
@@ -1242,7 +1242,7 @@ func TestScaleDownNoMove(t *testing.T) {
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
-	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
+	scaleDownStatus, err := wrapper.StartDeletion(empty, drain)
 	waitForDeleteToFinish(t, wrapper)
 
 	assert.NoError(t, err)

--- a/cluster-autoscaler/core/scaledown/legacy/wrapper.go
+++ b/cluster-autoscaler/core/scaledown/legacy/wrapper.go
@@ -92,21 +92,21 @@ func (p *ScaleDownWrapper) NodesToDelete(currentTime time.Time) (empty, needDrai
 }
 
 // StartDeletion triggers an actual scale down logic.
-func (p *ScaleDownWrapper) StartDeletion(empty, needDrain []*apiv1.Node, currentTime time.Time) (*status.ScaleDownStatus, errors.AutoscalerError) {
+func (p *ScaleDownWrapper) StartDeletion(empty, needDrain []*apiv1.Node) (*status.ScaleDownStatus, errors.AutoscalerError) {
 	// Done to preserve legacy behavior, see comment on NodesToDelete.
 	if p.lastNodesToDeleteErr != nil || p.lastNodesToDeleteResult != status.ScaleDownNodeDeleteStarted {
 		// When there is no need for scale-down, p.lastNodesToDeleteResult is set to ScaleDownNoUnneeded. We have to still report node delete
 		// results in this case, otherwise they wouldn't get reported until the next call to actuator.StartDeletion (i.e. until the next scale-down
 		// attempt).
 		// Run actuator.StartDeletion with no nodes just to grab the delete results.
-		origStatus, _ := p.actuator.StartDeletion(nil, nil, currentTime)
+		origStatus, _ := p.actuator.StartDeletion(nil, nil)
 		return &status.ScaleDownStatus{
 			Result:                p.lastNodesToDeleteResult,
 			NodeDeleteResults:     origStatus.NodeDeleteResults,
 			NodeDeleteResultsAsOf: origStatus.NodeDeleteResultsAsOf,
 		}, p.lastNodesToDeleteErr
 	}
-	return p.actuator.StartDeletion(empty, needDrain, currentTime)
+	return p.actuator.StartDeletion(empty, needDrain)
 }
 
 // CheckStatus snapshots current deletion status

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -57,7 +57,7 @@ type Actuator interface {
 	// function are not guaranteed to be deleted, it is possible for the
 	// Actuator to ignore some of them e.g. if max configured level of
 	// parallelism is reached.
-	StartDeletion(empty, needDrain []*apiv1.Node, currentTime time.Time) (*status.ScaleDownStatus, errors.AutoscalerError)
+	StartDeletion(empty, needDrain []*apiv1.Node) (*status.ScaleDownStatus, errors.AutoscalerError)
 	// CheckStatus returns an immutable snapshot of ongoing deletions.
 	CheckStatus() ActuationStatus
 	// ClearResultsNotNewerThan removes information about deletions finished

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -613,7 +613,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 			scaleDownStart := time.Now()
 			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
 			empty, needDrain := a.scaleDownPlanner.NodesToDelete(currentTime)
-			scaleDownStatus, typedErr := a.scaleDownActuator.StartDeletion(empty, needDrain, currentTime)
+			scaleDownStatus, typedErr := a.scaleDownActuator.StartDeletion(empty, needDrain)
 			a.scaleDownActuator.ClearResultsNotNewerThan(scaleDownStatus.NodeDeleteResultsAsOf)
 			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 			metrics.UpdateUnremovableNodesCount(countsByReason(a.scaleDownPlanner.UnremovableNodes()))


### PR DESCRIPTION
The `scaledown:nodedeletion` is improperly tracking the actual time required for scheduling node deletions. It's using the `currentTime` as a reference point for the duration, which is set at the start of `RunOnce`.  Long duration activities like a long cloud provider refresh result in this metric being skewed and essentially tracking similar quantiles to that of `main`.

This change moves the start time inside of `StartDeletion` (similar to how `TryScaleDown` tracked the metric in 1.24), so the metric now more directly tracks the duration of `StartDeletion`

##### Before
![image](https://user-images.githubusercontent.com/63749938/216391535-040c0b54-ab6e-4a5b-a368-a7f097d6c276.png)
The quantiles for `scaledown:nodedeletion` very closely track those of `main`

##### After
![image](https://user-images.githubusercontent.com/63749938/216389106-2826803e-1959-4ea5-b718-ffd802f1f0c5.png)
The quantiles for `scaledown:nodedeletion` are no longer skewed alongside `main` 

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes an issue where the `scaledown:nodedeletion` metric was using the wrong frame of reference for the starting time.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
