### PR TITLE
Azure: Bugfix: Check PowerState before setting OutOfResources on instance 

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -35,6 +35,18 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
+// PowerStates reflect the operational state of a VM
+// From https://learn.microsoft.com/en-us/java/api/com.microsoft.azure.management.compute.powerstate?view=azure-java-stable
+const (
+	PowerStateStarting     = "PowerState/starting"
+	PowerStateRunning      = "PowerState/running"
+	PowerStateStopping     = "PowerState/stopping"
+	PowerStateStopped      = "PowerState/stopped"
+	PowerStateDeallocating = "PowerState/deallocating"
+	PowerStateDeallocated  = "PowerState/deallocated"
+	PowerStateUnknown      = "PowerState/unknown"
+)
+
 var (
 	defaultVmssInstancesRefreshPeriod = 5 * time.Minute
 	vmssContextTimeout                = 3 * time.Minute
@@ -295,7 +307,7 @@ func (scaleSet *ScaleSet) GetScaleSetVms() ([]compute.VirtualMachineScaleSetVM, 
 	defer cancel()
 
 	resourceGroup := scaleSet.manager.config.ResourceGroup
-	vmList, rerr := scaleSet.manager.azClient.virtualMachineScaleSetVMsClient.List(ctx, resourceGroup, scaleSet.Name, "")
+	vmList, rerr := scaleSet.manager.azClient.virtualMachineScaleSetVMsClient.List(ctx, resourceGroup, scaleSet.Name, "instanceView")
 	klog.V(4).Infof("GetScaleSetVms: scaleSet.Name: %s, vmList: %v", scaleSet.Name, vmList)
 	if rerr != nil {
 		klog.Errorf("VirtualMachineScaleSetVMsClient.List failed for %s: %v", scaleSet.Name, rerr)
@@ -612,18 +624,26 @@ func buildInstanceCache(vmList interface{}) []cloudprovider.Instance {
 	switch vms := vmList.(type) {
 	case []compute.VirtualMachineScaleSetVM:
 		for _, vm := range vms {
-			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState)
+			powerState := PowerStateRunning
+			if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
+				powerState = powerStateFromStatuses(*vm.InstanceView.Statuses)
+			}
+			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState, powerState)
 		}
 	case []compute.VirtualMachine:
 		for _, vm := range vms {
-			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState)
+			powerState := PowerStateRunning
+			if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
+				powerState = powerStateFromStatuses(*vm.InstanceView.Statuses)
+			}
+			addInstanceToCache(&instances, vm.ID, vm.ProvisioningState, powerState)
 		}
 	}
 
 	return instances
 }
 
