### PR TITLE
Addition of BinpackingLimiter interface

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -141,7 +141,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(nodeGroups, nodeInfos, resourcesLeft, now)
 
 	// Mark skipped node groups as processed.
-	for nodegroupID, _ := range skippedNodeGroups {
+	for nodegroupID := range skippedNodeGroups {
 		processedNodeGroups[nodegroupID] = true
 	}
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -805,6 +805,69 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	assert.False(t, scaleUpStatus.WasSuccessful())
 }
 
+func TestBinpackingLimiter(t *testing.T) {
+	n1 := BuildTestNode("n1", 1000, 1000)
+	n2 := BuildTestNode("n2", 100000, 100000)
+	now := time.Now()
+
+	SetNodeReadyState(n1, true, now.Add(-2*time.Minute))
+	SetNodeReadyState(n2, true, now.Add(-2*time.Minute))
+
+	nodes := []*apiv1.Node{n1, n2}
+
+	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
+	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
+
+	provider := testprovider.NewTestCloudProvider(func(nodeGroup string, increase int) error {
+		return nil
+	}, nil)
+
+	options := defaultOptions
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider.AddNode("ng1", n1)
+	provider.AddNodeGroup("ng2", 1, 10, 1)
+	provider.AddNode("ng2", n2)
+	assert.NotNil(t, provider)
+
+	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
+	assert.NoError(t, err)
+
+	nodeInfos, err := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).
+		Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	assert.NoError(t, err)
+
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), clusterstate.NewStaticMaxNodeProvisionTimeProvider(15*time.Minute))
+	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+
+	extraPod := BuildTestPod("p-new", 500, 0)
+
+	processors := NewTestProcessors(&context)
+
+	// We should stop binpacking after finding expansion option from first node.
+	// It is because we know that extra pod (requiring 500 cpu) is a good fit on
+	// node1. The pod can also be scheduled on node n2 but it's not a good fit.
+	// Hence we can use heuristics with BinpackingLimiter to stop binpacking early
+	// to save time on computation.
+	processors.BinpackingLimiter = &MockBinpackingLimiter{}
+	processors.BinpackingLimiter.InitBinpacking(&context, []cloudprovider.NodeGroup{})
+
+	suOrchestrator := New()
+	suOrchestrator.Initialize(&context, processors, clusterState, taints.TaintConfig{})
+
+	expander := NewMockRepotingStrategy(t, &GroupSizeChange{GroupName: "ng1", SizeChange: 1})
+	context.ExpanderStrategy = expander
+
+	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{extraPod}, nodes, []*appsv1.DaemonSet{}, nodeInfos)
+	processors.ScaleUpStatusProcessor.Process(&context, scaleUpStatus)
+	assert.NoError(t, err)
+	assert.True(t, scaleUpStatus.WasSuccessful())
+
+	expansionOptions := expander.LastInputOptions()
+	// Only 1 expansion option should be there. Without BinpackingLimiter there will be 2.
+	assert.True(t, len(expansionOptions) == 1)
+	assert.Equal(t, expansionOptions, []GroupSizeChange{{GroupName: "ng1", SizeChange: 1}})
+}
+
 func TestScaleUpNoHelp(t *testing.T) {
 	n1 := BuildTestNode("n1", 100, 1000)
 	now := time.Now()

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -843,13 +843,8 @@ func TestBinpackingLimiter(t *testing.T) {
 
 	processors := NewTestProcessors(&context)
 
-	// We should stop binpacking after finding expansion option from first node.
-	// It is because we know that extra pod (requiring 500 cpu) is a good fit on
-	// node1. The pod can also be scheduled on node n2 but it's not a good fit.
-	// Hence we can use heuristics with BinpackingLimiter to stop binpacking early
-	// to save time on computation.
+	// We should stop binpacking after finding expansion option from first node group.
 	processors.BinpackingLimiter = &MockBinpackingLimiter{}
-	processors.BinpackingLimiter.InitBinpacking(&context, []cloudprovider.NodeGroup{})
 
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&context, processors, clusterState, taints.TaintConfig{})

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -334,7 +334,6 @@ func (p *MockAutoprovisioningNodeGroupListProcessor) CleanUp() {
 // MockBinpackingLimiter is a fake BinpackingLimiter to be used in tests.
 type MockBinpackingLimiter struct {
 	requiredExpansionOptions int
-	T                        *testing.T
 }
 
 // InitBinpacking initialises the MockBinpackingLimiter and sets requiredExpansionOptions to 1.

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -342,8 +342,13 @@ func (p *MockBinpackingLimiter) InitBinpacking(context *context.AutoscalingConte
 }
 
 // StopBinpacking stops the binpacking early, if we already have requiredExpansionOptions i.e. 1.
-func (p *MockBinpackingLimiter) StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option, usedNodeGroups map[string]bool) bool {
+func (p *MockBinpackingLimiter) StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	return len(evaluatedOptions) == p.requiredExpansionOptions
+}
+
+// MarkProcessed is here to satisfy the interface.
+func (p *MockBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
+
 }
 
 // NewBackoff creates a new backoff object

--- a/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binpacking
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+)
+
+// BinpackingLimiter processes expansion options to stop binpacking early.
+type BinpackingLimiter interface {
+	InitBinpacking(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup)
+	StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option, usedNodeGroups map[string]bool) bool
+}
+
+// NoOpBinpackingLimiter returns true without processing expansion options.
+type NoOpBinpackingLimiter struct {
+}
+
+// NewDefaultBinpackingLimiter creates an instance of NoOpBinpackingLimiter.
+func NewDefaultBinpackingLimiter() BinpackingLimiter {
+	return &NoOpBinpackingLimiter{}
+}
+
+// InitBinpacking initialises the BinpackingLimiter.
+func (p *NoOpBinpackingLimiter) InitBinpacking(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup) {
+}
+
+// StopBinpacking is used to make decsions on the evaluated expansion options.
+func (p *NoOpBinpackingLimiter) StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option, usedNodeGroups map[string]bool) bool {
+	return false
+}

