### PR TITLE
Track PDBRemainingDisruptions in AutoscalingContext

### DIFF
--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -57,6 +58,8 @@ type AutoscalingContext struct {
 	DebuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	// ScaleDownActuator is the interface for draining and deleting nodes
 	ScaleDownActuator scaledown.Actuator
+	// RemainingPdbTracker tracks the remaining pod disruption budget
+	RemainingPdbTracker pdb.RemainingPdbTracker
 }
 
 // AutoscalingKubeClients contains all Kubernetes API clients,
@@ -101,7 +104,8 @@ func NewAutoscalingContext(
 	expanderStrategy expander.Strategy,
 	estimatorBuilder estimator.EstimatorBuilder,
 	processorCallbacks processor_callbacks.ProcessorCallbacks,
-	debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter) *AutoscalingContext {
+	debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter,
+	remainingPdbTracker pdb.RemainingPdbTracker) *AutoscalingContext {
 	return &AutoscalingContext{
 		AutoscalingOptions:     options,
 		CloudProvider:          cloudProvider,
@@ -112,6 +116,7 @@ func NewAutoscalingContext(
 		EstimatorBuilder:       estimatorBuilder,
 		ProcessorCallbacks:     processorCallbacks,
 		DebuggingSnapshotter:   debuggingSnapshotter,
+		RemainingPdbTracker:    remainingPdbTracker,
 	}
 }
 

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -24,6 +24,7 @@ import (
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -50,6 +51,7 @@ type AutoscalerOptions struct {
 	Processors             *ca_processors.AutoscalingProcessors
 	Backoff                backoff.Backoff
 	DebuggingSnapshotter   debuggingsnapshot.DebuggingSnapshotter
+	RemainingPdbTracker    pdb.RemainingPdbTracker
 }
 
 // Autoscaler is the main component of CA which scales up/down node groups according to its configuration
@@ -79,7 +81,8 @@ func NewAutoscaler(opts AutoscalerOptions) (Autoscaler, errors.AutoscalerError) 
 		opts.ExpanderStrategy,
 		opts.EstimatorBuilder,
 		opts.Backoff,
-		opts.DebuggingSnapshotter), nil
+		opts.DebuggingSnapshotter,
+		opts.RemainingPdbTracker), nil
 }
 
 // Initialize default options if not provided.
@@ -92,6 +95,9 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 	}
 	if opts.ClusterSnapshot == nil {
 		opts.ClusterSnapshot = clustersnapshot.NewBasicClusterSnapshot()
+	}
+	if opts.RemainingPdbTracker == nil {
+		opts.RemainingPdbTracker = pdb.NewBasicRemainingPdbTracker()
 	}
 	if opts.CloudProvider == nil {
 		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts.AutoscalingOptions)

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -152,7 +152,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	allNodes := []*apiv1.Node{n1, n2, n3, n4, n5, n7, n8, n9}
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4, p5, p6})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now())
 	assert.NoError(t, autoscalererr)
 
 	assert.Equal(t, 3, len(sd.unneededNodes.AsList()))
@@ -172,7 +172,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	sd.unneededNodes.Update([]simulator.NodeToBeRemoved{{Node: n1}, {Node: n2}, {Node: n3}, {Node: n4}}, time.Now())
 	allNodes = []*apiv1.Node{n1, n2, n3, n4}
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now())
 	assert.NoError(t, autoscalererr)
 
 	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
@@ -189,7 +189,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	sd.unremovableNodes = unremovable.NewNodes()
 	scaleDownCandidates := []*apiv1.Node{n1, n3, n4}
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now())
 	assert.NoError(t, autoscalererr)
 
 	assert.Equal(t, 0, len(sd.unneededNodes.AsList()))
@@ -197,7 +197,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	// Node n1 is unneeded, but should be skipped because it has just recently been found to be unremovable
 	allNodes = []*apiv1.Node{n1}
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now())
 	assert.NoError(t, autoscalererr)
 
 	assert.Equal(t, 0, len(sd.unneededNodes.AsList()))
@@ -206,7 +206,7 @@ func TestFindUnneededNodes(t *testing.T) {
 
 	// But it should be checked after timeout
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now().Add(context.UnremovableNodeRecheckTimeout+time.Second), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now().Add(context.UnremovableNodeRecheckTimeout+time.Second))
 	assert.NoError(t, autoscalererr)
 
 	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