-func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisioningState *string) {
+func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisioningState *string, powerState string) {
 	// The resource ID is empty string, which indicates the instance may be in deleting state.
 	if len(*id) == 0 {
 		return
@@ -638,7 +658,7 @@ func addInstanceToCache(instances *[]cloudprovider.Instance, id *string, provisi
 
 	*instances = append(*instances, cloudprovider.Instance{
 		Id:     "azure://" + resourceID,
-		Status: instanceStatusFromProvisioningState(provisioningState),
+		Status: instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, powerState),
 	})
 }
 
@@ -665,13 +685,13 @@ func (scaleSet *ScaleSet) setInstanceStatusByProviderID(providerID string, statu
 	scaleSet.lastInstanceRefresh = time.Now()
 }
 
-// instanceStatusFromProvisioningState converts the VM provisioning state to cloudprovider.InstanceStatus
-func instanceStatusFromProvisioningState(provisioningState *string) *cloudprovider.InstanceStatus {
+// instanceStatusFromProvisioningStateAndPowerState converts the VM provisioning state and power state to cloudprovider.InstanceStatus
+func instanceStatusFromProvisioningStateAndPowerState(resourceId string, provisioningState *string, powerState string) *cloudprovider.InstanceStatus {
 	if provisioningState == nil {
 		return nil
 	}
 
-	klog.V(5).Infof("Getting vm instance provisioning state %s", *provisioningState)
+	klog.V(5).Infof("Getting vm instance provisioning state %s for %s", *provisioningState, resourceId)
 
 	status := &cloudprovider.InstanceStatus{}
 	switch *provisioningState {
@@ -680,17 +700,57 @@ func instanceStatusFromProvisioningState(provisioningState *string) *cloudprovid
 	case string(compute.ProvisioningStateCreating):
 		status.State = cloudprovider.InstanceCreating
 	case string(compute.ProvisioningStateFailed):
-		status.State = cloudprovider.InstanceCreating
-		status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
-			ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
-			ErrorCode:    "provisioning-state-failed",
-			ErrorMessage: "Azure failed to provision a node for this node group",
+		// Provisioning can fail both during instance creation or after the instance is running.
+		// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
+		// ProvisioningState represents the most recent provisioning state, therefore only report
+		// InstanceCreating errors when the power state indicates the instance has not yet started running
+		if !isRunningPowerState(powerState) {
+			klog.V(4).Infof("VM %s reports failed provisioning state with non-running power state: %s", resourceId, powerState)
+			status.State = cloudprovider.InstanceCreating
+			status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+				ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+				ErrorCode:    "provisioning-state-failed",
+				ErrorMessage: "Azure failed to provision a node for this node group",
+			}
+		} else {
+			klog.V(5).Infof("VM %s reports a failed provisioning state but is running (%s)", resourceId, powerState)
+			status.State = cloudprovider.InstanceRunning
 		}
 	default:
 		status.State = cloudprovider.InstanceRunning
 	}
 
 	return status
+}
+
+func powerStateFromStatuses(statuses []compute.InstanceViewStatus) string {
+	for _, status := range statuses {
+		if status.Code == nil || !isKnownPowerState(*status.Code) {
+			continue
+		}
+		return *status.Code
+	}
+
+	// PowerState is not set if the VM is still creating (or has failed creation),
+	// so the absence of a PowerState is treated the same as a VM that is stopped
+	return PowerStateStopped
+}
+
+func isRunningPowerState(powerState string) bool {
+	return powerState == PowerStateRunning || powerState == PowerStateStarting
+}
+
+func isKnownPowerState(powerState string) bool {
+	knownPowerStates := map[string]bool{
+		PowerStateStarting:     true,
+		PowerStateRunning:      true,
+		PowerStateStopping:     true,
+		PowerStateStopped:      true,
+		PowerStateDeallocating: true,
+		PowerStateDeallocated:  true,
+		PowerStateUnknown:      true,
+	}
+	return knownPowerStates[powerState]
 }
 
 func (scaleSet *ScaleSet) invalidateInstanceCache() {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -226,45 +226,77 @@ func TestIncreaseSize(t *testing.T) {
 }
 
 func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	testCases := map[string]struct {
+		expectInstanceRunning bool
+		isMissingInstanceView bool
+		statuses              []compute.InstanceViewStatus
+	}{
+		"out of resources when no power state exists": {},
+		"out of resources when VM is stopped": {
+			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateStopped)}},
+		},
+		"out of resources when VM reports unknown power state": {
+			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr("PowerState/invalid")}},
+		},
+		"instance running when power state is running": {
+			expectInstanceRunning: true,
+			statuses:              []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateRunning)}},
+		},
+		"instance running if instance view cannot be retrieved": {
+			expectInstanceRunning: true,
+			isMissingInstanceView: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-	manager := newTestAzureManager(t)
-	vmssName := "vmss-failed-upscale"
+			manager := newTestAzureManager(t)
+			vmssName := "vmss-failed-upscale"
 
-	expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus", compute.Uniform)
-	expectedVMSSVMs := newTestVMSSVMList(3)
-	expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateFailed))
+			expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus", compute.Uniform)
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			expectedVMSSVMs[2].ProvisioningState = to.StringPtr(string(compute.ProvisioningStateFailed))
+			if !testCase.isMissingInstanceView {
+				expectedVMSSVMs[2].InstanceView = &compute.VirtualMachineScaleSetVMInstanceView{Statuses: &testCase.statuses}
+			}
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
-	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
-	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
-	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
-	manager.explicitlyConfigured["vmss-failed-upscale"] = true
-	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
-	assert.True(t, registered)
-	manager.Refresh()
+			mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
+			mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
+			mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+			manager.explicitlyConfigured["vmss-failed-upscale"] = true
+			registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
+			assert.True(t, registered)
+			manager.Refresh()
 
