### PR TITLE
Hetzner node specific cloud init

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -8,6 +8,8 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 
 `HCLOUD_CLOUD_INIT` Base64 encoded Cloud Init yaml with commands to join the cluster, Sample [examples/cloud-init.txt for (Kubernetes 1.20.1)](examples/cloud-init.txt)
 
+`HCLOUD_{POOL_NAME}_CLOUD_INIT` Base64 encoded Cloud Init yaml. Allows for specifying a different cloud init per pool name. `{POOL_NAME}` should be the uppercase equivalent of the node group's name. e.g. `--nodes=0:2:cpx41:fsn1:test-pool` would look for `HCLOUD_TEST-POOL_CLOUD_INIT`. If not set it will default to `HCLOUD_CLOUD_INIT`.
+
 `HCLOUD_IMAGE` Defaults to `ubuntu-20.04`, @see https://docs.hetzner.cloud/#images. You can also use an image ID here (e.g. `15512617`), or a label selector associated with a custom snapshot (e.g. `customized_ubuntu=true`). The most recent snapshot will be used in the latter case.
 
 `HCLOUD_NETWORK` Default empty , The name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
@@ -18,7 +20,11 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 
 `HCLOUD_PUBLIC_IPV4` Default true , Whether the server is created with a public IPv4 address or not, @see https://docs.hetzner.cloud/#primary-ips
 
+`HCLOUD_{POOL_NAME}_PUBLIC_IPV4` is the pool name equivalent of `HCLOUD_PUBLIC_IPV4` and follows the same rules as `HCLOUD_CLOUD_INIT` above.
+
 `HCLOUD_PUBLIC_IPV6` Default true , Whether the server is created with a public IPv6 address or not, @see https://docs.hetzner.cloud/#primary-ips
+
+`HCLOUD_{POOL_NAME}_PUBLIC_IPV6` is the pool name equivalent of `HCLOUD_PUBLIC_IPV6` and follows the same rules as `HCLOUD_CLOUD_INIT` above.
 
 Node groups must be defined with the `--nodes=<min-servers>:<max-servers>:<instance-type>:<region>:<name>` flag.
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -210,7 +210,7 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 
 		// Get this node's cloud-init
 		var cloudInitBase64 string
-		nodeCloudInitVar := fmt.Sprintf("HCLOUD_CLOUD_INIT_%s", spec.name)
+		nodeCloudInitVar := fmt.Sprintf("HCLOUD_%s_CLOUD_INIT", strings.ToUpper(spec.name))
 		if nodeSpecificCloudInit, ok := os.LookupEnv(nodeCloudInitVar); ok {
 			cloudInitBase64 = nodeSpecificCloudInit
 		} else {
@@ -227,6 +227,43 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 		}
 
 		manager.cloudInit[spec.name] = string(cloudInit)
+
+		// Get this node's public IP setting
+		publicIPv4 := true
+		var publicIPv4Str string
+		nodePublicIPv4Var := fmt.Sprintf("HCLOUD_%s_PUBLIC_IPV4", strings.ToUpper(spec.name))
+		if nodeSpecificPublicIPv4, ok := os.LookupEnv(nodePublicIPv4Var); ok {
+			publicIPv4Str = nodeSpecificPublicIPv4
+		} else {
+			publicIPv4Str = os.Getenv("HCLOUD_PUBLIC_IPV4")
+		}
+
+		if publicIPv4Str != "" {
+			publicIPv4, err = strconv.ParseBool(publicIPv4Str)
+			if err != nil {
+				klog.Fatalf("failed to parse HCLOUD_PUBLIC_IPV4 or %s: %s", nodePublicIPv4Var, err)
+			}
+		}
+
+		manager.publicIPv4[spec.name] = publicIPv4
+
+		publicIPv6 := true
+		var publicIPv6Str string
+		nodePublicIPv6Var := fmt.Sprintf("HCLOUD_%s_PUBLIC_IPV6", strings.ToUpper(spec.name))
+		if nodeSpecificPublicIPv6, ok := os.LookupEnv(nodePublicIPv6Var); ok {
+			publicIPv6Str = nodeSpecificPublicIPv6
+		} else {
+			publicIPv6Str = os.Getenv("HCLOUD_PUBLIC_IPV6")
+		}
+
+		if publicIPv6Str != "" {
+			publicIPv6, err = strconv.ParseBool(publicIPv6Str)
+			if err != nil {
+				klog.Fatalf("failed to parse HCLOUD_PUBLIC_IPV6 or %s: %s", nodePublicIPv6Var, err)
+			}
+		}
+
+		manager.publicIPv6[spec.name] = publicIPv6
 
 		manager.nodeGroups[spec.name] = &hetznerNodeGroup{
 			manager:            manager,

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -50,8 +50,8 @@ type hetznerManager struct {
 	network          *hcloud.Network
 	firewall         *hcloud.Firewall
 	createTimeout    time.Duration
-	publicIPv4       bool
-	publicIPv6       bool
+	publicIPv4       map[string]bool
+	publicIPv6       map[string]bool
 	cachedServerType *serverTypeCache
 	cachedServers    *serversCache
 }
@@ -74,24 +74,6 @@ func newManager() (*hetznerManager, error) {
 	imageName := os.Getenv("HCLOUD_IMAGE")
 	if imageName == "" {
 		imageName = "ubuntu-20.04"
-	}
-
-	publicIPv4 := true
-	publicIPv4Str := os.Getenv("HCLOUD_PUBLIC_IPV4")
-	if publicIPv4Str != "" {
-		publicIPv4, err = strconv.ParseBool(publicIPv4Str)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse HCLOUD_PUBLIC_IPV4: %s", err)
-		}
-	}
-
-	publicIPv6 := true
-	publicIPv6Str := os.Getenv("HCLOUD_PUBLIC_IPV6")
-	if publicIPv6Str != "" {
-		publicIPv6, err = strconv.ParseBool(publicIPv6Str)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse HCLOUD_PUBLIC_IPV6: %s", err)
-		}
 	}
 
 	// Search for an image ID corresponding to the supplied HCLOUD_IMAGE env