--- a/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
@@ -31,7 +31,6 @@ type BinpackingLimiter interface {
 
 // NoOpBinpackingLimiter returns true without processing expansion options.
 type NoOpBinpackingLimiter struct {
-	processedNodeGroups map[string]bool
 }
 
 // NewDefaultBinpackingLimiter creates an instance of NoOpBinpackingLimiter.
@@ -41,10 +40,6 @@ func NewDefaultBinpackingLimiter() BinpackingLimiter {
 
 // InitBinpacking initialises the BinpackingLimiter.
 func (p *NoOpBinpackingLimiter) InitBinpacking(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup) {
-	p.processedNodeGroups = make(map[string]bool)
-	for _, nodegroup := range nodeGroups {
-		p.processedNodeGroups[nodegroup.Id()] = true
-	}
 }
 
 // StopBinpacking is used to make decsions on the evaluated expansion options.
@@ -54,5 +49,4 @@ func (p *NoOpBinpackingLimiter) StopBinpacking(context *context.AutoscalingConte
 
 // MarkProcessed marks the nodegroup as processed.
 func (p *NoOpBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
-	p.processedNodeGroups[nodegroupId] = true
 }

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -19,6 +19,7 @@ package processors
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/binpacking"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
@@ -38,6 +39,8 @@ type AutoscalingProcessors struct {
 	PodListProcessor pods.PodListProcessor
 	// NodeGroupListProcessor is used to process list of NodeGroups that can be used in scale-up.
 	NodeGroupListProcessor nodegroups.NodeGroupListProcessor
+	// BinpackingLimiter processes expansion options to stop binpacking early.
+	BinpackingLimiter binpacking.BinpackingLimiter
 	// NodeGroupSetProcessor is used to divide scale-up between similar NodeGroups.
 	NodeGroupSetProcessor nodegroupset.NodeGroupSetProcessor
 	// ScaleUpStatusProcessor is used to process the state of the cluster after a scale-up.

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -74,6 +74,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 	return &AutoscalingProcessors{
 		PodListProcessor:       pods.NewDefaultPodListProcessor(),
 		NodeGroupListProcessor: nodegroups.NewDefaultNodeGroupListProcessor(),
+		BinpackingLimiter:      binpacking.NewDefaultBinpackingLimiter(),
 		NodeGroupSetProcessor: nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{
 			MaxAllocatableDifferenceRatio:    config.DefaultMaxAllocatableDifferenceRatio,
 			MaxCapacityMemoryDifferenceRatio: config.DefaultMaxCapacityMemoryDifferenceRatio,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Addition of BinpackingLimiter interface.
The idea behind this is to stop computing expansion options if we have already found good enough expansion option/s.

Talking about why we need it?
Currently we iterate over all the unschedulable pods and for each pod we try to check if it could fit in that node. However, this computation can be improved if somehow we could analyse the current expansion options and stop the binpacking early.

Eg.  Suppose a cluster has 3 nodegroups as follows:
1. NG1 with 100 unit CPU and 100 unit memory.
2. NG2 with 10 unit CPU and 10 unit memory.
3. NG3 with 1000 unit CPU and 1000 unit memory.

Let's say the extra pod that we want to schedule requires 80 unit CPU and 80 unit memory.

Now we can see that the pod can easily fit on NG1 and NG3, however, the expansion option of NG1 is definitely a great fit. So, if we can stop computing expansion option after processing one nodegroup (here NG1), we can save on time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
