### PR TITLE
Cherry picking #5602 for cluster-autoscaler-release-1.27

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -192,6 +192,12 @@ The `AZURE_ENABLE_DYNAMIC_INSTANCE_LIST` environment variable enables workflow t
 |---------------------------|---------|------------------------------------|---------------------------|
 | enableDynamicInstanceList | false   | AZURE_ENABLE_DYNAMIC_INSTANCE_LIST | enableDynamicInstanceList |
 
+The `AZURE_ENABLE_VMSS_FLEX` environment variable enables VMSS Flex support. By default, support is disabled.
+
+| Config Name               | Default | Environment Variable                    | Cloud Config File         |
+|---------------------------|---------|-----------------------------------------|---------------------------|
+| enableVmssFlex            | false   | AZURE_ENABLE_VMSS_FLEX                  | enableVmssFlex            |
+
 When using K8s 1.18 or higher, it is also recommended to configure backoff and retries on the client as described [here](#rate-limit-and-back-off-retries)
 
 ### Standard deployment

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -341,11 +341,13 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 
 	if vmType == vmTypeVMSS {
-		// Omit virtual machines not managed by vmss.
-		if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
-			klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
-			m.unownedInstances[inst] = true
-			return nil, nil
+		if m.areAllScaleSetsUniform() {
+			// Omit virtual machines not managed by vmss only in case of uniform scale set.
+			if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {
+				klog.V(3).Infof("Instance %q is not managed by vmss, omit it in autoscaler", instance.Name)
+				m.unownedInstances[inst] = true
+				return nil, nil
+			}
 		}
 	}
 
@@ -366,6 +368,16 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 	klog.V(4).Infof("FindForInstance: Couldn't find node group of instance %q", inst)
 	return nil, nil
+}
+
+// isAllScaleSetsAreUniform determines if all the scale set autoscaler is monitoring are Uniform or not.
+func (m *azureCache) areAllScaleSetsUniform() bool {
+	for _, scaleSet := range m.scaleSets {
+		if scaleSet.VirtualMachineScaleSetProperties.OrchestrationMode == compute.Flexible {
+			return false
+		}
+	}
+	return true
 }
 
 // getInstanceFromCache gets the node group from cache. Returns nil if not found.

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -62,6 +62,7 @@ const (
 
 	// toggle
 	dynamicInstanceListDefault = false
+	enableVmssFlexDefault      = false
 )
 
 // CloudProviderRateLimitConfig indicates the rate limit config for each clients.
@@ -136,6 +137,9 @@ type Config struct {
 
 	// EnableDynamicInstanceList defines whether to enable dynamic instance workflow for instance information check
 	EnableDynamicInstanceList bool `json:"enableDynamicInstanceList,omitempty" yaml:"enableDynamicInstanceList,omitempty"`
+
+	// EnableVmssFlex defines whether to enable Vmss Flex support or not
+	EnableVmssFlex bool `json:"enableVmssFlex,omitempty" yaml:"enableVmssFlex,omitempty"`
 }
 
 // BuildAzureConfig returns a Config object for the Azure clients
@@ -246,6 +250,15 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 			}
 		} else {
 			cfg.EnableDynamicInstanceList = dynamicInstanceListDefault
+		}
+
+		if enableVmssFlex := os.Getenv("AZURE_ENABLE_VMSS_FLEX"); enableVmssFlex != "" {
+			cfg.EnableVmssFlex, err = strconv.ParseBool(enableVmssFlex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse AZURE_ENABLE_VMSS_FLEX %q: %v", enableVmssFlex, err)
+			}
+		} else {
+			cfg.EnableVmssFlex = enableVmssFlexDefault
 		}
 
 		if cfg.CloudProviderBackoff {

--- a/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_fakes.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	fakeVirtualMachineScaleSetVMID = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachineScaleSets/agents/virtualMachines/%d"
+	fakeVirtualMachineVMID         = "/subscriptions/test-subscription-id/resourceGroups/test-asg/providers/Microsoft.Compute/virtualMachines/%d"
 )
 
 // DeploymentsClientMock mocks for DeploymentsClient.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -577,23 +577,39 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 		},
 	}
 