@@ -284,7 +284,7 @@ func TestFindUnneededGPUNodes(t *testing.T) {
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3})
 
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, 1, len(sd.unneededNodes.AsList()))
 	assert.True(t, sd.unneededNodes.Contains("n2"))
@@ -402,7 +402,7 @@ func TestFindUnneededWithPerNodeGroupThresholds(t *testing.T) {
 			ng2 := provider.GetNodeGroup("n2").(*testprovider.TestNodeGroup)
 			ng2.SetOptions(tc.n2opts)
 
-			autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now(), nil)
+			autoscalererr = sd.UpdateUnneededNodes(allNodes, scaleDownCandidates, time.Now())
 			assert.NoError(t, autoscalererr)
 			assert.Equal(t, len(tc.wantUnneeded), len(sd.unneededNodes.AsList()))
 			for _, node := range tc.wantUnneeded {
@@ -481,7 +481,7 @@ func TestPodsWithPreemptionsFindUnneededNodes(t *testing.T) {
 
 	allNodes := []*apiv1.Node{n1, n2, n3, n4}
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, []*apiv1.Pod{p1, p2, p3, p4})
-	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(allNodes, allNodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, 2, len(sd.unneededNodes.AsList()))
 	assert.True(t, sd.unneededNodes.Contains("n2"))
@@ -544,7 +544,7 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	sd := wrapper.sd
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
-	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, numCandidates, len(sd.unneededNodes.AsList()))
 	// Simulate one of the unneeded nodes got deleted
@@ -567,7 +567,7 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	}
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
-	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	// Check that the deleted node was replaced
 	assert.Equal(t, numCandidates, len(sd.unneededNodes.AsList()))
@@ -628,7 +628,7 @@ func TestFindUnneededEmptyNodes(t *testing.T) {
 	sd := wrapper.sd
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
-	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	assert.Equal(t, numEmpty+numCandidates, len(sd.unneededNodes.AsList()))
 }
@@ -684,7 +684,7 @@ func TestFindUnneededNodePool(t *testing.T) {
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
-	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now(), nil)
+	autoscalererr = sd.UpdateUnneededNodes(nodes, nodes, time.Now())
 	assert.NoError(t, autoscalererr)
 	assert.NotEmpty(t, sd.unneededNodes)
 }
@@ -774,7 +774,7 @@ func TestScaleDown(t *testing.T) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
-	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
+	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
 	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
@@ -1031,7 +1031,7 @@ func simpleScaleDownEmpty(t *testing.T, config *ScaleTestConfig) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, config.NodeDeletionTracker)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{})
-	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
+	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
 	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
@@ -1125,7 +1125,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
-	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
+	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
 	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())
@@ -1149,7 +1149,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 	context.CloudProvider = provider
 	wrapper = newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
-	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-2*time.Hour))
+	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-2*time.Hour))
 	assert.NoError(t, autoscalererr)
 	empty, drain = wrapper.NodesToDelete(time.Now())
 	scaleDownStatus, err = wrapper.StartDeletion(empty, drain, time.Now())
@@ -1239,7 +1239,7 @@ func TestScaleDownNoMove(t *testing.T) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
-	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, nil, time.Now().Add(-5*time.Minute))
+	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
 	assert.NoError(t, autoscalererr)
 	empty, drain := wrapper.NodesToDelete(time.Now())
 	scaleDownStatus, err := wrapper.StartDeletion(empty, drain, time.Now())

--- a/cluster-autoscaler/core/scaledown/legacy/wrapper.go
+++ b/cluster-autoscaler/core/scaledown/legacy/wrapper.go
@@ -27,14 +27,12 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 )
 
 // ScaleDownWrapper wraps legacy scaledown logic to satisfy scaledown.Planner &
 // scaledown.Actuator interfaces.
 type ScaleDownWrapper struct {
 	sd                      *ScaleDown
-	pdbs                    []*policyv1.PodDisruptionBudget
 	actuator                *actuation.Actuator
 	lastNodesToDeleteResult status.ScaleDownResult
 	lastNodesToDeleteErr    errors.AutoscalerError
@@ -49,10 +47,9 @@ func NewScaleDownWrapper(sd *ScaleDown, actuator *actuation.Actuator) *ScaleDown
 }
 
 // UpdateClusterState updates unneeded nodes in the underlying ScaleDown.
-func (p *ScaleDownWrapper) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, actuationStatus scaledown.ActuationStatus, pdbs []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError {
+func (p *ScaleDownWrapper) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, actuationStatus scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
 	p.sd.CleanUp(currentTime)
-	p.pdbs = pdbs
-	return p.sd.UpdateUnneededNodes(podDestinations, scaleDownCandidates, currentTime, pdbs)
+	return p.sd.UpdateUnneededNodes(podDestinations, scaleDownCandidates, currentTime)
 }
 
 // CleanUpUnneededNodes cleans up unneeded nodes.
