### PR TITLE
Make the "OOMing pods under VPA" test more robust.

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -67,7 +67,6 @@ const (
 
 var (
 	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "50000"}
 )
 
 var (
@@ -436,16 +435,17 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 	ginkgo.By(fmt.Sprintf("Running OOMing RC %s with %v replicas", name, replicas))
 
 	rcConfig := testutils.RCConfig{
-		Client:      c,
-		Image:       stressImage,
-		Command:     stressCommand,
+		Client: c,
+		Image:  stressImage,
+		// request exactly 1025 MiB, in a single chunk (1 MiB above the limit)
+		Command:     []string{"/stress", "--mem-total", "1074790400", "--logtostderr", "--mem-alloc-size", "1074790400"},
 		Name:        name,
 		Namespace:   ns,
 		Timeout:     timeoutRC,
 		Replicas:    replicas,
 		Annotations: make(map[string]string),
-		MemRequest:  1024 * 1024 * 300,
-		MemLimit:    1024 * 1024 * 500,
+		MemRequest:  1024 * 1024 * 1024,
+		MemLimit:    1024 * 1024 * 1024,
 	}
 
 	dpConfig := testutils.DeploymentConfig{

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -43,7 +43,7 @@ const (
 	// the initial values should be outside minimal bounds
 	initialCPU     = int64(10) // mCPU
 	initialMemory  = int64(10) // MB
-	oomTestTimeout = 12 * time.Minute
+	oomTestTimeout = 8 * time.Minute
 )
 
 var _ = FullVpaE2eDescribe("Pods under VPA", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

After #5326 the VPA test in "OOMing pods under VPA" in full_vpa.go became unstable when ran in GKE.

I debugged it a bit and I can see that in the set-up used by the test VPA is reacting to both OOMs and regular memory samples which kind of defeats the purpose of the test.
IIUC the whole idea of the test is based on how fast VPA would scale on average - multiple scale ups are required to reach 1.4 GB. This makes the test brittle as the VPA reaction time is not specified and could vary.

This PR attempts to create a more deterministic test:
* set memory limit to 1024 MiB,
* allocate 1025 MiB worth of memory in one go to significantly decrease a chance of a regular sample,
* expect a recommendation taking into account both the OOM bump (+20% by default) and the usual 15% margin, to make sure at least one OOM was taken into account,
* never allocate more than 1025 MiB worth of memory to decrease a chance of getting to the expected recommendation w/o OOMs.

It's definitely not perfect since I don't see a way to make 100% sure that there are no regular memory samples but I think that decreasing the number of moving parts will make the test more robust.

However I ran the stress command from the test for over 1 hour in my cluster and I haven't seen any regular memory sample for these containers.

#### Which issue(s) this PR fixes:

Related to #5326 & thus also #4981

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
