### PR TITLE
Revert "Add new method 'ReachedLimit' to EstimationLimiter"

### DIFF
--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -71,7 +71,4 @@ type EstimationLimiter interface {
 	// There is no requirement for the Estimator to stop calculations, it's
 	// just not expected to add any more nodes.
 	PermissionToAddNode() bool
-	// ReachedLimit returns true if the limiter blocked addition of the new node.
-	// Otherwise returns false.
-	ReachedLimit() bool
 }

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -25,17 +25,15 @@ import (
 )
 
 type thresholdBasedEstimationLimiter struct {
-	maxDuration  time.Duration
-	maxNodes     int
-	nodes        int
-	start        time.Time
-	reachedLimit bool
+	maxDuration time.Duration
+	maxNodes    int
+	nodes       int
+	start       time.Time
 }
 
 func (tbel *thresholdBasedEstimationLimiter) StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup) {
 	tbel.start = time.Now()
 	tbel.nodes = 0
-	tbel.reachedLimit = false
 }
 
 func (*thresholdBasedEstimationLimiter) EndEstimation() {}
@@ -43,21 +41,15 @@ func (*thresholdBasedEstimationLimiter) EndEstimation() {}
 func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode() bool {
 	if tbel.maxNodes > 0 && tbel.nodes >= tbel.maxNodes {
 		klog.V(4).Infof("Capping binpacking after exceeding threshold of %d nodes", tbel.maxNodes)
-		tbel.reachedLimit = true
 		return false
 	}
 	timeDefined := tbel.maxDuration > 0 && tbel.start != time.Time{}
 	if timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration)) {
 		klog.V(4).Infof("Capping binpacking after exceeding max duration of %v", tbel.maxDuration)
-		tbel.reachedLimit = true
 		return false
 	}
 	tbel.nodes++
 	return true
-}
-
-func (tbel *thresholdBasedEstimationLimiter) ReachedLimit() bool {
-	return tbel.reachedLimit
 }
 
 // NewThresholdBasedEstimationLimiter returns an EstimationLimiter that will prevent estimation

--- a/cluster-autoscaler/estimator/threshold_based_limiter_test.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter_test.go
@@ -42,13 +42,12 @@ func resetLimiter(t *testing.T, l EstimationLimiter) {
 
 func TestThresholdBasedLimiter(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		maxNodes             int
-		maxDuration          time.Duration
-		startDelta           time.Duration
-		operations           []limiterOperation
-		expectNodeCount      int
-		expectedReachedLimit bool
+		name            string
+		maxNodes        int
+		maxDuration     time.Duration
+		startDelta      time.Duration
+		operations      []limiterOperation
+		expectNodeCount int
 	}{
 		{
 			name:     "no limiting happens",
@@ -69,8 +68,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				expectDeny,
 				expectDeny,
 			},
-			expectNodeCount:      0,
-			expectedReachedLimit: true,
+			expectNodeCount: 0,
 		},
 		{
 			name:     "sequence of additions works until the threshold is hit",
@@ -81,8 +79,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				expectAllow,
 				expectDeny,
 			},
-			expectNodeCount:      3,
-			expectedReachedLimit: true,
+			expectNodeCount: 3,
 		},
 		{
 			name:     "node counter is reset",
@@ -126,7 +123,6 @@ func TestThresholdBasedLimiter(t *testing.T) {
 				op(t, limiter)
 			}
 			assert.Equal(t, tc.expectNodeCount, limiter.nodes)
-			assert.Equal(t, tc.expectedReachedLimit, limiter.reachedLimit)
 			limiter.EndEstimation()
 		})
 	}


### PR DESCRIPTION
This was meant to be used as a signal that the estimation did consider all of the pods, but @x13n pointed out that other k8s primitives may also limit it so the best option is to compare a list of estimated pods.

This reverts commit 3ad77e8341eecc038ce9d706d20c0231b5eb7954.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign x13n
