### PR TITLE
[helm chart] Update to use cluster-autoscaler 1.26.2 + default tag value from the Chart's AppVersion

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.24.0
+appVersion: 1.26.1
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.27.0
+version: 9.28.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -383,7 +383,7 @@ vpa:
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"registry.k8s.io/autoscaling/cluster-autoscaler"` | Image repository |
-| image.tag | string | `"v1.24.0"` | Image tag |
+| image.tag | string | `""` | Image tag  - defaults to the version defined in Chart.AppVersion |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | magnumCABundlePath | string | `"/etc/kubernetes/ca-bundle.crt"` | Path to the host's CA bundle, from `ca-file` in the cloud-config file. |
 | magnumClusterName | string | `""` | Cluster name or ID in Magnum. Required if `cloudProvider=magnum` and not setting `autoDiscovery.clusterName`. |

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "cluster-autoscaler.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           command:
             - ./cluster-autoscaler

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -229,8 +229,7 @@ hostNetwork: false
 image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
-  # image.tag -- Image tag
-  tag: v1.24.0
+  tag: ""  # If not defined, uses appVersion of Chart.yaml
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -229,6 +229,7 @@ hostNetwork: false
 image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
+  # image.tag - Image tag - defaults to the version defined in Chart.AppVersion
   tag: ""  # If not defined, uses appVersion of Chart.yaml
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This is similar to how it is done in other chats:
https://github.com/kubernetes/dashboard/blob/313af7c8e1922fb4d7c6be4dc3fc006e286e759a/charts/helm-chart/kubernetes-dashboard/templates/deployment.yaml#L66 https://github.com/kubernetes/dashboard/blob/313af7c8e1922fb4d7c6be4dc3fc006e286e759a/charts/helm-chart/kubernetes-dashboard/values.yaml#L23

/kind feature

