### PR TITLE
chart: Add option to install VPA

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.26.0
+version: 9.27.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -318,6 +318,26 @@ Containers:
 
 Though enough for the majority of installations, the default PodSecurityPolicy _could_ be too restrictive depending on the specifics of your release. Please make sure to check that the template fits with any customizations made or disable it by setting `rbac.pspEnabled` to `false`.
 
+### VerticalPodAutoscaler
+
+The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically.
+The following example snippet can be used to install a [`autoscaling.k8s.io/v1` VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go).
+
+```yaml
+vpa:
+  enabled: true
+  apiVersion: v1
+  containerPolicy:
+    minAllowed:
+      cpu: 50m
+      memory: 150Mi
+    maxAllowed:
+      cpu: 100m
+      memory: 300Mi
+```
+
+Supported VPA versions are `v1` and `v1beta2`.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -413,3 +433,7 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 | tolerations | list | `[]` | List of node taints to tolerate (requires Kubernetes >= 1.6). |
 | topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |
 | updateStrategy | object | `{}` | [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| vpa | object | `{"apiVersion":"v1","containerPolicy":{},"enabled":false}` | Configure a VerticalPodAutoscaler for the cluster-autoscaler Deployment. |
+| vpa.apiVersion | string | `"v1"` | APIVersion of the VerticalPodAutoscaler. The template only supports v1 and v1beta2. |
+| vpa.containerPolicy | object | `{}` | Configure the containerPolicy of the cluster-autoscaler container. Content is rendered as YAML. |
+| vpa.enabled | bool | `false` | If true, creates a VerticalPodAutoscaler. |

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -320,23 +320,18 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 
 ### VerticalPodAutoscaler
 
-The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically.
-The following example snippet can be used to install a [`autoscaling.k8s.io/v1` VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go).
+The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically or remediate containers that are being OOMKilled.
+
+The following example snippet can be used to install VPA that allows scaling down from the default recommendations of the deployment template:
 
 ```yaml
 vpa:
   enabled: true
-  apiVersion: v1
   containerPolicy:
     minAllowed:
-      cpu: 50m
-      memory: 150Mi
-    maxAllowed:
-      cpu: 100m
-      memory: 300Mi
+      cpu: 20m
+      memory: 50Mi
 ```
-
-Supported VPA versions are `v1` and `v1beta2`.
 
 ## Values
 
@@ -433,7 +428,7 @@ Supported VPA versions are `v1` and `v1beta2`.
 | tolerations | list | `[]` | List of node taints to tolerate (requires Kubernetes >= 1.6). |
 | topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |
 | updateStrategy | object | `{}` | [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
-| vpa | object | `{"apiVersion":"v1","containerPolicy":{},"enabled":false}` | Configure a VerticalPodAutoscaler for the cluster-autoscaler Deployment. |
-| vpa.apiVersion | string | `"v1"` | APIVersion of the VerticalPodAutoscaler. The template only supports v1 and v1beta2. |
-| vpa.containerPolicy | object | `{}` | Configure the containerPolicy of the cluster-autoscaler container. Content is rendered as YAML. |
+| vpa | object | `{"containerPolicy":{},"enabled":false,"updateMode":"Auto"}` | Configure a VerticalPodAutoscaler for the cluster-autoscaler Deployment. |
+| vpa.containerPolicy | object | `{}` | [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always et to the deployment's container name. This value is required if VPA is enabled. |
 | vpa.enabled | bool | `false` | If true, creates a VerticalPodAutoscaler. |
+| vpa.updateMode | string | `"Auto"` | [UpdateMode](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L124) |

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -320,22 +320,17 @@ Though enough for the majority of installations, the default PodSecurityPolicy _
 
 ### VerticalPodAutoscaler
 
-The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically.
-The following example snippet can be used to install a [`autoscaling.k8s.io/v1` VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go).
+The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically or remediate containers that are being OOMKilled.
+
+The following example snippet can be used to install VPA that allows scaling down from the default recommendations of the deployment template:
 
 ```yaml
 vpa:
   enabled: true
-  apiVersion: v1
   containerPolicy:
     minAllowed:
-      cpu: 50m
-      memory: 150Mi
-    maxAllowed:
-      cpu: 100m
-      memory: 300Mi
+      cpu: 20m
+      memory: 50Mi
 ```
-
-Supported VPA versions are `v1` and `v1beta2`.
 
 {{ template "chart.valuesSection" . }}

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -318,4 +318,24 @@ Containers:
 
 Though enough for the majority of installations, the default PodSecurityPolicy _could_ be too restrictive depending on the specifics of your release. Please make sure to check that the template fits with any customizations made or disable it by setting `rbac.pspEnabled` to `false`.
 
+### VerticalPodAutoscaler
+
+The chart can install a [`VerticalPodAutoscaler`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for the Deployment if needed. A VPA can help minimize wasted resources when usage spikes periodically.
+The following example snippet can be used to install a [`autoscaling.k8s.io/v1` VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go).
+
+```yaml
+vpa:
+  enabled: true
+  apiVersion: v1
+  containerPolicy:
+    minAllowed:
+      cpu: 50m
+      memory: 150Mi
+    maxAllowed:
+      cpu: 100m
+      memory: 300Mi
+```
+
+Supported VPA versions are `v1` and `v1beta2`.
+
 {{ template "chart.valuesSection" . }}

--- a/charts/cluster-autoscaler/templates/vpa.yaml
+++ b/charts/cluster-autoscaler/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.vpa.enabled -}}
-apiVersion: "autoscaling.k8s.io/{{ .Values.vpa.apiVersion }}"
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   labels:
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: {{ template "cluster-autoscaler.fullname" . }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ .Values.vpa.updateMode | quote }}
   resourcePolicy:
     containerPolicies:
     - containerName: {{ template "cluster-autoscaler.name" . }}

--- a/charts/cluster-autoscaler/templates/vpa.yaml
+++ b/charts/cluster-autoscaler/templates/vpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.vpa.enabled -}}
+apiVersion: "autoscaling.k8s.io/{{ .Values.vpa.apiVersion }}"
+kind: VerticalPodAutoscaler
+metadata:
+  labels:
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
+  name: {{ template "cluster-autoscaler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ template "deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ template "cluster-autoscaler.fullname" . }}
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ template "cluster-autoscaler.name" . }}
+      {{- .Values.vpa.containerPolicy | toYaml | nindent 6 }}
+{{- end -}}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -392,17 +392,7 @@ updateStrategy: {}
 vpa:
   # vpa.enabled -- If true, creates a VerticalPodAutoscaler.
   enabled: false
