### PR TITLE
Updated the owners of civo cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/civo/OWNERS
+++ b/cluster-autoscaler/cloudprovider/civo/OWNERS
@@ -1,10 +1,4 @@
-#approvers:
-#- DMajrekar
-#- birdiesanders
-#- vishalanarase
-#- RealHarshThakur
-#reviewers:
-#- DMajrekar
-#- birdiesanders
-#- vishalanarase
-#- RealHarshThakur
+approvers:
+  - vishalanarase
+reviewers:
+  - vishalanarase


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

This PR adds owners for civo cloud provider

#### Special notes for your reviewer:
According to https://github.com/kubernetes/autoscaler/pull/5198 Adding owners for civo cloud provider

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

