### PR TITLE
Adding VMSS Flex support in Azure AutoScaler

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -103,6 +103,10 @@ Make a copy of [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.y
 - SubscriptionID: `<base64-encoded-subscription-id>`
 - TenantID: `<base64-encoded-tenant-id>`
 
+By default VMSS Flex Scale set support is disabled. To Enable the support for VMSS Flex Scale Set, add base64 encoded value of 'true'.
+
+- EnableVmssFlex: `<base64-encoded-boolean-value>`
+
 > **_NOTE_**: Use a command such as `echo $CLIENT_ID | base64` to encode each of the fields above.
 
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.

--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -103,10 +103,6 @@ Make a copy of [cluster-autoscaler-vmss.yaml](examples/cluster-autoscaler-vmss.y
 - SubscriptionID: `<base64-encoded-subscription-id>`
 - TenantID: `<base64-encoded-tenant-id>`
 
-By default VMSS Flex Scale set support is disabled. To Enable the support for VMSS Flex Scale Set, add base64 encoded value of 'true'.
-
-- EnableVmssFlex: `<base64-encoded-boolean-value>`
-
 > **_NOTE_**: Use a command such as `echo $CLIENT_ID | base64` to encode each of the fields above.
 
 In the `cluster-autoscaler` spec, find the `image:` field and replace `{{ ca_version }}` with a specific cluster autoscaler release.
@@ -195,6 +191,12 @@ The `AZURE_ENABLE_DYNAMIC_INSTANCE_LIST` environment variable enables workflow t
 | Config Name               | Default | Environment Variable               | Cloud Config File         |
 |---------------------------|---------|------------------------------------|---------------------------|
 | enableDynamicInstanceList | false   | AZURE_ENABLE_DYNAMIC_INSTANCE_LIST | enableDynamicInstanceList |
+
+The `AZURE_ENABLE_VMSS_FLEX` environment variable enables VMSS Flex support. By default, support is disabled.
+
+| Config Name               | Default | Environment Variable                    | Cloud Config File         |
+|---------------------------|---------|-----------------------------------------|---------------------------|
+| enableVmssFlex            | false   | AZURE_ENABLE_VMSS_FLEX                  | enableVmssFlex            |
 
 When using K8s 1.18 or higher, it is also recommended to configure backoff and retries on the client as described [here](#rate-limit-and-back-off-retries)
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -341,11 +341,13 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 
 	if vmType == vmTypeVMSS {
-		// Omit virtual machines not managed by vmss.
-		if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
-			klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
-			m.unownedInstances[inst] = true
-			return nil, nil
+		if m.isAllScaleSetsAreUniform() {
+			// Omit virtual machines not managed by vmss only in case of uniform scale set.
+			if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
+				klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
+				m.unownedInstances[inst] = true
+				return nil, nil
+			}
 		}
 	}
 
@@ -366,6 +368,16 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 	klog.V(4).Infof("FindForInstance: Couldn't find node group of instance %q", inst)
 	return nil, nil
+}
+
+// isAllScaleSetsAreUniform determines if all the scale set autoscaler is monitoring are Uniform or not.
+func (m *azureCache) isAllScaleSetsAreUniform() bool {
+	for _, scaleSet := range m.scaleSets {
+		if scaleSet.VirtualMachineScaleSetProperties.OrchestrationMode == compute.Flexible {
+			return false
+		}
+	}
+	return true
 }
 
 // getInstanceFromCache gets the node group from cache. Returns nil if not found.

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -341,7 +341,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 
 	if vmType == vmTypeVMSS {
-		if m.isAllScaleSetsAreUniform() {
+		if m.areAllScaleSetsAreUniform() {
 			// Omit virtual machines not managed by vmss only in case of uniform scale set.
 			if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
 				klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
@@ -371,7 +371,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 }
 
 // isAllScaleSetsAreUniform determines if all the scale set autoscaler is monitoring are Uniform or not.
-func (m *azureCache) isAllScaleSetsAreUniform() bool {
+func (m *azureCache) areAllScaleSetsAreUniform() bool {
 	for _, scaleSet := range m.scaleSets {
 		if scaleSet.VirtualMachineScaleSetProperties.OrchestrationMode == compute.Flexible {
 			return false

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -341,7 +341,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 
 	if vmType == vmTypeVMSS {
-		if m.areAllScaleSetsAreUniform() {
+		if m.areAllScaleSetsUniform() {
 			// Omit virtual machines not managed by vmss only in case of uniform scale set.
 			if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
 				klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
@@ -371,7 +371,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 }
 
 // isAllScaleSetsAreUniform determines if all the scale set autoscaler is monitoring are Uniform or not.
-func (m *azureCache) areAllScaleSetsAreUniform() bool {
+func (m *azureCache) areAllScaleSetsUniform() bool {
 	for _, scaleSet := range m.scaleSets {
 		if scaleSet.VirtualMachineScaleSetProperties.OrchestrationMode == compute.Flexible {
 			return false

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -18,9 +18,11 @@ package azure
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest/to"
-	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -36,7 +38,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-vmss", "eastus")
+	expectedScaleSets := newTestVMSSList(3, "test-vmss", "eastus", compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), "rg").Return(expectedScaleSets, nil).AnyTimes()
@@ -123,7 +125,7 @@ func TestNodeGroupForNode(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 
 	provider := newTestProvider(t)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
@@ -26,6 +25,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
 
@@ -123,47 +123,60 @@ func TestNodeGroups(t *testing.T) {
 func TestNodeGroupForNode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	for _, orchMode := range orchestrationModes {
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
+		provider := newTestProvider(t)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	node := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-		},
+		if orchMode == compute.Uniform {
+
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
+
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+		}
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		provider.azureManager.explicitlyConfigured["test-asg"] = true
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		node := newApiNode(orchMode, 0)
+		// refresh cache
+		provider.azureManager.forceRefresh()
+		group, err := provider.NodeGroupForNode(node)
+		assert.NoError(t, err)
+		assert.NotNil(t, group, "Group should not be nil")
+		assert.Equal(t, group.Id(), "test-asg")
+		assert.Equal(t, group.MinSize(), 1)
+		assert.Equal(t, group.MaxSize(), 5)
+
+		// test node in cluster that is not in a group managed by cluster autoscaler
+		nodeNotInGroup := &apiv1.Node{
+			Spec: apiv1.NodeSpec{
+				ProviderID: "azure:///subscriptions/subscripion/resourceGroups/test-resource-group/providers/Microsoft.Compute/virtualMachines/test-instance-id-not-in-group",
+			},
+		}
+		group, err = provider.NodeGroupForNode(nodeNotInGroup)
+		assert.NoError(t, err)
+		assert.Nil(t, group)
 	}
-	// refresh cache
-	provider.azureManager.forceRefresh()
-	group, err := provider.NodeGroupForNode(node)
-	assert.NoError(t, err)
-	assert.NotNil(t, group, "Group should not be nil")
-	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
 
-	// test node in cluster that is not in a group managed by cluster autoscaler
-	nodeNotInGroup := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure:///subscriptions/subscripion/resourceGroups/test-resource-group/providers/Microsoft.Compute/virtualMachines/test-instance-id-not-in-group",
-		},
-	}
-	group, err = provider.NodeGroupForNode(nodeNotInGroup)
-	assert.NoError(t, err)
-	assert.Nil(t, group)
 }
 
 func TestNodeGroupForNodeWithNoProviderId(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -62,6 +62,7 @@ const (
 
 	// toggle
 	dynamicInstanceListDefault = false
+	enableVmssFlexDefault      = false
 )
 
 // CloudProviderRateLimitConfig indicates the rate limit config for each clients.
@@ -136,6 +137,9 @@ type Config struct {
 
 	// EnableDynamicInstanceList defines whether to enable dynamic instance workflow for instance information check
 	EnableDynamicInstanceList bool `json:"enableDynamicInstanceList,omitempty" yaml:"enableDynamicInstanceList,omitempty"`
+
+	// EnableVmssFlex defines whether to enable Vmss Flex support or not
+	EnableVmssFlex bool `json:"enableVmssFlex,omitempty" yaml:"enableVmssFlex,omitempty"`
 }
 
 // BuildAzureConfig returns a Config object for the Azure clients
@@ -246,6 +250,15 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 			}
 		} else {
 			cfg.EnableDynamicInstanceList = dynamicInstanceListDefault
+		}
+
+		if enableVmssFlex := os.Getenv("AZURE_ENABLE_VMSS_FLEX"); enableVmssFlex != "" {
+			cfg.EnableVmssFlex, err = strconv.ParseBool(enableVmssFlex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_ENABLE_VMSS_FLEX %q: %v", enableVmssFlex, err)
+			}
+		} else {
+			cfg.EnableVmssFlex = enableVmssFlexDefault
 		}
 
 		if cfg.CloudProviderBackoff {

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/%d"
+	fakeVirtualMachineVMID         = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachines/%d"
 )
 
 // DeploymentsClientMock mocks for DeploymentsClient.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -577,23 +577,39 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 		},
 	}
 
-	manager := newTestAzureManager(t)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
+	expectedVMs := newTestVMList(3)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
+	for _, orchMode := range orchestrationModes {
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 
-	asgs := manager.azureCache.getRegisteredNodeGroups()
-	assert.Equal(t, 1, len(asgs))
-	assert.Equal(t, name, asgs[0].Id())
-	assert.Equal(t, min, asgs[0].MinSize())
-	assert.Equal(t, max, asgs[0].MaxSize())
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+		if orchMode == compute.Uniform {
+
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
+
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			manager.config.EnableVmssFlex = true
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
+
+		asgs := manager.azureCache.getRegisteredNodeGroups()
+		assert.Equal(t, 1, len(asgs))
+		assert.Equal(t, name, asgs[0].Id())
+		assert.Equal(t, min, asgs[0].MinSize())
+		assert.Equal(t, max, asgs[0].MaxSize())
+	}
 
 	// test vmTypeStandard
 	testAS := newTestAgentPool(newTestAzureManager(t), "testAS")
@@ -618,6 +634,7 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test invalidVMType
+	manager := newTestAzureManager(t)
 	manager.config.VMType = "invalidVMType"
 	err = manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
 	expectedErr = fmt.Errorf("failed to parse node group spec: vmtype invalidVMType not supported")

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -579,7 +579,7 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 
 	manager := newTestAzureManager(t)
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -90,6 +89,20 @@ func newTestVMList(count int) []compute.VirtualMachine {
 	return vmssVMList
 }
 
+func newApiNode(orchmode compute.OrchestrationMode, vmID int64) *apiv1.Node {
+	providerId := fakeVirtualMachineScaleSetVMID
+
+	if orchmode == compute.Flexible {
+		providerId = fakeVirtualMachineVMID
+	}
+
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "azure://" + fmt.Sprintf(providerId, vmID),
+		},
+	}
+	return node
+}
 func TestMaxSize(t *testing.T) {
 	provider := newTestProvider(t)
 	registered := provider.azureManager.RegisterNodeGroup(
@@ -112,71 +125,104 @@ func TestTargetSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
 	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := provider.azureManager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
+		provider := newTestProvider(t)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		if orchMode == compute.Uniform {
 
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		err := provider.azureManager.forceRefresh()
+		assert.NoError(t, err)
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+	}
 }
 
 func TestIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), provider.azureManager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := provider.azureManager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
 
-	ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
-	err = ss.IncreaseSize(100)
-	expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
-	assert.Equal(t, expectedErr, err)
+		provider := newTestProvider(t)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), provider.azureManager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// current target size is 2.
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+		if orchMode == compute.Uniform {
 
-	// increase 3 nodes.
-	err = provider.NodeGroups()[0].IncreaseSize(2)
-	assert.NoError(t, err)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
 
-	// new target size should be 5.
-	targetSize, err = provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 5, targetSize)
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+		err := provider.azureManager.forceRefresh()
+		assert.NoError(t, err)
+
+		ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
+		err = ss.IncreaseSize(100)
+		expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
+		assert.Equal(t, expectedErr, err)
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		// current target size is 2.
+		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+
+		// increase 3 nodes.
+		err = provider.NodeGroups()[0].IncreaseSize(2)
+		assert.NoError(t, err)
+
+		// new target size should be 5.
+		targetSize, err = provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 5, targetSize)
+	}
 }
 
 func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
@@ -228,222 +274,238 @@ func TestBelongs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	for _, orchMode := range orchestrationModes {
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
+		provider := newTestProvider(t)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
-	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	provider.azureManager.Refresh()
+		if orchMode == compute.Uniform {
 
-	invalidNode := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure:///subscriptions/test-subscrition-id/resourcegroups/invalid-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0",
-		},
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+		provider.azureManager.explicitlyConfigured["test-asg"] = true
+		provider.azureManager.Refresh()
+
+		invalidNode := &apiv1.Node{
+			Spec: apiv1.NodeSpec{
+				ProviderID: "azure:///subscriptions/test-subscrition-id/resourcegroups/invalid-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0",
+			},
+		}
+		_, err := scaleSet.Belongs(invalidNode)
+		assert.Error(t, err)
+
+		validNode := newApiNode(orchMode, 0)
+		belongs, err := scaleSet.Belongs(validNode)
+		assert.Equal(t, true, belongs)
+		assert.NoError(t, err)
 	}
-	_, err := scaleSet.Belongs(invalidNode)
-	assert.Error(t, err)
 
-	validNode := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-		},
-	}
-	belongs, err := scaleSet.Belongs(validNode)
-	assert.Equal(t, true, belongs)
-	assert.NoError(t, err)
 }
 
 func TestDeleteNodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
 	vmssName := "test-asg"
 	var vmssCapacity int64 = 3