-	manager := newTestAzureManager(t)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	expectedVMs := newTestVMList(3)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
+	for _, orchMode := range orchestrationModes {
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 
-	asgs := manager.azureCache.getRegisteredNodeGroups()
-	assert.Equal(t, 1, len(asgs))
-	assert.Equal(t, name, asgs[0].Id())
-	assert.Equal(t, min, asgs[0].MinSize())
-	assert.Equal(t, max, asgs[0].MaxSize())
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+		if orchMode == compute.Uniform {
+
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
+
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			manager.config.EnableVmssFlex = true
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
+
+		asgs := manager.azureCache.getRegisteredNodeGroups()
+		assert.Equal(t, 1, len(asgs))
+		assert.Equal(t, name, asgs[0].Id())
+		assert.Equal(t, min, asgs[0].MinSize())
+		assert.Equal(t, max, asgs[0].MaxSize())
+	}
 
 	// test vmTypeStandard
 	testAS := newTestAgentPool(newTestAzureManager(t), "testAS")
@@ -618,6 +634,7 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test invalidVMType
+	manager := newTestAzureManager(t)
 	manager.config.VMType = "invalidVMType"
 	err = manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
 	expectedErr = fmt.Errorf("failed to parse node group spec: vmtype invalidVMType not supported")

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -305,6 +305,31 @@ func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, 
 	return vmList, nil
 }
 
+// GetFlexibleScaleSetVms returns list of nodes for flexible scale set.
+func (scaleSet *ScaleSet) GetFlexibleScaleSetVms() ([]compute.VirtualMachine, *retry.Error) {
+	klog.V(4).Infof("GetScaleSetVms: starts")
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+
+	// get VMSS info from cache to obtain ID currently scaleSet does not store ID info.
+	vmssInfo, err := scaleSet.getVMSSFromCache()
+
+	if err != nil {
+		klog.Errorf("Failed to get information for VMSS (%q): %v", scaleSet.Name, err)
+		var rerr = &retry.Error{
+			RawError: err,
+		}
+		return nil, rerr
+	}
+	vmList, rerr := scaleSet.manager.azClient.virtualMachinesClient.ListVmssFlexVMsWithoutInstanceView(ctx, *vmssInfo.ID)
+	if rerr != nil {
+		klog.Errorf("VirtualMachineScaleSetVMsClient.List failed for %s: %v", scaleSet.Name, rerr)
+		return nil, rerr
+	}
+	klog.V(4).Infof("GetFlexibleScaleSetVms: scaleSet.Name: %s, vmList: %v", scaleSet.Name, vmList)
+	return vmList, nil
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
@@ -511,48 +536,110 @@ func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 	splay := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(scaleSet.instancesRefreshJitter + 1)
 	lastRefresh := time.Now().Add(-time.Second * time.Duration(splay))
 
+	orchestrationMode, err := scaleSet.getOrchestrationMode()
+	if err != nil {
+		klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
+		return nil, err
+	}
+
+	klog.V(4).Infof("VMSS: orchestration Mode %s", orchestrationMode)
+
+	if orchestrationMode == compute.Uniform {
+		err := scaleSet.buildScaleSetCache(lastRefresh)
+		if err != nil {
+			return nil, err
+		}
+
+	} else if orchestrationMode == compute.Flexible {
+		if scaleSet.manager.config.EnableVmssFlex {
+			err := scaleSet.buildScaleSetCacheForFlex(lastRefresh)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fmt.Errorf("vmss - %q with Flexible orchestration detected but 'enableVmssFlex' feature flag is turned off", scaleSet.Name)
+		}
+
+	} else {
+		return nil, fmt.Errorf("Failed to determine orchestration mode for vmss %q", scaleSet.Name)
+	}
+
+	klog.V(4).Infof("Nodes: returns")
+	return scaleSet.instanceCache, nil
+}
+
+func (scaleSet *ScaleSet) buildScaleSetCache(lastRefresh time.Time) error {
 	vms, rerr := scaleSet.GetScaleSetVms()
 	if rerr != nil {
 		if isAzureRequestsThrottled(rerr) {
 			// Log a warning and update the instance refresh time so that it would retry after cache expiration
 			klog.Warningf("GetScaleSetVms() is throttled with message %v, would return the cached instances", rerr)
 			scaleSet.lastInstanceRefresh = lastRefresh
-			return scaleSet.instanceCache, nil
+			return nil
 		}
-		return nil, rerr.Error()
+		return rerr.Error()
 	}
 
 	scaleSet.instanceCache = buildInstanceCache(vms)
 	scaleSet.lastInstanceRefresh = lastRefresh
-	klog.V(4).Infof("Nodes: returns")
-	return scaleSet.instanceCache, nil
+
+	return nil
+}
+
+func (scaleSet *ScaleSet) buildScaleSetCacheForFlex(lastRefresh time.Time) error {
+	vms, rerr := scaleSet.GetFlexibleScaleSetVms()
+	if rerr != nil {
+		if isAzureRequestsThrottled(rerr) {
+			// Log a warning and update the instance refresh time so that it would retry after cache expiration
+			klog.Warningf("GetFlexibleScaleSetVms() is throttled with message %v, would return the cached instances", rerr)
+			scaleSet.lastInstanceRefresh = lastRefresh
+			return nil
+		}
+		return rerr.Error()
+	}
+
+	scaleSet.instanceCache = buildInstanceCache(vms)
+	scaleSet.lastInstanceRefresh = lastRefresh
+
+	return nil
 }
 
 // Note that the GetScaleSetVms() results is not used directly because for the List endpoint,
 // their resource ID format is not consistent with Get endpoint
