### PR TITLE
Feature: parallel scale up

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -128,6 +128,8 @@ type AutoscalingOptions struct {
 	OkTotalUnreadyCount int
 	// ScaleUpFromZero defines if CA should scale up when there 0 ready nodes.
 	ScaleUpFromZero bool
+	// ParallelScaleUp defines whether CA can scale up node groups in parallel.
+	ParallelScaleUp bool
 	// CloudConfig is the path to the cloud provider configuration file. Empty string for no configuration file.
 	CloudConfig string
 	// CloudProviderName sets the type of the cloud provider CA is about to run in. Allowed values: gce, aws

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+)
+
+// ScaleUpExecutor scales up node groups.
+type scaleUpExecutor struct {
+	autoscalingContext   *context.AutoscalingContext
+	clusterStateRegistry *clusterstate.ClusterStateRegistry
+}
+
+// New returns new instance of scale up executor.
+func newScaleUpExecutor(
+	autoscalingContext *context.AutoscalingContext,
+	clusterStateRegistry *clusterstate.ClusterStateRegistry,
+) *scaleUpExecutor {
+	return &scaleUpExecutor{
+		autoscalingContext:   autoscalingContext,
+		clusterStateRegistry: clusterStateRegistry,
+	}
+}
+
+// ExecuteScaleUps executes the scale ups, based on the provided scale up infos and options.
+// May scale up groups concurrently when autoscler option is enabled.
+// In case of issues returns an error and a scale up info which failed to execute.
+// If there were multiple concurrent errors one combined error is returned.
+func (e *scaleUpExecutor) ExecuteScaleUps(
+	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	nodeInfos map[string]*schedulerframework.NodeInfo,
+	now time.Time,
+) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
+	options := e.autoscalingContext.AutoscalingOptions
+	if options.ParallelScaleUp {
+		return e.executeScaleUpsParallel(scaleUpInfos, nodeInfos, now)
+	}
+	return e.executeScaleUpsSync(scaleUpInfos, nodeInfos, now)
+}
+
+func (e *scaleUpExecutor) executeScaleUpsSync(
+	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	nodeInfos map[string]*schedulerframework.NodeInfo,
+	now time.Time,
+) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
+	availableGPUTypes := e.autoscalingContext.CloudProvider.GetAvailableGPUTypes()
+	for _, scaleUpInfo := range scaleUpInfos {
+		nodeInfo, ok := nodeInfos[scaleUpInfo.Group.Id()]
+		if !ok {
+			klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", scaleUpInfo.Group.Id())
+			continue
+		}
+		if aErr := e.executeScaleUp(scaleUpInfo, nodeInfo, availableGPUTypes, now); aErr != nil {
+			return aErr, []cloudprovider.NodeGroup{scaleUpInfo.Group}
+		}
+	}
+	return nil, nil
+}
+
+func (e *scaleUpExecutor) executeScaleUpsParallel(
+	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	nodeInfos map[string]*schedulerframework.NodeInfo,
+	now time.Time,
+) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
+	if err := assertUniqueNodeGroups(scaleUpInfos); err != nil {
+		return err, extractNodeGroups(scaleUpInfos)
+	}
+	type errResult struct {
+		err  errors.AutoscalerError
+		info *nodegroupset.ScaleUpInfo
+	}
+	scaleUpsLen := len(scaleUpInfos)
+	errResults := make(chan errResult, scaleUpsLen)
+	var wg sync.WaitGroup
+	wg.Add(scaleUpsLen)
+	availableGPUTypes := e.autoscalingContext.CloudProvider.GetAvailableGPUTypes()
+	for _, scaleUpInfo := range scaleUpInfos {
+		go func(info nodegroupset.ScaleUpInfo) {
+			defer wg.Done()
+			nodeInfo, ok := nodeInfos[info.Group.Id()]
+			if !ok {
+				klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", info.Group.Id())
+				return
+			}
+			if aErr := e.executeScaleUp(info, nodeInfo, availableGPUTypes, now); aErr != nil {
+				errResults <- errResult{err: aErr, info: &info}
+			}
+		}(scaleUpInfo)
+	}
+	wg.Wait()
+	close(errResults)
+	var results []errResult
+	for err := range errResults {
+		results = append(results, err)
+	}
+	if len(results) > 0 {
+		failedNodeGroups := make([]cloudprovider.NodeGroup, len(results))
+		scaleUpErrors := make([]errors.AutoscalerError, len(results))
+		for i, result := range results {
+			failedNodeGroups[i] = result.info.Group
+			scaleUpErrors[i] = result.err
+		}
+		return combineConcurrentScaleUpErrors(scaleUpErrors), failedNodeGroups
+	}
+	return nil, nil
+}
+
+func (e *scaleUpExecutor) executeScaleUp(
+	info nodegroupset.ScaleUpInfo,
+	nodeInfo *schedulerframework.NodeInfo,
+	availableGPUTypes map[string]struct{},
+	now time.Time,
+) errors.AutoscalerError {
+	gpuConfig := e.autoscalingContext.CloudProvider.GetNodeGpuConfig(nodeInfo.Node())
+	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
+	klog.V(0).Infof("Scale-up: setting group %s size to %d", info.Group.Id(), info.NewSize)
+	e.autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
+		"Scale-up: setting group %s size to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
+	increase := info.NewSize - info.CurrentSize
+	if err := info.Group.IncreaseSize(increase); err != nil {
+		e.autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "FailedToScaleUpGroup", "Scale-up failed for group %s: %v", info.Group.Id(), err)
+		aerr := errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to increase node group size: ")
+		e.clusterStateRegistry.RegisterFailedScaleUp(info.Group, metrics.FailedScaleUpReason(string(aerr.Type())), now)
+		return aerr
+	}
+	e.clusterStateRegistry.RegisterOrUpdateScaleUp(
+		info.Group,
+		increase,
+		time.Now())
+	metrics.RegisterScaleUp(increase, gpuResourceName, gpuType)
+	e.autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
+		"Scale-up: group %s size set to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
+	return nil
+}
+
+func combineConcurrentScaleUpErrors(errs []errors.AutoscalerError) errors.AutoscalerError {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	// sort to stabilize the results and easier log aggregation
+	sort.Slice(errs, func(i, j int) bool {
+		errA := errs[i]
+		errB := errs[j]
+		if errA.Type() == errB.Type() {
+			return errs[i].Error() < errs[j].Error()
+		}
+		return errA.Type() < errB.Type()
+	})
+	firstErrMsg := errs[0].Error()
+	firstErrType := errs[0].Type()
+	singleError := true
+	singleType := true
+	for _, err := range errs {
+		singleType = singleType && firstErrType == err.Type()
+		singleError = singleError && singleType && firstErrMsg == err.Error()
+	}
+	if singleError {
+		return errs[0]
+	}
+	var builder strings.Builder
+	builder.WriteString(firstErrMsg)
+	builder.WriteString(" ...other concurrent errors: [")
+	concurrentErrs := make(map[string]bool)
+	for _, err := range errs {
+		var concurrentErr string
+		if singleType {
+			concurrentErr = err.Error()
+		} else {
+			concurrentErr = fmt.Sprintf("[%s] %s", err.Type(), err.Error())
+		}
+		n := len(concurrentErrs)
+		if !concurrentErrs[concurrentErr] && n > 0 {
+			if n > 1 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(fmt.Sprintf("%q", concurrentErr))
+		}
+		concurrentErrs[concurrentErr] = true
+	}
+	builder.WriteString("]")
+	return errors.NewAutoscalerError(firstErrType, builder.String())
+}
+
+// Asserts all groups are scaled only once.
+// Scaling one group multiple times concurrently may cause problems.
+func assertUniqueNodeGroups(scaleUpInfos []nodegroupset.ScaleUpInfo) errors.AutoscalerError {
+	uniqueGroups := make(map[string]bool)
+	for _, info := range scaleUpInfos {
+		if uniqueGroups[info.Group.Id()] {
+			return errors.NewAutoscalerError(
+				errors.InternalError,
+				"assertion failure: detected group double scaling: %s", info.Group.Id(),
+			)
+		}
+		uniqueGroups[info.Group.Id()] = true
+	}
+	return nil
+}
+
+func extractNodeGroups(scaleUpInfos []nodegroupset.ScaleUpInfo) []cloudprovider.NodeGroup {
+	groups := make([]cloudprovider.NodeGroup, len(scaleUpInfos))
+	for i, info := range scaleUpInfos {
+		groups[i] = info.Group
+	}
+	return groups
+}

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor_test.go
@@ -19,9 +19,9 @@ package orchestrator
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
@@ -58,7 +58,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.CloudProviderError,
-				"provider error ...other concurrent errors: [\"[internalError] internal error\"]",
+				"provider error ...and other concurrent errors: [\"[internalError] internal error\"]",
 			),
 		},
 		{
@@ -69,7 +69,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.CloudProviderError,
-				"provider error ...other concurrent errors: [\"[internalError] internal error\"]",
+				"provider error ...and other concurrent errors: [\"[internalError] internal error\"]",
 			),
 		},
 		{
@@ -81,7 +81,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.InternalError,
-				"A ...other concurrent errors: [\"B\", \"C\"]"),
+				"A ...and other concurrent errors: [\"B\", \"C\"]"),
 		},
 		{
 			desc: "errors with the same type and some duplicated messages",
@@ -92,7 +92,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.InternalError,
-				"A ...other concurrent errors: [\"B\"]"),
+				"A ...and other concurrent errors: [\"B\"]"),
 		},
 		{
 			desc: "some duplicated errors",
@@ -104,7 +104,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.CloudProviderError,
-				"A ...other concurrent errors: [\"[cloudProviderError] B\", \"[internalError] A\"]"),
+				"A ...and other concurrent errors: [\"[cloudProviderError] B\", \"[internalError] A\"]"),
 		},
 		{
 			desc: "different errors with quotes in messages",
@@ -114,7 +114,7 @@ func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
 			},
 			expectedErr: errors.NewAutoscalerError(
 				errors.InternalError,
-				"\"first\" ...other concurrent errors: [\"\\\"second\\\"\"]"),
+				"\"first\" ...and other concurrent errors: [\"\\\"second\\\"\"]"),
 		},
 	}
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+func TestCombinedConcurrentScaleUpErrors(t *testing.T) {
+	cloudProviderErr := errors.NewAutoscalerError(errors.CloudProviderError, "provider error")
+	internalErr := errors.NewAutoscalerError(errors.InternalError, "internal error")
+	testCases := []struct {
+		desc        string
+		errors      []errors.AutoscalerError
+		expectedErr errors.AutoscalerError
+	}{
+		{
+			desc:        "no errors",
+			errors:      []errors.AutoscalerError{},
+			expectedErr: nil,
+		},
+		{
+			desc:        "single error",
+			errors:      []errors.AutoscalerError{internalErr},
+			expectedErr: internalErr,
+		},
+		{
+			desc: "two duplicated errors",
+			errors: []errors.AutoscalerError{
+				internalErr,
+				internalErr,
+			},
+			expectedErr: internalErr,
+		},
+		{
+			desc: "two different errors",
+			errors: []errors.AutoscalerError{
+				cloudProviderErr,
+				internalErr,
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.CloudProviderError,
+				"provider error ...other concurrent errors: [\"[internalError] internal error\"]",
+			),
+		},
+		{
+			desc: "two different errors - reverse alphabetical order",
+			errors: []errors.AutoscalerError{
+				internalErr,
+				cloudProviderErr,
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.CloudProviderError,
+				"provider error ...other concurrent errors: [\"[internalError] internal error\"]",
+			),
+		},
+		{
+			desc: "errors with the same type and different messages",
+			errors: []errors.AutoscalerError{
+				errors.NewAutoscalerError(errors.InternalError, "A"),
+				errors.NewAutoscalerError(errors.InternalError, "B"),
+				errors.NewAutoscalerError(errors.InternalError, "C"),
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.InternalError,
+				"A ...other concurrent errors: [\"B\", \"C\"]"),
+		},
+		{
+			desc: "errors with the same type and some duplicated messages",
+			errors: []errors.AutoscalerError{
+				errors.NewAutoscalerError(errors.InternalError, "A"),
+				errors.NewAutoscalerError(errors.InternalError, "B"),
+				errors.NewAutoscalerError(errors.InternalError, "A"),
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.InternalError,
+				"A ...other concurrent errors: [\"B\"]"),
+		},
+		{
+			desc: "some duplicated errors",
+			errors: []errors.AutoscalerError{
+				errors.NewAutoscalerError(errors.CloudProviderError, "A"),
+				errors.NewAutoscalerError(errors.CloudProviderError, "A"),
+				errors.NewAutoscalerError(errors.CloudProviderError, "B"),
+				errors.NewAutoscalerError(errors.InternalError, "A"),
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.CloudProviderError,
+				"A ...other concurrent errors: [\"[cloudProviderError] B\", \"[internalError] A\"]"),
+		},
+		{
+			desc: "different errors with quotes in messages",
+			errors: []errors.AutoscalerError{
+				errors.NewAutoscalerError(errors.InternalError, "\"first\""),
+				errors.NewAutoscalerError(errors.InternalError, "\"second\""),
+			},
+			expectedErr: errors.NewAutoscalerError(
+				errors.InternalError,
+				"\"first\" ...other concurrent errors: [\"\\\"second\\\"\"]"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			combinedErr := combineConcurrentScaleUpErrors(testCase.errors)
+			assert.Equal(t, testCase.expectedErr, combinedErr)
+		})
+	}
+}

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -57,10 +57,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_record "k8s.io/client-go/tools/record"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 )
 
 // NodeConfig is a node config used in tests