-
-	expectedScaleSets := []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-				OrchestrationMode: compute.Uniform,
-			},
-		},
-	}
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := manager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
 
-	resourceLimiter := cloudprovider.NewResourceLimiter(
-		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
-		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
-	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
-	assert.NoError(t, err)
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
 
-	registered := manager.RegisterNodeGroup(
-		newTestScaleSet(manager, "test-asg"))
-	manager.explicitlyConfigured["test-asg"] = true
-	assert.True(t, registered)
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+		mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+		mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+		mockVMClient := mockvmclient.NewMockInterface(ctrl)
 
-	targetSize, err := scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+		if orchMode == compute.Uniform {
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
+			manager.config.EnableVmssFlex = true
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
 
-	// Perform the delete operation
-	nodesToDelete := []*apiv1.Node{
-		{
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-			},
-		},
-		{
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2),
-			},
-		},
+		}
+
+		err := manager.forceRefresh()
+		assert.NoError(t, err)
+
+		resourceLimiter := cloudprovider.NewResourceLimiter(
+			map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+			map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+		provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+
+		assert.NoError(t, err)
+
+		registered := manager.RegisterNodeGroup(
+			newTestScaleSet(manager, "test-asg"))
+		manager.explicitlyConfigured["test-asg"] = true
+
+		assert.True(t, registered)
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+
+		targetSize, err := scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+
+		// Perform the delete operation
+		nodesToDelete := []*apiv1.Node{
+			newApiNode(orchMode, 0),
+			newApiNode(orchMode, 2),
+		}
+		err = scaleSet.DeleteNodes(nodesToDelete)
+		assert.NoError(t, err)
+
+		// create scale set with vmss capacity 1
+		expectedScaleSets = newTestVMSSList(1, vmssName, "eastus", orchMode)
+
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+
+		if orchMode == compute.Uniform {
+			expectedVMSSVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+		} else {
+			expectedVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			expectedVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+		}
+
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		// Ensure the the cached size has been proactively decremented by 2
+		targetSize, err = scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, targetSize)
+
+		// Ensure that the status for the instances is Deleting
+		instance0, found := scaleSet.getInstanceByProviderID(nodesToDelete[0].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
+
+		instance2, found := scaleSet.getInstanceByProviderID(nodesToDelete[1].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance2.Status.State, cloudprovider.InstanceDeleting)
+
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
-	assert.NoError(t, err)
-	vmssCapacity = 1
-	expectedScaleSets = []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-				OrchestrationMode: compute.Uniform,
-			},
-		},
-	}
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	expectedVMSSVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
-	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
-
-	// Ensure the the cached size has been proactively decremented by 2
-	targetSize, err = scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, targetSize)
-
-	// Ensure that the status for the instances is Deleting
-	instance0, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0))
-	assert.True(t, found, true)
-	assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
-
-	instance2, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2))
-	assert.True(t, found, true)
-	assert.Equal(t, instance2.Status.State, cloudprovider.InstanceDeleting)
 }
 
 func TestDeleteNodeUnregistered(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
 	vmssName := "test-asg"
 	var vmssCapacity int64 = 2
-
-	expectedScaleSets := []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-				OrchestrationMode: compute.Uniform,
-			},
-		},
-	}
 	expectedVMSSVMs := newTestVMSSVMList(2)