-func buildInstanceCache(vms []compute.VirtualMachineScaleSetVM) []cloudprovider.Instance {
+func buildInstanceCache(vmList interface{}) []cloudprovider.Instance {
 	instances := []cloudprovider.Instance{}
 
-	for _, vm := range vms {
-		// The resource ID is empty string, which indicates the instance may be in deleting state.
-		if len(*vm.ID) == 0 {
-			continue
+	switch vms := vmList.(type) {
+	case []compute.VirtualMachineScaleSetVM:
+		for _, vm := range vms {
+			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState)
 		}
-
-		resourceID, err := convertResourceGroupNameToLower(*vm.ID)
-		if err != nil {
-			// This shouldn't happen. Log a warning message for tracking.
-			klog.Warningf("buildInstanceCache.convertResourceGroupNameToLower failed with error: %v", err)
-			continue
+	case []compute.VirtualMachine:
+		for _, vm := range vms {
+			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState)
 		}
-
-		instances = append(instances, cloudprovider.Instance{
-			Id:     "azure://" + resourceID,
-			Status: instanceStatusFromVM(vm),
-		})
 	}
 
 	return instances
+}
+
+func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisioningState *string) {
+	// The resource ID is empty string, which indicates the instance may be in deleting state.
+	if len(*id) == 0 {
+		return
+	}
+
+	resourceID, err := convertResourceGroupNameToLower(*id)
+	if err != nil {
+		// This shouldn't happen. Log a warning message for tracking.
+		klog.Warningf("buildInstanceCache.convertResourceGroupNameToLower failed with error: %v", err)
+		return
+	}
+
+	*instances = append(*instances, cloudprovider.Instance{
+		Id:     "azure://" + resourceID,
+		Status: instanceStatusFromProvisioningState(provisioningState),
+	})
 }
 
 func (scaleSet *ScaleSet) getInstanceByProviderID(providerID string) (cloudprovider.Instance, bool) {
@@ -578,14 +665,16 @@ func (scaleSet *ScaleSet) setInstanceStatusByProviderID(providerID string, statu
 	scaleSet.lastInstanceRefresh = time.Now()
 }
 
-// instanceStatusFromVM converts the VM provisioning state to cloudprovider.InstanceStatus
-func instanceStatusFromVM(vm compute.VirtualMachineScaleSetVM) *cloudprovider.InstanceStatus {
-	if vm.ProvisioningState == nil {
+// instanceStatusFromProvisioningState converts the VM provisioning state to cloudprovider.InstanceStatus
+func instanceStatusFromProvisioningState(provisioningState *string) *cloudprovider.InstanceStatus {
+	if provisioningState == nil {
 		return nil
 	}
 
+	klog.V(5).Infof("Getting vm instance provisioning state %s", *provisioningState)
+
 	status := &cloudprovider.InstanceStatus{}
-	switch *vm.ProvisioningState {
+	switch *provisioningState {
 	case string(compute.ProvisioningStateDeleting):
 		status.State = cloudprovider.InstanceDeleting
 	case string(compute.ProvisioningStateCreating):
@@ -608,4 +697,13 @@ func (scaleSet *ScaleSet) invalidateLastSizeRefreshWithLock() {
 	scaleSet.sizeMutex.Lock()
 	scaleSet.lastSizeRefresh = time.Now().Add(-1 * scaleSet.sizeRefreshPeriod)
 	scaleSet.sizeMutex.Unlock()
+}
+
+func (scaleSet *ScaleSet) getOrchestrationMode() (compute.OrchestrationMode, error) {
+	vmss, err := scaleSet.getVMSSFromCache()
+	if err != nil {
+		klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
+		return "", err
+	}
+	return vmss.OrchestrationMode, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
 )
@@ -43,7 +43,7 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 	}
 }
 
-func newTestVMSSList(cap int64, name, loc string) []compute.VirtualMachineScaleSet {
+func newTestVMSSList(cap int64, name, loc string, orchmode compute.OrchestrationMode) []compute.VirtualMachineScaleSet {
 	return []compute.VirtualMachineScaleSet{
 		{
 			Name: to.StringPtr(name),
@@ -51,8 +51,11 @@ func newTestVMSSList(cap int64, name, loc string) []compute.VirtualMachineScaleS
 				Capacity: to.Int64Ptr(cap),
 				Name:     to.StringPtr("Standard_D4_v2"),
 			},
-			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{},
-			Location:                         to.StringPtr(loc),
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: orchmode,
+			},
+			Location: to.StringPtr(loc),
+			ID:       to.StringPtr(name),
 		},
 	}
 }
@@ -72,6 +75,34 @@ func newTestVMSSVMList(count int) []compute.VirtualMachineScaleSetVM {
 	return vmssVMList
 }
 
+func newTestVMList(count int) []compute.VirtualMachine {
+	var vmssVMList []compute.VirtualMachine
+	for i := 0; i < count; i++ {
+		vmssVM := compute.VirtualMachine{
+			ID: to.StringPtr(fmt.Sprintf(fakeVirtualMachineVMID, i)),
+			VirtualMachineProperties: &compute.VirtualMachineProperties{
+				VMID: to.StringPtr(fmt.Sprintf("123E4567-E89B-12D3-A456-426655440000-%d", i)),
+			},
+		}
+		vmssVMList = append(vmssVMList, vmssVM)
+	}
+	return vmssVMList
+}
+
+func newApiNode(orchmode compute.OrchestrationMode, vmID int64) *apiv1.Node {
+	providerId := fakeVirtualMachineScaleSetVMID
+
+	if orchmode == compute.Flexible {
+		providerId = fakeVirtualMachineVMID
+	}
+
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "azure://" + fmt.Sprintf(providerId, vmID),
+		},
+	}
+	return node
+}
 func TestMaxSize(t *testing.T) {
 	provider := newTestProvider(t)
 	registered := provider.azureManager.RegisterNodeGroup(
@@ -94,71 +125,104 @@ func TestTargetSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
+	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := provider.azureManager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
+		provider := newTestProvider(t)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		if orchMode == compute.Uniform {
 
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		err := provider.azureManager.forceRefresh()
+		assert.NoError(t, err)
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+	}
 }
 
 func TestIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), provider.azureManager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := provider.azureManager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
 
-	ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
-	err = ss.IncreaseSize(100)
-	expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
-	assert.Equal(t, expectedErr, err)
+		provider := newTestProvider(t)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), provider.azureManager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// current target size is 2.
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+		if orchMode == compute.Uniform {
 
-	// increase 3 nodes.
-	err = provider.NodeGroups()[0].IncreaseSize(2)
-	assert.NoError(t, err)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
 
-	// new target size should be 5.
-	targetSize, err = provider.NodeGroups()[0].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 5, targetSize)
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+		err := provider.azureManager.forceRefresh()
+		assert.NoError(t, err)
+
+		ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
+		err = ss.IncreaseSize(100)
+		expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
+		assert.Equal(t, expectedErr, err)
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		// current target size is 2.
+		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+
+		// increase 3 nodes.
+		err = provider.NodeGroups()[0].IncreaseSize(2)
+		assert.NoError(t, err)
+
+		// new target size should be 5.
+		targetSize, err = provider.NodeGroups()[0].TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 5, targetSize)
+	}
 }
 
 func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
