### PR TITLE
hetzner: update hcloud-go v1.42.0 to support arm64 servers

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/action.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/action.go
@@ -197,7 +197,24 @@ func (c *ActionClient) AllWithOpts(ctx context.Context, opts ActionListOpts) ([]
 	return allActions, nil
 }
 
-// WatchOverallProgress watches several actions' progress until they complete with success or error.
+// WatchOverallProgress watches several actions' progress until they complete
+// with success or error. This watching happens in a goroutine and updates are
+// provided through the two returned channels:
+//
+//   - The first channel receives percentage updates of the progress, based on
+//     the number of completed versus total watched actions. The return value
+//     is an int between 0 and 100.
+//   - The second channel returned receives errors for actions that did not
+//     complete successfully, as well as any errors that happened while
+//     querying the API.
+//
+// By default the method keeps watching until all actions have finished
+// processing. If you want to be able to cancel the method or configure a
+// timeout, use the [context.Context]. Once the method has stopped watching,
+// both returned channels are closed.
+//
+// WatchOverallProgress uses the [WithPollBackoffFunc] of the [Client] to wait
+// until sending the next request.
 func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Action) (<-chan int, <-chan error) {
 	errCh := make(chan error, len(actions))
 	progressCh := make(chan int)
@@ -212,15 +229,15 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 			watchIDs[action.ID] = struct{}{}
 		}
 
-		ticker := time.NewTicker(c.client.pollInterval)
-		defer ticker.Stop()
+		retries := 0
+
 		for {
 			select {
 			case <-ctx.Done():
 				errCh <- ctx.Err()
 				return
-			case <-ticker.C:
-				break
+			case <-time.After(c.client.pollBackoffFunc(retries)):
+				retries++
 			}
 
 			opts := ActionListOpts{}
@@ -257,7 +274,24 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 	return progressCh, errCh
 }
 
