### PR TITLE
Added RBAC Permission to cherryservers.

### DIFF
--- a/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-rbac.yaml
+++ b/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-rbac.yaml
@@ -50,7 +50,7 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]

--- a/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-svcaccount.yaml
+++ b/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-svcaccount.yaml
@@ -39,7 +39,7 @@ rules:
     resources: ["daemonsets", "replicasets", "statefulsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["watch", "list", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR added the missing RBAC permission in the [examples](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/cherryservers/examples) mentioned under the cherryservers Cloud Provider.
#### Which issue(s) this PR fixes:

Fixes #5511

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
NONE
```