### PR TITLE
Use snapshot of NodeDeletionTracker for ActuationStatus

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -66,12 +66,9 @@ func NewActuator(ctx *context.AutoscalingContext, csr *clusterstate.ClusterState
 	}
 }
 
-// CheckStatus should return an immutable snapshot of ongoing deletions. Before the TODO is addressed, a live object
-// is returned instead of an immutable snapshot.
+// CheckStatus should returns an immutable snapshot of ongoing deletions.
 func (a *Actuator) CheckStatus() scaledown.ActuationStatus {
-	// TODO: snapshot information from the tracker instead of keeping live
-	// updated object.
-	return a.nodeDeletionTracker
+	return a.nodeDeletionTracker.Snapshot()
 }
 
 // ClearResultsNotNewerThan removes information about deletions finished before or exactly at the provided timestamp.

--- a/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
+++ b/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
@@ -168,3 +168,26 @@ func (n *NodeDeletionTracker) ClearResultsNotNewerThan(t time.Time) {
 	defer n.Unlock()
 	n.deletionResults.DropNotNewerThan(t)
 }
+
+// Snapshot return a copy of NodeDeletionTracker.
+func (n *NodeDeletionTracker) Snapshot() *NodeDeletionTracker {
+	n.Lock()
+	defer n.Unlock()
+	snapshot := NewNodeDeletionTracker(n.evictionsTTL)
+	for k, val := range n.emptyNodeDeletions {
+		snapshot.emptyNodeDeletions[k] = val
+	}
+	for k, val := range n.drainedNodeDeletions {
+		snapshot.drainedNodeDeletions[k] = val
+	}
+	for k, val := range n.deletionsPerNodeGroup {
+		snapshot.deletionsPerNodeGroup[k] = val
+	}
+	for _, eviction := range n.evictions.ToSlice() {
+		snapshot.evictions.RegisterElement(eviction)
+	}
+	for _, result := range n.deletionResults.ToSlice() {
+		snapshot.deletionResults.RegisterElement(result)
+	}
+	return snapshot
+}

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -65,6 +65,7 @@ type Actuator interface {
 }
 
 // ActuationStatus is used for feeding Actuator status back into Planner
+// TODO: Replace ActuationStatus with simple struct with getter methods.
 type ActuationStatus interface {
 	// DeletionsInProgress returns two lists of node names that are
 	// currently undergoing deletion, for empty and non-empty (i.e. drained)
@@ -77,10 +78,4 @@ type ActuationStatus interface {
 	// the Actuator and hence are likely to get recreated elsewhere in the
 	// cluster.
 	RecentEvictions() (pods []*apiv1.Pod)
-	// DeletionResults returns a map of recent node deletion results, keyed
-	// by the node name. Note: if node deletion was scheduled more than
-	// once, only the latest result will be present.
-	// The timestamp returned as the second value indicates the time at
-	// which the last result was collected.
-	DeletionResults() (map[string]status.NodeDeleteResult, time.Time)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Node deletions happens in separate go routine, so it's possible that node was removed during unneeded node verification. In such case we have updated number of ongoing deletions but outdated size of the node group, so CA will have wrong verification of min size of the node group.