### PR TITLE
Fix RemovalSimulation for parallel scale down

### DIFF
--- a/cluster-autoscaler/core/scaledown/unremovable/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unremovable/nodes.go
@@ -67,6 +67,12 @@ func (n *Nodes) Update(nodeInfos NodeInfoGetter, timestamp time.Time) {
 	n.ttls = newTTLs
 }
 
+// Contains returns true iff a given node is unremovable.
+func (n *Nodes) Contains(nodeName string) bool {
+	_, found := n.reasons[nodeName]
+	return found
+}
+
 // Add adds an unremovable node.
 func (n *Nodes) Add(node *simulator.UnremovableNode) {
 	n.reasons[node.Node.Name] = node

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -215,7 +215,7 @@ var (
 	skipNodesWithLocalStorage          = flag.Bool("skip-nodes-with-local-storage", true, "If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath")
 	minReplicaCount                    = flag.Int("min-replica-count", 0, "Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down")
 	nodeDeleteDelayAfterTaint          = flag.Duration("node-delete-delay-after-taint", 5*time.Second, "How long to wait before deleting a node after tainting it")
-	scaleDownSimulationTimeout         = flag.Duration("scale-down-simulation-timeout", 5*time.Minute, "How long should we run scale down simulation.")
+	scaleDownSimulationTimeout         = flag.Duration("scale-down-simulation-timeout", 30*time.Second, "How long should we run scale down simulation.")
 	parallelDrain                      = flag.Bool("parallel-drain", false, "Whether to allow parallel drain of nodes.")
 	maxCapacityMemoryDifferenceRatio   = flag.Float64("memory-difference-ratio", config.DefaultMaxCapacityMemoryDifferenceRatio, "Maximum difference in memory capacity between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's memory capacity.")
 	maxFreeDifferenceRatio             = flag.Float64("max-free-difference-ratio", config.DefaultMaxFreeDifferenceRatio, "Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource.")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Added label for outer loop and break outer loop if the timer send signal. Before CA did nothing and didn't have any limit for scale down simulation. 

Also, I modified the default value for scaleDownSimulationTimeout flag, because 30 seconds is enough to process ~1000 non empty nodes and in the same time cluster snapshot is not too old comparing to the snapshot for 5 minutes timeout.