### PR TITLE
[cluster-api] Handle ignored errors

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -270,7 +270,7 @@ func (c *machineController) findMachineByProviderID(providerID normalizedProvide
 		return nil, nil
 	}
 
-	machineID, _ := node.Annotations[machineAnnotationKey]
+	machineID := node.Annotations[machineAnnotationKey]
 	return c.findMachine(machineID)
 }
 
@@ -380,7 +380,9 @@ func newMachineController(
 			Resource: resourceNameMachineDeployment,
 		}
 		machineDeploymentInformer = managementInformerFactory.ForResource(gvrMachineDeployment)
-		machineDeploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+		if _, err := machineDeploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{}); err != nil {
+			return nil, fmt.Errorf("failed to add event handler for resource %q: %v", resourceNameMachineDeployment, err)
+		}
 	}
 
 	gvrMachineSet := schema.GroupVersionResource{
@@ -389,7 +391,9 @@ func newMachineController(
 		Resource: resourceNameMachineSet,
 	}
 	machineSetInformer := managementInformerFactory.ForResource(gvrMachineSet)
-	machineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	if _, err := machineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{}); err != nil {
+		return nil, fmt.Errorf("failed to add event handler for resource %q: %v", resourceNameMachineSet, err)
+	}
 
 	gvrMachine := schema.GroupVersionResource{
 		Group:    CAPIGroup,
@@ -397,10 +401,14 @@ func newMachineController(
 		Resource: resourceNameMachine,
 	}
 	machineInformer := managementInformerFactory.ForResource(gvrMachine)
-	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	if _, err := machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{}); err != nil {
+		return nil, fmt.Errorf("failed to add event handler for resource %q: %v", resourceNameMachine, err)
+	}
 
 	nodeInformer := workloadInformerFactory.Core().V1().Nodes().Informer()
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	if _, err := nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{}); err != nil {
+		return nil, fmt.Errorf("failed to add event handler for resource %q: %v", "nodes", err)
+	}
 
 	if err := machineInformer.Informer().GetIndexer().AddIndexers(cache.Indexers{
 		machineProviderIDIndex: indexMachineByProviderID,
@@ -750,7 +758,7 @@ func (c *machineController) getInfrastructureResource(resource schema.GroupVersi
 
 	infra, ok := obj.(*unstructured.Unstructured)
 	if !ok {
-		err := fmt.Errorf("Unable to convert infrastructure reference for %s/%s", namespace, name)
+		err := fmt.Errorf("unable to convert infrastructure reference for %s/%s", namespace, name)
 		klog.V(4).Infof("%v", err)
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -281,6 +281,9 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 
 		scalableResource, err := ng.machineController.managementScaleClient.Scales(testConfig.spec.namespace).
 			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if scalableResource.Spec.Replicas != tc.initial {
 			t.Errorf("expected %v, got %v", tc.initial, scalableResource.Spec.Replicas)
@@ -354,6 +357,9 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 
 		scalableResource, err := ng.machineController.managementScaleClient.Scales(ng.scalableResource.Namespace()).
 			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if scalableResource.Spec.Replicas != tc.expected {
 			t.Errorf("expected %v, got %v", tc.expected, scalableResource.Spec.Replicas)
@@ -478,8 +484,12 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 				}
 			},
 		}
-		controller.machineSetInformer.Informer().AddEventHandler(handler)
-		controller.machineDeploymentInformer.Informer().AddEventHandler(handler)
+		if _, err := controller.machineSetInformer.Informer().AddEventHandler(handler); err != nil {
+			t.Fatalf("unexpected error adding event handler for machineSetInformer: %v", err)
+		}
+		if _, err := controller.machineDeploymentInformer.Informer().AddEventHandler(handler); err != nil {
+			t.Fatalf("unexpected error adding event handler for machineDeploymentInformer: %v", err)
+		}
 
 		scalableResource.Spec.Replicas += tc.targetSizeIncrement
 
@@ -606,6 +616,9 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 
 		scalableResource, err := ng.machineController.managementScaleClient.Scales(testConfig.spec.namespace).
 			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if scalableResource.Spec.Replicas != tc.initial {
 			t.Errorf("expected %v, got %v", tc.initial, scalableResource.Spec.Replicas)
@@ -1126,6 +1139,9 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 
 		scalableResource, err := ng.machineController.managementScaleClient.Scales(testConfig.spec.namespace).
 			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if scalableResource.Spec.Replicas != int32(expectedSize) {
 			t.Errorf("expected %v, got %v", expectedSize, scalableResource.Spec.Replicas)
@@ -1181,7 +1197,9 @@ func TestNodeGroupWithFailedMachine(t *testing.T) {
 		machine := testConfig.machines[3].DeepCopy()
 
 		unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
-		unstructured.SetNestedField(machine.Object, "FailureMessage", "status", "failureMessage")
+		if err := unstructured.SetNestedField(machine.Object, "FailureMessage", "status", "failureMessage"); err != nil {
+			t.Fatalf("unexpected error setting nested field: %v", err)
+		}
 
 		if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -66,6 +66,9 @@ func TestSetSize(t *testing.T) {
 
 		s, err := sr.controller.managementScaleClient.Scales(testResource.GetNamespace()).
 			Get(context.TODO(), gvr.GroupResource(), testResource.GetName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("error getting scale subresource: %v", err)
+		}
 
 		if s.Spec.Replicas != int32(updatedReplicas) {
 			t.Errorf("expected %v, got: %v", updatedReplicas, s.Spec.Replicas)
@@ -185,8 +188,12 @@ func TestReplicas(t *testing.T) {
 			},
 		}
 
-		controller.machineSetInformer.Informer().AddEventHandler(handler)
-		controller.machineDeploymentInformer.Informer().AddEventHandler(handler)
+		if _, err := controller.machineSetInformer.Informer().AddEventHandler(handler); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := controller.machineDeploymentInformer.Informer().AddEventHandler(handler); err != nil {
+			t.Fatal(err)
+		}
 
 		_, err = sr.controller.managementScaleClient.Scales(testResource.GetNamespace()).
 			Update(context.TODO(), gvr.GroupResource(), s, metav1.UpdateOptions{})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleans up code in the cluster-api cluster-autoscaler backend, in particular handling ignored errors. Also makes other small changes suggested by golangci-lint.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
