### PR TITLE
Bump golang version & release tag

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -22,12 +22,12 @@ ARCH ?= amd64
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 GOARM=7
-GOLANG_VERSION = 1.20.3
+GOLANG_VERSION = 1.20.4
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.18
+TAG = 1.8.19
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Bumps Golang version to `1.20.4` & pump release tag to `1.8.19`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
 - [GO-2023-1751](https://pkg.go.dev/vuln/GO-2023-1751)
 - [GO-2023-1752](https://pkg.go.dev/vuln/GO-2023-1752)
 - [GO-2023-1753](https://pkg.go.dev/vuln/GO-2023-1753)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
 NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

