### PR TITLE
Add revisionHistoryLimit override to cluster-autoscaler

### DIFF
--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -141,7 +141,8 @@ containerSecurityContext: {}
 deployment:
   # deployment.annotations -- Annotations to add to the Deployment object.
   annotations: {}
-
+  # deployment.revisionHistoryLimit -- The number of ReplicaSets to keep for this Deployment.
+  revisionHistoryLimit: 10
 # dnsPolicy -- Defaults to `ClusterFirst`. Valid values are:
 # `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`.
 # If autoscaler does not depend on cluster DNS, recommended to set this to `Default`.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows us to override revisionHistoryLimit.

#### Which issue(s) this PR fixes:
Nothing

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
