### PR TITLE
Add a dedicated struct for the MaxResourceLimitReached Reasons

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -513,7 +513,7 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.
 }
 
 // IsNodeGroupResourceExceeded returns nil if node group resource limits are not exceeded, otherwise a reason is provided.
-func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(resourcesLeft resource.Limits, nodeGroup cloudprovider.NodeGroup, nodeInfo *schedulerframework.NodeInfo) *SkippedReasons {
+func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(resourcesLeft resource.Limits, nodeGroup cloudprovider.NodeGroup, nodeInfo *schedulerframework.NodeInfo) status.Reasons {
 	resourcesDelta, err := o.resourceManager.DeltaForNode(o.autoscalingContext, nodeInfo, nodeGroup)
 	if err != nil {
 		klog.Errorf("Skipping node group %s; error getting node group resources: %v", nodeGroup.Id(), err)
@@ -533,7 +533,7 @@ func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(resourcesLeft resource
 				continue
 			}
 		}
-		return MaxResourceLimitReached(checkResult.ExceededResources)
+		return NewMaxResourceLimitReached(checkResult.ExceededResources)
 	}
 	return nil
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
@@ -45,7 +45,26 @@ var (
 	NotReadyReason = NewSkippedReasons("not ready for scale-up")
 )
 
-// MaxResourceLimitReached returns a reason describing which cluster wide resource limits were reached.
-func MaxResourceLimitReached(resources []string) *SkippedReasons {
-	return NewSkippedReasons(fmt.Sprintf("max cluster %s limit reached", strings.Join(resources, ", ")))
+// MaxResourceLimitReached contains information why given node group was skipped.
+type MaxResourceLimitReached struct {
+	messages  []string
+	resources []string
+}
+
+// Reasons returns a slice of reasons why the node group was not considered for scale up.
+func (sr *MaxResourceLimitReached) Reasons() []string {
+	return sr.messages
+}
+
+// Resources returns a slice of resources which were missing in the node group.
+func (sr *MaxResourceLimitReached) Resources() []string {
+	return sr.resources
+}
+
+// NewMaxResourceLimitReached returns a reason describing which cluster wide resource limits were reached.
+func NewMaxResourceLimitReached(resources []string) *MaxResourceLimitReached {
+	return &MaxResourceLimitReached{
+		messages:  []string{fmt.Sprintf("max cluster %s limit reached", strings.Join(resources, ", "))},
+		resources: resources,
+	}
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons_test.go
@@ -44,7 +44,7 @@ func TestMaxResourceLimitReached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MaxResourceLimitReached(tt.resources); !reflect.DeepEqual(got.Reasons(), tt.wantReasons) {
+			if got := NewMaxResourceLimitReached(tt.resources); !reflect.DeepEqual(got.Reasons(), tt.wantReasons) {
 				t.Errorf("MaxResourceLimitReached(%v) = %v, want %v", tt.resources, got.Reasons(), tt.wantReasons)
 			}
 		})


### PR DESCRIPTION
This allows us to get the list of missing resources from the skipped reasons object, without computing it one more time.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It simplifies extracting the details about missing resources.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
