### PR TITLE
Update image references from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/addon-resizer/deploy/example.yaml
+++ b/addon-resizer/deploy/example.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       serviceAccountName: pod-nanny
       containers:
-        - image: k8s.gcr.io/autoscaling/addon-resizer:1.8.14
+        - image: registry.k8s.io/autoscaling/addon-resizer:1.8.14
           imagePullPolicy: Always
           name: pod-nanny
           resources:

--- a/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
@@ -723,7 +723,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.

--- a/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/generated.proto
@@ -723,7 +723,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types.go
@@ -3993,7 +3993,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types.go
@@ -3993,7 +3993,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -340,7 +340,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"registry.k8s.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/addon-resizer/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -340,7 +340,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"registry.k8s.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.23.2
+version: 9.24.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -357,7 +357,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | fullnameOverride | string | `""` | String to fully override `cluster-autoscaler.fullname` template. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
-| image.repository | string | `"k8s.gcr.io/autoscaling/cluster-autoscaler"` | Image repository |
+| image.repository | string | `"registry.k8s.io/autoscaling/cluster-autoscaler"` | Image repository |
 | image.tag | string | `"v1.23.0"` | Image tag |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | magnumCABundlePath | string | `"/etc/kubernetes/ca-bundle.crt"` | Path to the host's CA bundle, from `ca-file` in the cloud-config file. |

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -234,7 +234,7 @@ fullnameOverride: ""
 
 image:
   # image.repository -- Image repository
-  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
+  repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
   tag: v1.23.0
   # image.pullPolicy -- Image pull policy

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -441,7 +441,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: reserve-resources
-        image: k8s.gcr.io/pause
+        image: registry.k8s.io/pause
         resources:
           requests:
             cpu: "200m"
@@ -464,7 +464,7 @@ spec:
         app: overprovisioning-autoscaler
     spec:
       containers:
-        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
+        - image: registry.k8s.io/cluster-proportional-autoscaler-amd64:1.8.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -144,7 +144,7 @@ spec:
         fsGroup: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
@@ -144,7 +144,7 @@ spec:
         fsGroup: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml
@@ -144,7 +144,7 @@ spec:
         fsGroup: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -151,7 +151,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-aks.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-aks.yaml
@@ -154,7 +154,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
@@ -188,7 +188,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-control-plane.yaml
@@ -204,7 +204,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
@@ -189,7 +189,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard.yaml
@@ -197,7 +197,7 @@ spec:
                 secretKeyRef:
                   key: Deployment
                   name: cluster-autoscaler-azure
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-control-plane.yaml
@@ -159,7 +159,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           command:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
@@ -157,7 +157,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           command:

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss.yaml
@@ -152,7 +152,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
           imagePullPolicy: Always
           env:
             - name: BOOTSTRAP_TOKEN_ID

--- a/cluster-autoscaler/cloudprovider/civo/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/civo/examples/cluster-autoscaler-standard.yaml
@@ -139,7 +139,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.25.0 # or your custom image
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0 # or your custom image
           name: cluster-autoscaler
           imagePullPolicy: Always
           resources:

--- a/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -143,7 +143,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0
           imagePullPolicy: "Always"
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler.yaml
@@ -143,7 +143,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0
           imagePullPolicy: "Always"
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/cluster-autoscaler-manifests/cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/cluster-autoscaler-manifests/cluster-autoscaler.yaml
@@ -139,7 +139,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
@@ -152,7 +152,7 @@ spec:
                   - key: node-role.kubernetes.io/master
                     operator: Exists
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest  # or your custom image
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest  # or your custom image
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/huaweicloud/README.md
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/README.md
@@ -151,7 +151,7 @@ dns: {}
 etcd:
   local:
     dataDir: /var/lib/etcd
-imageRepository: k8s.gcr.io
+imageRepository: registry.k8s.io
 kind: ClusterConfiguration
 kubernetesVersion: 1.22.0
 networking:

--- a/cluster-autoscaler/cloudprovider/ionoscloud/examples/cluster-autoscaler-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/examples/cluster-autoscaler-standard.yaml
@@ -148,7 +148,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest  # or your custom image
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest  # or your custom image
           name: cluster-autoscaler
           imagePullPolicy: Always
           resources:

