### PR TITLE
Automatically apply `balancer` label to balancer PRs

### DIFF
--- a/balancer/OWNERS
+++ b/balancer/OWNERS
@@ -4,3 +4,5 @@ approvers:
 reviewers:
 - mwielgus
 - kgolab
+labels:
+- balancer


### PR DESCRIPTION
This will automatically apply labels to PRs which makes it easier to search for relevant PRs, without adding any toil

/kind cleanup
/kind documentation