### PR TITLE
[Cluster-Autoscaler] Change magnum to use control-plane role

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -124,6 +124,10 @@ func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; found {
 		return nil, nil
 	}
+	// Ignore control-plane nodes
+	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/control-plane"]; found {
+		return nil, nil
+	}
 
 	ngUUID, err := mcp.magnumManager.nodeGroupForNode(node)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Magnum still tries to fetch nodes that have the master node role, but since the role is now called control-plane, it cannot find the nodegroup for those nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5751

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
