### PR TITLE
GCE: Fallback f1 and g1 machine families to n1

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/machine_types.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types.go
@@ -57,7 +57,7 @@ func GetMachineFamily(machineType string) (string, error) {
 	if len(parts) < 2 {
 		return "", fmt.Errorf("unable to parse machine type %q", machineType)
 	}
-	if parts[0] == "custom" {
+	if parts[0] == "custom" || parts[0] == "f1" || parts[0] == "g1" {
 		return "n1", nil
 	}
 	return parts[0], nil

--- a/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
@@ -137,6 +137,14 @@ func TestGetMachineFamily(t *testing.T) {
 			machineType: "e2-small",
 			wantFamily:  "e2",
 		},
+		"fallback f1 family to n1": {
+			machineType: "f1-micro",
+			wantFamily:  "n1",
+		},
+		"fallback g1 family to n1": {
+			machineType: "g1-small",
+			wantFamily:  "n1",
+		},
 		"custom machine type with family prefix": {
 			machineType: "n2-custom-2-2816",
 			wantFamily:  "n2",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
