### PR TITLE
Automated cherry pick of #5246: Don't break scale up with priority expander config

### DIFF
--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -123,7 +123,7 @@ func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[
 
 	priorities, cm, err := p.reloadConfigMap()
 	if err != nil {
-		return nil
+		return expansionOptions
 	}
 
 	maxPrio := -1


### PR DESCRIPTION
Cherry pick of #5246 on cluster-autoscaler-release-1.25.

#5246: Don't break scale up with priority expander config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
