### PR TITLE
Add new method 'ReachedLimit' to EstimationLimiter

### DIFF
--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -71,4 +71,7 @@ type EstimationLimiter interface {
 	// There is no requirement for the Estimator to stop calculations, it's
 	// just not expected to add any more nodes.
 	PermissionToAddNode() bool
+	// ReachedLimit returns true if the limiter blocked addition of the new node.
+	// Otherwise returns false.
+	ReachedLimit() bool
 }

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -25,15 +25,17 @@ import (
 )
 
 type thresholdBasedEstimationLimiter struct {
-	maxDuration time.Duration
-	maxNodes    int
-	nodes       int
-	start       time.Time
+	maxDuration  time.Duration
+	maxNodes     int
+	nodes        int
+	start        time.Time
+	reachedLimit bool
 }
 
 func (tbel *thresholdBasedEstimationLimiter) StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup) {
 	tbel.start = time.Now()
 	tbel.nodes = 0
+	tbel.reachedLimit = false
 }
 
 func (*thresholdBasedEstimationLimiter) EndEstimation() {}
@@ -41,15 +43,21 @@ func (*thresholdBasedEstimationLimiter) EndEstimation() {}
 func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode() bool {
 	if tbel.maxNodes > 0 && tbel.nodes >= tbel.maxNodes {
 		klog.V(4).Infof("Capping binpacking after exceeding threshold of %d nodes", tbel.maxNodes)
+		tbel.reachedLimit = true
 		return false
 	}
 	timeDefined := tbel.maxDuration > 0 && tbel.start != time.Time{}
 	if timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration)) {
 		klog.V(4).Infof("Capping binpacking after exceeding max duration of %v", tbel.maxDuration)
+		tbel.reachedLimit = true
 		return false
 	}
 	tbel.nodes++
 	return true
+}
+
+func (tbel *thresholdBasedEstimationLimiter) ReachedLimit() bool {
+	return tbel.reachedLimit
 }
 
 // NewThresholdBasedEstimationLimiter returns an EstimationLimiter that will prevent estimation

--- a/cluster-autoscaler/estimator/threshold_based_limiter_test.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter_test.go
@@ -42,12 +42,13 @@ func resetLimiter(t *testing.T, l EstimationLimiter) {
 
 func TestThresholdBasedLimiter(t *testing.T) {
 	testCases := []struct {
-		name            string
-		maxNodes        int
-		maxDuration     time.Duration
-		startDelta      time.Duration
-		operations      []limiterOperation
-		expectNodeCount int
+		name                 string
+		maxNodes             int
+		maxDuration          time.Duration
+		startDelta           time.Duration
+		operations           []limiterOperation
+		expectNodeCount      int
+		expectedReachedLimit bool
 	}{
 		{
 			name:     "no limiting happens",
@@ -68,7 +69,8 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				expectDeny,
 				expectDeny,
 			},
-			expectNodeCount: 0,
+			expectNodeCount:      0,
+			expectedReachedLimit: true,
 		},
 		{
 			name:     "sequence of additions works until the threshold is hit",
@@ -79,7 +81,8 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				expectAllow,
 				expectDeny,
 			},
-			expectNodeCount: 3,
+			expectNodeCount:      3,
+			expectedReachedLimit: true,
 		},
 		{
 			name:     "node counter is reset",
@@ -123,6 +126,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				op(t, limiter)
 			}
 			assert.Equal(t, tc.expectNodeCount, limiter.nodes)
+			assert.Equal(t, tc.expectedReachedLimit, limiter.reachedLimit)
 			limiter.EndEstimation()
 		})
 	}


### PR DESCRIPTION
This method will allow CA to check if any the limiter blocked addition of any new Node.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds a new function to the EstimationLimiter and implements it for the ThresholdBasedEstimationLimiter.
ReachedLimit function allows CA to check if the Limiter blocked addition of a new Node.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
