### PR TITLE
[vpa] [recommender] use factories for recommender and clusterStateFeeder

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -27,8 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	kube_client "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
@@ -39,27 +44,12 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
-	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/client-go/informers"
-	kube_client "k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1lister "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
 
 const (
-	evictionWatchRetryWait               = 10 * time.Second
-	evictionWatchJitterFactor            = 0.5
-	scaleCacheLoopPeriod                 = 7 * time.Second
-	scaleCacheEntryLifetime              = time.Hour
-	scaleCacheEntryFreshnessTime         = 10 * time.Minute
-	scaleCacheEntryJitterFactor  float64 = 1.
-	defaultResyncPeriod                  = 10 * time.Minute
-	// DefaultRecommenderName designates the recommender that will handle VPA objects which don't specify
-	// recommender name explicitly (and so implicitly specify that the default recommender should handle them)
+	evictionWatchRetryWait    = 10 * time.Second
+	evictionWatchJitterFactor = 0.5
+	// DefaultRecommenderName default name for the recommender
 	DefaultRecommenderName = "default"
 )
 
@@ -114,34 +104,6 @@ func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
 		controllerFetcher:   m.ControllerFetcher,
 		recommenderName:     m.RecommenderName,
 	}
-}
-
-// NewClusterStateFeeder creates new ClusterStateFeeder with internal data providers, based on kube client config.
-// Deprecated; Use ClusterStateFeederFactory instead.
-func NewClusterStateFeeder(config *rest.Config, clusterState *model.ClusterState, memorySave bool, namespace, metricsClientName string, recommenderName string) ClusterStateFeeder {
-	kubeClient := kube_client.NewForConfigOrDie(config)
-	podLister, oomObserver := NewPodListerAndOOMObserver(kubeClient, namespace)
-	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(namespace))
-	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
-	controllerFetcher.Start(context.TODO(), scaleCacheLoopPeriod)
-	return ClusterStateFeederFactory{
-		PodLister:           podLister,
-		OOMObserver:         oomObserver,
-		KubeClient:          kubeClient,
-		MetricsClient:       newMetricsClient(config, namespace, metricsClientName),
-		VpaCheckpointClient: vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
-		VpaLister:           vpa_api_util.NewVpasLister(vpa_clientset.NewForConfigOrDie(config), make(chan struct{}), namespace),
-		ClusterState:        clusterState,
-		SelectorFetcher:     target.NewVpaTargetSelectorFetcher(config, kubeClient, factory),
-		MemorySaveMode:      memorySave,
-		ControllerFetcher:   controllerFetcher,
-		RecommenderName:     recommenderName,
-	}.Make()
-}
-
-func newMetricsClient(config *rest.Config, namespace, clientName string) metrics.MetricsClient {
-	metricsGetter := resourceclient.NewForConfigOrDie(config)
-	return metrics.NewMetricsClient(metricsGetter, namespace, clientName)
 }
 
 // WatchEvictionEventsWithRetries watches new Events with reason=Evicted and passes them to the observer.

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -49,7 +49,7 @@ import (
 const (
 	evictionWatchRetryWait    = 10 * time.Second
 	evictionWatchJitterFactor = 0.5
-	// DefaultRecommenderName default name for the recommender
+	// DefaultRecommenderName recommender name explicitly (and so implicitly specify that the default recommender should handle them)
 	DefaultRecommenderName = "default"
 )
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -29,9 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/client-go/testing"
 
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/fake"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
 type metricsClientTestCase struct {
@@ -84,7 +85,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "", "fake")
+	return newMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -17,21 +17,31 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"time"
 
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
-
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	kube_client "k8s.io/client-go/kubernetes"
+	kube_flag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
+	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/checkpoint"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
+	input_metrics "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
-	kube_flag "k8s.io/component-base/cli/flag"
-	klog "k8s.io/klog/v2"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 var (
@@ -58,6 +68,7 @@ var (
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container pod names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 	vpaObjectNamespace  = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects and pod stats. Empty means all namespaces will be used.")
+	memorySaver         = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
 // Aggregation configuration flags
@@ -76,12 +87,27 @@ var (
 	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental)")
 )
 
+const (
+	// aggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
+	aggregateContainerStateGCInterval               = 1 * time.Hour
+	scaleCacheEntryLifetime           time.Duration = time.Hour
+	scaleCacheEntryFreshnessTime      time.Duration = 10 * time.Minute
+	scaleCacheEntryJitterFactor       float64       = 1.
+	scaleCacheLoopPeriod                            = 7 * time.Second
+	defaultResyncPeriod               time.Duration = 10 * time.Minute
+)
+
 func main() {
 	klog.InitFlags(nil)
 	kube_flag.InitFlags()
 	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender: %v", common.VerticalPodAutoscalerVersion, recommenderName)
 
 	config := common.CreateKubeConfigOrDie(*kubeconfig, float32(*kubeApiQps), int(*kubeApiBurst))
+	kubeClient := kube_client.NewForConfigOrDie(config)
+	clusterState := model.NewClusterState(aggregateContainerStateGCInterval)
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(*vpaObjectNamespace))
+	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
+	podLister, oomObserver := input.NewPodListerAndOOMObserver(kubeClient, *vpaObjectNamespace)
 
 	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp))
 
