### PR TITLE
Add dependabot configuration for VPA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/vertical-pod-autoscaler"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0 # setting this to 0 means only allowing security updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+- package-ecosystem: docker
+  directory: "/vertical-pod-autoscaler/builder"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 0 # setting this to 0 means only allowing security updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+  labels:
+    - "vertical-pod-autoscaler"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/builder"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+    - "vertical-pod-autoscaler"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds dependabot configuration for VPA. We can try to automate updates of the builder golang version and security fixes for the dependencies in go.mod. Recent examples where we did these update by hand are [bumping golang to 1.19.5](https://github.com/kubernetes/autoscaler/pull/5484) and updating [github.com/emicklei/go-restful/v3](https://github.com/kubernetes/autoscaler/pull/5482).

By setting `open-pull-requests-limit: 0`, you limit the dependabot updates to security fixes only – [these PRs are done with a separate pull-request-limit pool](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5341

#### Special notes for your reviewer:
As discussed in the last SIG meeting, let's see if this creates too much noise. We can revisit this in ~4 weeks and can revert this is it is not useful.
As discussed in #5341, we enable this for VPA only at this point in time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