@@ -177,6 +241,7 @@ func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {
 			},
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				ProvisioningState: to.StringPtr(string(compute.ProvisioningStateUpdating)),
+				OrchestrationMode: compute.Uniform,
 			},
 		},
 	}
@@ -209,213 +274,238 @@ func TestBelongs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	provider := newTestProvider(t)
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
-	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	for _, orchMode := range orchestrationModes {
 
-	registered := provider.azureManager.RegisterNodeGroup(
-		newTestScaleSet(provider.azureManager, "test-asg"))
-	assert.True(t, registered)
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
+		provider := newTestProvider(t)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil)
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
-	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	provider.azureManager.Refresh()
+		if orchMode == compute.Uniform {
 
-	invalidNode := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure:///subscriptions/test-subscrition-id/resourcegroups/invalid-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0",
-		},
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		assert.True(t, registered)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+		provider.azureManager.explicitlyConfigured["test-asg"] = true
+		provider.azureManager.Refresh()
+
+		invalidNode := &apiv1.Node{
+			Spec: apiv1.NodeSpec{
+				ProviderID: "azure:///subscriptions/test-subscrition-id/resourcegroups/invalid-asg/providers/microsoft.compute/virtualmachinescalesets/agents/virtualmachines/0",
+			},
+		}
+		_, err := scaleSet.Belongs(invalidNode)
+		assert.Error(t, err)
+
+		validNode := newApiNode(orchMode, 0)
+		belongs, err := scaleSet.Belongs(validNode)
+		assert.Equal(t, true, belongs)
+		assert.NoError(t, err)
 	}
