### PR TITLE
fix: implement function to identify if node is present in aws

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -128,8 +128,19 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (aws *awsCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
-	return true, cloudprovider.ErrNotImplemented
+func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	awsRef, err := AwsRefFromProviderId(node.Spec.ProviderID)
+	if err != nil {
+		return false, err
+	}
+
+	// we don't care about the status
+	status, err := aws.awsManager.asgCache.InstanceStatus(*awsRef)
+	if status != nil {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("node is not present in aws: %v", err)
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.


### PR DESCRIPTION
- this is a follow-up to https://github.com/kubernetes/autoscaler/pull/5054
- this might fix https://github.com/kubernetes/autoscaler/issues/4456

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
I think description of https://github.com/kubernetes/autoscaler/pull/5054#issue-1319989728 explains it well:

> ...original intent of determining the deleted nodes was incorrect, which led to the issues reported by other users. The nodes tainted with ToBeDeleted were misidentified as Deleted instead of Ready/Unready, which caused a miscalculation of the node being included as Upcoming. This caused problems described in https://github.com/kubernetes/autoscaler/issues/3949 and https://github.com/kubernetes/autoscaler/issues/4456.

https://github.com/kubernetes/autoscaler/pull/5054 exposed interface function `HasInstance` for cloud providers to implement. This function is used to determine if a node is deleted by querying the cloud provider. It falls back to the `ToBeDeleted` taint if the function is not implemented. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4456

#### Special notes for your reviewer: 
Nothing in particular.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Nothing in particular.
```

cc: @fookenc 