### PR TITLE
fix: empty status configmap leads to nil ptr error

### DIFF
--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -91,6 +91,9 @@ func WriteStatusConfigMap(kubeClient kube_client.Interface, namespace string, ms
 	maps := kubeClient.CoreV1().ConfigMaps(namespace)
 	configMap, getStatusError = maps.Get(context.TODO(), statusConfigMapName, metav1.GetOptions{})
 	if getStatusError == nil {
+		if configMap.Data == nil {
+			configMap.Data = make(map[string]string)
+		}
 		configMap.Data["status"] = statusMsg
 		if configMap.ObjectMeta.Annotations == nil {
 			configMap.ObjectMeta.Annotations = make(map[string]string)

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -95,6 +95,17 @@ func TestWriteStatusConfigMapExisting(t *testing.T) {
 	assert.True(t, ti.getCalled)
 	assert.True(t, ti.updateCalled)
 	assert.False(t, ti.createCalled)
+
+	// to test the case where configmap is empty
+	ti.configMap.Data = nil
+	result, err = WriteStatusConfigMap(ti.client, ti.namespace, "TEST_MSG", nil, "my-cool-configmap")
+	assert.Equal(t, ti.configMap, result)
+	assert.Contains(t, result.Data["status"], "TEST_MSG")
+	assert.Contains(t, result.ObjectMeta.Annotations, ConfigMapLastUpdatedKey)
+	assert.Nil(t, err)
+	assert.True(t, ti.getCalled)
+	assert.True(t, ti.updateCalled)
+	assert.False(t, ti.createCalled)
 }
 
 func TestWriteStatusConfigMapCreate(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fix nil pointer error if the status configmap is empty #5704.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5704 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
