### PR TITLE
[WIP] Improve ignore-taint naming

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -184,8 +184,8 @@ type AutoscalingOptions struct {
 	MaxBulkSoftTaintTime time.Duration
 	// MaxPodEvictionTime sets the maximum time CA tries to evict a pod before giving up.
 	MaxPodEvictionTime time.Duration
-	// IgnoredTaints is a list of taints to ignore when considering a node template for scheduling.
-	IgnoredTaints []string
+	// InitializationTaints is a list of taints to ignore when considering a node template for scheduling.
+	InitializationTaints []string
 	// BalancingExtraIgnoredLabels is a list of labels to additionally ignore when comparing if two node groups are similar.
 	// Labels in BasicIgnoredLabels and the cloud provider-specific ignored labels are always ignored.
 	BalancingExtraIgnoredLabels []string

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -916,8 +916,8 @@ func TestStartDeletion(t *testing.T) {
 					break taintsLoop
 				}
 			}
-			ignoreTaintValue := cmpopts.IgnoreFields(apiv1.Taint{}, "Value")
-			if diff := cmp.Diff(tc.wantTaintUpdates, gotTaintUpdates, ignoreTaintValue, cmpopts.EquateEmpty()); diff != "" {
+			taintValue := cmpopts.IgnoreFields(apiv1.Taint{}, "Value")
+			if diff := cmp.Diff(tc.wantTaintUpdates, gotTaintUpdates, taintValue, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("taintUpdates diff (-want +got):\n%s", diff)
 			}
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -160,8 +160,8 @@ func NewStaticAutoscaler(
 	}
 
 	ignoredTaints := make(taints.TaintKeySet)
-	for _, taintKey := range opts.IgnoredTaints {
-		klog.V(4).Infof("Ignoring taint %s on all NodeGroups", taintKey)
+	for _, taintKey := range opts.InitializationTaints {
+		klog.V(4).Infof("Ignoring initialization taint %s on all NodeGroups", taintKey)
 		ignoredTaints[taintKey] = true
 	}
 
@@ -884,7 +884,7 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
-	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.ignoredTaints, allNodes, readyNodes)
+	allNodes, readyNodes = taints.FilterOutNodesWithInitializationTaints(a.ignoredTaints, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -187,7 +187,9 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
-	ignoreTaintsFlag                   = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	ignoreTaintsFlag         = multiStringFlag("ignore-taint", "DEPRECATED. Use --initialization-taint instead.")
+	initializationTaintsFlag = multiStringFlag("initialization-taint", "Nodes with specified taint are treaded as Unready by CA clusterstate")
+
 	balancingIgnoreLabelsFlag          = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag                = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
 	awsUseStaticInstanceList           = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
@@ -246,6 +248,10 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 	if *maxDrainParallelismFlag > 1 && !*parallelDrain {
 		klog.Fatalf("Invalid configuration, could not use --max-drain-parallelism > 1 if --parallel-drain is false")
 	}
+
+	// join two arrays as long as "ignoreTaintsFlag" is not fully deprecated
+	initializationTaints := append(*ignoreTaintsFlag, *initializationTaintsFlag...)
+
 	return config.AutoscalingOptions{
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
 			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
@@ -298,7 +304,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ExpendablePodsPriorityCutoff:       *expendablePodsPriorityCutoff,
 		Regional:                           *regional,
 		NewPodScaleUpDelay:                 *newPodScaleUpDelay,
-		IgnoredTaints:                      *ignoreTaintsFlag,
+		InitializationTaints:               initializationTaints,
 		BalancingExtraIgnoredLabels:        *balancingIgnoreLabelsFlag,
 		BalancingLabels:                    *balancingLabelsFlag,
 		KubeConfigPath:                     *kubeConfigFile,

--- a/cluster-autoscaler/utils/kubernetes/ready.go
+++ b/cluster-autoscaler/utils/kubernetes/ready.go
@@ -35,10 +35,10 @@ const (
 	// still upcoming due to a missing resource (e.g. GPU).
 	ResourceUnready NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/resource-not-ready"
 
-	// IgnoreTaint is a fake identifier used internally by Cluster Autoscaler
+	// InitializationTaint is a fake identifier used internally by Cluster Autoscaler
 	// to indicate nodes that appear Ready in the API, but are treated as
-	// still upcoming due to applied ignore taint.
-	IgnoreTaint NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/ignore-taint"
+	// still upcoming due to applied initialization taint.
+	InitializationTaint NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/initialization-taint"
 )
 
 // IsNodeReadyAndSchedulable returns true if the node is ready and schedulable.

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -370,7 +370,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				Spec: apiv1.NodeSpec{
 					Taints: []apiv1.Taint{
 						{
-							Key:    IgnoreTaintPrefix + "another-taint",
+							Key:    initializationTaintPrefix + "another-taint",
 							Value:  "myValue",
 							Effect: apiv1.TaintEffectNoSchedule,
 						},
@@ -415,7 +415,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 			if tc.node != nil {
 				nodes = append(nodes, tc.node)
 			}
-			allNodes, readyNodes := FilterOutNodesWithIgnoredTaints(tc.ignoredTaints, nodes, nodes)
+			allNodes, readyNodes := FilterOutNodesWithInitializationTaints(tc.ignoredTaints, nodes, nodes)
 			assert.Equal(t, tc.allNodes, len(allNodes))
 			assert.Equal(t, tc.readyNodes, len(readyNodes))
 
@@ -451,7 +451,12 @@ func TestSanitizeTaints(t *testing.T) {
 		Spec: apiv1.NodeSpec{
 			Taints: []apiv1.Taint{
 				{
-					Key:    IgnoreTaintPrefix + "another-taint",
+					Key:    initializationTaintPrefix + "another-taint",
+					Value:  "myValue",
+					Effect: apiv1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    initializationTaintPrefix + "another-taint",
 					Value:  "myValue",
 					Effect: apiv1.TaintEffectNoSchedule,
 				},
@@ -482,6 +487,11 @@ func TestSanitizeTaints(t *testing.T) {
 				},
 				{
 					Key:    "ignore-taint.cluster-autoscaler.kubernetes.io/to-be-ignored",
+					Value:  "I-am-the-invisible-man-Incredible-how-you-can",
+					Effect: apiv1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "initialization-resource-unready.cluster-autoscaler.kubernetes.io/",
 					Value:  "I-am-the-invisible-man-Incredible-how-you-can",
 					Effect: apiv1.TaintEffectNoSchedule,
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Rename:
 * "ignore-taint" flag to "initialization-taint"
 * "ignore-taint.cluster-autoscaler.kubernetes.io/" special, hardcoded prefix into "initialization-resource-unready.cluster-autoscaler.kubernetes.io/"

The “ignore-taint” naming is confusing and even inaccurate. 
It's initial purpose was to mark those node that needs additional startup/initialization/installation before they are ready to run workloads (example: GPU Nvidia driver installation).

Current flag description: "Specifies a taint to ignore in node templates when considering to scale a node group".

The more precise description, would be something like: "Specify a list of special* initialization taints, would you be used to mark nodes which are not ready yet. Those nodes would be counted as `NotStarted` in CA clasterstate (to avoid unnecessary scale-ups). If node doesn't start in 15min - they are considered an unexpectedly Unready. Too many of those (max-total-unready-percentage flag, default to 45%) would stop the CA all together.

Those taints are skipped when creating/cloning a new node (on scale-up).

#### Does this PR introduce a user-facing change?

```release-note
A new "initialization-taint" flag, which would be 1-1 replacement for the "ignore-taint", which is meant to be Deprecated.
```

/assign MaciekPytel