### PR TITLE
cluster-autoscaler: Add option to disable scale down of unready nodes

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -128,6 +128,8 @@ type AutoscalingOptions struct {
 	EnforceNodeGroupMinSize bool
 	// ScaleDownEnabled is used to allow CA to scale down the cluster
 	ScaleDownEnabled bool
+	// ScaleDownUnreadyEnabled is used to allow CA to scale down unready nodes of the cluster
+	ScaleDownUnreadyEnabled bool
 	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options
 	ScaleDownDelayAfterAdd time.Duration
 	// ScaleDownDelayAfterDelete sets the duration between scale down attempts if scale down removes one or more nodes

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
 
 	apiv1 "k8s.io/api/core/v1"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	klog "k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -133,6 +134,15 @@ func (c *Checker) unremovableReasonAndNodeUtilization(context *context.Autoscali
 		// (and the default PreFilteringScaleDownNodeProcessor would indeed filter them out).
 		klog.Warningf("Skipped %s from delete consideration - the node is not autoscaled", node.Name)
 		return simulator.NotAutoscaled, nil
+	}
+
+	// If scale down of unready nodes is disabled, skip the node if it is unready
+	if !context.ScaleDownUnreadyEnabled {
+		ready, _, _ := kube_util.GetReadinessState(node)
+		if !ready {
+			klog.V(4).Infof("Skipping unready node %s from delete consideration - scale-down of unready nodes is disabled", node.Name)
+			return simulator.ScaleDownUnreadyDisabled, nil
+		}
 	}
 
 	underutilized, err := c.isNodeBelowUtilizationThreshold(context, node, nodeGroup, utilInfo)

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -50,6 +50,9 @@ func TestFilterOutUnremovable(t *testing.T) {
 	noScaleDownNode.Annotations = map[string]string{ScaleDownDisabledKey: "true"}
 	SetNodeReadyState(noScaleDownNode, true, time.Time{})
 
+	unreadyNode := BuildTestNode("unready", 1000, 10)
+	SetNodeReadyState(unreadyNode, false, time.Time{})
+
 	bigPod := BuildTestPod("bigPod", 600, 0)
 	bigPod.Spec.NodeName = "regular"
 
@@ -57,37 +60,55 @@ func TestFilterOutUnremovable(t *testing.T) {
 	smallPod.Spec.NodeName = "regular"
 
 	testCases := []struct {
-		desc  string
-		nodes []*apiv1.Node
-		pods  []*apiv1.Pod
-		want  []string
+		desc             string
+		nodes            []*apiv1.Node
+		pods             []*apiv1.Pod
+		want             []string
+		scaleDownUnready bool
 	}{
 		{
-			desc:  "regular node stays",
-			nodes: []*apiv1.Node{regularNode},
-			want:  []string{"regular"},
+			desc:             "regular node stays",
+			nodes:            []*apiv1.Node{regularNode},
+			want:             []string{"regular"},
+			scaleDownUnready: true,
 		},
 		{
-			desc:  "recently deleted node is filtered out",
-			nodes: []*apiv1.Node{regularNode, justDeletedNode},
-			want:  []string{"regular"},
+			desc:             "recently deleted node is filtered out",
+			nodes:            []*apiv1.Node{regularNode, justDeletedNode},
+			want:             []string{"regular"},
+			scaleDownUnready: true,
 		},
 		{
-			desc:  "marked no scale down is filtered out",
-			nodes: []*apiv1.Node{noScaleDownNode, regularNode},
-			want:  []string{"regular"},
+			desc:             "marked no scale down is filtered out",
+			nodes:            []*apiv1.Node{noScaleDownNode, regularNode},
+			want:             []string{"regular"},
+			scaleDownUnready: true,
 		},
 		{
-			desc:  "highly utilized node is filtered out",
-			nodes: []*apiv1.Node{regularNode},
-			pods:  []*apiv1.Pod{bigPod},
-			want:  []string{},
+			desc:             "highly utilized node is filtered out",
+			nodes:            []*apiv1.Node{regularNode},
+			pods:             []*apiv1.Pod{bigPod},
+			want:             []string{},
+			scaleDownUnready: true,
 		},
 		{
-			desc:  "underutilized node stays",
-			nodes: []*apiv1.Node{regularNode},
-			pods:  []*apiv1.Pod{smallPod},
-			want:  []string{"regular"},
+			desc:             "underutilized node stays",
+			nodes:            []*apiv1.Node{regularNode},
+			pods:             []*apiv1.Pod{smallPod},
+			want:             []string{"regular"},
+			scaleDownUnready: true,
+		},
+		{
+			desc:             "unready node stays",
+			nodes:            []*apiv1.Node{unreadyNode},
+			want:             []string{"unready"},
+			scaleDownUnready: true,
+		},
+		{
+			desc:             "unready node is filtered oud when scale-down of unready is disabled",
+			nodes:            []*apiv1.Node{unreadyNode},
+			want:             []string{},
+			scaleDownUnready: false,
 		},
 	}
 	for _, tc := range testCases {
@@ -97,6 +118,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 			c := NewChecker(&staticThresholdGetter{0.5})
 			options := config.AutoscalingOptions{
 				UnremovableNodeRecheckTimeout: 5 * time.Minute,
+				ScaleDownUnreadyEnabled:       tc.scaleDownUnready,
 			}
 			provider := testprovider.NewTestCloudProvider(nil, nil)
 			provider.AddNodeGroup("ng1", 1, 10, 2)

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -1110,6 +1110,7 @@ func TestNoScaleDownUnready(t *testing.T) {
 			ScaleDownUnreadyTime:          time.Hour,
 		},
 		MaxGracefulTerminationSec: 60,
+		ScaleDownUnreadyEnabled:   true,
 	}
 
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{p2})

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -98,6 +98,7 @@ var (
 	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
 	enforceNodeGroupMinSize = flag.Bool("enforce-node-group-min-size", false, "Should CA scale up the node group to the configured min size if needed.")
 	scaleDownEnabled        = flag.Bool("scale-down-enabled", true, "Should CA scale down the cluster")
+	scaleDownUnreadyEnabled = flag.Bool("scale-down-unready-enabled", true, "Should CA scale down unready nodes of the cluster")
 	scaleDownDelayAfterAdd  = flag.Duration("scale-down-delay-after-add", 10*time.Minute,
 		"How long after scale up that scale down evaluation resumes")
 	scaleDownDelayAfterDelete = flag.Duration("scale-down-delay-after-delete", 0,
@@ -279,6 +280,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownDelayAfterDelete:          *scaleDownDelayAfterDelete,
 		ScaleDownDelayAfterFailure:         *scaleDownDelayAfterFailure,
 		ScaleDownEnabled:                   *scaleDownEnabled,
+		ScaleDownUnreadyEnabled:            *scaleDownUnreadyEnabled,
 		ScaleDownNonEmptyCandidatesCount:   *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:       *scaleDownCandidatesPoolRatio,
 		ScaleDownCandidatesPoolMinCount:    *scaleDownCandidatesPoolMinCount,

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -61,6 +61,8 @@ const (
 	NoReason UnremovableReason = iota
 	// ScaleDownDisabledAnnotation - node can't be removed because it has a "scale down disabled" annotation.
 	ScaleDownDisabledAnnotation
+	// ScaleDownUnreadyDisabled - node can't be removed because it is unready and scale down is disabled for unready nodes.
+	ScaleDownUnreadyDisabled
 	// NotAutoscaled - node can't be removed because it doesn't belong to an autoscaled node group.
 	NotAutoscaled
 	// NotUnneededLongEnough - node can't be removed because it wasn't unneeded for long enough.


### PR DESCRIPTION
Add flag '--scale-down-unready-enabled' to enable or disable scale-down of unready nodes. Default value set to true for backwards compatibility (i.e., allow scale-down of unready nodes).


#### Which component this PR applies to?
Cluster Autoscaler
<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the option to disable scale down for unready nodes. 

There are cases where a user may not want the unready nodes to be removed from a cluster.
As an example, but not limited to, this might be useful in case a node is unreachable for a period of time and local data live there, the node shall remain in the cluster, and possibly an admin may want to take any actions for recovering it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4876.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Set the --scale-down-unready-enabled flag to a false in order to disable scale-down for unready nodes. The default value is true for backwards compatibility.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
