### PR TITLE
remove dead code in clusterapi provider tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1413,8 +1413,6 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 				} else {
 					t.Errorf("Expected node label %q to exist in node", key)
 				}
-				if value != config.expectedNodeLabels[key] {
-				}
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:

This change removes an `if` statement that was left behind after a refactor. The test in question has the same logic embedded into a previous conditional and the removed statement has no effect on the tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
