### PR TITLE
Fix the buildTemplateLabels method for the ClusterApi provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -276,7 +276,7 @@ func (ng *nodegroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
 }
 
 func (ng *nodegroup) buildTemplateLabels(nodeName string) (map[string]string, error) {
-	labels := cloudprovider.JoinStringMaps(ng.scalableResource.Labels(), buildGenericLabels(nodeName))
+	labels := cloudprovider.JoinStringMaps(buildGenericLabels(nodeName), ng.scalableResource.Labels())
 
 	nodes, err := ng.Nodes()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1344,6 +1344,31 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "When the NodeGroup can scale from zero, the label capacity annotations merge with the pre-built node labels and take precedence if the same key is defined in both",
+			nodeGroupAnnotations: map[string]string{
+				memoryKey:   "2048Mi",
+				cpuKey:      "2",
+				gpuTypeKey:  gpuapis.ResourceNvidiaGPU,
+				gpuCountKey: "1",
+				labelsKey:   "kubernetes.io/arch=arm64,my-custom-label=custom-value",
+			},
+			config: testCaseConfig{
+				expectedErr: nil,
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:        2,
+					corev1.ResourceMemory:     2048 * 1024 * 1024,
+					corev1.ResourcePods:       110,
+					gpuapis.ResourceNvidiaGPU: 1,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/os":       "linux",
+					"kubernetes.io/arch":     "arm64",
+					"kubernetes.io/hostname": "random value",
+					"my-custom-label":        "custom-value",
+				},
+			},
+		},
+		{
 			name: "When the NodeGroup can scale from zero and the Node still exists, it includes the known node labels",
 			nodeGroupAnnotations: map[string]string{
 				memoryKey: "2048Mi",


### PR DESCRIPTION
The joinStringMaps call in the `buildTemplateLabels` method of the clusterApi provider should not overwrite any custom labels with the generic ones returned by `buildGenericLabels()`

/kind bug

#### What this PR does / why we need it:

Currently, when the joinStringMaps is called and the `unstructuredScalableResource` already defines one of the labels also returned by the `buildGenericLabels` method (e.g., `kubernetes.io/arch: arm64`), the generic value returned by `buildGenericLabels` gets precedence over the user-defined one. This should be considered an unwanted behavior.

For example, the `buildGenericLabels` method sets the `kubernetes.io/arch` value to amd64. 

If the nodeGroup is for arm64 machines and the label `kubernetes.io/arch: arm64` is set in the annotation   `capacity.cluster-autoscaler.kubernetes.io/labels: "kubernetes.io/arch=arm64"`, the autoscaler will finally consider the value for that label set to amd64, not arm64, leading it to be unable to choose the proper nodeGroup to scale when a workload with nodeSelector/Affinity requires a node having the label `kubernetes.io/arch: arm64`.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


cc @Prashanth684 @elmiko 