### PR TITLE
Removes incorrect PodSecurityPolicy version

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.23.1
+version: 9.23.2

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -70,8 +70,6 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if semverCompare "<1.10-0" $kubeTargetVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare ">1.21-0" $kubeTargetVersion -}}
-{{- print "policy/v1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}
 {{- end -}}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Following #5500, it was noticed that the api version set by the template is incorrect. Version `policy/v1` does not exist in any K8s version, and there never will be one since PSPs have been deprecated. 

K8s docs for v1.25 have removed any references to PSP (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/)
K8s docs for v1.24 are still referring to `policy/v1beta1` (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podsecuritypolicy-v1beta1-policy)

#### Which issue(s) this PR fixes:
Fixes #5499  

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
