### PR TITLE
Add FetchReservations to GCE Autoscaling client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -100,6 +100,10 @@ func (client *mockAutoscalingGceClient) FetchAvailableCpuPlatforms() (map[string
 	return nil, nil
 }
 
+func (client *mockAutoscalingGceClient) FetchReservations() ([]*gce.Reservation, error) {
+	return nil, nil
+}
+
 func (client *mockAutoscalingGceClient) ResizeMig(_ GceRef, _ int64) error {
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Extend GCE Autoscaling client by adding a FetchReservations method.
This change is necessary, if we want to support Reservations, when making a scaling decisions.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Other doc]: https://cloud.google.com/compute/docs/instances/reserving-zonal-resources
```
