### PR TITLE
leave a buffer of underutilized nodes when scaling down

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -149,6 +149,8 @@ type AutoscalingOptions struct {
 	// The formula to calculate additional candidates number is following:
 	// max(#nodes * ScaleDownCandidatesPoolRatio, ScaleDownCandidatesPoolMinCount)
 	ScaleDownCandidatesPoolMinCount int
+	// ScaleDownBufferRatio Ratio of empty or underutilized nodes to leave as capacity buffer per nodegroup
+	ScaleDownBufferRatio float64
 	// ScaleDownSimulationTimeout defines the maximum time that can be
 	// spent on scale down simulation.
 	ScaleDownSimulationTimeout time.Duration

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -132,6 +132,8 @@ var (
 			"for scale down when some candidates from previous iteration are no longer valid."+
 			"When calculating the pool size for additional candidates we take"+
 			"max(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count).")
+	scaleDownBufferRatio = flag.Float64("scale-down-buffer-ratio", 0.1,
+		"Ratio of empty or underutilized nodes to leave as capacity buffer per nodegroup")
 	nodeDeletionDelayTimeout    = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
 	nodeDeletionBatcherInterval = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
 	scanInterval                = flag.Duration("scan-interval", 10*time.Second, "How often cluster is reevaluated for scale up or down")
@@ -287,6 +289,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownNonEmptyCandidatesCount:   *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:       *scaleDownCandidatesPoolRatio,
 		ScaleDownCandidatesPoolMinCount:    *scaleDownCandidatesPoolMinCount,
+		ScaleDownBufferRatio:               *scaleDownBufferRatio,
 		WriteStatusConfigMap:               *writeStatusConfigMapFlag,
 		StatusConfigMapName:                *statusConfigMapName,
 		BalanceSimilarNodeGroups:           *balanceSimilarNodeGroupsFlag,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- When scheduling nodes with topologySpreadConstraints ScheduleAnyway the scheduler does not evict capacity buffers and creates skew
- When trying to de-schedule skewed pods descheduler noops when there is no empty space
... so allow users to opt-in to empty space

This is not perfect since it will not create "new empty space" by scaling up, but I think it's a good step forward and allows us to fix some edge-cases that capacity buffer does not solve.

#### Which issue(s) this PR fixes:
Fixes #5377

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
New --scale-down-buffer-ratio flag for ratio of empty or underutilized nodes to leave as capacity buffer per nodegroup
```