-	_, err := scaleSet.Belongs(invalidNode)
-	assert.Error(t, err)
 
-	validNode := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-		},
-	}
-	belongs, err := scaleSet.Belongs(validNode)
-	assert.Equal(t, true, belongs)
-	assert.NoError(t, err)
 }
 
 func TestDeleteNodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
 	vmssName := "test-asg"
 	var vmssCapacity int64 = 3
-
-	expectedScaleSets := []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-		},
-	}
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := manager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
 
-	resourceLimiter := cloudprovider.NewResourceLimiter(
-		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
-		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
-	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
-	assert.NoError(t, err)
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
 
-	registered := manager.RegisterNodeGroup(
-		newTestScaleSet(manager, "test-asg"))
-	manager.explicitlyConfigured["test-asg"] = true
-	assert.True(t, registered)
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+		mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+		mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+		mockVMClient := mockvmclient.NewMockInterface(ctrl)
 
-	targetSize, err := scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 3, targetSize)
+		if orchMode == compute.Uniform {
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
+			manager.config.EnableVmssFlex = true
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
 
-	// Perform the delete operation
-	nodesToDelete := []*apiv1.Node{
-		{
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-			},
-		},
-		{
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2),
-			},
-		},
+		}
+
+		err := manager.forceRefresh()
+		assert.NoError(t, err)
+
+		resourceLimiter := cloudprovider.NewResourceLimiter(
+			map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+			map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+		provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+
+		assert.NoError(t, err)
+
+		registered := manager.RegisterNodeGroup(
+			newTestScaleSet(manager, "test-asg"))
+		manager.explicitlyConfigured["test-asg"] = true
+
+		assert.True(t, registered)
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+
+		targetSize, err := scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, targetSize)
+
+		// Perform the delete operation
+		nodesToDelete := []*apiv1.Node{
+			newApiNode(orchMode, 0),
+			newApiNode(orchMode, 2),
+		}
+		err = scaleSet.DeleteNodes(nodesToDelete)
+		assert.NoError(t, err)
+
+		// create scale set with vmss capacity 1
+		expectedScaleSets = newTestVMSSList(1, vmssName, "eastus", orchMode)
+
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+
+		if orchMode == compute.Uniform {
+			expectedVMSSVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+		} else {
+			expectedVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			expectedVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+		}
+
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		// Ensure the the cached size has been proactively decremented by 2
+		targetSize, err = scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, targetSize)
+
+		// Ensure that the status for the instances is Deleting
+		instance0, found := scaleSet.getInstanceByProviderID(nodesToDelete[0].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
+
+		instance2, found := scaleSet.getInstanceByProviderID(nodesToDelete[1].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance2.Status.State, cloudprovider.InstanceDeleting)
+
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
-	assert.NoError(t, err)
-	vmssCapacity = 1
-	expectedScaleSets = []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-		},
-	}
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
-	expectedVMSSVMs[0].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
-	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateDeleting))
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
-
-	// Ensure the the cached size has been proactively decremented by 2
-	targetSize, err = scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, targetSize)
-
-	// Ensure that the status for the instances is Deleting
-	instance0, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0))
-	assert.True(t, found, true)
-	assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
-
-	instance2, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2))
-	assert.True(t, found, true)
-	assert.Equal(t, instance2.Status.State, cloudprovider.InstanceDeleting)
 }
 
 func TestDeleteNodeUnregistered(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
+
 	vmssName := "test-asg"
 	var vmssCapacity int64 = 2
-
-	expectedScaleSets := []compute.VirtualMachineScaleSet{
-		{
-			Name: &vmssName,
-			Sku: &compute.Sku{
-				Capacity: &vmssCapacity,
-			},
-		},
-	}
 	expectedVMSSVMs := newTestVMSSVMList(2)
+	expectedVMs := newTestVMList(2)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	err := manager.forceRefresh()
-	assert.NoError(t, err)
+	for _, orchMode := range orchestrationModes {
+		manager := newTestAzureManager(t)
+		expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
 
-	resourceLimiter := cloudprovider.NewResourceLimiter(
-		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
-		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
-	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
-	assert.NoError(t, err)
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+		mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), false).Return(nil, nil)
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+		manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	registered := manager.RegisterNodeGroup(
-		newTestScaleSet(manager, "test-asg"))
-	manager.explicitlyConfigured["test-asg"] = true
-	assert.True(t, registered)
-	err = manager.forceRefresh()
-	assert.NoError(t, err)
+		if orchMode == compute.Uniform {
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+		} else {
 
-	targetSize, err := scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, targetSize)
+			manager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+		}
+		err := manager.forceRefresh()
+		assert.NoError(t, err)
 
