### PR TITLE
Azure: Fast nodegroup backoff on failed provisioning 

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -679,6 +679,13 @@ func instanceStatusFromProvisioningState(provisioningState *string) *cloudprovid
 		status.State = cloudprovider.InstanceDeleting
 	case string(compute.ProvisioningStateCreating):
 		status.State = cloudprovider.InstanceCreating
+	case string(compute.ProvisioningStateFailed):
+		status.State = cloudprovider.InstanceCreating
+		status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+			ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+			ErrorCode:    "provisioning-state-failed",
+			ErrorMessage: "Azure failed to provision a node for this node group",
+		}
 	default:
 		status.State = cloudprovider.InstanceRunning
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -225,6 +225,48 @@ func TestIncreaseSize(t *testing.T) {
 	}
 }
 
+func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	vmssName := "vmss-failed-upscale"
+
+	expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus", compute.Uniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateFailed))
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
+	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
+	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	manager.explicitlyConfigured["vmss-failed-upscale"] = true
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
+	assert.True(t, registered)
+	manager.Refresh()
+
+	provider, err := BuildAzureCloudProvider(manager, nil)
+	assert.NoError(t, err)
+
+	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	assert.True(t, ok)
+
+	// Increase size by one, but the new node fails provisioning
+	err = scaleSet.IncreaseSize(1)
+	assert.NoError(t, err)
+
+	nodes, err := scaleSet.Nodes()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(nodes))
+	assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, nodes[2].Status.ErrorInfo.ErrorClass)
+}
+
 func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a case to the Azure VMSS instance status check to cover an instance that failed provisioning. If the instance fails to provision (generally due to Azure being unable to provide capacity for the instance type), the error percolate to the cluster state registry and put the nodegroup into backoff (faster than if it had to wait `maxNodeProvisionTime`). 

This is inspired by the other cloudProviders that implement similar behavior, like https://github.com/kubernetes/autoscaler/pull/4489

#### Testing Methodology

An nodegroup using an instance type that was actively experiencing Azure capacity issues was selected.  A scale up was triggered for that nodegroup which promptly fails.  The nodegroup is put into backoff in ~20s, and another compatible nodegroup can be upscaled instead, without having to wait `maxNodeProvisionTime` (15m):

![image](https://user-images.githubusercontent.com/63749938/221903796-e54a09e3-c2b7-492a-ab97-2857ca81ddd4.png)


```
2023-02-28T14:14:49.615Z: virtualMachineScaleSetsClient.WaitForCreateOrUpdateResult - updateVMSSCapacity for scale set ""<NODEGROUP>"" failed: Code=""ZonalAllocationFailed"" Message=""Allocation failed. We do not have sufficient capacity for the requested VM size in this zone. Read more about improving likelihood of allocation success at http://aka.ms/allocation-guidance"" Target=""53""
2023-02-28T14:14:49.615Z: Failed to update the capacity for <NODEGROUP> with error Code=""ZonalAllocationFailed"" Message=""Allocation failed. We do not have sufficient capacity for the requested VM size in this zone. Read more about improving likelihood of allocation success at http://aka.ms/allocation-guidance"" Target=""53"", invalidate the cache so as to get the real size from API
2023-02-28T14:14:49.619Z: Provisioning has failed for VM: azure:///subscriptions/<SUBSCRIPTION>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Compute/virtualMachineScaleSets/<NODEGROUP>/virtualMachines/53
2023-02-28T14:14:49.621Z: Nodegroup is nil for azure:///subscriptions/<SUBSCRIPTION>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Compute/virtualMachineScaleSets/<NODEGROUP>/virtualMachines/53
2023-02-28T14:14:49.621Z: Disabling scale-up for node group <NODEGROUP> until 2023-02-28 14:19:49.558793898 +0000 UTC m=+59470.373573234; errorClass=OutOfResource; errorCode=provisioning-state-failed
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
