### PR TITLE
[vpa] [recommender] post processor: maintain ratio between resources

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -27,8 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	kube_client "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
@@ -39,27 +44,12 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
-	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/client-go/informers"
-	kube_client "k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1lister "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
 
 const (
-	evictionWatchRetryWait               = 10 * time.Second
-	evictionWatchJitterFactor            = 0.5
-	scaleCacheLoopPeriod                 = 7 * time.Second
-	scaleCacheEntryLifetime              = time.Hour
-	scaleCacheEntryFreshnessTime         = 10 * time.Minute
-	scaleCacheEntryJitterFactor  float64 = 1.
-	defaultResyncPeriod                  = 10 * time.Minute
-	// DefaultRecommenderName designates the recommender that will handle VPA objects which don't specify
-	// recommender name explicitly (and so implicitly specify that the default recommender should handle them)
+	evictionWatchRetryWait    = 10 * time.Second
+	evictionWatchJitterFactor = 0.5
+	// DefaultRecommenderName default name for the recommender
 	DefaultRecommenderName = "default"
 )
 
@@ -114,34 +104,6 @@ func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
 		controllerFetcher:   m.ControllerFetcher,
 		recommenderName:     m.RecommenderName,
 	}
-}
-
-// NewClusterStateFeeder creates new ClusterStateFeeder with internal data providers, based on kube client config.
-// Deprecated; Use ClusterStateFeederFactory instead.
-func NewClusterStateFeeder(config *rest.Config, clusterState *model.ClusterState, memorySave bool, namespace, metricsClientName string, recommenderName string) ClusterStateFeeder {
-	kubeClient := kube_client.NewForConfigOrDie(config)
-	podLister, oomObserver := NewPodListerAndOOMObserver(kubeClient, namespace)
-	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(namespace))
-	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
-	controllerFetcher.Start(context.TODO(), scaleCacheLoopPeriod)
-	return ClusterStateFeederFactory{
-		PodLister:           podLister,
-		OOMObserver:         oomObserver,
-		KubeClient:          kubeClient,
-		MetricsClient:       newMetricsClient(config, namespace, metricsClientName),
-		VpaCheckpointClient: vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
-		VpaLister:           vpa_api_util.NewVpasLister(vpa_clientset.NewForConfigOrDie(config), make(chan struct{}), namespace),
-		ClusterState:        clusterState,
-		SelectorFetcher:     target.NewVpaTargetSelectorFetcher(config, kubeClient, factory),
-		MemorySaveMode:      memorySave,
-		ControllerFetcher:   controllerFetcher,
-		RecommenderName:     recommenderName,
-	}.Make()
-}
-
-func newMetricsClient(config *rest.Config, namespace, clientName string) metrics.MetricsClient {
-	metricsGetter := resourceclient.NewForConfigOrDie(config)
-	return metrics.NewMetricsClient(metricsGetter, namespace, clientName)
 }
 
 // WatchEvictionEventsWithRetries watches new Events with reason=Evicted and passes them to the observer.

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
@@ -39,6 +41,10 @@ import (
 type fakeControllerFetcher struct {
 	key *controllerfetcher.ControllerKeyWithAPIVersion
 	err error
+}
+
+func (f *fakeControllerFetcher) GetPodTemplateFromTopMostWellKnown(controller *controllerfetcher.ControllerKeyWithAPIVersion) (*apiv1.PodTemplateSpec, error) {
+	return nil, nil
 }
 
 func (f *fakeControllerFetcher) FindTopMostWellKnownOrScalable(_ *controllerfetcher.ControllerKeyWithAPIVersion) (*controllerfetcher.ControllerKeyWithAPIVersion, error) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -29,9 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/client-go/testing"
 
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/fake"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
 type metricsClientTestCase struct {
@@ -84,7 +85,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "", "fake")
+	return newMetricsClient(fakeMetricsGetter.MetricsV1beta1(), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -17,21 +17,31 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"time"
 
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
-
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	kube_client "k8s.io/client-go/kubernetes"
+	kube_flag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
+	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/checkpoint"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
+	input_metrics "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
-	kube_flag "k8s.io/component-base/cli/flag"
-	klog "k8s.io/klog/v2"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 var (
@@ -58,6 +68,7 @@ var (
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container pod names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 	vpaObjectNamespace  = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects and pod stats. Empty means all namespaces will be used.")
+	memorySaver         = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
 // Aggregation configuration flags
@@ -76,12 +87,27 @@ var (
 	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental)")
 )
 
+const (
+	// aggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
+	aggregateContainerStateGCInterval               = 1 * time.Hour
+	scaleCacheEntryLifetime           time.Duration = time.Hour
+	scaleCacheEntryFreshnessTime      time.Duration = 10 * time.Minute
+	scaleCacheEntryJitterFactor       float64       = 1.
+	scaleCacheLoopPeriod                            = 7 * time.Second
+	defaultResyncPeriod               time.Duration = 10 * time.Minute
+)
+
 func main() {
 	klog.InitFlags(nil)
 	kube_flag.InitFlags()
 	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender: %v", common.VerticalPodAutoscalerVersion, recommenderName)
 
 	config := common.CreateKubeConfigOrDie(*kubeconfig, float32(*kubeApiQps), int(*kubeApiBurst))
+	kubeClient := kube_client.NewForConfigOrDie(config)
+	clusterState := model.NewClusterState(aggregateContainerStateGCInterval)
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(*vpaObjectNamespace))
+	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
+	podLister, oomObserver := input.NewPodListerAndOOMObserver(kubeClient, *vpaObjectNamespace)
 
 	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp))
 
@@ -99,7 +125,32 @@ func main() {
 	// CappingPostProcessor, should always come in the last position for post-processing
 	postProcessors = append(postProcessors, &routines.CappingPostProcessor{})
 
-	recommender := routines.NewRecommender(config, *checkpointsGCInterval, useCheckpoints, *vpaObjectNamespace, *recommenderName, postProcessors)
+	clusterStateFeeder := input.ClusterStateFeederFactory{
+		PodLister:           podLister,
+		OOMObserver:         oomObserver,
+		KubeClient:          kubeClient,
+		MetricsClient:       input_metrics.NewMetricsClient(config, *vpaObjectNamespace, "default-metrics-client"),
+		VpaCheckpointClient: vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
+		VpaLister:           vpa_api_util.NewVpasLister(vpa_clientset.NewForConfigOrDie(config), make(chan struct{}), *vpaObjectNamespace),
+		ClusterState:        clusterState,
+		SelectorFetcher:     target.NewVpaTargetSelectorFetcher(config, kubeClient, factory),
+		MemorySaveMode:      *memorySaver,
+		ControllerFetcher:   controllerFetcher,
+		RecommenderName:     *recommenderName,
+	}.Make()
+	controllerFetcher.Start(context.Background(), scaleCacheLoopPeriod)
+
+	recommender := routines.RecommenderFactory{
+		ClusterState:                 clusterState,
+		ClusterStateFeeder:           clusterStateFeeder,
+		ControllerFetcher:            controllerFetcher,
+		CheckpointWriter:             checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
+		VpaClient:                    vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
+		PodResourceRecommender:       logic.CreatePodResourceRecommender(),
+		RecommendationPostProcessors: postProcessors,
+		CheckpointsGCInterval:        *checkpointsGCInterval,
+		UseCheckpoints:               useCheckpoints,
+	}.Make()
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -85,6 +85,8 @@ var (
 var (
 	// CPU as integer to benefit for CPU management Static Policy ( https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy )
 	postProcessorCPUasInteger = flag.Bool("cpu-integer-post-processor-enabled", false, "Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental)")
+	// Resource ratio post-processor. Ability to ensure that resource ratio is maintained. For example CPU recommendation is done as usual, and the Memory recommendation is computed so that the initial ratio between memory and CPU is maintained. This could be useful for garbage collected languages where the runtime tries to release memory when consumption is closed to the limit, resulting in degraded performances.
+	postProcessorMaintainResourceRatio = flag.Bool("resource-ratio-post-processor-enabled", false, "Enable the resource-ratio recommendation post processor. The post processor will ensure that resource ratio is maintain for pods which were opted in by setting an appropriate label on VPA object (experimental)")
 )
 
 const (
@@ -121,6 +123,9 @@ func main() {
 	var postProcessors []routines.RecommendationPostProcessor
 	if *postProcessorCPUasInteger {
 		postProcessors = append(postProcessors, &routines.IntegerCPUPostProcessor{})
+	}
+	if *postProcessorMaintainResourceRatio {
+		postProcessors = append(postProcessors, &routines.ResourceRatioRecommendationPostProcessor{ControllerFetcher: controllerFetcher})
 	}
 	// CappingPostProcessor, should always come in the last position for post-processing
 	postProcessors = append(postProcessors, &routines.CappingPostProcessor{})

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -26,10 +26,11 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -64,6 +65,10 @@ var (
 type fakeControllerFetcher struct {
 	key *controllerfetcher.ControllerKeyWithAPIVersion
 	err error
+}
+
+func (f *fakeControllerFetcher) GetPodTemplateFromTopMostWellKnown(controller *controllerfetcher.ControllerKeyWithAPIVersion) (*apiv1.PodTemplateSpec, error) {
+	return nil, nil
 }
 
 func (f *fakeControllerFetcher) FindTopMostWellKnownOrScalable(controller *controllerfetcher.ControllerKeyWithAPIVersion) (*controllerfetcher.ControllerKeyWithAPIVersion, error) {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
@@ -17,11 +17,13 @@ limitations under the License.
 package routines
 
 import (
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	"strings"
 )
 
 // IntegerCPUPostProcessor ensures that the recommendation delivers an integer value for CPU
@@ -38,7 +40,7 @@ const (
 
 var _ RecommendationPostProcessor = &IntegerCPUPostProcessor{}
 
-// Process apply the capping post-processing to the recommendation.
+// Process apply the CPU integer post-processing to the recommendation.
 // For this post processor the CPU value is rounded up to an integer
 func (p *IntegerCPUPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
 

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -21,7 +21,8 @@ import (
 	"flag"
 	"time"
 
-	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/klog/v2"
+
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/checkpoint"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
@@ -30,25 +31,11 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 	vpa_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/client-go/informers"
-	kube_client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	klog "k8s.io/klog/v2"
-)
-
-const (
-	// AggregateContainerStateGCInterval defines how often expired AggregateContainerStates are garbage collected.
-	AggregateContainerStateGCInterval               = 1 * time.Hour
-	scaleCacheEntryLifetime           time.Duration = time.Hour
-	scaleCacheEntryFreshnessTime      time.Duration = 10 * time.Minute
-	scaleCacheEntryJitterFactor       float64       = 1.
-	defaultResyncPeriod               time.Duration = 10 * time.Minute
 )
 
 var (
 	checkpointsWriteTimeout = flag.Duration("checkpoints-timeout", time.Minute, `Timeout for writing checkpoints since the start of the recommender's main loop`)
 	minCheckpointsPerRun    = flag.Int("min-checkpoints", 10, "Minimum number of checkpoints to write per recommender's main loop")
-	memorySaver             = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
 // Recommender recommend resources for certain containers, based on utilization periodically got from metrics api.
@@ -222,26 +209,4 @@ func (c RecommenderFactory) Make() Recommender {
 	}
 	klog.V(3).Infof("New Recommender created %+v", recommender)
 	return recommender
-}
-
-// NewRecommender creates a new recommender instance.
-// Dependencies are created automatically.
-// Deprecated; use RecommenderFactory instead.
-func NewRecommender(config *rest.Config, checkpointsGCInterval time.Duration, useCheckpoints bool, namespace string, recommenderName string, recommendationPostProcessors []RecommendationPostProcessor) Recommender {
-	clusterState := model.NewClusterState(AggregateContainerStateGCInterval)
-	kubeClient := kube_client.NewForConfigOrDie(config)
-	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(namespace))
-	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
-
-	return RecommenderFactory{
-		ClusterState:                 clusterState,
-		ClusterStateFeeder:           input.NewClusterStateFeeder(config, clusterState, *memorySaver, namespace, "default-metrics-client", recommenderName),
-		ControllerFetcher:            controllerFetcher,
-		CheckpointWriter:             checkpoint.NewCheckpointWriter(clusterState, vpa_clientset.NewForConfigOrDie(config).AutoscalingV1()),
-		VpaClient:                    vpa_clientset.NewForConfigOrDie(config).AutoscalingV1(),
-		PodResourceRecommender:       logic.CreatePodResourceRecommender(),
-		RecommendationPostProcessors: recommendationPostProcessors,
-		CheckpointsGCInterval:        checkpointsGCInterval,
-		UseCheckpoints:               useCheckpoints,
-	}.Make()
 }

--- a/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+)
+
+const (
+	vpaPostProcessorResourceRationSuffix = "_resourceRatios"
+)
+
+// ResourceRatioRecommendationPostProcessor ensures that defined ratio constraints between resources is applied.
+// The definition is done via annotation on the VPA object with format: vpa-post-processor.kubernetes.io/{containerName}_resourceRatios="{resourceA:resourceB}"
+// The value of the annotation is map of resource to resource. If the value is {"cpu":"memory"} that means that the CPU recommendation is used and the memory recommendation is computed to match the initial ratio CPU/Memory that is defined in the podTemplateSpec.
+type ResourceRatioRecommendationPostProcessor struct {
+	ControllerFetcher controllerfetcher.ControllerFetcher
+}
+
+type resourceRatioList [][2]apiv1.ResourceName
+
+// Process applies the Resource Ratio post-processing to the recommendation.
+func (r *ResourceRatioRecommendationPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, _ *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+	ratios := readResourceRatioFromVPAAnnotations(vpa)
+	if len(ratios) == 0 || recommendation == nil {
+		return recommendation
+	}
+
+	podTemplate, err := r.ControllerFetcher.GetPodTemplateFromTopMostWellKnown(&controllerfetcher.ControllerKeyWithAPIVersion{
+		ControllerKey: controllerfetcher.ControllerKey{
+			Namespace: vpa.ID.Namespace,
+			Kind:      vpa.TargetRef.Kind,
+			Name:      vpa.TargetRef.Name,
+		},
+		ApiVersion: vpa.TargetRef.APIVersion,
+	})
+	if err != nil {
+		klog.Errorf("Failed to apply ResourceRatioRecommendationPostProcessor (controller fetch) to vpa %s/%s due to error: %#v", vpa.ID.Namespace, vpa.ID.VpaName, err)
+		return recommendation
+	}
+
+	pod := newPodFromTemplate(podTemplate)
+
+	updatedRecommendation, err := r.apply(recommendation, ratios, pod)
+	if err != nil {
+		klog.Errorf("Failed to apply ResourceRatioRecommendationPostProcessor to vpa %s/%s due to error: %#v", vpa.ID.Namespace, vpa.ID.VpaName, err)
+	}
+	return updatedRecommendation
+}
+
+func readResourceRatioFromVPAAnnotations(vpa *model.Vpa) map[string]resourceRatioList {
+	ratios := map[string]resourceRatioList{}
+	for key, value := range vpa.Annotations {
+		containerName := extractContainerName(key, vpaPostProcessorPrefix, vpaPostProcessorResourceRationSuffix)
+		if containerName == "" {
+			continue
+		}
+
+		annotationMap := map[string]string{}
+
+		if err := json.Unmarshal([]byte(value), &annotationMap); err != nil {
+			klog.Errorf("Skipping ratio definition '%s' for container '%s' in vpa %s/%s due to bad format, error:%#v", value, containerName, vpa.ID.Namespace, vpa.ID.VpaName, err)
+		}
+
+		for r1, r2 := range annotationMap {
+			ratios[containerName] = append(ratios[containerName], [2]apiv1.ResourceName{apiv1.ResourceName(r1), apiv1.ResourceName(r2)})
+		}
+	}
+	return ratios
+}
+
+// ResourceRatioRecommendationPostProcessor must implement RecommendationProcessor
+var _ RecommendationPostProcessor = &ResourceRatioRecommendationPostProcessor{}
+
+// Apply returns a recommendation for the given pod, adjusted to obey maintainedRatio policy
+func (r *ResourceRatioRecommendationPostProcessor) apply(
+	podRecommendation *vpa_types.RecommendedPodResources,
+	ratios map[string]resourceRatioList,
+	pod *apiv1.Pod) (*vpa_types.RecommendedPodResources, error) {
+
+	if podRecommendation == nil {
+		// If there is no recommendation let's skip this post-processor
+		return nil, nil
+	}
+	updatedRecommendations := []vpa_types.RecommendedContainerResources{}
+
+	for _, containerRecommendation := range podRecommendation.ContainerRecommendations {
+		container := getContainer(containerRecommendation.ContainerName, pod)
+		if container == nil {
+			klog.V(2).Infof("no matching Container found for recommendation %s", containerRecommendation.ContainerName)
+			continue
+		}
+
+		updatedContainerResources, err := getRecommendationForContainerWithRatioApplied(*container, &containerRecommendation, ratios)
+		if err != nil {
+			return nil, fmt.Errorf("cannot update recommendation for container name %v", container.Name)
+		}
+		updatedRecommendations = append(updatedRecommendations, *updatedContainerResources)
+	}
+
+	return &vpa_types.RecommendedPodResources{ContainerRecommendations: updatedRecommendations}, nil
+}
+
+func newPodFromTemplate(template *apiv1.PodTemplateSpec) *apiv1.Pod {
+	return &apiv1.Pod{
+		ObjectMeta: *template.ObjectMeta.DeepCopy(),
+		Spec:       *template.Spec.DeepCopy(),
+	}
+}
+
+func getContainer(containerName string, pod *apiv1.Pod) *apiv1.Container {
+	for i, c := range pod.Spec.Containers {
+		if c.Name == containerName {
+			return &pod.Spec.Containers[i]
+		}
+	}
+	for i, c := range pod.Spec.InitContainers {
+		if c.Name == containerName {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+// getRecommendationForContainerWithRatioApplied returns a recommendation for the given container, adjusted to obey maintainedRatios policy
+func getRecommendationForContainerWithRatioApplied(
+	container apiv1.Container,
+	containerRecommendation *vpa_types.RecommendedContainerResources,
+	ratios map[string]resourceRatioList) (*vpa_types.RecommendedContainerResources, error) {
+
+	// containerPolicy can be nil (user does not have to configure it).
+	containerPolicy := ratios[container.Name]
+
+	amendedRecommendations := containerRecommendation.DeepCopy()
+
+	process := func(recommendation apiv1.ResourceList) {
+		applyMaintainRatioVPAPolicy(recommendation, containerPolicy, container.Resources.Requests)
+	}
+
+	process(amendedRecommendations.Target)
+	process(amendedRecommendations.LowerBound)
+	process(amendedRecommendations.UpperBound)
+
+	return amendedRecommendations, nil
+}
+
+// applyMaintainRatioVPAPolicy uses the maintainRatio constraints and the defined ratios in the Pod
+// and amend the recommendation to respect the original ratios
+func applyMaintainRatioVPAPolicy(recommendation apiv1.ResourceList, ratiosPolicies [][2]apiv1.ResourceName, containerOriginalResources apiv1.ResourceList) {
+	if ratiosPolicies == nil {
+		return
+	}
+
+	maintainedRatiosCalculationOrdered, err := getMaintainedRatiosCalculationOrder(ratiosPolicies)
+	if err != nil {
+		klog.V(1).ErrorS(err, "The VPA definition is not correct and should not have passed the admission (if ratio policies are checked). Can't apply MaintainedRatio Processor")
+		return
+	}
+
+	for _, ratioConstraint := range maintainedRatiosCalculationOrdered {
+		qA := containerOriginalResources.Name(ratioConstraint[0], resource.DecimalSI)
+		qB := containerOriginalResources.Name(ratioConstraint[1], resource.DecimalSI)
+
+		if qA.MilliValue() == 0 {
+			continue
+		}
+
+		rA := recommendation.Name(ratioConstraint[0], resource.DecimalSI)
+		rB := recommendation.Name(ratioConstraint[1], resource.DecimalSI)
+		rB.SetMilli(rA.MilliValue() * qB.MilliValue() / qA.MilliValue())
+		recommendation[ratioConstraint[1]] = *rB
+	}
+	return
+}
+
+// getMaintainedRatiosCalculationOrder validates (no cycle) and sort the constraints
+// in an order that should be used to compute resource values
+// for example if the user gives:
+// {"B","C"},{"A","B"} , we must first compute B using value of A, and then only compute C using value of B
+// this function will return:
+// {"A","B"},{"B","C"}
+// The function will return an error if the graph defined contains cycle.
+// The function support multiple graphs like: {"A","B"},{"C","D"} ... but in that case the ordered output is undetermined
+// it could be {"A","B"},{"C","D"} or {"C","D"},{"A","B"}
+func getMaintainedRatiosCalculationOrder(m [][2]apiv1.ResourceName) ([][2]apiv1.ResourceName, error) {
+	ordered, predecessorsMap, ok := getSortedResourceAndPredecessors(m)
+	if !ok {
+		klog.V(1).Infof("Error the graph is not acyclic")
+		return nil, fmt.Errorf("Error the graph is not acyclic")
+	}
+
+	// Check that no resourceNode of the graph has more than 1 predecessor
+	for k, v := range predecessorsMap {
+		if len(v) > 1 {
+			klog.V(1).Infof("Resource '%s' has more that one predecessor for value computation", k)
+			return nil, fmt.Errorf("Resource '%s' has more than one predecessor in maintainedRatios", k)
+		}
+	}
+
+	orderedResult := [][2]apiv1.ResourceName{}
+
+	// build the ordered list of relation
+	// this list will tell us in which order we should compute resources
+	for _, resource := range ordered {
+		m := predecessorsMap[resource]
+		var predecessor apiv1.ResourceName
+		if len(m) == 0 {
+			continue
+		}
+		for k := range m { // we are sure that there is only one element here
+			predecessor = k
+		}
+		orderedResult = append(orderedResult, [2]apiv1.ResourceName{predecessor, resource})
+	}
+	return orderedResult, nil
+
+}
+
+// getSortedResourceAndPredecessors returns an ordered list of nodes (from root to leaves) and also checks that the defined graph is acyclic
+func getSortedResourceAndPredecessors(edges [][2]apiv1.ResourceName) ([]apiv1.ResourceName, map[apiv1.ResourceName]map[apiv1.ResourceName]struct{}, bool) {
+	g := resourceGraph{nodes: map[apiv1.ResourceName]*resourceNode{}}
+	for _, edge := range edges {
+		g.addEdge(edge[0], edge[1])
+	}
+	return g.getOrderedListAndPredecessors()
+}
+
+type resourceGraph struct {
+	nodes map[apiv1.ResourceName]*resourceNode
+}
+
+type resourceNode struct {
+	key              apiv1.ResourceName
+	children, parent map[*resourceNode]struct{}
+}
+
+func (g *resourceGraph) addEdge(from, to apiv1.ResourceName) {
+	var nodeFrom, nodeTo *resourceNode
+	var ok bool
+	if nodeTo, ok = g.nodes[to]; !ok {
+		nodeTo = &resourceNode{key: to, parent: map[*resourceNode]struct{}{}, children: map[*resourceNode]struct{}{}}
+		g.nodes[to] = nodeTo
+	}
+
+	if nodeFrom, ok = g.nodes[from]; !ok {
+		nodeFrom = &resourceNode{key: from, parent: map[*resourceNode]struct{}{}, children: map[*resourceNode]struct{}{}}
+		g.nodes[from] = nodeFrom
+	}
+
+	nodeFrom.children[nodeTo] = struct{}{}
+	nodeTo.parent[nodeFrom] = struct{}{}
+}
+
+// getOrderedListAndPredecessors check that the graph is acyclic and build output like ordered list of resourceNode from root to leaves
+// To test a graph for being acyclic:
+// 1 - If the graph has no nodes, stop. The graph is acyclic.
+// 2 - If the graph has no leaf, stop. The graph is cyclic.
+// 3 - Choose a leaf of the graph. Remove this leaf and all arcs going into the leaf to get a new graph.
+// Go to 1.
+func (g *resourceGraph) getOrderedListAndPredecessors() (orderedList []apiv1.ResourceName, predecessors map[apiv1.ResourceName]map[apiv1.ResourceName]struct{}, acyclic bool) {
+	predecessors = map[apiv1.ResourceName]map[apiv1.ResourceName]struct{}{}
+
+	for len(g.nodes) > 0 {
+		oneLeafFound := false
+		for _, n := range g.nodes {
+			if len(n.children) == 0 {
+				orderedList = append([]apiv1.ResourceName{n.key}, orderedList...)
+				parentKeys := map[apiv1.ResourceName]struct{}{}
+				for p := range n.parent {
+					parentKeys[p.key] = struct{}{}
+					delete(p.children, n)
+				}
+				predecessors[n.key] = parentKeys
+				oneLeafFound = true
+				delete(g.nodes, n.key)
+				break
+			}
+		}
+		if !oneLeafFound {
+			break
+		}
+	}
+	if len(g.nodes) > 0 {
+		return nil, nil, false
+	}
+	return orderedList, predecessors, true
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/resource_ratio_post_processor_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routines
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func Test_getMaintainedRatiosCalculationOrder(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		input     [][2]apiv1.ResourceName
+		wantOneOf [][][2]apiv1.ResourceName // in some configuration some items can be swapped and that is fine
+		wantErr   bool
+	}{
+		{
+			name:      "empty",
+			input:     nil,
+			wantOneOf: nil,
+			wantErr:   false,
+		},
+		{
+			name:      "simple",
+			input:     [][2]apiv1.ResourceName{{"cpu", "memory"}},
+			wantOneOf: [][][2]apiv1.ResourceName{{{"cpu", "memory"}}},
+			wantErr:   false,
+		},
+		{
+			name:  "simple",
+			input: [][2]apiv1.ResourceName{{"cpu", "memory"}, {"cpu", "storage"}},
+			wantOneOf: [][][2]apiv1.ResourceName{
+				{{"cpu", "memory"}, {"cpu", "storage"}},
+				{{"cpu", "storage"}, {"cpu", "memory"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "cycle 1",
+			input:     [][2]apiv1.ResourceName{{"cpu", "cpu"}},
+			wantOneOf: nil,
+			wantErr:   true,
+		},
+		{
+			name:      "cycle 3",
+			input:     [][2]apiv1.ResourceName{{"cpu", "memory"}, {"memory", "storage"}, {"storage", "cpu"}},
+			wantOneOf: nil,
+			wantErr:   true,
+		},
+		{
+			name:  "2 graphs",
+			input: [][2]apiv1.ResourceName{{"cpu", "memory"}, {"storage", "net"}},
+			wantOneOf: [][][2]apiv1.ResourceName{
+				{{"cpu", "memory"}, {"storage", "net"}},
+				{{"storage", "net"}, {"cpu", "memory"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Same ancestor",
+			input: [][2]apiv1.ResourceName{{"cpu", "memory"}, {"cpu", "net"}},
+			wantOneOf: [][][2]apiv1.ResourceName{
+				{{"cpu", "memory"}, {"cpu", "net"}},
+				{{"cpu", "net"}, {"cpu", "memory"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "reorder 3",
+			input:     [][2]apiv1.ResourceName{{"cpu", "memory"}, {"memory", "net"}, {"storage", "cpu"}},
+			wantOneOf: [][][2]apiv1.ResourceName{{{"storage", "cpu"}, {"cpu", "memory"}, {"memory", "net"}}},
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			{
+				got, err := getMaintainedRatiosCalculationOrder(tt.input)
+				assert.Equalf(t, tt.wantErr, err != nil, "Error is not the expected one: %v", err)
+				if len(tt.wantOneOf) == 0 && len(got) == 0 {
+					return
+				}
+				found := false
+				for _, option := range tt.wantOneOf {
+					if assert.ObjectsAreEqual(option, got) {
+						found = true
+						continue
+					}
+				}
+				assert.Truef(t, found, "getMaintainedRatiosCalculationOrder(%v)  =>  %v", tt.input, got)
+			}
+		})
+	}
+}
+
+func Test_applyMaintainRatioVPAPolicy(t *testing.T) {
+	tests := []struct {
+		name                       string
+		recommendation             apiv1.ResourceList
+		policyRatios               [][2]apiv1.ResourceName
+		containerOriginalResources apiv1.ResourceList
+		expectedAnnotations        []string
+		expectedRecommendation     apiv1.ResourceList
+	}{
+		{
+			name: "no Policy",
+			recommendation: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewQuantity(1, resource.DecimalSI),
+			},
+			policyRatios: nil,
+			containerOriginalResources: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewQuantity(3000, resource.DecimalSI),
+			},
+			expectedRecommendation: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewQuantity(1, resource.DecimalSI),
+			},
+		},
+		{
+			name: "Policy simple cpu to memory",
+			recommendation: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewQuantity(1, resource.DecimalSI),
+			},
+			policyRatios: [][2]apiv1.ResourceName{{"cpu", "memory"}},
+			containerOriginalResources: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewQuantity(3000, resource.DecimalSI),
+			},
+			expectedRecommendation: apiv1.ResourceList{
+				"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+				"memory": *resource.NewScaledQuantity(3000000, resource.Milli),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyMaintainRatioVPAPolicy(tt.recommendation, tt.policyRatios, tt.containerOriginalResources)
+			assert.Equalf(t, tt.recommendation, tt.expectedRecommendation, "Expected recommendation differs: %#v", tt.recommendation)
+		})
+	}
+}
+
+func Test_resourceRatioRecommendationProcessor_Apply(t *testing.T) {
+	pod13 := test.Pod().WithName("pod1").AddContainer(test.BuildTestContainer("ctr-name", "1", "3")).Get()
+
+	podRecommendation := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: "ctr-name",
+				Target: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(5, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(10, 1)},
+				LowerBound: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(50, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(100, 1)},
+				UpperBound: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(150, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(200, 1)},
+			},
+		},
+	}
+	podRecommendationExpected13 := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: "ctr-name",
+				Target: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(5, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(15000, -3)},
+				LowerBound: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(50, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(150000, -3)},
+				UpperBound: apiv1.ResourceList{
+					apiv1.ResourceCPU:    *resource.NewScaledQuantity(150, 0),
+					apiv1.ResourceMemory: *resource.NewScaledQuantity(450000, -3)},
+			},
+		},
+	}
+
+	type args struct {
+		podRecommendation *vpa_types.RecommendedPodResources
+		ratioPolicies     map[string]resourceRatioList
+		conditions        []vpa_types.VerticalPodAutoscalerCondition
+		pod               *apiv1.Pod
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantReco *vpa_types.RecommendedPodResources
+		wantErr  bool
+	}{
+		{
+			name: "nil",
+			args: args{
+				podRecommendation: nil,
+				ratioPolicies:     nil,
+				conditions:        nil,
+				pod:               pod13,
+			},
+			wantReco: nil,
+			wantErr:  false,
+		},
+		{
+			name: "no policy",
+			args: args{
+				podRecommendation: podRecommendation,
+				ratioPolicies:     nil,
+				conditions:        nil,
+				pod:               pod13,
+			},
+			wantReco: podRecommendation,
+			wantErr:  false,
+		},
+		{
+			name: "cpu to mem",
+			args: args{
+				podRecommendation: podRecommendation,
+				ratioPolicies:     map[string]resourceRatioList{"ctr-name": [][2]apiv1.ResourceName{{"cpu", "memory"}}},
+				pod:               pod13,
+			},
+			wantReco: podRecommendationExpected13,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ResourceRatioRecommendationPostProcessor{}
+			got, err := r.apply(tt.args.podRecommendation, tt.args.ratioPolicies, tt.args.pod)
+			assert.Equalf(t, tt.wantErr, err != nil, "Error is not the expected one: %v", err)
+			assert.Equalf(t, tt.wantReco, got, "Recommendation: Apply(%v, %v, %v, %v)", tt.args.podRecommendation, tt.args.ratioPolicies, tt.args.conditions, tt.args.pod)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Under some circumstances, it is preferable to maintain the resource ratio (CPU/Memory) as defined in the podTemplate. Situations are describe in https://github.com/kubernetes/autoscaler/issues/5212 . Thanks to this PR it is possible to define which resource should be calculated based on another resource recommendation.

For example one can say that CPU recommendation should be deliver by the recommender (as usual) but the memory has to be computed by maintaining the ratio initially defined in the podTemplateSpec. The use is able to describe this situation by setting an annotation: `vpa-post-processor.kubernetes.io/{container-name}_resourceRatios = {"cpu":"memory"}`

#### Which issue(s) this PR fixes:

Fixes #5212 

#### Special notes for your reviewer:

This PR is based on https://github.com/kubernetes/autoscaler/pull/5676 . Thanks to that PR the ControllerFetcher can be passed to the post processing layer. I keep this one as `draft` till we conclude on #5676, then I will rebase.

#### Does this PR introduce a user-facing change?

Yes

```release-note
The "resource ratio post-processor" can be enabled using flag --resource-ratio-post-processor-enabled=true when starting the VPA recommender.
The post-processor would maintain resource ratio for containers referenced by a VPA annotation with this format:
vpa-post-processor.kubernetes.io/{containerName}_resourceRatios={resourceName:resourceName} where the value is a json representation of a map of resourceName to resourceName. For example:

vpa-post-processor.kubernetes.io/server_resourceRatios = {"cpu":"memory"}
```