-  # vpa.apiVersion -- APIVersion of the VerticalPodAutoscaler. The template only supports v1 and v1beta2.
-  apiVersion: v1
-  # vpa.containerPolicy -- Configure the containerPolicy of the cluster-autoscaler container. Content is rendered as YAML.
+  # vpa.updateMode -- [UpdateMode](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L124)
+  updateMode: "Auto"
+  # vpa.containerPolicy -- [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always et to the deployment's container name. This value is required if VPA is enabled.
   containerPolicy: {}
-    # minAllowed:
-    #   cpu: 50m
-    #   memory: 150Mi
-    # maxAllowed:
-    #   cpu: 100m
-    #   memory: 300Mi
-    # controlledResources:
-    #   - cpu
-    #   - memory
-    # controlledValues: RequestsAndLimits

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -387,3 +387,22 @@ updateStrategy: {}
   #   maxSurge: 1
   #   maxUnavailable: 0
   # type: RollingUpdate
+
+# vpa -- Configure a VerticalPodAutoscaler for the cluster-autoscaler Deployment.
+vpa:
+  # vpa.enabled -- If true, creates a VerticalPodAutoscaler.
+  enabled: false
+  # vpa.apiVersion -- APIVersion of the VerticalPodAutoscaler. The template only supports v1 and v1beta2.
+  apiVersion: v1
+  # vpa.containerPolicy -- Configure the containerPolicy of the cluster-autoscaler container. Content is rendered as YAML.
+  containerPolicy: {}
+    # minAllowed:
+    #   cpu: 50m
+    #   memory: 150Mi
+    # maxAllowed:
+    #   cpu: 100m
+    #   memory: 300Mi
+    # controlledResources:
+    #   - cpu
+    #   - memory
+    # controlledValues: RequestsAndLimits


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I currently install a VPA for the cluster-autoscaler alongside the chart, but it would be nice to get it all from the same source.

#### Does this PR introduce a user-facing change?

```release-note
Add chart option to install VPA
```