### PR TITLE
ovhcloud: Add support for nodepool templating

### DIFF
--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/nodepool.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/nodepool.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // NodePool defines the nodes group deployed on OVHcloud
@@ -44,6 +46,19 @@ type NodePool struct {
 	UpToDateNodes  uint32 `json:"upToDateNodes"`
 
 	Autoscaling *NodePoolAutoscaling `json:"autoscaling,omitempty"`
+
+	Template struct {
+		Metadata struct {
+			Labels      map[string]string `json:"labels"`
+			Annotations map[string]string `json:"annotations"`
+			Finalizers  []string          `json:"finalizers"`
+		} `json:"metadata"`
+
+		Spec struct {
+			Unschedulable bool       `json:"unschedulable"`
+			Taints        []v1.Taint `json:"taints"`
+		} `json:"spec"`
+	} `json:"template"`
 
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allows the autoscaler to scale up an empty OVHCloud nodepool with specific templating (e.g. labels) that is needed to accommodate the Pending pods.

The templating was not taken into account when generating the node upscale simulation, which resulted in errors of the following kind:
```
Pod runner-t7kqpv4z-project-2-concurrent-0swpm6 can't be scheduled on gitlab-runner-pool-small, predicate checking error: node(s) didn't match Pod's node affinity/selector; predicateName=NodeAffinity; reasons: node(s) didn't match Pod's node affinity/selector
```

With this PR the simulation is closer to the truth and the node group is successfully scaled up by the autoscaler.

This fix has already been released in production for the cluster-autoscaler instances running on the OVHcloud Managed Kubernetes product.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

The OVHCloud nodepool template feature is described in the following documentation: https://support.us.ovhcloud.com/hc/en-us/articles/1500005054502-How-to-Manage-Nodes-and-Node-Pools-with-the-OVHcloud-API

#### Does this PR introduce a user-facing change?

```release-note
## OVHcloud
- Add support for OVHCloud's nodepool templating features
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
