### PR TITLE
AWS: only look for InstanceRequirements when needed

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -334,7 +334,7 @@ func joinNodeLabelsChoosingUserValuesOverAPIValues(extractedLabels map[string]st
 }
 
 func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.ResourceList, policy *mixedInstancesPolicy) error {
-	if policy == nil {
+	if policy == nil || len(policy.instanceTypesOverrides) > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
In order to support optional InstanceRequirements specifications for ASGs using LaunchTemplates and not directly embedding InstanceRequirements specs within the ASG, the cluster-autoscaler's AWS cloud provider was recently improved to look for possible requirements (specifying eg. CPU and memory capacities) by retrieving LaunchTemplates and their versions, when it builds NodeInfos templates, like so:
```
  GetNodeInfoFromTemplate()
    TemplateNodeInfo()
      buildNodeFromTemplate()
        updateCapacityWithRequirementsOverrides()
          getInstanceRequirementsFromMixedInstancesPolicy()
            // when ASG doesn't specify an instanceRequirementsOverrides,
            // we might still find one in its LaunchTemplate, so
            awsService.getLaunchTemplateData()
              DescribeLaunchTemplateVersions()
```

Those LT/versions lookups can't be fetched in batch, and aren't cached, so we're hitting AWS API at O(n) proportionally to the number of ASGs having LaunchTemplates at every loop, which is a change compared to cluster-autoscaler 1.24. On clusters having many LTs attached, that can cause a slowdown or trigger throttling from AWS.

But retrieving InstanceRequirements should only be needed when the LT overrides don't specify an InstanceType, as both are mutually exclusive. The [api reference doc](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateOverrides.html) states:
> If you specify InstanceRequirements, you can't specify InstanceType.

That mutual exclusion [is already leveraged](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.26.1/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go#L683-L686) by `getInstanceTypesForAsgs`: we don't look for InstanceRequirements when we have a mixed instance policy specifying instance types overrides:


This change reduces the overhead for ASGs with LaunchTemplates not using InstanceRequirements. As a follow-up, we should also cache resources retrieved by getInstanceRequirementsFromMixedInstancesPolicy to mitigate the API call pressure when using InstanceRequirements from LT.

The graph below illustrates the change, on a cluster having 15 ASGs with LaunchTemplates (no InstanceRequirements):
![AWS  API calls](https://user-images.githubusercontent.com/628273/221949053-4d840a57-cd96-4084-8bb7-b8b4f8830abd.png)


#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