+	expectedVMs := newTestVMList(2)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := manager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
 
-	resourceLimiter := cloudprovider.NewResourceLimiter(
-		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
-		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
-	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
-	assert.NoError(t, err)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+		mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	registered := manager.RegisterNodeGroup(
-		newTestScaleSet(manager, "test-asg"))
-	manager.explicitlyConfigured["test-asg"] = true
-	assert.True(t, registered)
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
+		if orchMode == compute.Uniform {
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
 
-	targetSize, err := scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, targetSize)
+			manager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+		}
+		err := manager.forceRefresh()
+		assert.NoError(t, err)
 
-	// annotate node with unregistered annotation
-	annotations := make(map[string]string)
-	annotations[cloudprovider.FakeNodeReasonAnnotation] = cloudprovider.FakeNodeUnregistered
-	nodesToDelete := []*apiv1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: annotations,
-			},
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-			},
-		},
+		resourceLimiter := cloudprovider.NewResourceLimiter(
+			map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+			map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+		provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+		assert.NoError(t, err)
+
+		registered := manager.RegisterNodeGroup(
+			newTestScaleSet(manager, "test-asg"))
+		manager.explicitlyConfigured["test-asg"] = true
+		assert.True(t, registered)
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+
+		targetSize, err := scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, targetSize)
+
+		// annotate node with unregistered annotation
+		annotations := make(map[string]string)
+		annotations[cloudprovider.FakeNodeReasonAnnotation] = cloudprovider.FakeNodeUnregistered
+
+		nodesToDelete := []*apiv1.Node{
+			newApiNode(orchMode, 0),
+		}
+		nodesToDelete[0].ObjectMeta.Annotations = annotations
+
+		err = scaleSet.DeleteNodes(nodesToDelete)
+		assert.NoError(t, err)
+
+		// Ensure the the cached size has NOT been proactively decremented
+		targetSize, err = scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, targetSize)
+
+		// Ensure that the status for the instances is Deleting
+		instance0, found := scaleSet.getInstanceByProviderID(nodesToDelete[0].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
-	assert.NoError(t, err)
 
-	// Ensure the the cached size has NOT been proactively decremented
-	targetSize, err = scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, targetSize)
-
-	// Ensure that the status for the instances is Deleting
-	instance0, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0))
-	assert.True(t, found, true)
-	assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
 }
 
 func TestDeleteNoConflictRequest(t *testing.T) {
@@ -529,97 +591,73 @@ func TestDebug(t *testing.T) {
 func TestScaleSetNodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
-
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	provider.azureManager.Refresh()
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
-
-	node := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-		},
-	}
-	group, err := provider.NodeGroupForNode(node)
-	assert.NoError(t, err)
-	assert.NotNil(t, group, "Group should not be nil")
-	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
-
-	ss, ok := group.(*ScaleSet)
-	assert.True(t, ok)
-	assert.NotNil(t, ss)
-	instances, err := group.Nodes()
-	assert.NoError(t, err)
-	assert.Equal(t, len(instances), 3)
-	assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)})
-	assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)})
-	assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)})
-}
-
-func TestScaleSetNodesForFlexScaleSet(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	expectedVMs := newTestVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Flexible)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	provider.azureManager.config.EnableVmssFlex = true
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMClient := mockvmclient.NewMockInterface(ctrl)
-	mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+	for _, orchMode := range orchestrationModes {
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	provider.azureManager.Refresh()
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
+		provider := newTestProvider(t)
 
-	node := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 0),
-		},
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+		if orchMode == compute.Uniform {
+
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		provider.azureManager.explicitlyConfigured["test-asg"] = true
+		provider.azureManager.Refresh()
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		node := newApiNode(orchMode, 0)
+		group, err := provider.NodeGroupForNode(node)
+		assert.NoError(t, err)
+		assert.NotNil(t, group, "Group should not be nil")
+		assert.Equal(t, group.Id(), "test-asg")
+		assert.Equal(t, group.MinSize(), 1)
+		assert.Equal(t, group.MaxSize(), 5)
+
+		ss, ok := group.(*ScaleSet)
+		assert.True(t, ok)
+		assert.NotNil(t, ss)
+		instances, err := group.Nodes()
+		assert.NoError(t, err)
+		assert.Equal(t, len(instances), 3)
+
+		if orchMode == compute.Uniform {
+
+			assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)})
+			assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)})
+			assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)})
+		} else {
+
+			assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 0)})
+			assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 1)})
+			assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 2)})
+		}
 	}