-	// annotate node with unregistered annotation
-	annotations := make(map[string]string)
-	annotations[cloudprovider.FakeNodeReasonAnnotation] = cloudprovider.FakeNodeUnregistered
-	nodesToDelete := []*apiv1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: annotations,
-			},
-			Spec: apiv1.NodeSpec{
-				ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-			},
-		},
+		resourceLimiter := cloudprovider.NewResourceLimiter(
+			map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+			map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+		provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+		assert.NoError(t, err)
+
+		registered := manager.RegisterNodeGroup(
+			newTestScaleSet(manager, "test-asg"))
+		manager.explicitlyConfigured["test-asg"] = true
+		assert.True(t, registered)
+		err = manager.forceRefresh()
+		assert.NoError(t, err)
+
+		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		assert.True(t, ok)
+
+		targetSize, err := scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, targetSize)
+
+		// annotate node with unregistered annotation
+		annotations := make(map[string]string)
+		annotations[cloudprovider.FakeNodeReasonAnnotation] = cloudprovider.FakeNodeUnregistered
+
+		nodesToDelete := []*apiv1.Node{
+			newApiNode(orchMode, 0),
+		}
+		nodesToDelete[0].ObjectMeta.Annotations = annotations
+
+		err = scaleSet.DeleteNodes(nodesToDelete)
+		assert.NoError(t, err)
+
+		// Ensure the the cached size has NOT been proactively decremented
+		targetSize, err = scaleSet.TargetSize()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, targetSize)
+
+		// Ensure that the status for the instances is Deleting
+		instance0, found := scaleSet.getInstanceByProviderID(nodesToDelete[0].Spec.ProviderID)
+		assert.True(t, found, true)
+		assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
-	assert.NoError(t, err)
 
