### PR TITLE
ovhcloud: Fix panic on concurrent map read/write

### DIFF
--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -195,7 +195,7 @@ func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 		instances = append(instances, instance)
 
 		// Store the associated node group in cache for future reference
-		ng.Manager.NodeGroupPerProviderID[instance.Id] = ng
+		ng.Manager.setNodeGroupPerProviderID(instance.Id, ng)
 	}
 
 	return instances, nil

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -159,10 +159,11 @@ func (provider *OVHCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 
 // findNodeGroupFromCache tries to retrieve the associated node group from an already built mapping in cache
 func (provider *OVHCloudProvider) findNodeGroupFromCache(providerID string) cloudprovider.NodeGroup {
-	if ng, ok := provider.manager.NodeGroupPerProviderID[providerID]; ok {
-		return ng
+	nodeGroup := provider.manager.getNodeGroupPerProviderID(providerID)
+	if nodeGroup != nil {
+		return nodeGroup
 	}
-	return nil
+	return nil // To avoid returning a (*cloudprovider.NodeGroup)(nil), which is different from nil
 }
 
 // findNodeGroupFromLabel tries to find the associated node group from the nodepool label on the node


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a crash occurring in the ovhcloud provider code, due to a concurrent read/write access to a map.

This fix has already been released in production for the cluster-autoscaler instances running on the OVHcloud Managed Kubernetes product.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
