### PR TITLE
Binpacking Estimator pod priority

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -115,7 +115,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.ExpanderStrategy = expanderStrategy
 	}
 	if opts.EstimatorBuilder == nil {
-		estimatorBuilder, err := estimator.NewEstimatorBuilder(opts.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(opts.MaxNodesPerScaleUp, opts.MaxNodeGroupBinpackingDuration))
+		estimatorBuilder, err := estimator.NewEstimatorBuilder(opts.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(opts.MaxNodesPerScaleUp, opts.MaxNodeGroupBinpackingDuration), estimator.NewDecreasingPodOrderer())
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -169,7 +169,7 @@ func NewScaleTestAutoscalingContext(
 	}
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
-	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0))
+	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0), estimator.NewDecreasingPodOrderer())
 	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	if err != nil {
 		return context.AutoscalingContext{}, err

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -105,6 +105,7 @@ func makeNode(cpu int64, mem int64, name string, zone string) *apiv1.Node {
 }
 
 func TestBinpackingEstimate(t *testing.T) {
+	highResourcePodList := makePods(500, 1000, 0, 0, "", 10)
 	testCases := []struct {
 		name                 string
 		millicores           int64
@@ -114,6 +115,7 @@ func TestBinpackingEstimate(t *testing.T) {
 		topologySpreadingKey string
 		expectNodeCount      int
 		expectPodCount       int
+		expectProcessedPods  []*apiv1.Pod
 	}{
 		{
 			name:            "simple resource-based binpacking",
@@ -149,6 +151,16 @@ func TestBinpackingEstimate(t *testing.T) {
 			expectPodCount:  10,
 		},
 		{
+			name:                "decreasing ordered pods are processed first",
+			millicores:          1000,
+			memory:              5000,
+			pods:                append(makePods(50, 1000, 0, 0, "", 10), highResourcePodList...),
+			maxNodes:            5,
+			expectNodeCount:     5,
+			expectPodCount:      10,
+			expectProcessedPods: highResourcePodList,
+		},
+		{
 			name:            "hostname topology spreading with maxSkew=2 forces 2 pods/node",
 			millicores:      1000,
 			memory:          5000,
@@ -174,7 +186,8 @@ func TestBinpackingEstimate(t *testing.T) {
 			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 			assert.NoError(t, err)
 			limiter := NewThresholdBasedEstimationLimiter(tc.maxNodes, time.Duration(0))
-			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter)
+			processor := NewDecreasingPodOrderer()
+			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, processor)
 
 			node := makeNode(tc.millicores, tc.memory, "template", "zone-mars")
 			nodeInfo := schedulerframework.NewNodeInfo()
@@ -183,6 +196,9 @@ func TestBinpackingEstimate(t *testing.T) {
 			estimatedNodes, estimatedPods := estimator.Estimate(tc.pods, nodeInfo, nil)
 			assert.Equal(t, tc.expectNodeCount, estimatedNodes)
 			assert.Equal(t, tc.expectPodCount, len(estimatedPods))
+			if tc.expectProcessedPods != nil {
+				assert.Equal(t, tc.expectProcessedPods, estimatedPods)
+			}
 		})
 	}
 }

--- a/cluster-autoscaler/estimator/decreasing_pod_orderer.go
+++ b/cluster-autoscaler/estimator/decreasing_pod_orderer.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"sort"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// podScoreInfo contains Pod and score that corresponds to how important it is to handle the pod first.
+type podScoreInfo struct {
+	score float64
+	pod   *apiv1.Pod
+}
+
+// DecreasingPodOrderer is the default implementation of the EstimationPodOrderer
+// It implements sorting pods by pod score in decreasing order
+type DecreasingPodOrderer struct {
+}
+
+// NewDecreasingPodOrderer returns the object of DecreasingPodOrderer
+func NewDecreasingPodOrderer() *DecreasingPodOrderer {
+	return &DecreasingPodOrderer{}
+}
+
+// Order is the processing func that sorts the pods based on the size of the pod
+func (d *DecreasingPodOrderer) Order(pods []*apiv1.Pod, nodeTemplate *framework.NodeInfo, _ cloudprovider.NodeGroup) []*apiv1.Pod {
+	podInfos := make([]*podScoreInfo, 0, len(pods))
+	for _, pod := range pods {
+		podInfos = append(podInfos, d.calculatePodScore(pod, nodeTemplate))
+	}
+	sort.Slice(podInfos, func(i, j int) bool { return podInfos[i].score > podInfos[j].score })
+	podList := make([]*apiv1.Pod, 0, len(pods))
+	for _, podInfo := range podInfos {
+		podList = append(podList, podInfo.pod)
+	}
+
+	return podList
+}
+
+// calculatePodScore score for  pod and returns podScoreInfo structure.
+// Score is defined as cpu_sum/node_capacity + mem_sum/node_capacity.
+// Pods that have bigger requirements should be processed first, thus have higher scores.
+func (d *DecreasingPodOrderer) calculatePodScore(pod *apiv1.Pod, nodeTemplate *framework.NodeInfo) *podScoreInfo {
+
+	cpuSum := resource.Quantity{}
+	memorySum := resource.Quantity{}
+
+	for _, container := range pod.Spec.Containers {
+		if request, ok := container.Resources.Requests[apiv1.ResourceCPU]; ok {
+			cpuSum.Add(request)
+		}
+		if request, ok := container.Resources.Requests[apiv1.ResourceMemory]; ok {
+			memorySum.Add(request)
+		}
+	}
+	score := float64(0)
+	if cpuAllocatable, ok := nodeTemplate.Node().Status.Allocatable[apiv1.ResourceCPU]; ok && cpuAllocatable.MilliValue() > 0 {
+		score += float64(cpuSum.MilliValue()) / float64(cpuAllocatable.MilliValue())
+	}
+	if memAllocatable, ok := nodeTemplate.Node().Status.Allocatable[apiv1.ResourceMemory]; ok && memAllocatable.Value() > 0 {
+		score += float64(memorySum.Value()) / float64(memAllocatable.Value())
+	}
+
+	return &podScoreInfo{
+		score: score,
+		pod:   pod,
+	}
+}

--- a/cluster-autoscaler/estimator/decreasing_pod_orderer_test.go
+++ b/cluster-autoscaler/estimator/decreasing_pod_orderer_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestPodPriorityProcessor(t *testing.T) {
+	p1 := test.BuildTestPod("p1", 1, 1)
+	p2 := test.BuildTestPod("p2", 2, 1)
+	p3 := test.BuildTestPod("p3", 2, 100)
+	node := makeNode(4, 600, "node1", "zone-sun")
+	testCases := map[string]struct {
+		inputPods    []*apiv1.Pod
+		expectedPods []*apiv1.Pod
+	}{
+		"single pod": {
+			inputPods:    []*apiv1.Pod{p1},
+			expectedPods: []*apiv1.Pod{p1},
+		},
+		"sorted list of pods": {
+			inputPods:    []*apiv1.Pod{p3, p2, p1},
+			expectedPods: []*apiv1.Pod{p3, p2, p1},
+		},
+		"randomised list of pods": {
+			inputPods:    []*apiv1.Pod{p1, p3, p2},
+			expectedPods: []*apiv1.Pod{p3, p2, p1},
+		},
+		"empty pod list": {
+			inputPods:    []*apiv1.Pod{},
+			expectedPods: []*apiv1.Pod{},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+			processor := NewDecreasingPodOrderer()
+			nodeInfo := schedulerframework.NewNodeInfo()
+			nodeInfo.SetNode(node)
+			actual := processor.Order(tc.inputPods, nodeInfo, nil)
+			assert.Equal(t, tc.expectedPods, actual)
+		})
+	}
+}


### PR DESCRIPTION
Refactor the Binpacking estimator by making the pod sort extendable by moving the logic into pod_priority_processor.go Cleanup sorting logic/structs from binpacking_estimator.go

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We would like to have to ability to customise pod order which is used while binpacking.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
