### PR TITLE
Consider pods with emptydir volume in memory be evictable

### DIFF
--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -261,7 +261,7 @@ func HasLocalStorage(pod *apiv1.Pod) bool {
 }
 
 func isLocalVolume(volume *apiv1.Volume) bool {
-	return volume.HostPath != nil || volume.EmptyDir != nil
+	return volume.HostPath != nil || (volume.EmptyDir != nil && volume.EmptyDir.Medium != apiv1.StorageMediumMemory)
 }
 
 // This only checks if a matching PDB exist and therefore if it makes sense to attempt drain simulation,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, pods with in-memory storage are considered as having local storage and are not evictable. This prevents cluster autoscaling to down-scale the node if such pods are present.

In-memory storage is widely used for organizing init or sidecar container communication and in the vast majority of cases should not contain critical data to be lost (see details explanation at https://github.com/kubernetes/autoscaler/issues/3984).
If the new default behavior is not desired then annotation could be added: `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` 

#### Which issue(s) this PR fixes:
Fixes #3984, #2048

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Pods having `emptyDir` volumes with `medium: Memory` are not considered to have local storage and therefore are evictable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