-	group, err := provider.NodeGroupForNode(node)
-	assert.NoError(t, err)
-	assert.NotNil(t, group, "Group should not be nil")
-	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
 
-	ss, ok := group.(*ScaleSet)
-	assert.True(t, ok)
-	assert.NotNil(t, ss)
-	instances, err := group.Nodes()
-	assert.NoError(t, err)
-	assert.Equal(t, len(instances), 3)
-	assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 0)})
-	assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 1)})
-	assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 2)})
 }
 
 func TestEnableVmssFlexFlag(t *testing.T) {
 
-	//flag set to false
+	// flag set to false
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -641,7 +679,7 @@ func TestEnableVmssFlexFlag(t *testing.T) {
 	err := provider.azureManager.Refresh()
 	assert.Error(t, err, "vmss - \"test-asg\" with Flexible orchestration detected but 'enbaleVmssFlex' feature flag is turned off")
 
-	//flag set to true
+	// flag set to true
 	provider.azureManager.config.EnableVmssFlex = true
 	err = provider.azureManager.Refresh()
 	assert.NoError(t, err)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -51,8 +51,10 @@ func newTestVMSSList(cap int64, name, loc string) []compute.VirtualMachineScaleS
 				Capacity: to.Int64Ptr(cap),
 				Name:     to.StringPtr("Standard_D4_v2"),
 			},
-			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{},
-			Location:                         to.StringPtr(loc),
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
+			},
+			Location: to.StringPtr(loc),
 		},
 	}
 }