-// WatchProgress watches one action's progress until it completes with success or error.
+// WatchProgress watches one action's progress until it completes with success
+// or error. This watching happens in a goroutine and updates are provided
+// through the two returned channels:
+//
+//   - The first channel receives percentage updates of the progress, based on
+//     the progress percentage indicated by the API. The return value is an int
+//     between 0 and 100.
+//   - The second channel receives any errors that happened while querying the
+//     API, as well as the error of the action if it did not complete
+//     successfully, or nil if it did.
+//
+// By default the method keeps watching until the action has finished
+// processing. If you want to be able to cancel the method or configure a
+// timeout, use the [context.Context]. Once the method has stopped watching,
+// both returned channels are closed.
+//
+// WatchProgress uses the [WithPollBackoffFunc] of the [Client] to wait until
+// sending the next request.
 func (c *ActionClient) WatchProgress(ctx context.Context, action *Action) (<-chan int, <-chan error) {
 	errCh := make(chan error, 1)
 	progressCh := make(chan int)
@@ -266,16 +300,15 @@ func (c *ActionClient) WatchProgress(ctx context.Context, action *Action) (<-cha
 		defer close(errCh)
 		defer close(progressCh)
 
-		ticker := time.NewTicker(c.client.pollInterval)
-		defer ticker.Stop()
+		retries := 0
 
 		for {
 			select {
 			case <-ctx.Done():
 				errCh <- ctx.Err()
 				return
-			case <-ticker.C:
-				break
+			case <-time.After(c.client.pollBackoffFunc(retries)):
+				retries++
 			}
 
 			a, _, err := c.GetByID(ctx, action.ID)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/architecture.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/architecture.go
@@ -1,0 +1,12 @@
+package hcloud
+
+// Architecture specifies the architecture of the CPU.
+type Architecture string
+
+const (
+	// ArchitectureX86 is the architecture for Intel/AMD x86 CPUs.
+	ArchitectureX86 Architecture = "x86"
+
+	// ArchitectureARM is the architecture for ARM CPUs.
+	ArchitectureARM Architecture = "arm"
+)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
@@ -47,10 +47,10 @@ const (
 	CertificateStatusTypePending CertificateStatusType = "pending"
 	CertificateStatusTypeFailed  CertificateStatusType = "failed"
 
-	// only in issuance
+	// only in issuance.
 	CertificateStatusTypeCompleted CertificateStatusType = "completed"
 
-	// only in renewal
+	// only in renewal.
 	CertificateStatusTypeScheduled   CertificateStatusType = "scheduled"
 	CertificateStatusTypeUnavailable CertificateStatusType = "unavailable"
 )

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
@@ -44,14 +44,14 @@ const (
 	ErrorCodeResourceLocked        ErrorCode = "resource_locked"         // The resource is locked. The caller should contact support
 	ErrorUnsupportedError          ErrorCode = "unsupported_error"       // The given resource does not support this
 
-	// Server related error codes
+	// Server related error codes.
 	ErrorCodeInvalidServerType     ErrorCode = "invalid_server_type"     // The server type does not fit for the given server or is deprecated
 	ErrorCodeServerNotStopped      ErrorCode = "server_not_stopped"      // The action requires a stopped server
 	ErrorCodeNetworksOverlap       ErrorCode = "networks_overlap"        // The network IP range overlaps with one of the server networks
 	ErrorCodePlacementError        ErrorCode = "placement_error"         // An error during the placement occurred
 	ErrorCodeServerAlreadyAttached ErrorCode = "server_already_attached" // The server is already attached to the resource
 
-	// Load Balancer related error codes
+	// Load Balancer related error codes.
 	ErrorCodeIPNotOwned                       ErrorCode = "ip_not_owned"                          // The IP you are trying to add as a target is not owned by the Project owner
 	ErrorCodeSourcePortAlreadyUsed            ErrorCode = "source_port_already_used"              // The source port you are trying to add is already in use
 	ErrorCodeCloudResourceIPNotAllowed        ErrorCode = "cloud_resource_ip_not_allowed"         // The IP you are trying to add as a target belongs to a Hetzner Cloud resource
@@ -62,16 +62,16 @@ const (
 	ErrorCodeTargetsWithoutUsePrivateIP       ErrorCode = "targets_without_use_private_ip"        // The Load Balancer has targets that use the public IP instead of the private IP
 	ErrorCodeLoadBalancerNotAttachedToNetwork ErrorCode = "load_balancer_not_attached_to_network" // The Load Balancer is not attached to a network
 
-	// Network related error codes
+	// Network related error codes.
 	ErrorCodeIPNotAvailable     ErrorCode = "ip_not_available"        // The provided Network IP is not available
 	ErrorCodeNoSubnetAvailable  ErrorCode = "no_subnet_available"     // No Subnet or IP is available for the Load Balancer/Server within the network
 	ErrorCodeVSwitchAlreadyUsed ErrorCode = "vswitch_id_already_used" // The given Robot vSwitch ID is already registered in another network
 
-	// Volume related error codes
+	// Volume related error codes.
 	ErrorCodeNoSpaceLeftInLocation ErrorCode = "no_space_left_in_location" // There is no volume space left in the given location
 	ErrorCodeVolumeAlreadyAttached ErrorCode = "volume_already_attached"   // Volume is already attached to a server, detach first
 
-	// Firewall related error codes
+	// Firewall related error codes.
 	ErrorCodeFirewallAlreadyApplied   ErrorCode = "firewall_already_applied"    // Firewall was already applied on resource
 	ErrorCodeFirewallAlreadyRemoved   ErrorCode = "firewall_already_removed"    // Firewall was already removed from the resource
 	ErrorCodeIncompatibleNetworkType  ErrorCode = "incompatible_network_type"   // The Network type is incompatible for the given resource
@@ -79,7 +79,7 @@ const (
 	ErrorCodeServerAlreadyAdded       ErrorCode = "server_already_added"        // Server added more than one time to resource
 	ErrorCodeFirewallResourceNotFound ErrorCode = "firewall_resource_not_found" // Resource a firewall should be attached to / detached from not found
 
-	// Certificate related error codes
+	// Certificate related error codes.
 	ErrorCodeCAARecordDoesNotAllowCA                        ErrorCode = "caa_record_does_not_allow_ca"                          // CAA record does not allow certificate authority
 	ErrorCodeCADNSValidationFailed                          ErrorCode = "ca_dns_validation_failed"                              // Certificate Authority: DNS validation failed
 	ErrorCodeCATooManyAuthorizationsFailedRecently          ErrorCode = "ca_too_many_authorizations_failed_recently"            // Certificate Authority: Too many authorizations failed recently

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
@@ -48,7 +48,7 @@ type FloatingIP struct {
 }
 
 // DNSPtrForIP returns the reverse DNS pointer of the IP address.
-// Deprecated: Use GetDNSPtrForIP instead
+// Deprecated: Use GetDNSPtrForIP instead.
 func (f *FloatingIP) DNSPtrForIP(ip net.IP) string {
 	return f.DNSPtr[ip.String()]
 }
@@ -257,10 +257,10 @@ func (c *FloatingIPClient) Create(ctx context.Context, opts FloatingIPCreateOpts
 		Name:        opts.Name,
 	}
 	if opts.HomeLocation != nil {
-		reqBody.HomeLocation = String(opts.HomeLocation.Name)
+		reqBody.HomeLocation = Ptr(opts.HomeLocation.Name)
 	}
 	if opts.Server != nil {
-		reqBody.Server = Int(opts.Server.ID)
+		reqBody.Server = Ptr(opts.Server.ID)
 	}
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
@@ -18,4 +18,4 @@ limitations under the License.
 package hcloud
 
 // Version is the library's version following Semantic Versioning.
-const Version = "1.35.0"
+const Version = "1.42.0" // x-release-please-version

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/helper.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/helper.go
@@ -18,17 +18,27 @@ package hcloud
 
 import "time"
 
+// Ptr returns a pointer to p.
+func Ptr[T any](p T) *T {
+	return &p
+}
+
 // String returns a pointer to the passed string s.
-func String(s string) *string { return &s }
+//
+// Deprecated: Use [Ptr] instead.
+func String(s string) *string { return Ptr(s) }
 
 // Int returns a pointer to the passed integer i.
-func Int(i int) *int { return &i }
+//
+// Deprecated: Use [Ptr] instead.
+func Int(i int) *int { return Ptr(i) }
 
 // Bool returns a pointer to the passed bool b.
-func Bool(b bool) *bool { return &b }
+//
+// Deprecated: Use [Ptr] instead.
+func Bool(b bool) *bool { return Ptr(b) }
 
 // Duration returns a pointer to the passed time.Duration d.
-func Duration(d time.Duration) *time.Duration { return &d }
-
-func intSlice(is []int) *[]int          { return &is }
-func stringSlice(ss []string) *[]string { return &ss }
+//
+// Deprecated: Use [Ptr] instead.
+func Duration(d time.Duration) *time.Duration { return Ptr(d) }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/image.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/image.go
@@ -42,8 +42,9 @@ type Image struct {
 	BoundTo     *Server
 	RapidDeploy bool
 
-	OSFlavor  string
-	OSVersion string
+	OSFlavor     string
+	OSVersion    string
+	Architecture Architecture
 
 	Protection ImageProtection
 	Deprecated time.Time // The zero value denotes the image is not deprecated.
@@ -114,6 +115,8 @@ func (c *ImageClient) GetByID(ctx context.Context, id int) (*Image, *Response, e
 }
 
 // GetByName retrieves an image by its name. If the image does not exist, nil is returned.
+//
+// Deprecated: Use [ImageClient.GetByNameAndArchitecture] instead.
 func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Response, error) {
 	if name == "" {
 		return nil, nil, nil
@@ -125,13 +128,42 @@ func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Resp
 	return images[0], response, err
 }
 
+// GetByNameAndArchitecture retrieves an image by its name and architecture. If the image does not exist,
+// nil is returned.
+// In contrast to [ImageClient.Get], this method also returns deprecated images. Depending on your needs you should
+// check for this in your calling method.
+func (c *ImageClient) GetByNameAndArchitecture(ctx context.Context, name string, architecture Architecture) (*Image, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
+	images, response, err := c.List(ctx, ImageListOpts{Name: name, Architecture: []Architecture{architecture}, IncludeDeprecated: true})
+	if len(images) == 0 {
+		return nil, response, err
+	}
+	return images[0], response, err
+}
+
 // Get retrieves an image by its ID if the input can be parsed as an integer, otherwise it
 // retrieves an image by its name. If the image does not exist, nil is returned.
+//
+// Deprecated: Use [ImageClient.GetForArchitecture] instead.
 func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
+}
+
+// GetForArchitecture retrieves an image by its ID if the input can be parsed as an integer, otherwise it
+// retrieves an image by its name and architecture. If the image does not exist, nil is returned.
+//
+// In contrast to [ImageClient.Get], this method also returns deprecated images. Depending on your needs you should
+// check for this in your calling method.
+func (c *ImageClient) GetForArchitecture(ctx context.Context, idOrName string, architecture Architecture) (*Image, *Response, error) {
+	if id, err := strconv.Atoi(idOrName); err == nil {
+		return c.GetByID(ctx, id)
+	}
+	return c.GetByNameAndArchitecture(ctx, idOrName, architecture)
 }
 
 // ImageListOpts specifies options for listing images.
@@ -143,6 +175,7 @@ type ImageListOpts struct {
 	Sort              []string
 	Status            []ImageStatus
 	IncludeDeprecated bool
+	Architecture      []Architecture
 }
 
 func (l ImageListOpts) values() url.Values {
@@ -164,6 +197,9 @@ func (l ImageListOpts) values() url.Values {
 	}
 	for _, status := range l.Status {
 		vals.Add("status", string(status))
+	}
+	for _, arch := range l.Architecture {
+		vals.Add("architecture", string(arch))
 	}
 	return vals
 }
@@ -238,7 +274,7 @@ func (c *ImageClient) Update(ctx context.Context, image *Image, opts ImageUpdate
 		Description: opts.Description,
 	}
 	if opts.Type != "" {
-		reqBody.Type = String(string(opts.Type))
+		reqBody.Type = Ptr(string(opts.Type))
 	}
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/internal/instrumentation/metrics.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/internal/instrumentation/metrics.go
@@ -32,7 +32,7 @@ type Instrumenter struct {
 	instrumentationRegistry *prometheus.Registry
 }
 
-// New creates a new Instrumenter. The subsystemIdentifier will be used as part of the metric names (e.g. hcloud_<identifier>_requests_total)
+// New creates a new Instrumenter. The subsystemIdentifier will be used as part of the metric names (e.g. hcloud_<identifier>_requests_total).
 func New(subsystemIdentifier string, instrumentationRegistry *prometheus.Registry) *Instrumenter {
 	return &Instrumenter{subsystemIdentifier: subsystemIdentifier, instrumentationRegistry: instrumentationRegistry}
 }
@@ -74,8 +74,10 @@ func (i *Instrumenter) InstrumentedRoundTripper() http.RoundTripper {
 
 // instrumentRoundTripperEndpoint implements a hcloud specific round tripper to count requests per API endpoint
 // numeric IDs are removed from the URI Path.
+//
 // Sample:
-// /volumes/1234/actions/attach --> /volumes/actions/attach
+//
+//	/volumes/1234/actions/attach --> /volumes/actions/attach
 func (i *Instrumenter) instrumentRoundTripperEndpoint(counter *prometheus.CounterVec, next http.RoundTripper) promhttp.RoundTripperFunc {
 	return func(r *http.Request) (*http.Response, error) {
 		resp, err := next.RoundTrip(r)
@@ -83,6 +85,7 @@ func (i *Instrumenter) instrumentRoundTripperEndpoint(counter *prometheus.Counte
 			statusCode := strconv.Itoa(resp.StatusCode)
 			counter.WithLabelValues(statusCode, strings.ToLower(resp.Request.Method), preparePathForLabel(resp.Request.URL.Path)).Inc()
 		}
+
 		return resp, err
 	}
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
@@ -28,14 +28,15 @@ import (
 
 // ISO represents an ISO image in the Hetzner Cloud.
 type ISO struct {
-	ID          int
-	Name        string
-	Description string
-	Type        ISOType
-	Deprecated  time.Time
+	ID           int
+	Name         string
+	Description  string
+	Type         ISOType
+	Architecture *Architecture
+	Deprecated   time.Time
 }
 
-// IsDeprecated returns true if the ISO is deprecated
+// IsDeprecated returns true if the ISO is deprecated.
 func (iso *ISO) IsDeprecated() bool {
 	return !iso.Deprecated.IsZero()
 }
@@ -99,6 +100,12 @@ type ISOListOpts struct {
 	ListOpts
 	Name string
 	Sort []string
+	// Architecture filters the ISOs by Architecture. Note that custom ISOs do not have any architecture set, and you
+	// must use IncludeWildcardArchitecture to include them.
+	Architecture []Architecture
+	// IncludeWildcardArchitecture must be set to also return custom ISOs that have no architecture set, if you are
+	// also setting the Architecture field.
+	IncludeWildcardArchitecture bool
 }
 
 func (l ISOListOpts) values() url.Values {
@@ -108,6 +115,12 @@ func (l ISOListOpts) values() url.Values {
 	}
 	for _, sort := range l.Sort {
 		vals.Add("sort", sort)
+	}
+	for _, arch := range l.Architecture {
+		vals.Add("architecture", string(arch))
+	}
+	if l.IncludeWildcardArchitecture {
+		vals.Add("include_architecture_wildcard", "true")
 	}
 	return vals
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/labels.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/labels.go
@@ -7,7 +7,7 @@ import (
 
 var keyRegexp = regexp.MustCompile(
 	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,62}[a-z0-9A-Z])?$`)
-var valueRegexp = regexp.MustCompile(`^([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$`)
+var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$|$)`)
 
 func ValidateResourceLabels(labels map[string]interface{}) (bool, error) {
 	for k, v := range labels {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
@@ -507,7 +507,6 @@ type LoadBalancerCreateResult struct {
 func (c *LoadBalancerClient) Create(ctx context.Context, opts LoadBalancerCreateOpts) (LoadBalancerCreateResult, *Response, error) {
 	reqBody := loadBalancerCreateOptsToSchema(opts)
 	reqBodyData, err := json.Marshal(reqBody)
-
 	if err != nil {
 		return LoadBalancerCreateResult{}, nil, err
 	}
@@ -881,7 +880,7 @@ func (c *LoadBalancerClient) AttachToNetwork(ctx context.Context, loadBalancer *
 		Network: opts.Network.ID,
 	}
 	if opts.IP != nil {
-		reqBody.IP = String(opts.IP.String())
+		reqBody.IP = Ptr(opts.IP.String())
 	}
 	reqBodyData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/metadata/client.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/metadata/client.go
@@ -18,7 +18,7 @@ package metadata
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -90,7 +90,7 @@ func (c *Client) get(path string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -102,7 +102,7 @@ func (c *Client) get(path string) (string, error) {
 }
 
 // IsHcloudServer checks if the currently called server is a hcloud server by calling a metadata endpoint
-// if the endpoint answers with a non-empty value this method returns true, otherwise false
+// if the endpoint answers with a non-empty value this method returns true, otherwise false.
 func (c *Client) IsHcloudServer() bool {
 	hostname, err := c.Hostname()
 	if err != nil {
@@ -114,12 +114,12 @@ func (c *Client) IsHcloudServer() bool {
 	return false
 }
 
-// Hostname returns the hostname of the server that did the request to the Metadata server
+// Hostname returns the hostname of the server that did the request to the Metadata server.
 func (c *Client) Hostname() (string, error) {
 	return c.get("/hostname")
 }
 
-// InstanceID returns the ID of the server that did the request to the Metadata server
+// InstanceID returns the ID of the server that did the request to the Metadata server.
 func (c *Client) InstanceID() (int, error) {
 	resp, err := c.get("/instance-id")
 	if err != nil {
@@ -128,7 +128,7 @@ func (c *Client) InstanceID() (int, error) {
 	return strconv.Atoi(resp)
 }
 
-// PublicIPv4 returns the Public IPv4 of the server that did the request to the Metadata server
+// PublicIPv4 returns the Public IPv4 of the server that did the request to the Metadata server.
 func (c *Client) PublicIPv4() (net.IP, error) {
 	resp, err := c.get("/public-ipv4")
 	if err != nil {
@@ -137,18 +137,18 @@ func (c *Client) PublicIPv4() (net.IP, error) {
 	return net.ParseIP(resp), nil
 }
 
-// Region returns the Network Zone of the server that did the request to the Metadata server
+// Region returns the Network Zone of the server that did the request to the Metadata server.
 func (c *Client) Region() (string, error) {
 	return c.get("/region")
 }
 
-// AvailabilityZone returns the datacenter of the server that did the request to the Metadata server
+// AvailabilityZone returns the datacenter of the server that did the request to the Metadata server.
 func (c *Client) AvailabilityZone() (string, error) {
 	return c.get("/availability-zone")
 }
 
-// PrivateNetworks returns details about the private networks the server is attached to
-// Returns YAML (unparsed)
+// PrivateNetworks returns details about the private networks the server is attached to.
+// Returns YAML (unparsed).
 func (c *Client) PrivateNetworks() (string, error) {
 	return c.get("/private-networks")
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/network.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/network.go
@@ -37,6 +37,7 @@ type NetworkZone string
 const (
 	NetworkZoneEUCentral NetworkZone = "eu-central"
 	NetworkZoneUSEast    NetworkZone = "us-east"
+	NetworkZoneUSWest    NetworkZone = "us-west"
 )
 
 // NetworkSubnetType specifies a type of a subnet.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/placement_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/placement_group.go
@@ -39,11 +39,11 @@ type PlacementGroup struct {
 	Type    PlacementGroupType
 }
 
-// PlacementGroupType specifies the type of a Placement Group
+// PlacementGroupType specifies the type of a Placement Group.
 type PlacementGroupType string
 
 const (
-	// PlacementGroupTypeSpread spreads all servers in the group on different vhosts
+	// PlacementGroupTypeSpread spreads all servers in the group on different vhosts.
 	PlacementGroupTypeSpread PlacementGroupType = "spread"
 )
 
@@ -174,7 +174,7 @@ type PlacementGroupCreateOpts struct {
 	Type   PlacementGroupType
 }
 
-// Validate checks if options are valid
+// Validate checks if options are valid.
 func (o PlacementGroupCreateOpts) Validate() error {
 	if o.Name == "" {
 		return errors.New("missing name")
@@ -188,7 +188,7 @@ type PlacementGroupCreateResult struct {
 	Action         *Action
 }
 
-// Create creates a new PlacementGroup
+// Create creates a new PlacementGroup.
 func (c *PlacementGroupClient) Create(ctx context.Context, opts PlacementGroupCreateOpts) (PlacementGroupCreateResult, *Response, error) {
 	if err := opts.Validate(); err != nil {
 		return PlacementGroupCreateResult{}, nil, err

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
@@ -72,12 +72,13 @@ type FloatingIPTypePricing struct {
 // PrimaryIPTypePricing defines the schema of pricing information for a primary IP
 // type at a datacenter.
 type PrimaryIPTypePricing struct {
-	Datacenter string
+	Datacenter string // Deprecated: the API does not return pricing for the individual DCs anymore
+	Location   string
 	Hourly     PrimaryIPPrice
 	Monthly    PrimaryIPPrice
 }
 
-// PrimaryIPTypePricing provides pricing information for PrimaryIPs
+// PrimaryIPTypePricing provides pricing information for PrimaryIPs.
 type PrimaryIPPricing struct {
 	Type     string
 	Pricings []PrimaryIPTypePricing

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/primary_ip.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
-// PrimaryIP defines a Primary IP
+// PrimaryIP defines a Primary IP.
 type PrimaryIP struct {
 	ID           int
 	IP           net.IP
@@ -90,12 +90,6 @@ type PrimaryIPUpdateOpts struct {
 	Name       string             `json:"name,omitempty"`
 }
 
-// PrimaryIPUpdateResult defines the response
-// when updating a Primary IP.
-type PrimaryIPUpdateResult struct {
-	PrimaryIP PrimaryIP `json:"primary_ip"`
-}
-
 // PrimaryIPAssignOpts defines the request to
 // assign a Primary IP to an assignee (usually a server).
 type PrimaryIPAssignOpts struct {
@@ -111,7 +105,7 @@ type PrimaryIPAssignResult struct {
 }
 
 // PrimaryIPChangeDNSPtrOpts defines the request to
-// change a DNS PTR entry from a Primary IP
+// change a DNS PTR entry from a Primary IP.
 type PrimaryIPChangeDNSPtrOpts struct {
 	ID     int
 	DNSPtr string `json:"dns_ptr"`
@@ -125,19 +119,19 @@ type PrimaryIPChangeDNSPtrResult struct {
 }
 
 // PrimaryIPChangeProtectionOpts defines the request to
-// change protection configuration of a Primary IP
+// change protection configuration of a Primary IP.
 type PrimaryIPChangeProtectionOpts struct {
 	ID     int
 	Delete bool `json:"delete"`
 }
 
 // PrimaryIPChangeProtectionResult defines the response
-// when changing a protection of a PrimaryIP
+// when changing a protection of a PrimaryIP.
 type PrimaryIPChangeProtectionResult struct {
 	Action schema.Action `json:"action"`
 }
 
-// PrimaryIPClient is a client for the Primary IP API
+// PrimaryIPClient is a client for the Primary IP API.
 type PrimaryIPClient struct {
 	client *Client
 }
@@ -240,10 +234,12 @@ func (c *PrimaryIPClient) List(ctx context.Context, opts PrimaryIPListOpts) ([]*
 
 // All returns all Primary IPs.
 func (c *PrimaryIPClient) All(ctx context.Context) ([]*PrimaryIP, error) {
-	allPrimaryIPs := []*PrimaryIP{}
+	return c.AllWithOpts(ctx, PrimaryIPListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
 
-	opts := PrimaryIPListOpts{}
-	opts.PerPage = 50
+// AllWithOpts returns all Primary IPs for the given options.
+func (c *PrimaryIPClient) AllWithOpts(ctx context.Context, opts PrimaryIPListOpts) ([]*PrimaryIP, error) {
+	var allPrimaryIPs []*PrimaryIP
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page
@@ -311,15 +307,15 @@ func (c *PrimaryIPClient) Update(ctx context.Context, primaryIP *PrimaryIP, reqB
 		return nil, nil, err
 	}
 
-	respBody := PrimaryIPUpdateResult{}
+	var respBody schema.PrimaryIPUpdateResult
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
 		return nil, resp, err
 	}
-	return &respBody.PrimaryIP, resp, nil
+	return PrimaryIPFromSchema(respBody.PrimaryIP), resp, nil
 }
 
-// Assign a Primary IP to a resource
+// Assign a Primary IP to a resource.
 func (c *PrimaryIPClient) Assign(ctx context.Context, opts PrimaryIPAssignOpts) (*Action, *Response, error) {
 	reqBodyData, err := json.Marshal(opts)
 	if err != nil {
@@ -340,7 +336,7 @@ func (c *PrimaryIPClient) Assign(ctx context.Context, opts PrimaryIPAssignOpts) 
 	return ActionFromSchema(respBody.Action), resp, nil
 }
 
-// Unassign a Primary IP from a resource
+// Unassign a Primary IP from a resource.
 func (c *PrimaryIPClient) Unassign(ctx context.Context, id int) (*Action, *Response, error) {
 	path := fmt.Sprintf("/primary_ips/%d/actions/unassign", id)
 	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader([]byte{}))
@@ -356,7 +352,7 @@ func (c *PrimaryIPClient) Unassign(ctx context.Context, id int) (*Action, *Respo
 	return ActionFromSchema(respBody.Action), resp, nil
 }
 
-// ChangeDNSPtr Change the reverse DNS from a Primary IP
+// ChangeDNSPtr Change the reverse DNS from a Primary IP.
 func (c *PrimaryIPClient) ChangeDNSPtr(ctx context.Context, opts PrimaryIPChangeDNSPtrOpts) (*Action, *Response, error) {
 	reqBodyData, err := json.Marshal(opts)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/rdns.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/rdns.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RDNSSupporter defines functions to change and lookup reverse dns entries.
-// currently implemented by Server, FloatingIP and LoadBalancer
+// currently implemented by Server, FloatingIP and LoadBalancer.
 type RDNSSupporter interface {
 	// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
 	// Pass a nil ptr to reset the reverse DNS pointer to its default value.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema.go
@@ -134,13 +134,17 @@ func PrimaryIPFromSchema(s schema.PrimaryIP) *PrimaryIP {
 
 // ISOFromSchema converts a schema.ISO to an ISO.
 func ISOFromSchema(s schema.ISO) *ISO {
-	return &ISO{
+	iso := &ISO{
 		ID:          s.ID,
 		Name:        s.Name,
 		Description: s.Description,
 		Type:        ISOType(s.Type),
 		Deprecated:  s.Deprecated,
 	}
+	if s.Architecture != nil {
+		iso.Architecture = Ptr(Architecture(*s.Architecture))
+	}
+	return iso
 }
 
 // LocationFromSchema converts a schema.Location to a Location.
@@ -290,14 +294,15 @@ func ServerPrivateNetFromSchema(s schema.ServerPrivateNet) ServerPrivateNet {
 // ServerTypeFromSchema converts a schema.ServerType to a ServerType.
 func ServerTypeFromSchema(s schema.ServerType) *ServerType {
 	st := &ServerType{
-		ID:          s.ID,
-		Name:        s.Name,
-		Description: s.Description,
-		Cores:       s.Cores,
-		Memory:      s.Memory,
-		Disk:        s.Disk,
-		StorageType: StorageType(s.StorageType),
-		CPUType:     CPUType(s.CPUType),
+		ID:           s.ID,
+		Name:         s.Name,
+		Description:  s.Description,
+		Cores:        s.Cores,
+		Memory:       s.Memory,
+		Disk:         s.Disk,
+		StorageType:  StorageType(s.StorageType),
+		CPUType:      CPUType(s.CPUType),
+		Architecture: Architecture(s.Architecture),
 	}
 	for _, price := range s.Prices {
 		st.Pricings = append(st.Pricings, ServerTypeLocationPricing{
@@ -334,14 +339,15 @@ func SSHKeyFromSchema(s schema.SSHKey) *SSHKey {
 // ImageFromSchema converts a schema.Image to an Image.
 func ImageFromSchema(s schema.Image) *Image {
 	i := &Image{
-		ID:          s.ID,
-		Type:        ImageType(s.Type),
-		Status:      ImageStatus(s.Status),
-		Description: s.Description,
-		DiskSize:    s.DiskSize,
-		Created:     s.Created,
-		RapidDeploy: s.RapidDeploy,
-		OSFlavor:    s.OSFlavor,
+		ID:           s.ID,
+		Type:         ImageType(s.Type),
+		Status:       ImageStatus(s.Status),
+		Description:  s.Description,
+		DiskSize:     s.DiskSize,
+		Created:      s.Created,
+		RapidDeploy:  s.RapidDeploy,
+		OSFlavor:     s.OSFlavor,
+		Architecture: Architecture(s.Architecture),
 		Protection: ImageProtection{
 			Delete: s.Protection.Delete,
 		},
@@ -737,7 +743,7 @@ func PricingFromSchema(s schema.Pricing) Pricing {
 		var pricings []PrimaryIPTypePricing
 		for _, price := range primaryIPType.Prices {
 			p := PrimaryIPTypePricing{
-				Datacenter: price.Datacenter,
+				Location: price.Location,
 				Monthly: PrimaryIPPrice{
 					Net:   price.PriceMonthly.Net,
 					Gross: price.PriceMonthly.Gross,
@@ -897,19 +903,19 @@ func loadBalancerCreateOptsToSchema(opts LoadBalancerCreateOpts) schema.LoadBala
 	}
 	if opts.Location != nil {
 		if opts.Location.ID != 0 {
-			req.Location = String(strconv.Itoa(opts.Location.ID))
+			req.Location = Ptr(strconv.Itoa(opts.Location.ID))
 		} else {
-			req.Location = String(opts.Location.Name)
+			req.Location = Ptr(opts.Location.Name)
 		}
 	}
 	if opts.NetworkZone != "" {
-		req.NetworkZone = String(string(opts.NetworkZone))
+		req.NetworkZone = Ptr(string(opts.NetworkZone))
 	}
 	if opts.Labels != nil {
 		req.Labels = &opts.Labels
 	}
 	if opts.Network != nil {
-		req.Network = Int(opts.Network.ID)
+		req.Network = Ptr(opts.Network.ID)
 	}
 	for _, target := range opts.Targets {
 		schemaTarget := schema.LoadBalancerCreateRequestTarget{
@@ -943,7 +949,7 @@ func loadBalancerCreateOptsToSchema(opts LoadBalancerCreateOpts) schema.LoadBala
 			}
 			if service.HTTP.CookieLifetime != nil {
 				if sec := service.HTTP.CookieLifetime.Seconds(); sec != 0 {
-					schemaService.HTTP.CookieLifetime = Int(int(sec))
+					schemaService.HTTP.CookieLifetime = Ptr(int(sec))
 				}
 			}
 			if service.HTTP.Certificates != nil {
@@ -961,10 +967,10 @@ func loadBalancerCreateOptsToSchema(opts LoadBalancerCreateOpts) schema.LoadBala
 				Retries:  service.HealthCheck.Retries,
 			}
 			if service.HealthCheck.Interval != nil {
-				schemaHealthCheck.Interval = Int(int(service.HealthCheck.Interval.Seconds()))
+				schemaHealthCheck.Interval = Ptr(int(service.HealthCheck.Interval.Seconds()))
 			}
 			if service.HealthCheck.Timeout != nil {
-				schemaHealthCheck.Timeout = Int(int(service.HealthCheck.Timeout.Seconds()))
+				schemaHealthCheck.Timeout = Ptr(int(service.HealthCheck.Timeout.Seconds()))
 			}
 			if service.HealthCheck.HTTP != nil {
 				schemaHealthCheckHTTP := &schema.LoadBalancerCreateRequestServiceHealthCheckHTTP{
@@ -999,7 +1005,7 @@ func loadBalancerAddServiceOptsToSchema(opts LoadBalancerAddServiceOpts) schema.
 			StickySessions: opts.HTTP.StickySessions,
 		}
 		if opts.HTTP.CookieLifetime != nil {
-			req.HTTP.CookieLifetime = Int(int(opts.HTTP.CookieLifetime.Seconds()))
+			req.HTTP.CookieLifetime = Ptr(int(opts.HTTP.CookieLifetime.Seconds()))
 		}
 		if opts.HTTP.Certificates != nil {
 			certificates := []int{}
@@ -1016,10 +1022,10 @@ func loadBalancerAddServiceOptsToSchema(opts LoadBalancerAddServiceOpts) schema.
 			Retries:  opts.HealthCheck.Retries,
 		}
 		if opts.HealthCheck.Interval != nil {
-			req.HealthCheck.Interval = Int(int(opts.HealthCheck.Interval.Seconds()))
+			req.HealthCheck.Interval = Ptr(int(opts.HealthCheck.Interval.Seconds()))
 		}
 		if opts.HealthCheck.Timeout != nil {
-			req.HealthCheck.Timeout = Int(int(opts.HealthCheck.Timeout.Seconds()))
+			req.HealthCheck.Timeout = Ptr(int(opts.HealthCheck.Timeout.Seconds()))
 		}
 		if opts.HealthCheck.HTTP != nil {
 			req.HealthCheck.HTTP = &schema.LoadBalancerActionAddServiceRequestHealthCheckHTTP{
@@ -1042,7 +1048,7 @@ func loadBalancerUpdateServiceOptsToSchema(opts LoadBalancerUpdateServiceOpts) s
 		Proxyprotocol:   opts.Proxyprotocol,
 	}
 	if opts.Protocol != "" {
-		req.Protocol = String(string(opts.Protocol))
+		req.Protocol = Ptr(string(opts.Protocol))
 	}
 	if opts.HTTP != nil {
 		req.HTTP = &schema.LoadBalancerActionUpdateServiceRequestHTTP{
@@ -1051,7 +1057,7 @@ func loadBalancerUpdateServiceOptsToSchema(opts LoadBalancerUpdateServiceOpts) s
 			StickySessions: opts.HTTP.StickySessions,
 		}
 		if opts.HTTP.CookieLifetime != nil {
-			req.HTTP.CookieLifetime = Int(int(opts.HTTP.CookieLifetime.Seconds()))
+			req.HTTP.CookieLifetime = Ptr(int(opts.HTTP.CookieLifetime.Seconds()))
 		}
 		if opts.HTTP.Certificates != nil {
 			certificates := []int{}
@@ -1067,13 +1073,13 @@ func loadBalancerUpdateServiceOptsToSchema(opts LoadBalancerUpdateServiceOpts) s
 			Retries: opts.HealthCheck.Retries,
 		}
 		if opts.HealthCheck.Interval != nil {
-			req.HealthCheck.Interval = Int(int(opts.HealthCheck.Interval.Seconds()))
+			req.HealthCheck.Interval = Ptr(int(opts.HealthCheck.Interval.Seconds()))
 		}
 		if opts.HealthCheck.Timeout != nil {
-			req.HealthCheck.Timeout = Int(int(opts.HealthCheck.Timeout.Seconds()))
+			req.HealthCheck.Timeout = Ptr(int(opts.HealthCheck.Timeout.Seconds()))
 		}
 		if opts.HealthCheck.Protocol != "" {
-			req.HealthCheck.Protocol = String(string(opts.HealthCheck.Protocol))
+			req.HealthCheck.Protocol = Ptr(string(opts.HealthCheck.Protocol))
 		}
 		if opts.HealthCheck.HTTP != nil {
 			req.HealthCheck.HTTP = &schema.LoadBalancerActionUpdateServiceRequestHealthCheckHTTP{

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/image.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/image.go
@@ -20,23 +20,24 @@ import "time"
 
 // Image defines the schema of an image.
 type Image struct {
-	ID          int               `json:"id"`
-	Status      string            `json:"status"`
-	Type        string            `json:"type"`
-	Name        *string           `json:"name"`
-	Description string            `json:"description"`
-	ImageSize   *float32          `json:"image_size"`
-	DiskSize    float32           `json:"disk_size"`
-	Created     time.Time         `json:"created"`
-	CreatedFrom *ImageCreatedFrom `json:"created_from"`
-	BoundTo     *int              `json:"bound_to"`
-	OSFlavor    string            `json:"os_flavor"`
-	OSVersion   *string           `json:"os_version"`
-	RapidDeploy bool              `json:"rapid_deploy"`
-	Protection  ImageProtection   `json:"protection"`
-	Deprecated  time.Time         `json:"deprecated"`
-	Deleted     time.Time         `json:"deleted"`
-	Labels      map[string]string `json:"labels"`
+	ID           int               `json:"id"`
+	Status       string            `json:"status"`
+	Type         string            `json:"type"`
+	Name         *string           `json:"name"`
+	Description  string            `json:"description"`
+	ImageSize    *float32          `json:"image_size"`
+	DiskSize     float32           `json:"disk_size"`
+	Created      time.Time         `json:"created"`
+	CreatedFrom  *ImageCreatedFrom `json:"created_from"`
+	BoundTo      *int              `json:"bound_to"`
+	OSFlavor     string            `json:"os_flavor"`
+	OSVersion    *string           `json:"os_version"`
+	Architecture string            `json:"architecture"`
+	RapidDeploy  bool              `json:"rapid_deploy"`
+	Protection   ImageProtection   `json:"protection"`
+	Deprecated   time.Time         `json:"deprecated"`
+	Deleted      time.Time         `json:"deleted"`
+	Labels       map[string]string `json:"labels"`
 }
 
 // ImageProtection represents the protection level of a image.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/iso.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/iso.go
@@ -20,11 +20,12 @@ import "time"
 
 // ISO defines the schema of an ISO image.
 type ISO struct {
-	ID          int       `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Type        string    `json:"type"`
-	Deprecated  time.Time `json:"deprecated"`
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description"`
+	Type         string    `json:"type"`
+	Architecture *string   `json:"architecture"`
+	Deprecated   time.Time `json:"deprecated"`
 }
 
 // ISOGetResponse defines the schema of the response when retrieving a single ISO.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
@@ -110,15 +110,16 @@ type PricingGetResponse struct {
 	Pricing Pricing `json:"pricing"`
 }
 
-// PricingPrimaryIPTypePrice defines the schema of pricing information for a primary IP
+// PricingPrimaryIPTypePrice defines the schema of pricing information for a primary IP.
 // type at a datacenter.
 type PricingPrimaryIPTypePrice struct {
-	Datacenter   string `json:"datacenter"`
+	Datacenter   string `json:"datacenter"` // Deprecated: the API does not return pricing for the individual DCs anymore
+	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
 }
 
-// PricingPrimaryIP define the schema of pricing information for a primary IP at a datacenter
+// PricingPrimaryIP define the schema of pricing information for a primary IP at a datacenter.
 type PricingPrimaryIP struct {
 	Type   string                      `json:"type"`
 	Prices []PricingPrimaryIPTypePrice `json:"prices"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
@@ -2,7 +2,7 @@ package schema
 
 import "time"
 
-// PrimaryIP defines a Primary IP
+// PrimaryIP defines a Primary IP.
 type PrimaryIP struct {
 	ID           int                 `json:"id"`
 	IP           string              `json:"ip"`
@@ -46,4 +46,10 @@ type PrimaryIPGetResult struct {
 // PrimaryIPListResult defines the response when listing Primary IPs.
 type PrimaryIPListResult struct {
 	PrimaryIPs []PrimaryIP `json:"primary_ips"`
+}
+
+// PrimaryIPUpdateResult defines the response
+// when updating a Primary IP.
+type PrimaryIPUpdateResult struct {
+	PrimaryIP PrimaryIP `json:"primary_ip"`
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
@@ -152,6 +152,12 @@ type ServerCreateResponse struct {
 	NextActions  []Action `json:"next_actions"`
 }
 
+// ServerDeleteResponse defines the schema of the response when
+// deleting a server.
+type ServerDeleteResponse struct {
+	Action Action `json:"action"`
+}
+
 // ServerUpdateRequest defines the schema of the request to update a server.
 type ServerUpdateRequest struct {
 	Name   string             `json:"name,omitempty"`
@@ -272,7 +278,8 @@ type ServerActionRebuildRequest struct {
 // ServerActionRebuildResponse defines the schema of the response when
 // creating a rebuild server action.
 type ServerActionRebuildResponse struct {
-	Action Action `json:"action"`
+	Action       Action  `json:"action"`
+	RootPassword *string `json:"root_password"`
 }
 
 // ServerActionAttachISORequest defines the schema for the request to

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
@@ -18,15 +18,16 @@ package schema
 
 // ServerType defines the schema of a server type.
 type ServerType struct {
-	ID          int                      `json:"id"`
-	Name        string                   `json:"name"`
-	Description string                   `json:"description"`
-	Cores       int                      `json:"cores"`
-	Memory      float32                  `json:"memory"`
-	Disk        int                      `json:"disk"`
-	StorageType string                   `json:"storage_type"`
-	CPUType     string                   `json:"cpu_type"`
-	Prices      []PricingServerTypePrice `json:"prices"`
+	ID           int                      `json:"id"`
+	Name         string                   `json:"name"`
+	Description  string                   `json:"description"`
+	Cores        int                      `json:"cores"`
+	Memory       float32                  `json:"memory"`
+	Disk         int                      `json:"disk"`
+	StorageType  string                   `json:"storage_type"`
+	CPUType      string                   `json:"cpu_type"`
+	Architecture string                   `json:"architecture"`
+	Prices       []PricingServerTypePrice `json:"prices"`
 }
 
 // ServerTypeListResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
@@ -27,15 +27,16 @@ import (
 
 // ServerType represents a server type in the Hetzner Cloud.
 type ServerType struct {
-	ID          int
-	Name        string
-	Description string
-	Cores       int
-	Memory      float32
-	Disk        int
-	StorageType StorageType
-	CPUType     CPUType
-	Pricings    []ServerTypeLocationPricing
+	ID           int
+	Name         string
+	Description  string
+	Cores        int
+	Memory       float32
+	Disk         int
+	StorageType  StorageType
+	CPUType      CPUType
+	Architecture Architecture
+	Pricings     []ServerTypeLocationPricing
 }
 
 // StorageType specifies the type of storage.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/volume.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/volume.go
@@ -226,7 +226,7 @@ func (c *VolumeClient) Create(ctx context.Context, opts VolumeCreateOpts) (Volum
 		reqBody.Labels = &opts.Labels
 	}
 	if opts.Server != nil {
-		reqBody.Server = Int(opts.Server.ID)
+		reqBody.Server = Ptr(opts.Server.ID)
 	}
 	if opts.Location != nil {
 		if opts.Location.ID != 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In order to support Hetzner CAX servers (ARM64 architecture), we need to update hcloud-go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