@@ -99,7 +125,32 @@ func main() {
 	// CappingPostProcessor, should always come in the last position for post-processing
 	postProcessors = append(postProcessors, &routines.CappingPostProcessor{})
 
-	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace, *recommenderName, postProcessors)
+	clusterStateFeeder := input.ClusterStateFeederFactory{
+		PodLister:           podLister,
+		OOMObserver:         oomObserver,
+		KubeClient:          kubeClient,
+		MetricsClient:       input_metrics.NewMetricsClient(config, *vpaObjectNamespace, "default-metrics-client"),
+		VpaCheckpointClient: vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
+		VpaLister:           vpa_api_util.NewVpasLister(vpa_clientset.NewForConfigOrDie(config), make(chan struct{}), *vpaObjectNamespace),
+		ClusterState:        clusterState,
+		SelectorFetcher:     target.NewVpaTargetSelectorFetcher(config, kubeClient, factory),
+		MemorySaveMode:      *memorySaver,
+		ControllerFetcher:   controllerFetcher,
+		RecommenderName:     *recommenderName,
+	}.Make()
+	controllerFetcher.Start(context.Background(), scaleCacheLoopPeriod)
+
+	recommender := routines.RecommenderFactory{
+		ClusterState:                 clusterState,
+		ClusterStateFeeder:           clusterStateFeeder,
+		ControllerFetcher:            controllerFetcher,
+		CheckpointWriter:             checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
+		VpaClient:                    vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
+		PodResourceRecommender:       logic.CreatePodResourceRecommender(),
+		RecommendationPostProcessors: postProcessors,
+		CheckpointsGCInterval:        *checkpointsGCInterval,
+		UseCheckpoints:               useCheckpoints,
+	}.Make()
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_flag "k8s.io/component-base/cli/flag"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -21,7 +21,8 @@ import (
 	"flag"
 	"time"
 
-	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/klog/v2"
+
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/checkpoint"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
@@ -30,25 +31,11 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 	vpa_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/client-go/informers"
-	kube_client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	klog "k8s.io/klog/v2"
-)
-
-const (
-	// AggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
-	AggregateContainerStateGCInterval               = 1 * time.Hour
-	scaleCacheEntryLifetime           time.Duration = time.Hour
-	scaleCacheEntryFreshnessTime      time.Duration = 10 * time.Minute
-	scaleCacheEntryJitterFactor       float64       = 1.
-	defaultResyncPeriod               time.Duration = 10 * time.Minute
 )
 
 var (
 	checkpointsWriteTimeout = flag.Duration("checkpoints-timeout", time.Minute, `Timeout for writing checkpoints since the start of the recommender's main loop`)
 	minCheckpointsPerRun    = flag.Int("min-checkpoints", 10, "Minimum number of checkpoints to write per recommender's main loop")
-	memorySaver             = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
 // Recommender recommend resources for certain containers, based on utilization periodically got from metrics api.
@@ -222,26 +209,4 @@ func (c RecommenderFactory) Make() Recommender {
 	}
 	klog.V(3).Infof("New Recommender created %+v", recommender)
 	return recommender
-}
-
-// NewRecommender creates a new recommender instance.
-// Dependencies are created automatically.
-// Deprecated; use RecommenderFactory instead.
-func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, useCheckpoints bool, namespace string, recommenderName string, recommendationPostProcessors []RecommendationPostProcessor) Recommender {
-	clusterState := model.NewClusterState(AggregateContainerStateGCInterval)
-	kubeClient := kube_client.NewForConfigOrDie(config)
-	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(namespace))
-	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
-
-	return RecommenderFactory{
-		ClusterState:                 clusterState,
-		ClusterStateFeeder:           input.NewClusterStateFeeder(config, clusterState, *memorySaver, namespace, "default-metrics-client", recommenderName),
-		ControllerFetcher:            controllerFetcher,
-		CheckpointWriter:             checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
-		VpaClient:                    vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
-		PodResourceRecommender:       logic.CreatePodResourceRecommender(),
-		RecommendationPostProcessors: recommendationPostProcessors,
-		CheckpointsGCInterval:        checkpointsGCInterval,
-		UseCheckpoints:               useCheckpoints,
-	}.Make()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using factories in the main allow use to better initialise and share some resources between building blocks.
This also make some pieces like the sharedInformer, the controllerFetcher, .... available for other building blocks like the post-processing layer.

#### Which issue(s) this PR fixes:

None 

Fixes #

#### Special notes for your reviewer:

Removing function that are marked deprecated, use factory instead. This will allow to share some interfaces with post processors that are also bootstrapped in the main.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