-	provider, err := BuildAzureCloudProvider(manager, nil)
-	assert.NoError(t, err)
+			provider, err := BuildAzureCloudProvider(manager, nil)
+			assert.NoError(t, err)
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
-	assert.True(t, ok)
+			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
 
-	// Increase size by one, but the new node fails provisioning
-	err = scaleSet.IncreaseSize(1)
-	assert.NoError(t, err)
+			// Increase size by one, but the new node fails provisioning
+			err = scaleSet.IncreaseSize(1)
+			assert.NoError(t, err)
 
-	nodes, err := scaleSet.Nodes()
-	assert.NoError(t, err)
+			nodes, err := scaleSet.Nodes()
+			assert.NoError(t, err)
 
-	assert.Equal(t, 3, len(nodes))
-	assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
-	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, nodes[2].Status.ErrorInfo.ErrorClass)
+			assert.Equal(t, 3, len(nodes))
+			if testCase.expectInstanceRunning {
+				assert.Equal(t, cloudprovider.InstanceRunning, nodes[2].Status.State)
+			} else {
+				assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
+				assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, nodes[2].Status.ErrorInfo.ErrorClass)
+			}
+		})
+	}
 }
 
 func TestIncreaseSizeOnVMSSUpdating(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -233,14 +233,14 @@ func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 	}{
 		"out of resources when no power state exists": {},
 		"out of resources when VM is stopped": {
-			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateStopped)}},
+			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr(vmPowerStateStopped)}},
 		},
