### PR TITLE
Switch to docker buildx for cross-platform builds

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker build --pull -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker build --pull -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker build --pull -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
Switch to `docker buildx --platform` for building cross-platform images, such that the `Architecture` metadata is correctly set in the image manifest.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5667

#### Special notes for your reviewer:
Tested this change by running
` ALL_ARCHITECTURES="amd64 arm64" REGISTRY=voelzmo TAG=v0.99.0-dev make release`

inspected the image with 
`docker image inspect voelzmo/vpa-admission-controller-amd64:v0.99.0-dev` and `docker image inspect voelzmo/vpa-admission-controller-arm64:v0.99.0-dev`

and saw that the `Architecture` metadata in the manifest was `amd64` and `arm64`, respectively.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA images are now built using `docker buildx` to correctly set the `Architecture` metadata in the image manifest.
```