@@ -100,6 +101,32 @@ type ScaleTestConfig struct {
 
 	ExpectedScaleDowns     []string
 	ExpectedScaleDownCount int
+}
+
+// NodeGroupConfig is a node group config used in tests
+type NodeGroupConfig struct {
+	Name    string
+	MinSize int
+	MaxSize int
+}
+
+// GroupsScaleUpTestConfig represents a config of a scale test
+type GroupsScaleUpTestConfig struct {
+	Groups    []NodeGroupConfig
+	Nodes     []NodeConfig
+	Pods      []PodConfig
+	ExtraPods []PodConfig
+	OnScaleUp testcloudprovider.OnScaleUpFunc
+	Options   *config.AutoscalingOptions
+}
+
+// GroupsScaleUpTestResult represents a node groups scale up result
+type GroupsScaleUpTestResult struct {
+	Error            errors.AutoscalerError
+	ScaleUpStatus    ScaleUpStatusInfo
+	GroupSizeChanges []GroupSizeChange
+	Events           []string
+	TargetSizes      map[string]int
 }
 
 // ScaleTestResults contains results of a scale test

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -22,10 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
-	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testcloudprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
@@ -33,7 +29,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
+	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
@@ -50,18 +49,17 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
 
 	"github.com/stretchr/testify/assert"
