### PR TITLE
[WIP] fix: [ISS-5465] add a flag to let CA delegate node deletion to the cloud provider

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -792,6 +792,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `cordon-node-before-terminating` | Should CA cordon nodes before terminating during downscale process | false
 | `record-duplicated-events` | Enable the autoscaler to print duplicated events within a 5 minute window. | false
 | `debugging-snapshot-enabled` | Whether the debugging snapshot of cluster autoscaler feature is enabled. | false
+| `external-node-deletion` | If true, CA will not adjust replica counts to delete failed nodes, deletion is delegated to the cloud provider. | false
 
 # Troubleshooting:
 

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -115,6 +115,13 @@ func (asg *Asg) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *Asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := asg.manager.GetAsgSize(asg)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -289,6 +289,13 @@ func (ng *AwsNodeGroup) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *AwsNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	size := ng.asg.curSize

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -422,6 +422,13 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (as *AgentPool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)

--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
@@ -269,6 +269,13 @@ func (agentPool *AKSAgentPool) IncreaseSize(delta int) error {
 	return agentPool.SetSize(targetSize, false)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (agentPool *AKSAgentPool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // deleteNodesInternal calls the underlying vm service to delete the node.
 // It should be called within lock protected.
 func (agentPool *AKSAgentPool) deleteNodesInternal(providerIDs []string) (deleted int, err error) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -426,6 +426,13 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (scaleSet *ScaleSet) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -278,6 +278,13 @@ func (asg *Asg) IncreaseSize(delta int) error {
 	return asg.baiducloudManager.ScaleUpCluster(delta, asg.Name)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *Asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -100,6 +100,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
@@ -123,6 +123,13 @@ func (ng *brightboxNodeGroup) IncreaseSize(delta int) error {
 	)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *brightboxNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned
 // either on failure or if the given node doesn't belong to this
 // node group. This function should wait until node group size is

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
@@ -113,6 +113,13 @@ func (ng *cherryNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *cherryNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes a set of nodes chosen by the autoscaler.
 func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	// Batch simultaneous deletes on individual nodes

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -100,6 +100,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -176,7 +176,14 @@ type NodeGroup interface {
 	// node group size is updated. Implementation required.
 	IncreaseSize(delta int) error
 
-	// DeleteNodes deletes nodes from this node group. Error is returned either on
+	// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+	// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+	// Error is returned either on failure or if the given node doesn't belong to this node group.
+	// Implementation required.
+	MarkNodesForDeletion([]*apiv1.Node) error
+
+	// DeleteNodes deletes nodes from this node group and shrinks the node
+	// group target size by the number of deleted nodes. Error is returned either on
 	// failure or if the given node doesn't belong to this node group. This function
 	// should wait until node group size is updated. Implementation required.
 	DeleteNodes([]*apiv1.Node) error

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -93,6 +93,13 @@ func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 	return false, fmt.Errorf("Unable to find node %s in cluster", node.Name)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
 	if asg.cluster.WorkerCount-len(nodes) < asg.MinSize() {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -63,9 +63,14 @@ var (
 	errInvalidMaxAnnotation = errors.New("invalid max annotation")
 
 	// machineDeleteAnnotationKey is the annotation used by cluster-api to indicate
-	// that a machine should be deleted. Because this key can be affected by the
+	// that a machine should be preferred for deletion. Because this key can be affected by the
 	// CAPI_GROUP env variable, it is initialized here.
 	machineDeleteAnnotationKey = getMachineDeleteAnnotationKey()
+
+	// markMachineForDelete is the annotation used by cluster-api to indicate
+	// that a machine should be deleted ASAP. Because this key can be affected by the
+	// CAPI_GROUP env variable, it is initialized here.
+	markMachineForDeleteAnnotationKey = getMarkMachineForDeleteAnnotationKey()
 
 	// machineAnnotationKey is the annotation used by the cluster-api on Node objects
 	// to specify the name of the related Machine object. Because this can be affected
@@ -265,10 +270,21 @@ func getNodeGroupMaxSizeAnnotationKey() string {
 }
 
 // getMachineDeleteAnnotationKey returns the key that is used by cluster-api for marking
-// machines to be deleted. This function is needed because the user can change the default
+// machines to be preferred for deletion during scaling events.
+// This function is needed because the user can change the default
 // group name by using the CAPI_GROUP environment variable.
 func getMachineDeleteAnnotationKey() string {
 	key := fmt.Sprintf("%s/delete-machine", getCAPIGroup())
+	return key
+}
+
+// getMarkMachineForDeleteAnnotationKey returns the key that is used by cluster-api for marking
+// machines to be deleted as soon as possible by cluster-api without a scaling event occurring.
+// This function is needed because the user can change the default group name by using the CAPI_GROUP
+// environment variable. A new annotation was needed to avoid breaking compatibility with the existing
+// delete-machine annotation that only marks nodes as "preferred" for deletion during scaling events.
+func getMarkMachineForDeleteAnnotationKey() string {
+	key := fmt.Sprintf("%s/machine-marked-for-delete", getCAPIGroup())
 	return key
 }
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -876,6 +876,11 @@ func Test_getKeyHelpers(t *testing.T) {
 			testfunc: getMachineDeleteAnnotationKey,
 		},
 		{
+			name:     "test group, mark machine for delete annotation key",
+			expected: fmt.Sprintf("%s/machine-marked-for-delete", testgroup),
+			testfunc: getMarkMachineForDeleteAnnotationKey,
+		},
+		{
 			name:     "test group, machine annotation key",
 			expected: fmt.Sprintf("%s/machine", testgroup),
 			testfunc: getMachineAnnotationKey,

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -106,6 +106,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -93,6 +93,13 @@ func (n *instancePoolNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *instancePoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -92,6 +92,13 @@ func (n *sksNodepoolNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *sksNodepoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -90,6 +90,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -277,6 +277,13 @@ func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (mig *gceMig) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := mig.gceManager.GetMigSize(mig)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -130,6 +130,13 @@ func (n *hetznerNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *hetznerNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -94,6 +94,13 @@ func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *AutoScalingGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -81,6 +81,13 @@ func (n *nodePool) IncreaseSize(delta int) error {
 	return n.manager.SetNodeGroupSize(n, targetSize)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *nodePool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also decreasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
@@ -19,6 +19,9 @@ package kamatera
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strconv"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface. NodeGroup contains
@@ -82,6 +83,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	}
 
 	return nil
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -221,6 +221,13 @@ func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return instances, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (nodeGroup *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the specified nodes from the node group.
 func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := nodeGroup.kubemarkController.GetNodeGroupTargetSize(nodeGroup.Name)

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
@@ -98,6 +98,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -88,6 +88,13 @@ func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *magnumNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
 func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	ng.clusterUpdateLock.Lock()

--- a/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
+++ b/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
@@ -111,6 +111,20 @@ func (_m *NodeGroup) Delete() error {
 	return r0
 }
 
+// MarkNodesForDeletion provides a mock function with given fields: _a0
+func (_m *NodeGroup) MarkNodesForDeletion(_a0 []*v1.Node) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]*v1.Node) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteNodes provides a mock function with given fields: _a0
 func (_m *NodeGroup) DeleteNodes(_a0 []*v1.Node) error {
 	ret := _m.Called(_a0)

--- a/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -88,6 +89,13 @@ func (ip *InstancePoolNodeGroup) IncreaseSize(delta int) error {
 	}
 
 	return ip.manager.SetInstancePoolSize(*ip, size+delta)
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ip *InstancePoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this instance-pool. Error is returned either on

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -109,6 +109,13 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	// Do not use node group which does not support autoscaling

--- a/cluster-autoscaler/cloudprovider/packet/packet_node_group.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_node_group.go
@@ -97,6 +97,13 @@ func (ng *packetNodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *packetNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
 //
 // The process of deletion depends on the implementation of packetManager,

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -105,6 +105,13 @@ func (ng *nodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return instances, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *nodeGroup) MarkNodesForDeletion(nodes []*corev1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the specified nodes from the node group.
 func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
 	if ng.replicas-len(toDelete) < ng.MinSize() {

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface.
@@ -99,6 +100,13 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 
 	ng.p.Size = targetSize
 	return nil
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
@@ -194,6 +194,13 @@ func (asg *tcAsg) Autoprovisioned() bool {
 	return false
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *tcAsg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := asg.tencentcloudManager.GetAsgSize(asg)

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -435,6 +435,13 @@ func (tng *TestNodeGroup) DecreaseTargetSize(delta int) error {
 	return tng.cloudProvider.onScaleUp(tng.id, delta)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (tng *TestNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
@@ -96,6 +96,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -249,4 +249,6 @@ type AutoscalingOptions struct {
 	ParallelDrain bool
 	// NodeGroupSetRatio is a collection of ratios used by CA used to make scaling decisions.
 	NodeGroupSetRatios NodeGroupDifferenceRatios
+	// ExternalNodeDeletion controls whether or not CA will adjust replica counts to delete failed nodes. If true, replica counts are only modifed for scale up/down events and responsibility for the deletion of failed nodes is delegated to the cloud provider.
+	ExternalNodeDeletion bool
 }

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -35,14 +35,15 @@ type FakeNodeGroup struct {
 	id string
 }
 
-func (f *FakeNodeGroup) MaxSize() int                       { return 2 }
-func (f *FakeNodeGroup) MinSize() int                       { return 1 }
-func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
-func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
-func (f *FakeNodeGroup) Id() string                         { return f.id }
-func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) MaxSize() int                             { return 2 }
+func (f *FakeNodeGroup) MinSize() int                             { return 1 }
+func (f *FakeNodeGroup) TargetSize() (int, error)                 { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error             { return nil }
+func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error       { return nil }
+func (f *FakeNodeGroup) MarkNodesForDeletion([]*apiv1.Node) error { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error          { return nil }
+func (f *FakeNodeGroup) Id() string                               { return f.id }
+func (f *FakeNodeGroup) Debug() string                            { return f.id }
 func (f *FakeNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return []cloudprovider.Instance{}, nil
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -224,6 +224,7 @@ var (
 	maxFreeDifferenceRatio             = flag.Float64("max-free-difference-ratio", config.DefaultMaxFreeDifferenceRatio, "Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource.")
 	maxAllocatableDifferenceRatio      = flag.Float64("max-allocatable-difference-ratio", config.DefaultMaxAllocatableDifferenceRatio, "Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource.")
 	forceDaemonSets                    = flag.Bool("force-ds", false, "Blocks scale-up of node groups too small for all suitable Daemon Sets pods.")
+	externalNodeDeletion               = flag.Bool("external-node-deletion", false, "If true, CA will not adjust replica counts to delete failed nodes, deletion is delegated to the cloud provider.")
 )
 
 func createAutoscalingOptions() config.AutoscalingOptions {
@@ -333,6 +334,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 			MaxAllocatableDifferenceRatio:    *maxAllocatableDifferenceRatio,
 			MaxFreeDifferenceRatio:           *maxFreeDifferenceRatio,
 		},
+		ExternalNodeDeletion: *externalNodeDeletion,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind api-change

#### What this PR does / why we need it:
Cluster Autoscaler currently tries to remediate nodes that fail to join a cluster by deleting them. This is helpful to retry nodes sooner, but CA does not have a good way to delete nodes available to it. To accomplish this, it uses the replica count on a node group resource to downsize the number of desired nodes after marking a node with an annotation that the cloud provider should prefer this node for deletion.

During this period of time, the desired count of replicas is incorrect. Furthermore, this behavior can occur multiple times in parallel, resulting in multiple node deletions occurring simultaneously, which can significantly decrease the number of desired replicas in a node group far below what is actually needed to run all the pods that would schedule in that node group.

If a significant number of nodes fail to join the cluster, this can result in node groups operating with desired replica counts far below their actual intended replica count for extended periods of time, resulting in losses of cluster capacity and evicted pods with no node to schedule on.

#### Actual vs Expected Behavior
Example situation.
* 4 pods, which can schedule 2 per node.
* 1 worker node group, configured to replace nodes 1 at a time by adding a new node, then deleting an old node.
* 2 nodes, which hold the 4 pods.

You push an update the specifications of the worker node group, such as by changing the AMI, root volume size, etc.
* The node rollout begins, and a new worker begins to join the cluster.
* The worker node has a problem that prevents it from successfully joining the cluster (instance type shortage, failure to execute kubeadm successfully, etc)
* CA eventually notes the node as an "unregisteredOldNode" after `max-node-provision-time` expires and attempts to delete the node via `DeleteNodes()`.
* CA marks the new node for deletion.
* CA adjusts the node group desired replica count from 2 to 1.
* 1 replica is only enough to schedule 2 of our 4 pods.

The replica count should always reflect the number of replicas needed to schedule the pods in the cluster. CA has no other way to cause nodes to be deleted from the cluster, so it currently misuses the desired replica count in order to achieve this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5465

#### Special notes for your reviewer:
This change unfortunately is not compatible across all existing cloud providers, since it requires cloud provider specific implementation of marking nodes for deletion instead of downscaling the replica counts in certain situations. Previously, DeleteNodes() handled all cases equally.

The core cluster-api controller also needs to be modified to delete machines that have been annotated by Cluster Autoscaler, rather than only preferring them for deletion during scaling events.
https://github.com/kubernetes-sigs/cluster-api/pull/8205

These changes can be safely introduced independently of each other, but the external-node-deletion flag should not be enabled until the cluster-api core controller is running the updated version.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
No immediate user-facing changes are required. This change is gated behind a feature gate applied as an arg to CA. By default the behavior is unchanged.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
