### PR TITLE
Update go used to build VPA to 1.19.5

### DIFF
--- a/vertical-pod-autoscaler/builder/Dockerfile
+++ b/vertical-pod-autoscaler/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19
+FROM golang:1.19.5
 LABEL maintainer="Beata Skiba	<bskiba@google.com>"
 
 ENV GOPATH /gopath/


### PR DESCRIPTION
/kind cleanup

For #5455