@@ -85,7 +82,7 @@ func (p *ScaleDownWrapper) NodeUtilizationMap() map[string]utilization.Info {
 // the error returned by legacy TryToScaleDown (now called NodesToDelete) is also passed to StartDeletion.
 // TODO: Evaluate if we can get rid of the last bits of shared state.
 func (p *ScaleDownWrapper) NodesToDelete(currentTime time.Time) (empty, needDrain []*apiv1.Node) {
-	empty, drain, result, err := p.sd.NodesToDelete(currentTime, p.pdbs)
+	empty, drain, result, err := p.sd.NodesToDelete(currentTime)
 	p.lastNodesToDeleteResult = result
 	p.lastNodesToDeleteErr = err
 	return empty, drain

--- a/cluster-autoscaler/core/scaledown/pdb/basic.go
+++ b/cluster-autoscaler/core/scaledown/pdb/basic.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+)
+
+type pdbInfo struct {
+	pdb      *policyv1.PodDisruptionBudget
+	selector labels.Selector
+}
+
+// basicRemainingPdbTracker is the basic implementation of RemainingPdbTracker
+type basicRemainingPdbTracker struct {
+	pdbInfos []*pdbInfo
+}
+
+// NewBasicRemainingPdbTracker returns a new instance of basicRemainingPdbTracker
+func NewBasicRemainingPdbTracker() *basicRemainingPdbTracker {
+	return &basicRemainingPdbTracker{}
+}
+
+func (t *basicRemainingPdbTracker) SetPdbs(pdbs []*policyv1.PodDisruptionBudget) error {
+	t.Clear()
+	for _, pdb := range pdbs {
+		pdbCopy := pdb.DeepCopy()
+		selector, err := metav1.LabelSelectorAsSelector(pdbCopy.Spec.Selector)
+		if err != nil {
+			return err
+		}
+		t.pdbInfos = append(t.pdbInfos, &pdbInfo{
+			pdb:      pdbCopy,
+			selector: selector,
+		})
+	}
+	return nil
+}
+
+func (t *basicRemainingPdbTracker) GetPdbs() []*policyv1.PodDisruptionBudget {
+	var pdbs []*policyv1.PodDisruptionBudget
+	for _, pdbInfo := range t.pdbInfos {
+		pdbs = append(pdbs, pdbInfo.pdb)
+	}
+	return pdbs
+}
+
+func (t *basicRemainingPdbTracker) CanRemovePods(pods []*apiv1.Pod) (canRemove, inParallel bool, blockingPod *drain.BlockingPod) {
+	inParallel = true
+	for _, pdbInfo := range t.pdbInfos {
+		count := int32(0)
+		for _, pod := range pods {
+			if pod.Namespace == pdbInfo.pdb.Namespace && pdbInfo.selector.Matches(labels.Set(pod.Labels)) {
+				count += 1
+				if pdbInfo.pdb.Status.DisruptionsAllowed < 1 {
+					return false, false, &drain.BlockingPod{Pod: pod, Reason: drain.NotEnoughPdb}
+				}
+				if pdbInfo.pdb.Status.DisruptionsAllowed < count {
+					inParallel = false
+					blockingPod = &drain.BlockingPod{Pod: pod, Reason: drain.NotEnoughPdb}
+				}
+			}
+		}
+	}
+	return true, inParallel, blockingPod
+}
+
+func (t *basicRemainingPdbTracker) RemovePods(pods []*apiv1.Pod) {
+	for _, pdbInfo := range t.pdbInfos {
+		for _, pod := range pods {
+			if pod.Namespace == pdbInfo.pdb.Namespace && pdbInfo.selector.Matches(labels.Set(pod.Labels)) {
+				pdbInfo.pdb.Status.DisruptionsAllowed -= 1
+			}
+		}
+	}
+}
+
+func (t *basicRemainingPdbTracker) Clear() {
+	t.pdbInfos = nil
+}

--- a/cluster-autoscaler/core/scaledown/pdb/pdb.go
+++ b/cluster-autoscaler/core/scaledown/pdb/pdb.go
@@ -19,69 +19,23 @@ package pdb
 import (
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 )
 
-// PdbRemainingDisruptions stores how many discuptiption is left for pdb.
-type PdbRemainingDisruptions struct {
-	pdbs      []*policyv1.PodDisruptionBudget
-	selectors map[*policyv1.PodDisruptionBudget]labels.Selector
-}
+// RemainingPdbTracker is responsible for tracking the remaining PDBs
+type RemainingPdbTracker interface {
+	// SetPdbs sets PDBs of the remaining PDB tracker.
+	SetPdbs(pdbs []*policyv1.PodDisruptionBudget) error
+	// GetPdbs returns the current remaining PDBs.
+	GetPdbs() []*policyv1.PodDisruptionBudget
 
-// NewPdbRemainingDisruptions initialize PdbRemainingDisruptions.
-func NewPdbRemainingDisruptions(pdbs []*policyv1.PodDisruptionBudget) (*PdbRemainingDisruptions, error) {
-	pdbsCopy := make([]*policyv1.PodDisruptionBudget, len(pdbs))
-	selectors := make(map[*policyv1.PodDisruptionBudget]labels.Selector)
-	for i, pdb := range pdbs {
-		pdbsCopy[i] = pdb.DeepCopy()
-		selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-		if err != nil {
-			return nil, err
-		}
-		selectors[pdbsCopy[i]] = selector
-	}
-	return &PdbRemainingDisruptions{pdbsCopy, selectors}, nil
-}
+	// CanRemovePods checks if the set of pods can be removed.
+	// inParallel indicates if the pods can be removed in parallel. If it is false
+	// then evicting pods could fail due to drain timeout.
+	CanRemovePods(pods []*apiv1.Pod) (canRemove, inParallel bool, blockingPod *drain.BlockingPod)
+	// RemovePods updates the remaining PDBs after pod removal.
+	RemovePods(pods []*apiv1.Pod)
 
-// CanDisrupt return if the set of pods can be removed.
-// inParallel indicates that the pods could not be removed in parallel.
-// If inParallel == false, evicting this set of pods from node could fail due to drain timeout.
-func (p *PdbRemainingDisruptions) CanDisrupt(pods []*apiv1.Pod) (canRemove, inParallel bool, blockingPod *drain.BlockingPod) {
-	inParallel = true
-	for _, pdb := range p.pdbs {
-		selector := p.selectors[pdb]
-		count := int32(0)
-		for _, pod := range pods {
-			if pod.Namespace == pdb.Namespace && selector.Matches(labels.Set(pod.Labels)) {
-				count += 1
-				if pdb.Status.DisruptionsAllowed < 1 {
-					return false, false, &drain.BlockingPod{Pod: pod, Reason: drain.NotEnoughPdb}
-				}
-				if pdb.Status.DisruptionsAllowed < count {
-					inParallel = false
-					blockingPod = &drain.BlockingPod{Pod: pod, Reason: drain.NotEnoughPdb}
-				}
-			}
-		}
-	}
-	return true, inParallel, blockingPod
-}
-
-// Update make updates the remaining disruptions for pdb.
-func (p *PdbRemainingDisruptions) Update(pods []*apiv1.Pod) {
-	for _, pdb := range p.pdbs {
-		selector := p.selectors[pdb]
-		for _, pod := range pods {
-			if pod.Namespace == pdb.Namespace && selector.Matches(labels.Set(pod.Labels)) {
-				pdb.Status.DisruptionsAllowed -= 1
-			}
-		}
-	}
-}
-
-// GetPdbs return pdb list.
-func (p *PdbRemainingDisruptions) GetPdbs() []*policyv1.PodDisruptionBudget {
-	return p.pdbs
+	// Clear resets the remaining PDB tracker to empty state.
+	Clear()
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unneeded"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unremovable"
@@ -73,7 +72,6 @@ type Planner struct {
 	resourceLimitsFinder  *resource.LimitsFinder
 	cc                    controllerReplicasCalculator
 	scaleDownSetProcessor nodes.ScaleDownSetProcessor
-	remainingPdbTracker   pdb.RemainingPdbTracker
 }
 
 // New creates a new Planner object.
@@ -96,19 +94,13 @@ func New(context *context.AutoscalingContext, processors *processors.Autoscaling
 // UpdateClusterState needs to be periodically invoked to provide Planner with
 // up-to-date information about the cluster.
 // Planner will evaluate scaleDownCandidates in the order provided here.
-func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, pdbs []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError {
+func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
 	p.latestUpdate = currentTime
 	p.actuationStatus = as
-	p.remainingPdbTracker = pdb.NewBasicRemainingPdbTracker()
-	err := p.remainingPdbTracker.SetPdbs(pdbs)
-	if err != nil {
-		p.CleanUpUnneededNodes()
-		return errors.NewAutoscalerError(errors.InternalError, err.Error())
-	}
 	// Avoid persisting changes done by the simulation.
 	p.context.ClusterSnapshot.Fork()
 	defer p.context.ClusterSnapshot.Revert()
-	err = p.injectRecentlyEvictedPods()
+	err := p.injectRecentlyEvictedPods()
 	if err != nil {
 		klog.Warningf("Not all recently evicted pods could be injected")
 	}
@@ -266,14 +258,14 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			break
 		default:
 		}
-		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.remainingPdbTracker.GetPdbs())
+		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.context.RemainingPdbTracker.GetPdbs())
 		if removable != nil {
-			_, inParallel, _ := p.remainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
+			_, inParallel, _ := p.context.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
 				removable.IsRisky = true
 			}
 			delete(podDestinations, removable.Node.Name)
-			p.remainingPdbTracker.RemovePods(removable.PodsToReschedule)
+			p.context.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
 		}
 		if unremovable != nil {

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
-	pdbdisruptions "k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unneeded"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unremovable"
@@ -61,19 +61,19 @@ type replicasInfo struct {
 
 // Planner is responsible for deciding which nodes should be deleted during scale down.
 type Planner struct {
-	context                 *context.AutoscalingContext
-	unremovableNodes        *unremovable.Nodes
-	unneededNodes           *unneeded.Nodes
-	rs                      removalSimulator
-	actuationInjector       *scheduling.HintingSimulator
-	latestUpdate            time.Time
-	eligibilityChecker      eligibilityChecker
-	nodeUtilizationMap      map[string]utilization.Info
-	actuationStatus         scaledown.ActuationStatus
-	resourceLimitsFinder    *resource.LimitsFinder
-	cc                      controllerReplicasCalculator
-	scaleDownSetProcessor   nodes.ScaleDownSetProcessor
-	pdbRemainingDisruptions *pdbdisruptions.PdbRemainingDisruptions
+	context               *context.AutoscalingContext
+	unremovableNodes      *unremovable.Nodes
+	unneededNodes         *unneeded.Nodes
+	rs                    removalSimulator
+	actuationInjector     *scheduling.HintingSimulator
+	latestUpdate          time.Time
+	eligibilityChecker    eligibilityChecker
+	nodeUtilizationMap    map[string]utilization.Info
+	actuationStatus       scaledown.ActuationStatus
+	resourceLimitsFinder  *resource.LimitsFinder
+	cc                    controllerReplicasCalculator
+	scaleDownSetProcessor nodes.ScaleDownSetProcessor
+	remainingPdbTracker   pdb.RemainingPdbTracker
 }
 
 // New creates a new Planner object.
@@ -96,11 +96,11 @@ func New(context *context.AutoscalingContext, processors *processors.Autoscaling
 // UpdateClusterState needs to be periodically invoked to provide Planner with
 // up-to-date information about the cluster.
 // Planner will evaluate scaleDownCandidates in the order provided here.
-func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, pdb []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError {
-	var err error
+func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, pdbs []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError {
 	p.latestUpdate = currentTime
 	p.actuationStatus = as
-	p.pdbRemainingDisruptions, err = pdbdisruptions.NewPdbRemainingDisruptions(pdb)
+	p.remainingPdbTracker = pdb.NewBasicRemainingPdbTracker()
+	err := p.remainingPdbTracker.SetPdbs(pdbs)
 	if err != nil {
 		p.CleanUpUnneededNodes()
 		return errors.NewAutoscalerError(errors.InternalError, err.Error())
@@ -266,14 +266,14 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			break
 		default:
 		}
-		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.pdbRemainingDisruptions.GetPdbs())
+		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.remainingPdbTracker.GetPdbs())
 		if removable != nil {
-			_, inParallel, _ := p.pdbRemainingDisruptions.CanDisrupt(removable.PodsToReschedule)
+			_, inParallel, _ := p.remainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
 				removable.IsRisky = true
 			}
 			delete(podDestinations, removable.Node.Name)
-			p.pdbRemainingDisruptions.Update(removable.PodsToReschedule)
+			p.remainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
 		}
 		if unremovable != nil {

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -448,7 +448,7 @@ func TestUpdateClusterState(t *testing.T) {
 			p := New(&context, NewTestProcessors(&context), deleteOptions)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(tc.eligible)}
 			// TODO(x13n): test subsets of nodes passed as podDestinations/scaleDownCandidates.
-			assert.NoError(t, p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, nil, time.Now()))
+			assert.NoError(t, p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, time.Now()))
 			wantUnneeded := asMap(tc.wantUnneeded)
 			for _, n := range tc.nodes {
 				assert.Equal(t, wantUnneeded[n.Name], p.unneededNodes.Contains(n.Name), n.Name)

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -25,13 +25,12 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 )
 
 // Planner is responsible for selecting nodes that should be removed.
 type Planner interface {
 	// UpdateClusterState provides the Planner with information about the cluster.
-	UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as ActuationStatus, pdb []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError
+	UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as ActuationStatus, currentTime time.Time) errors.AutoscalerError
 	// CleanUpUnneededNodes resets internal state of the Planner.
 	CleanUpUnneededNodes()
 	// NodesToDelete returns a list of nodes that can be deleted right now,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -263,6 +263,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Times(2) // 1 to get pods + 1 per nodegroup when building nodeInfo map
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
 
 	context.MaxNodesTotal = 10
@@ -463,6 +464,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	allNodeLister.SetNodes([]*apiv1.Node{n1})
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Twice()
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	onNodeGroupCreateMock.On("Create", "autoprovisioned-TN2").Return(nil).Once()
 	onScaleUpMock.On("ScaleUp", "autoprovisioned-TN2", 1).Return(nil).Once()
@@ -614,6 +616,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Twice() // 1 to get pods + 1 per nodegroup when building nodeInfo map
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p2}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
 
 	err = autoscaler.RunOnce(later.Add(time.Hour))
@@ -761,6 +764,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p1, p2, p3}, nil).Times(2) // 1 to get pods + 1 when building nodeInfo map
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p4, p5, p6}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleUpMock.On("ScaleUp", "ng2", 1).Return(nil).Once()
 
 	err = autoscaler.RunOnce(time.Now())
