### PR TITLE
Add support for tags on AWS managed nodegroups to indicate resources

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -308,6 +308,18 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 			node.Spec.Taints = append(node.Spec.Taints, mngTaints...)
 			klog.V(5).Infof("node.Spec.Taints : %+v\n", node.Spec.Taints)
 		}
+
+		mngTags, err := m.managedNodegroupCache.getManagedNodegroupTags(nodegroupName, clusterName)
+		if err != nil {
+			klog.Errorf("Failed to get tags from EKS DescribeNodegroup API for nodegroup %s in cluster %s because %s.", nodegroupName, clusterName, err)
+		} else if mngTags != nil && len(mngTags) > 0 {
+			resourcesFromMngTags := extractAllocatableResourcesFromTags(mngTags)
+			klog.V(5).Infof("Extracted resources from EKS nodegroup tags %v", resourcesFromTags)
+			// ManagedNodeGroup resource-indicating tags override conflicting tags on the ASG if they exist
+			for resourceName, val := range resourcesFromMngTags {
+				node.Status.Capacity[apiv1.ResourceName(resourceName)] = *val
+			}
+		}
 	}
 
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
@@ -448,6 +460,27 @@ func extractAllocatableResourcesFromAsg(tags []*autoscaling.TagDescription) map[
 			if label != "" {
 				quantity, err := resource.ParseQuantity(v)
 				if err != nil {
+					continue
+				}
+				result[label] = &quantity
+			}
+		}
+	}
+
+	return result
+}
+
+func extractAllocatableResourcesFromTags(tags map[string]string) map[string]*resource.Quantity {
+	result := make(map[string]*resource.Quantity)
+
+	for k, v := range tags {
+		splits := strings.Split(k, "k8s.io/cluster-autoscaler/node-template/resources/")
+		if len(splits) > 1 {
+			label := splits[1]
+			if label != "" {
+				quantity, err := resource.ParseQuantity(v)
+				if err != nil {
+					klog.Warningf("Failed to parse resource quanitity '%s' for resource '%s'", v, label)
 					continue
 				}
 				result[label] = &quantity

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -103,6 +103,27 @@ func TestExtractAllocatableResourcesFromAsg(t *testing.T) {
 	assert.Equal(t, resource.NewQuantity(5, resource.DecimalSI).String(), labels["custom-resource"].String())
 }
 
+func TestExtractAllocatableResourcesFromTags(t *testing.T) {
+	tags := map[string]string{
+		"k8s.io/cluster-autoscaler/node-template/resources/cpu":               "100m",
+		"k8s.io/cluster-autoscaler/node-template/resources/memory":            "100M",
+		"k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage": "20G",
+		"k8s.io/cluster-autoscaler/node-template/resources/custom-resource":   "5",
+		"k8s.io/cluster-autoscaler/node-template/resources/error-resource":    "GG",
+	}
+
+	labels := extractAllocatableResourcesFromTags(tags)
+
+	assert.Equal(t, 4, len(labels))
+	assert.NotContains(t, labels, "error-resource")
+	assert.Equal(t, resource.NewMilliQuantity(100, resource.DecimalSI).String(), labels["cpu"].String())
+	expectedMemory := resource.MustParse("100M")
+	assert.Equal(t, (&expectedMemory).String(), labels["memory"].String())
+	expectedEphemeralStorage := resource.MustParse("20G")
+	assert.Equal(t, (&expectedEphemeralStorage).String(), labels["ephemeral-storage"].String())
+	assert.Equal(t, resource.NewQuantity(5, resource.DecimalSI).String(), labels["custom-resource"].String())
+}
+
 func TestGetAsgOptions(t *testing.T) {
 	defaultOptions := config.NodeGroupAutoscalingOptions{
 		ScaleDownUtilizationThreshold:    0.1,
@@ -212,11 +233,17 @@ func TestBuildNodeFromTemplateWithManagedNodegroup(t *testing.T) {
 		Value:  taintValue2,
 	}
 
+	ephemeralStorageKey := "ephemeral-storage"
+	diskSizeGb := 80
+	tagKey1 := fmt.Sprintf("k8s.io/cluster-autoscaler/node-template/resources/%s", ephemeralStorageKey)
+	tagValue1 := fmt.Sprintf("%dGi", diskSizeGb)
+
 	err := mngCache.Add(managedNodegroupCachedObject{
 		name:        ngNameLabelValue,
 		clusterName: clusterNameLabelValue,
 		taints:      []apiv1.Taint{taint1, taint2},
 		labels:      map[string]string{labelKey1: labelValue1, labelKey2: labelValue2},
+		tags:        map[string]string{tagKey1: tagValue1},
 	})
 	require.NoError(t, err)
 
@@ -239,6 +266,9 @@ func TestBuildNodeFromTemplateWithManagedNodegroup(t *testing.T) {
 		},
 	})
 	assert.NoError(t, observedErr)
+	esValue, esExist := observedNode.Status.Capacity[apiv1.ResourceName(ephemeralStorageKey)]
+	assert.True(t, esExist)
+	assert.Equal(t, int64(diskSizeGb*1024*1024*1024), esValue.Value())
 	assert.GreaterOrEqual(t, len(observedNode.Labels), 4)
 	ngNameValue, ngLabelExist := observedNode.Labels["nodegroup-name"]
 	assert.True(t, ngLabelExist)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -57,7 +57,7 @@ type awsWrapper struct {
 	eksI
 }
 
-func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName string) ([]apiv1.Taint, map[string]string, error) {
+func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName string) ([]apiv1.Taint, map[string]string, map[string]string, error) {
 	params := &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -66,13 +66,14 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 	r, err := m.DescribeNodegroup(params)
 	observeAWSRequest("DescribeNodegroup", err, start)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	klog.V(6).Infof("DescribeNodegroup output : %+v\n", r)
 
 	taints := make([]apiv1.Taint, 0)
 	labels := make(map[string]string)
+	tags := make(map[string]string)
 
 	// Labels will include diskSize, amiType, capacityType, version
 	if r.Nodegroup.DiskSize != nil {
@@ -104,6 +105,15 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		}
 	}
 
+	if r.Nodegroup.Tags != nil && len(r.Nodegroup.Tags) > 0 {
+		tagsMap := r.Nodegroup.Tags
+		for k, v := range tagsMap {
+			if v != nil {
+				tags[k] = *v
+			}
+		}
+	}
+
 	if r.Nodegroup.Taints != nil && len(r.Nodegroup.Taints) > 0 {
 		taintList := r.Nodegroup.Taints
 		for _, taint := range taintList {
@@ -117,7 +127,7 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		}
 	}
 
-	return taints, labels, nil
+	return taints, labels, tags, nil
 }
 
 func (m *awsWrapper) getInstanceTypeByLaunchConfigNames(launchConfigToQuery []*string) (map[string]string, error) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -137,6 +137,11 @@ func TestGetManagedNodegroup(t *testing.T) {
 	capacityType := "testCapacityType"
 	k8sVersion := "1.19"
 
+	tagKey1 := "tag 1"
+	tagValue1 := "value 1"
+	tagKey2 := "tag 2"
+	tagValue2 := "value 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -147,6 +152,7 @@ func TestGetManagedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -154,7 +160,7 @@ func TestGetManagedNodegroup(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 2)
 	assert.Equal(t, taintList[0].Effect, apiv1.TaintEffect(taintEffect1))
@@ -171,6 +177,9 @@ func TestGetManagedNodegroup(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 2)
+	assert.Equal(t, tagMap[tagKey1], tagValue1)
+	assert.Equal(t, tagMap[tagKey2], tagValue2)
 }
 
 func TestGetManagedNodegroupWithNilValues(t *testing.T) {
@@ -198,6 +207,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -205,7 +215,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
 	assert.Equal(t, len(labelMap), 4)
@@ -213,6 +223,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 0)
 }
 
 func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
@@ -240,6 +251,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        make([]*eks.Taint, 0),
+		Tags:          make(map[string]*string),
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -247,7 +259,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
 	assert.Equal(t, len(labelMap), 4)
@@ -255,6 +267,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 0)
 }
 
 func TestMoreThen100Groups(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -38,6 +38,8 @@ func TestManagedNodegroupCache(t *testing.T) {
 	taintEffect := "effect 1"
 	taintKey := "key 1"
 	taintValue := "value 1"
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 	taint := apiv1.Taint{
 		Effect: apiv1.TaintEffect(taintEffect),
 		Key:    taintKey,
@@ -50,6 +52,7 @@ func TestManagedNodegroupCache(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 	require.NoError(t, err)
 	obj, ok, err := c.GetByKey(nodegroupName)
@@ -63,6 +66,8 @@ func TestManagedNodegroupCache(t *testing.T) {
 	assert.Equal(t, apiv1.TaintEffect(taintEffect), obj.(managedNodegroupCachedObject).taints[0].Effect)
 	assert.Equal(t, taintKey, obj.(managedNodegroupCachedObject).taints[0].Key)
 	assert.Equal(t, taintValue, obj.(managedNodegroupCachedObject).taints[0].Value)
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).tags), 1)
+	assert.Equal(t, tagValue, obj.(managedNodegroupCachedObject).tags[tagKey])
 }
 
 func TestGetManagedNodegroupWithError(t *testing.T) {
@@ -111,6 +116,7 @@ func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -130,6 +136,7 @@ func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(cacheObj.tags), 0)
 }
 
 func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
