### PR TITLE
Fixes template for PSPs api version.

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.23.0
+version: 9.23.1

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- else -}}
 {{- print "policy/v1beta1" -}}
 {{- end -}}
-{{- end -}
+{{- end -}}
 
 {{/*
 Return the appropriate apiVersion for podDisruptionBudget.

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -70,13 +70,12 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if semverCompare "<1.10-0" $kubeTargetVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- if semverCompare ">1.21-0" $kubeTargetVersion -}}
+{{- else if semverCompare ">1.21-0" $kubeTargetVersion -}}
 {{- print "policy/v1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end -}
 
 {{/*
 Return the appropriate apiVersion for podDisruptionBudget.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
For kube versions more recent than 1.21, when enabling PSP, the `apiVersion` generated is empty, resulting in an invalid `PodSecurityPolicy`

#### Which issue(s) this PR fixes:
Fixes #5499 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