-		"out of resources when VM reports unknown power state": {
+		"out of resources when VM reports invalid power state": {
 			statuses: []compute.InstanceViewStatus{{Code: to.StringPtr("PowerState/invalid")}},
 		},
 		"instance running when power state is running": {
 			expectInstanceRunning: true,
-			statuses:              []compute.InstanceViewStatus{{Code: to.StringPtr(PowerStateRunning)}},
+			statuses:              []compute.InstanceViewStatus{{Code: to.StringPtr(vmPowerStateRunning)}},
 		},
 		"instance running if instance view cannot be retrieved": {
 			expectInstanceRunning: true,

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -82,6 +82,16 @@ const (
 	nodeTaintTagName     = "k8s.io_cluster-autoscaler_node-template_taint_"
 	nodeResourcesTagName = "k8s.io_cluster-autoscaler_node-template_resources_"
 	nodeOptionsTagName   = "k8s.io_cluster-autoscaler_node-template_autoscaling-options_"
+
+	// PowerStates reflect the operational state of a VM
+	// From https://learn.microsoft.com/en-us/java/api/com.microsoft.azure.management.compute.powerstate?view=azure-java-stable
+	vmPowerStateStarting     = "PowerState/starting"
+	vmPowerStateRunning      = "PowerState/running"
+	vmPowerStateStopping     = "PowerState/stopping"
+	vmPowerStateStopped      = "PowerState/stopped"
+	vmPowerStateDeallocating = "PowerState/deallocating"
+	vmPowerStateDeallocated  = "PowerState/deallocated"
+	vmPowerStateUnknown      = "PowerState/unknown"
 )
 
 var (
@@ -607,4 +617,33 @@ func isAzureRequestsThrottled(rerr *retry.Error) bool {
 	}
 
 	return rerr.HTTPStatusCode == http.StatusTooManyRequests
+}
+
+func isRunningVmPowerState(powerState string) bool {
+	return powerState == vmPowerStateRunning || powerState == vmPowerStateStarting
+}
+
+func isKnownVmPowerState(powerState string) bool {
+	knownPowerStates := map[string]bool{
+		vmPowerStateStarting:     true,
+		vmPowerStateRunning:      true,
+		vmPowerStateStopping:     true,
+		vmPowerStateStopped:      true,
+		vmPowerStateDeallocating: true,
+		vmPowerStateDeallocated:  true,
+		vmPowerStateUnknown:      true,
+	}
+	return knownPowerStates[powerState]
+}
+
+func vmPowerStateFromStatuses(statuses []compute.InstanceViewStatus) string {
+	for _, status := range statuses {
+		if status.Code == nil || !isKnownVmPowerState(*status.Code) {
+			continue
+		}
+		return *status.Code
+	}
+
+	// PowerState is not set if the VM is still creating (or has failed creation)
+	return vmPowerStateUnknown
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In https://github.com/kubernetes/autoscaler/pull/5548, I had added support for faster backoff on a failed provisioning state. We recently found a bug where a many simultaneous updates to the network profiles of a running VMs in a VMSS could sometimes fail with a `ProvisioningState/failed/NetworkingInternalOperationError` error. This would be reflected in the `vm.ProvisioningState` (which represents the status of the _last_ provisioning operation on the VM), and would result in the VMSS size being decreased and the running VM instance being removed without first properly draining the running pods on the node.

This PR adds behavior to also consider the PowerState of the VM when determining if an OutOfResources error should be created -- it now only sets the OutOfResource error if the provisioning state is failed _AND_ the instance is not running. I extended the test case I added in #5548 with several more configurations to ensure the power state behavior should be correct.

##### Reproduction with Fix

I was able to reproduce the issue and captured a situation where one of the existing VMs in a VMSS was running and got updated to a ProvisioningFailed state at the same time as a ProvisioningFailure on a newly created VM. The existing VM is reported as `cloudprovider.InstanceRunning` but the new instance triggers the provisioning failure codepath that produces an `OutOfResources` error.

```
"2023-05-17T19:43:47.151Z","Disabling scale-up for node group <vmss> until 2023-05-17 19:48:46.903222688 +0000 UTC m=+6595.425006719; errorClass=OutOfResource; errorCode=provisioning-state-failed"
...
"2023-05-17T19:43:47.135Z","VM /subscriptions/<subscription>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/1397 reports failed provisioning state with non-running power state: PowerState/stopped"
"2023-05-17T19:43:47.135Z","Getting vm instance provisioning state Failed for /subscriptions/<subscription>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/1397"
"2023-05-17T19:43:47.135Z","Getting vm instance provisioning state Succeeded for /subscriptions/<subscription>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/1390"
...
"2023-05-17T19:43:47.135Z","VM /subscriptions/<subscription>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/1330 reports a failed provisioning state but is running (PowerState/running)"
"2023-05-17T19:43:47.135Z","Getting vm instance provisioning state Failed for /subscriptions/<subscription>/resourceGroups/<resourceGroup>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/1330"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### expand: "instanceView"

Setting the `expand` field of `.virtualMachineScaleSetVMsClient.List` to `"instanceView"` is required to retrieve the PowerState for the VMs. It looks like eventually using `instanceView` [was referenced a few years ago](https://github.com/kubernetes/autoscaler/pull/3141#discussion_r427830194) when the provisioning state logic was first introduced. I've been running a build of the CA with this fix (and `expand=instanceView`) in some of our larger Azure clusters (1k nodes) without issue for over a week, and the net number of API calls the CA makes has not increased.

If there's some hesitancy towards setting `expand=instanceView` by default, it's probably something that could be configured via an environment variable flag (and would probably act as a pseudo-feature-gate for the fast backoff, as `PowerState` is assumed to be `PowerState/running` if the `vm.InstanceView == nil`, so in the event of a provisioning failure we'd always still report `cloudprovider.InstanceRunning`, which was the behavior before #5548) -- I'm open to exploring this if it's preferred!

##### PowerState

The azure-sdk-for-go does not directly expose the enumerations for the PowerState, even though there are official values for these in other languages like [Java](https://learn.microsoft.com/en-us/java/api/com.microsoft.azure.management.compute.powerstate?view=azure-java-stable). I saw the legacy Azure cloud provider also had logic to parse the [power state from an instanceView.Statuses,](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/azure_instances.go#L39) so I largely based this fix on that.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
