### PR TITLE
baseURI for skuClient based on cloud

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -278,7 +278,9 @@ func newAzClient(cfg *Config, env *azure.Environment) (*azClient, error) {
 	kubernetesServicesClient := containerserviceclient.New(aksClientConfig)
 	klog.V(5).Infof("Created kubernetes services client with authorizer: %v", kubernetesServicesClient)
 
-	skuClient := compute.NewResourceSkusClient(cfg.SubscriptionID)
+	// Reference on why selecting ResourceManagerEndpoint as baseURI -
+	// https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go
+	skuClient := compute.NewResourceSkusClientWithBaseURI(azClientConfig.ResourceManagerEndpoint, cfg.SubscriptionID)
 	skuClient.Authorizer = azClientConfig.Authorizer
 	klog.V(5).Infof("Created sku client with authorizer: %v", skuClient)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change provides correct endpoint/baseURI to the skuClient based on the cloud environment.
By default, endpoint always pointed to public cloud. If the environment was not cloud, sku Cache creation fails and CA pod crashes.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
yes, CA pod will no longer crash.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cluster autoscaler will work correctly without crash in non-public clouds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
