### PR TITLE
feat: support custom scheduler config (without extenders)

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"time"
+
+	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
 // GpuLimits define lower and upper bound on GPU instances of given type in cluster
@@ -166,6 +168,9 @@ type AutoscalingOptions struct {
 	// ScaleDownSimulationTimeout defines the maximum time that can be
 	// spent on scale down simulation.
 	ScaleDownSimulationTimeout time.Duration
+	// SchedulerConfig allows changing configuration of in-tree
+	// scheduler plugins acting on PreFilter and Filter extension points
+	SchedulerConfig *scheduler_config.KubeSchedulerConfiguration
 	// NodeDeletionDelayTimeout is maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.
 	NodeDeletionDelayTimeout time.Duration
 	// WriteStatusConfigMap tells if the status information should be written to a ConfigMap

--- a/cluster-autoscaler/config/const.go
+++ b/cluster-autoscaler/config/const.go
@@ -19,6 +19,10 @@ package config
 import "time"
 
 const (
+	// SchedulerConfigFileFlag is the name of the flag
+	// for passing in custom scheduler config for in-tree scheduelr plugins
+	SchedulerConfigFileFlag = "scheduler-config-file"
+
 	// DefaultMaxClusterCores is the default maximum number of cores in the cluster.
 	DefaultMaxClusterCores = 5000 * 64
 	// DefaultMaxClusterMemory is the default maximum number of gigabytes of memory in cluster.

--- a/cluster-autoscaler/config/test/config.go
+++ b/cluster-autoscaler/config/test/config.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+const (
+	// Custom scheduler configs for testing
+
+	// SchedulerConfigNodeResourcesFitDisabled is scheduler config
+	// with `NodeResourcesFit` plugin disabled
+	SchedulerConfigNodeResourcesFitDisabled = `
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  plugins:
+    multiPoint:
+      disabled:
+      - name: NodeResourcesFit
+        weight: 1
+  schedulerName: custom-scheduler`
+
+	// SchedulerConfigTaintTolerationDisabled is scheduler config
+	// with `TaintToleration` plugin disabled
+	SchedulerConfigTaintTolerationDisabled = `
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  plugins:
+    multiPoint:
+      disabled:
+      - name: TaintToleration
+        weight: 1
+  schedulerName: custom-scheduler`
+
+	// SchedulerConfigMinimalCorrect is the minimal
+	// correct scheduler config
+	SchedulerConfigMinimalCorrect = `
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration`
+
+	// SchedulerConfigDecodeErr is the scheduler config
+	// which throws decoding error when we try to load it
+	SchedulerConfigDecodeErr = `
+kind: KubeSchedulerConfiguration`
+
+	// SchedulerConfigInvalid is invalid scheduler config
+	// because we specify percentageOfNodesToScore > 100
+	SchedulerConfigInvalid = `
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+# percentageOfNodesToScore has to be between 0 and 100
+percentageOfNodesToScore: 130`
+)

--- a/cluster-autoscaler/simulator/predicatechecker/testchecker.go
+++ b/cluster-autoscaler/simulator/predicatechecker/testchecker.go
@@ -18,10 +18,27 @@ package predicatechecker
 
 import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	scheduler_config_latest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 )
 
 // NewTestPredicateChecker builds test version of PredicateChecker.
 func NewTestPredicateChecker() (PredicateChecker, error) {
+	schedConfig, err := scheduler_config_latest.Default()
+	if err != nil {
+		return nil, err
+	}
+
 	// just call out to NewSchedulerBasedPredicateChecker but use fake kubeClient
-	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), make(chan struct{}))
+	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), schedConfig, make(chan struct{}))
+}
+
+// NewTestPredicateCheckerWithCustomConfig builds test version of PredicateChecker with custom scheduler config.
+func NewTestPredicateCheckerWithCustomConfig(schedConfig *config.KubeSchedulerConfiguration) (PredicateChecker, error) {
+	if schedConfig != nil {
+		// just call out to NewSchedulerBasedPredicateChecker but use fake kubeClient
+		return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), schedConfig, make(chan struct{}))
+	}
+
+	return NewTestPredicateChecker()
 }

--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -18,12 +18,23 @@ package scheduler
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	scheduler_scheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+	scheduler_validation "k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	schedulerConfigDecodeErr   = "couldn't decode scheduler config"
+	schedulerConfigLoadErr     = "couldn't load scheduler config"
+	schedulerConfigTypeCastErr = "couldn't assert type as KubeSchedulerConfiguration"
+	schedulerConfigInvalidErr  = "invalid KubeSchedulerConfiguration"
 )
 
 // CreateNodeNameToInfoMap obtains a list of pods and pivots that list into a map where the keys are node names
@@ -105,4 +116,34 @@ func ResourceToResourceList(r *schedulerframework.Resource) apiv1.ResourceList {
 		}
 	}
 	return result
+}
+
+// ConfigFromPath loads scheduler config from a path.
+// TODO(vadasambar): replace code to parse scheduler config with upstream function
+// once https://github.com/kubernetes/kubernetes/pull/119057 is merged
+func ConfigFromPath(path string) (*scheduler_config.KubeSchedulerConfiguration, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", schedulerConfigLoadErr, err)
+	}
+
+	obj, gvk, err := scheduler_scheme.Codecs.UniversalDecoder().Decode(data, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", schedulerConfigDecodeErr, err)
+	}
+
+	cfgObj, ok := obj.(*scheduler_config.KubeSchedulerConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("%s, gvk: %s", schedulerConfigTypeCastErr, gvk)
+	}
+
+	// this needs to be set explicitly because config's api version is empty after decoding
+	// check kubernetes/cmd/kube-scheduler/app/options/configfile.go for more info
+	cfgObj.TypeMeta.APIVersion = gvk.GroupVersion().String()
+
+	if err := scheduler_validation.ValidateKubeSchedulerConfiguration(cfgObj); err != nil {
+		return nil, fmt.Errorf("%s: %v", schedulerConfigInvalidErr, err)
+	}
+
+	return cfgObj, nil
 }


### PR DESCRIPTION
Signed-off-by: vadasambar <surajrbanakar@gmail.com>

#### What type of PR is this?

/kind feature



#### What this PR does / why we need it:
**Problem**
1. We don't have a mechanism to to tweak configuration for default plugins acting on `PreFilter` and `Filter` extension points (which is used in predicate checker).
2. We don't have a way to support simulating custom scheduler logic without re-compiling the CA

This PR introduces `--scheduler-config-file` flag to 
1. tweak configuration for default plugins
~2. add support for [scheduler extenders](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) so that the predicate checker can call an external filter URL.~ DECIDED AGAINST GOING FORWARD WITH EXTENDERS. Check https://github.com/kubernetes/autoscaler/pull/5708#issuecomment-1538647324 and https://github.com/kubernetes/autoscaler/pull/5708#issuecomment-1539546973 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5106

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added: `--scheduler-config-file` flag which supports configuring `PreFilter` and `Filter` extension points for in-tree scheduler plugins used to run scheduler simulations in CA 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