-
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	kube_client "k8s.io/client-go/kubernetes"
 	kube_record "k8s.io/client-go/tools/record"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-
-	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 )
 
 // NodeConfig is a node config used in tests
@@ -110,28 +108,31 @@ type NodeGroupConfig struct {
 	MaxSize int
 }
 
-// GroupsScaleUpTestConfig represents a config of a scale test
-type GroupsScaleUpTestConfig struct {
-	Groups    []NodeGroupConfig
-	Nodes     []NodeConfig
-	Pods      []PodConfig
-	ExtraPods []PodConfig
-	OnScaleUp testcloudprovider.OnScaleUpFunc
-	Options   *config.AutoscalingOptions
+// ScaleUpTestConfig represents a config of a scale test
+type ScaleUpTestConfig struct {
+	Groups                  []NodeGroupConfig
+	Nodes                   []NodeConfig
+	Pods                    []PodConfig
+	ExtraPods               []PodConfig
+	OnScaleUp               testcloudprovider.OnScaleUpFunc
+	ExpansionOptionToChoose *GroupSizeChange
+	Options                 *config.AutoscalingOptions
 }
 
-// GroupsScaleUpTestResult represents a node groups scale up result
-type GroupsScaleUpTestResult struct {
-	Error            errors.AutoscalerError
+// ScaleUpTestResult represents a node groups scale up result
+type ScaleUpTestResult struct {
+	ScaleUpError     errors.AutoscalerError
 	ScaleUpStatus    ScaleUpStatusInfo
 	GroupSizeChanges []GroupSizeChange
+	ExpansionOptions []GroupSizeChange
 	Events           []string
-	TargetSizes      map[string]int
+	GroupTargetSizes map[string]int
 }
 
 // ScaleTestResults contains results of a scale test
 type ScaleTestResults struct {
 	ExpansionOptions []GroupSizeChange
+	GroupTargetSizes map[string]int
 	FinalOption      GroupSizeChange
 	NoScaleUpReason  string
 	FinalScaleDowns  []string
@@ -186,7 +187,8 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 func NewScaleTestAutoscalingContext(
 	options config.AutoscalingOptions, fakeClient kube_client.Interface,
 	listers kube_util.ListerRegistry, provider cloudprovider.CloudProvider,
-	processorCallbacks processor_callbacks.ProcessorCallbacks, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter) (context.AutoscalingContext, error) {
+	processorCallbacks processor_callbacks.ProcessorCallbacks, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter,
+) (context.AutoscalingContext, error) {
 	// Not enough buffer space causes the test to hang without printing any logs.
 	// This is not useful.
 	fakeRecorder := kube_record.NewFakeRecorder(100)
@@ -306,8 +308,8 @@ type MockAutoprovisioningNodeGroupListProcessor struct {
 
 // Process extends the list of node groups
 func (p *MockAutoprovisioningNodeGroupListProcessor) Process(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup, nodeInfos map[string]*schedulerframework.NodeInfo,
-	unschedulablePods []*apiv1.Pod) ([]cloudprovider.NodeGroup, map[string]*schedulerframework.NodeInfo, error) {
-
+	unschedulablePods []*apiv1.Pod,
+) ([]cloudprovider.NodeGroup, map[string]*schedulerframework.NodeInfo, error) {
 	machines, err := context.CloudProvider.GetAvailableMachineTypes()
 	assert.NoError(p.T, err)
 
@@ -331,4 +333,68 @@ func (p *MockAutoprovisioningNodeGroupListProcessor) CleanUp() {
 func NewBackoff() backoff.Backoff {
 	return backoff.NewIdBasedExponentialBackoff(5*time.Minute, /*InitialNodeGroupBackoffDuration*/
 		30*time.Minute /*MaxNodeGroupBackoffDuration*/, 3*time.Hour /*NodeGroupBackoffResetTimeout*/)
+}
+
+// To implement expander.Strategy, BestOption method must have a struct receiver.
+// This prevents it from modifying fields of reportingStrategy, so we need a thin
+// pointer wrapper for mutable parts.
+type expanderResults struct {
+	inputOptions []GroupSizeChange
+}
+
+// MockReportingStrategy implements expander.Strategy
+type MockReportingStrategy struct {
+	defaultStrategy expander.Strategy
+	optionToChoose  *GroupSizeChange
+	t               *testing.T
+	results         *expanderResults
+}
+
+// NewMockRepotingStrategy creates an expander strategy with reporting and mocking capabilities.
+func NewMockRepotingStrategy(t *testing.T, optionToChoose *GroupSizeChange) *MockReportingStrategy {
+	return &MockReportingStrategy{
+		defaultStrategy: random.NewStrategy(),
+		results:         &expanderResults{},
+		optionToChoose:  optionToChoose,
+		t:               t,
+	}
+}
+
+// LastInputOptions provides access to expansion options passed as an input in recent strategy execution
+func (r *MockReportingStrategy) LastInputOptions() []GroupSizeChange {
+	return r.results.inputOptions
+}
+
+// BestOption satisfies the Strategy interface. Picks the best option from those passed as an argument.
+// When parameter optionToChoose is defined, it's picked as the best one.
+// Otherwise, random option is used.
+func (r *MockReportingStrategy) BestOption(options []expander.Option, nodeInfo map[string]*schedulerframework.NodeInfo) *expander.Option {
+	r.results.inputOptions = expanderOptionsToGroupSizeChanges(options)
+	if r.optionToChoose == nil {
+		return r.defaultStrategy.BestOption(options, nodeInfo)
+	}
+	for _, option := range options {
+		groupSizeChange := expanderOptionToGroupSizeChange(option)
+		if groupSizeChange == *r.optionToChoose {
+			return &option
+		}
+	}
+	assert.Fail(r.t, "did not find expansionOptionToChoose %+v", r.optionToChoose)
+	return nil
+}
+
+func expanderOptionsToGroupSizeChanges(options []expander.Option) []GroupSizeChange {
+	groupSizeChanges := make([]GroupSizeChange, 0, len(options))
+	for _, option := range options {
+		groupSizeChange := expanderOptionToGroupSizeChange(option)
+		groupSizeChanges = append(groupSizeChanges, groupSizeChange)
+	}
+	return groupSizeChanges
+}
+
+func expanderOptionToGroupSizeChange(option expander.Option) GroupSizeChange {
+	groupName := option.NodeGroup.Id()
+	groupSizeIncrement := option.NodeCount
+	scaleUpOption := GroupSizeChange{GroupName: groupName, SizeChange: groupSizeIncrement}
+	return scaleUpOption
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -148,7 +148,7 @@ var (
 	maxTotalUnreadyPercentage  = flag.Float64("max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
 	okTotalUnreadyCount        = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	scaleUpFromZero            = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
-	parallelScaleUp            = flag.Bool("parallel-scale-up", false, "Whether to allow parallel node groups scale up")
+	parallelScaleUp            = flag.Bool("parallel-scale-up", false, "Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk.")
 	maxNodeProvisionTime       = flag.Duration("max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
 	maxPodEvictionTime         = flag.Duration("max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
 	nodeGroupsFlag             = multiStringFlag(

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -147,7 +147,8 @@ var (
 	maxGracefulTerminationFlag = flag.Int("max-graceful-termination-sec", 10*60, "Maximum number of seconds CA waits for pod termination when trying to scale down a node.")
 	maxTotalUnreadyPercentage  = flag.Float64("max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
 	okTotalUnreadyCount        = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
-	scaleUpFromZero            = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there 0 ready nodes.")
+	scaleUpFromZero            = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
+	parallelScaleUp            = flag.Bool("parallel-scale-up", false, "Whether to allow parallel node groups scale up")
 	maxNodeProvisionTime       = flag.Duration("max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
 	maxPodEvictionTime         = flag.Duration("max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
 	nodeGroupsFlag             = multiStringFlag(
@@ -265,6 +266,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxTotalUnreadyPercentage:        *maxTotalUnreadyPercentage,
 		OkTotalUnreadyCount:              *okTotalUnreadyCount,
 		ScaleUpFromZero:                  *scaleUpFromZero,
+		ParallelScaleUp:                  *parallelScaleUp,
 		EstimatorName:                    *estimatorFlag,
 		ExpanderNames:                    *expanderFlag,
 		GRPCExpanderCert:                 *grpcExpanderCert,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:
This PR introduces an optional flag `--parallel-scale-up=true/false` that makes the scale-up process parallel. Thanks to this change, the scale-up action across multiple node groups is faster.

The default behavior is unchanged - node groups are scaled synchronously, one by one. 

<!--
#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Fixes #
-->

#### Special notes for your reviewer:
- *Why it's a runtime flag and not a default behavior?* It's a runtime flag because there are some CloudProviders that are not thread-safe. It may become a default in the future.
- *Why is there no new/dedicated error to combine concurrent errors?* I wanted to keep the API simple without introducing big changes. Concurrent errors are preserved in the final error message, and each of them is logged separately, so information is preserved.
- *Why are there so many changes in test files?* Scale-up tests were designed to test the scale-up process on a single node group. I had to open the mechanism for testing changes across multiple node groups simultaneously. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new "parallel-scale-up" flag, that makes the scale-up process run parallel across multiple node groups. The default behavior is unchanged, node groups are scaled synchronously, one by one. Before using the flag make sure that the cloud provider you're using is thread-safe and ready for concurrent actions. 
```

/assign @x13n 