@@ -177,6 +179,7 @@ func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
 			},
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				ProvisioningState: to.StringPtr(string(compute.ProvisioningStateUpdating)),
+				OrchestrationMode: compute.Uniform,
 			},
 		},
 	}
@@ -261,6 +264,9 @@ func TestDeleteNodes(t *testing.T) {
 			Sku: &compute.Sku{
 				Capacity: &vmssCapacity,
 			},
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
+			},
 		},
 	}
 	expectedVMSSVMs := newTestVMSSVMList(3)
@@ -318,6 +324,9 @@ func TestDeleteNodes(t *testing.T) {
 			Sku: &compute.Sku{
 				Capacity: &vmssCapacity,
 			},
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
+			},
 		},
 	}
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
@@ -355,6 +364,9 @@ func TestDeleteNodeUnregistered(t *testing.T) {
 			Name: &vmssName,
 			Sku: &compute.Sku{
 				Capacity: &vmssCapacity,
+			},
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
 			},
 		},
 	}
@@ -442,6 +454,9 @@ func TestDeleteNoConflictRequest(t *testing.T) {
 			Name: &vmssName,
 			Sku: &compute.Sku{
 				Capacity: &vmssCapacity,
+			},
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The PR is to add VMSS Flex support to azure autoscaler

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5334

#### Special notes for your reviewer:
There are couple of changes in this PR.

1. Adding a feature flag "EnableVmssFlex" to turn on/off support for VMSS Flex scale set.
2. Refactor func instanceStatus in azure_scale_set to receive ProvisioningState instead of VM or VMSSVM so that it can be used in both type of scale sets (Uniform, Flexible) 
3. Retrieving VMs for Flex scale set using VM api instead of VMSSVM api.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