-	// Ensure the the cached size has NOT been proactively decremented
-	targetSize, err = scaleSet.TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, targetSize)
-
-	// Ensure that the status for the instances is Deleting
-	instance0, found := scaleSet.getInstanceByProviderID("azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0))
-	assert.True(t, found, true)
-	assert.Equal(t, instance0.Status.State, cloudprovider.InstanceDeleting)
 }
 
 func TestDeleteNoConflictRequest(t *testing.T) {
@@ -442,6 +532,9 @@ func TestDeleteNoConflictRequest(t *testing.T) {
 			Name: &vmssName,
 			Sku: &compute.Sku{
 				Capacity: &vmssCapacity,
+			},
+			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: compute.Uniform,
 			},
 		},
 	}
@@ -498,53 +591,105 @@ func TestDebug(t *testing.T) {
 func TestScaleSetNodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	orchestrationModes := [2]compute.OrchestrationMode{compute.Uniform, compute.Flexible}
 
 	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	expectedVMs := newTestVMList(3)
+
+	for _, orchMode := range orchestrationModes {
+
+		expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", orchMode)
+		provider := newTestProvider(t)
+
+		mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+		mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+		provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+		if orchMode == compute.Uniform {
+
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+		} else {
+			provider.azureManager.config.EnableVmssFlex = true
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+			provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+		}
+
+		registered := provider.azureManager.RegisterNodeGroup(
+			newTestScaleSet(provider.azureManager, "test-asg"))
+		provider.azureManager.explicitlyConfigured["test-asg"] = true
+		provider.azureManager.Refresh()
+		assert.True(t, registered)
+		assert.Equal(t, len(provider.NodeGroups()), 1)
+
+		node := newApiNode(orchMode, 0)
+		group, err := provider.NodeGroupForNode(node)
+		assert.NoError(t, err)
+		assert.NotNil(t, group, "Group should not be nil")
+		assert.Equal(t, group.Id(), "test-asg")
+		assert.Equal(t, group.MinSize(), 1)
+		assert.Equal(t, group.MaxSize(), 5)
+
+		ss, ok := group.(*ScaleSet)
+		assert.True(t, ok)
+		assert.NotNil(t, ss)
+		instances, err := group.Nodes()
+		assert.NoError(t, err)
+		assert.Equal(t, len(instances), 3)
+
+		if orchMode == compute.Uniform {
+
+			assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)})
+			assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)})
+			assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)})
+		} else {
+
+			assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 0)})
+			assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 1)})
+			assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineVMID, 2)})
+		}
+	}
+
+}
+
+func TestEnableVmssFlexFlag(t *testing.T) {
+
+	// flag set to false
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedVMs := newTestVMList(3)
+	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Flexible)
 
 	provider := newTestProvider(t)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.config.EnableVmssFlex = false
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), "test-asg").Return(expectedVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
 
-	registered := provider.azureManager.RegisterNodeGroup(
+	provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	provider.azureManager.explicitlyConfigured["test-asg"] = true
-	provider.azureManager.Refresh()
-	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+	err := provider.azureManager.Refresh()
+	assert.Error(t, err, "vmss - \"test-asg\" with Flexible orchestration detected but 'enbaleVmssFlex' feature flag is turned off")
 
-	node := &apiv1.Node{
-		Spec: apiv1.NodeSpec{
-			ProviderID: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
-		},
-	}
-	group, err := provider.NodeGroupForNode(node)
+	// flag set to true
+	provider.azureManager.config.EnableVmssFlex = true
+	err = provider.azureManager.Refresh()
 	assert.NoError(t, err)
-	assert.NotNil(t, group, "Group should not be nil")
-	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
-
-	ss, ok := group.(*ScaleSet)
-	assert.True(t, ok)
-	assert.NotNil(t, ss)
-	instances, err := group.Nodes()
-	assert.NoError(t, err)
-	assert.Equal(t, len(instances), 3)
-	assert.Equal(t, instances[0], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)})
-	assert.Equal(t, instances[1], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)})
-	assert.Equal(t, instances[2], cloudprovider.Instance{Id: "azure://" + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)})
 }
 
 func TestTemplateNodeInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus")
+	expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", compute.Uniform)
 
 	provider := newTestProvider(t)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is to cherry-pick changes of PR: https://github.com/kubernetes/autoscaler/pull/5602/ from main to release branch

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/5334

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