@@ -162,8 +144,6 @@ func newManager() (*hetznerManager, error) {
 		firewall:         firewall,
 		createTimeout:    createTimeout,
 		apiCallContext:   ctx,
-		publicIPv4:       publicIPv4,
-		publicIPv6:       publicIPv6,
 		cachedServerType: newServerTypeCache(ctx, client),
 		cachedServers:    newServersCache(ctx, client),
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -138,12 +138,15 @@ func newManager() (*hetznerManager, error) {
 	m := &hetznerManager{
 		client:           client,
 		nodeGroups:       make(map[string]*hetznerNodeGroup),
+		apiCallContext:   ctx,
+		cloudInit:        make(map[string]string),
 		image:            image,
 		sshKey:           sshKey,
 		network:          network,
 		firewall:         firewall,
 		createTimeout:    createTimeout,
-		apiCallContext:   ctx,
+		publicIPv4:       make(map[string]bool),
+		publicIPv6:       make(map[string]bool),
 		cachedServerType: newServerTypeCache(ctx, client),
 		cachedServers:    newServersCache(ctx, client),
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -18,7 +18,6 @@ package hetzner
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,7 +44,7 @@ type hetznerManager struct {
 	client           *hcloud.Client
 	nodeGroups       map[string]*hetznerNodeGroup
 	apiCallContext   context.Context
-	cloudInit        string
+	cloudInit        map[string]string
 	image            *hcloud.Image
 	sshKey           *hcloud.SSHKey
 	network          *hcloud.Network
@@ -63,11 +62,6 @@ func newManager() (*hetznerManager, error) {
 		return nil, errors.New("`HCLOUD_TOKEN` is not specified")
 	}
 
-	cloudInitBase64 := os.Getenv("HCLOUD_CLOUD_INIT")
-	if cloudInitBase64 == "" {
-		return nil, errors.New("`HCLOUD_CLOUD_INIT` is not specified")
-	}
-
 	client := hcloud.NewClient(
 		hcloud.WithToken(token),
 		hcloud.WithHTTPClient(httpClient),
@@ -75,10 +69,7 @@ func newManager() (*hetznerManager, error) {
 	)
 
 	ctx := context.Background()
-	cloudInit, err := base64.StdEncoding.DecodeString(cloudInitBase64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cloud init error: %s", err)
-	}
+	var err error
 
 	imageName := os.Getenv("HCLOUD_IMAGE")
 	if imageName == "" {
@@ -165,7 +156,6 @@ func newManager() (*hetznerManager, error) {
 	m := &hetznerManager{
 		client:           client,
 		nodeGroups:       make(map[string]*hetznerNodeGroup),
-		cloudInit:        string(cloudInit),
 		image:            image,
 		sshKey:           sshKey,
 		network:          network,

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -365,8 +365,8 @@ func createServer(n *hetznerNodeGroup) error {
 			nodeGroupLabel: n.id,
 		},
 		PublicNet: &hcloud.ServerCreatePublicNet{
-			EnableIPv4: n.manager.publicIPv4,
-			EnableIPv6: n.manager.publicIPv6,
+			EnableIPv4: n.manager.publicIPv4[n.id],
+			EnableIPv6: n.manager.publicIPv6[n.id],
 		},
 	}
 	if n.manager.sshKey != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -356,7 +356,7 @@ func createServer(n *hetznerNodeGroup) error {
 	StartAfterCreate := true
 	opts := hcloud.ServerCreateOpts{
 		Name:             newNodeName(n),
-		UserData:         n.manager.cloudInit,
+		UserData:         n.manager.cloudInit[n.id],
 		Location:         &hcloud.Location{Name: n.region},
 		ServerType:       &hcloud.ServerType{Name: n.instanceType},
 		Image:            n.manager.image,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds the ability to provide a different cloud-init and public IP value for each pool. This was developed specifically to address the need to label each autoscaling group differently but could enable far greater customisation of the node through cloud-init.

Existing functionality is maintained as the default operation if pool-specific environment variables are not set.

#### Which issue(s) this PR fixes:

Fixes #4604

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added the ability to customise the cloud-init and public IP address settings for Hetzner Cloud autoscale nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
