### PR TITLE
Bump version to 1.8.18 to release #5669.

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -27,7 +27,7 @@ REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.17
+TAG = 1.8.18
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

New tag to start a release process for the latest vulnerability fixes (fixed under #5669).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
