### PR TITLE
Fix multiple recommenders example: deployment name

### DIFF
--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -8,17 +8,17 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vpa-recommender-performance
+  name: vpa-recommender-frugal
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vpa-recommender-performance
+      app: vpa-recommender-frugal
   template:
     metadata:
       labels:
-        app: vpa-recommender-performance
+        app: vpa-recommender-frugal
     spec:
       serviceAccountName: vpa-recommender
       securityContext:


### PR DESCRIPTION
Seems like the example in `/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml` copied `Deployment` name from `recommender-deployment-high.yaml`. It is referenced from `vertical-pod-autoscaler/README.md`.

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
