### PR TITLE
Remove Factory interface since it is not used.

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1062,8 +1062,8 @@ func TestAuthError(t *testing.T) {
 	clusterStateRegistry := clusterstate.NewClusterStateRegistry(nil, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&context, processors, clusterStateRegistry, nil)
-	scaleUpWrapper := suOrchestrator.(*ScaleUpOrchestrator)
-	aerr := scaleUpWrapper.executeScaleUp(info, "", "", time.Now())
+	scaleUpOrchestrator := suOrchestrator.(*ScaleUpOrchestrator)
+	aerr := scaleUpOrchestrator.executeScaleUp(info, "", "", time.Now())
 	assert.Error(t, aerr)
 
 	req, err := http.NewRequest("GET", "/", nil)

--- a/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
@@ -26,6 +26,11 @@ type SkippedReasons struct {
 	messages []string
 }
 
+// NewSkippedReasons creates new SkippedReason object.
+func NewSkippedReasons(m string) *SkippedReasons {
+	return &SkippedReasons{[]string{m}}
+}
+
 // Reasons returns a slice of reasons why the node group was not considered for scale up.
 func (sr *SkippedReasons) Reasons() []string {
 	return sr.messages
@@ -33,14 +38,14 @@ func (sr *SkippedReasons) Reasons() []string {
 
 var (
 	// BackoffReason node group is in backoff.
-	BackoffReason = &SkippedReasons{[]string{"in backoff after failed scale-up"}}
+	BackoffReason = NewSkippedReasons("in backoff after failed scale-up")
 	// MaxLimitReachedReason node group reached max size limit.
-	MaxLimitReachedReason = &SkippedReasons{[]string{"max node group size reached"}}
+	MaxLimitReachedReason = NewSkippedReasons("max node group size reached")
 	// NotReadyReason node group is not ready.
-	NotReadyReason = &SkippedReasons{[]string{"not ready for scale-up"}}
+	NotReadyReason = NewSkippedReasons("not ready for scale-up")
 )
 
 // MaxResourceLimitReached returns a reason describing which cluster wide resource limits were reached.
 func MaxResourceLimitReached(resources []string) *SkippedReasons {
-	return &SkippedReasons{[]string{fmt.Sprintf("max cluster %s limit reached", strings.Join(resources, ", "))}}
+	return NewSkippedReasons(fmt.Sprintf("max cluster %s limit reached", strings.Join(resources, ", ")))
 }

--- a/cluster-autoscaler/core/scaleup/scaleup.go
+++ b/cluster-autoscaler/core/scaleup/scaleup.go
@@ -28,17 +28,6 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// ManagerFactory is a component that creates a new instance of the scale up manager.
-type ManagerFactory interface {
-	// NewManager builds a new instance of the scale up manager.
-	NewManager(
-		autoscalingContext *context.AutoscalingContext,
-		processors *ca_processors.AutoscalingProcessors,
-		clusterStateRegistry *clusterstate.ClusterStateRegistry,
-		ignoredTaints taints.TaintKeySet,
-	) Orchestrator
-}
-
 // Orchestrator is a component that picks the node group to resize and triggers
 // creation of needed instances.
 type Orchestrator interface {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Removes an unused interface that slipped in. It was an alternative to the initialize function of the orchestrator.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NA