@@ -165,6 +172,11 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 		Value:  &taintValue2,
 	}
 
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -175,6 +187,7 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -203,6 +216,9 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(cacheObj.tags), 2)
+	assert.Equal(t, cacheObj.tags[tagKey1], tagValue1)
+	assert.Equal(t, cacheObj.tags[tagKey2], tagValue2)
 }
 
 func TestGetManagedNodegroupInfoObjectWithError(t *testing.T) {
@@ -241,6 +257,8 @@ func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
 		Key:    taintKey,
 		Value:  taintValue,
 	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 
 	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
 	err := c.Add(managedNodegroupCachedObject{
@@ -248,6 +266,7 @@ func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 
 	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
@@ -275,6 +294,11 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 	labelValue1 := "testValue 1"
 	labelValue2 := "testValue 2"
 
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -285,6 +309,7 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -304,6 +329,9 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 	assert.Equal(t, mngInfoObject.labels["capacityType"], capacityType)
 	assert.Equal(t, mngInfoObject.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, mngInfoObject.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(mngInfoObject.tags), 2)
+	assert.Equal(t, mngInfoObject.tags[tagKey1], tagValue1)
+	assert.Equal(t, mngInfoObject.tags[tagKey2], tagValue2)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -325,6 +353,8 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
 		Key:    taintKey,
 		Value:  taintValue,
 	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 
 	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
 	err := c.Add(managedNodegroupCachedObject{
@@ -332,6 +362,7 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 
 	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
@@ -369,6 +400,7 @@ func TestGetManagedNodegroupLabelsNoCachedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -419,6 +451,7 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroupThatExpires(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -581,6 +614,107 @@ func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
 	assert.Equal(t, taintsList[1].Effect, apiv1.TaintEffect(taintEffect2))
 	assert.Equal(t, taintsList[1].Key, taintKey2)
 	assert.Equal(t, taintsList[1].Value, taintValue2)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTagsWithCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
+	})
+
+	tagsMap, err := c.getManagedNodegroupTags(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(tagsMap), 1)
+	assert.Equal(t, tagsMap[tagKey], tagValue)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTagsNoCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	taintEffect1 := "effect 1"
+	taintKey1 := "key 1"
+	taintValue1 := "value 1"
+	taint1 := eks.Taint{
+		Effect: &taintEffect1,
+		Key:    &taintKey1,
+		Value:  &taintValue1,
+	}
+
+	taintEffect2 := "effect 2"
+	taintKey2 := "key 2"
+	taintValue2 := "value 2"
+	taint2 := eks.Taint{
+		Effect: &taintEffect2,
+		Key:    &taintKey2,
+		Value:  &taintValue2,
+	}
+
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	tagsMap, err := c.getManagedNodegroupTags(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(tagsMap), 2)
+	assert.Equal(t, tagsMap[tagKey1], tagValue1)
+	assert.Equal(t, tagsMap[tagKey2], tagValue2)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a feature that allows handling of ephemeral storage and custom resources in a scale-from-zero scenario when using EKS nodegroups.

It does this via allowing tags in the form of `k8s.io/cluster-autoscaler/resources/<resource>: <quantity>` analogous to how they are allowed directly on an ASG.
As the EKS-managed ASGs in case of managed nodegroups don't support custom tags for those resources they will be read from the managed nodegroup and processed accordingly.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

I have modeled this after the implementation for ASGs and tried to be as clean as possible, passing through the Tags in the managed node group cache. I don't expect anybody will find it unexpected that these specific annotations influence the node templates.

As for documentation regarding this I didn't immediately find a place where one could mention that the ASG annotations also work for managed nodegroups, however I initially just assumed they would until I looked at the code.

#### Does this PR introduce a user-facing change?
```release-note
Allow k8s.io/cluster-autoscaler/resources/<resource>:<quantity> tags on AWS managed nodegroups (in addition to ASGs) to indicate availability of custom resources or ephemeral storage in a scale-from-zero scenario
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