@@ -892,6 +896,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p3, p4}, nil).Times(2) // 1 to get pods + 1 when building nodeInfo map
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
 	err = autoscaler.RunOnce(time.Now())
 	assert.NoError(t, err)
@@ -991,6 +996,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 	scheduledPodMock.On("List").Return([]*apiv1.Pod{p2, p3}, nil).Times(2) // 1 to get pods + 1 when building nodeInfo map
 	unschedulablePodMock.On("List").Return([]*apiv1.Pod{p1}, nil).Once()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
 	err = autoscaler.RunOnce(time.Now())
 	assert.NoError(t, err)
@@ -1280,7 +1286,7 @@ type candidateTrackingFakePlanner struct {
 	lastCandidateNodes map[string]bool
 }
 
-func (f *candidateTrackingFakePlanner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, pdb []*policyv1.PodDisruptionBudget, currentTime time.Time) errors.AutoscalerError {
+func (f *candidateTrackingFakePlanner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
 	f.lastCandidateNodes = map[string]bool{}
 	for _, node := range scaleDownCandidates {
 		f.lastCandidateNodes[node.Name] = true

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -173,6 +174,7 @@ func NewScaleTestAutoscalingContext(
 	if err != nil {
 		return context.AutoscalingContext{}, err
 	}
+	remainingPdbTracker := pdb.NewBasicRemainingPdbTracker()
 	if debuggingSnapshotter == nil {
 		debuggingSnapshotter = debuggingsnapshot.NewDebuggingSnapshotter(false)
 	}
@@ -192,6 +194,7 @@ func NewScaleTestAutoscalingContext(
 		EstimatorBuilder:     estimatorBuilder,
 		ProcessorCallbacks:   processorCallbacks,
 		DebuggingSnapshotter: debuggingSnapshotter,
+		RemainingPdbTracker:  remainingPdbTracker,
 	}, nil
 }
 

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -72,7 +72,7 @@ func GetPodsToMove(nodeInfo *schedulerframework.NodeInfo, deleteOptions NodeDele
 
 func checkPdbs(pods []*apiv1.Pod, pdbs []*policyv1.PodDisruptionBudget) (*drain.BlockingPod, error) {
 	// TODO: remove it after deprecating legacy scale down.
-	// PdbRemainingDisruption.CanDisrupt() to replace this function.
+	// RemainingPdbTracker.CanRemovePods() to replace this function.
 	for _, pdb := range pdbs {
 		selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds PDBRemainingDisruptions struct to AutoscalingContext, enabling remaining PDB tracking throughout the CA.

```release-note
NONE
```