--- a/cluster-autoscaler/cloudprovider/kamatera/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/kamatera/examples/deployment.yaml
@@ -171,7 +171,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/cluster-autoscaler:{{ ca_version }}
           name: cluster-autoscaler
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/linode/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/linode/examples/cluster-autoscaler-autodiscover.yaml
@@ -139,7 +139,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -172,7 +172,7 @@ Note the 3 specified instance-pools are intended to correspond to different avai
 ```yaml
 ...
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           name: cluster-autoscaler
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml
+++ b/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml
@@ -141,7 +141,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           name: cluster-autoscaler
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-principals.yaml
+++ b/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-principals.yaml
@@ -141,7 +141,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:{{ ca_version }}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           name: cluster-autoscaler
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/packet/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/packet/examples/cluster-autoscaler-deployment.yaml
@@ -147,7 +147,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
           imagePullPolicy: Always
           env:
             - name: BOOTSTRAP_TOKEN_ID

--- a/cluster-autoscaler/cloudprovider/vultr/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/vultr/examples/cluster-autoscaler-deployment.yaml
@@ -136,7 +136,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:latest
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
           name: cluster-autoscaler
           resources:
             limits:

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: k8s.gcr.io/autoscaling/vpa-admission-controller:0.13.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:0.13.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: k8s.gcr.io/autoscaling/vpa-recommender:0.13.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:0.13.0
         imagePullPolicy: Always
         args:
           - --name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: k8s.gcr.io/autoscaling/vpa-recommender:0.13.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:0.13.0
         imagePullPolicy: Always
         args:
           - --name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: k8s.gcr.io/autoscaling/vpa-recommender:0.13.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:0.13.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: k8s.gcr.io/autoscaling/vpa-updater:0.13.0
+          image: registry.k8s.io/autoscaling/vpa-updater:0.13.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -302,7 +302,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 			// TODO(krzysied): Update the image url when the agnhost:2.10 image
 			// is promoted to the k8s-e2e-test-images repository.
 			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
-			sidecarParam  = "--sidecar-image=k8s.gcr.io/pause:3.1"
+			sidecarParam  = "--sidecar-image=registry.k8s.io/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)
 			containerPort = int32(8444)

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"k8s.gcr.io/ubuntu-slim:0.1",               /*image*/
+		"registry.k8s.io/ubuntu-slim:0.1",               /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
@@ -278,7 +278,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "k8s.gcr.io/ubuntu-slim:0.1",
+		Image: "registry.k8s.io/ubuntu-slim:0.1",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"registry.k8s.io/ubuntu-slim:0.1",               /*image*/
+		"registry.k8s.io/ubuntu-slim:0.1",          /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name

--- a/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
@@ -290,7 +290,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 			// TODO(krzysied): Update the image url when the agnhost:2.10 image
 			// is promoted to the k8s-e2e-test-images repository.
 			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
-			sidecarParam  = "--sidecar-image=k8s.gcr.io/pause:3.1"
+			sidecarParam  = "--sidecar-image=registry.k8s.io/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)
 			containerPort = int32(8444)

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"k8s.gcr.io/ubuntu-slim:0.1",               /*image*/
+		"registry.k8s.io/ubuntu-slim:0.1",               /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
@@ -279,7 +279,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "k8s.gcr.io/ubuntu-slim:0.1",
+		Image: "registry.k8s.io/ubuntu-slim:0.1",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"registry.k8s.io/ubuntu-slim:0.1",               /*image*/
+		"registry.k8s.io/ubuntu-slim:0.1",          /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name

--- a/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: hamster
-          image: k8s.gcr.io/ubuntu-slim:0.1
+          image: registry.k8s.io/ubuntu-slim:0.1
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: hamster
-          image: k8s.gcr.io/ubuntu-slim:0.1
+          image: registry.k8s.io/ubuntu-slim:0.1
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/redis-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/redis-deprecated.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: k8s.gcr.io/redis:e2e  # or just image: redis
+          image: registry.k8s.io/redis:e2e  # or just image: redis
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/redis.yaml
+++ b/vertical-pod-autoscaler/examples/redis.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: k8s.gcr.io/redis:e2e  # or just image: redis
+          image: registry.k8s.io/redis:e2e  # or just image: redis
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -31,7 +31,7 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-DEFAULT_REGISTRY="k8s.gcr.io/autoscaling"
+DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
 DEFAULT_TAG="0.13.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

On the 3rd of April 2023, the old registry `k8s.gcr.io` will be frozen and no further images for Kubernetes and related subprojects will be pushed to the old registry. This PR updates the image references to point to the new registry `registry.k8s.io`

#### Which issue(s) this PR fixes:

Fixes #5491

#### Special notes for your reviewer:

There are a couple of references in `vertical-pod-autoscaler/RELEASE.md`:
- [Images](https://github.com/kubernetes/autoscaler/blob/98e319b99ddaf50ceb7c6db3fbe0cb513d66843d/vertical-pod-autoscaler/RELEASE.md?plain=1#L81)
- [OWNERS](https://github.com/kubernetes/autoscaler/blob/98e319b99ddaf50ceb7c6db3fbe0cb513d66843d/vertical-pod-autoscaler/RELEASE.md?plain=1#L145)

that link to [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) and the folder [k8s.gcr.io](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io). The files referenced by these links cannot be found under the path of the new registry [registry.k8s.io](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io). Do we ignore these references as with `staging-k8s.gcr.io`?

#### Does this PR introduce a user-facing change?

NONE
