### PR TITLE
docs: fix faq around expendable-pods-priority-cutoff

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -380,43 +380,25 @@ export ENABLE_POD_PRIORITY=true
 
 For AWS using kops, see [this issue](https://github.com/kubernetes/autoscaler/issues/1410#issuecomment-439840945).
 
-2. Define priority class for overprovisioning pods. Priority -1 will be reserved for
+2. Define priority class for overprovisioning pods. Priority -10 will be reserved for
 overprovisioning pods as it is the lowest priority that triggers scaling clusters. Other pods need
 to use priority 0 or higher in order to be able to preempt overprovisioning pods. You can use
 following definitions.
-
-**For 1.10, and below:**
-
-```yaml
-apiVersion: scheduling.k8s.io/v1alpha1
-kind: PriorityClass
-metadata:
-  name: overprovisioning
-value: -1
-globalDefault: false
-description: "Priority class used by overprovisioning."
-```
-
-**For 1.11+:**
 
 ```yaml
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: overprovisioning
-value: -1
+value: -10
 globalDefault: false
 description: "Priority class used by overprovisioning."
 ```
 
-3. Change pod priority cutoff in CA to -10 so pause pods are taken into account during scale down
-and scale up. Set flag ```expendable-pods-priority-cutoff``` to -10. If you already use priority
-preemption then pods with priorities between -10 and -1 won't be best effort anymore.
-
-4. Create service account that will be used by Horizontal Cluster Proportional Autoscaler which needs
+3. Create service account that will be used by Horizontal Cluster Proportional Autoscaler which needs
 specific roles. More details [here](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/tree/master/examples#rbac-configurations)
 
-5. Create deployments that will reserve resources. "overprovisioning" deployment will reserve
+4. Create deployments that will reserve resources. "overprovisioning" deployment will reserve
 resources and "overprovisioning-autoscaler" deployment will change the size of reserved resources.
 You can use following definitions (you need to change service account for "overprovisioning-autoscaler"
 deployment to the one created in the previous step):
@@ -445,6 +427,7 @@ spec:
         resources:
           requests:
             cpu: "200m"
+
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/autoscaler/blame/master/cluster-autoscaler/FAQ.md#L412 is wrong and confusing the default is -10 https://github.com/kubernetes/autoscaler/blob/63b334f81a8820511c835401e0133d242d84da08/cluster-autoscaler/main.go#L186 so no need for an extra step

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```