### PR TITLE
feat(metrics): add metrics to observe where time is consumed in scale up

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -97,6 +97,8 @@ const (
 	ScaleDownMiscOperations    FunctionLabel = "scaleDown:miscOperations"
 	ScaleDownSoftTaintUnneeded FunctionLabel = "scaleDown:softTaintUnneeded"
 	ScaleUp                    FunctionLabel = "scaleUp"
+	BuildPodEquivalenceGroups  FunctionLabel = "scaleUp:buildPodEquivalenceGroups"
+	Estimate                   FunctionLabel = "scaleUp:estimate"
 	FindUnneeded               FunctionLabel = "findUnneeded"
 	UpdateState                FunctionLabel = "updateClusterState"
 	FilterOutSchedulable       FunctionLabel = "filterOutSchedulable"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds two metrics to observe where time is consumed in scale up.

When there are more than 10000+ pending pods in cluster and these pods have a complicated scheduling constraint, CA may take a long time to execute `main` function. In our environment it takes almost 2min+. The time is consumed in:

- filtering out schedulable pods
- building equivalence pod groups
- using binpacking algorithm to estimate how many nodes needed(yes we have limiter  which may cut short binpacking but I still think it's necessary to observe the time)

https://github.com/kubernetes/autoscaler/blob/9624e7d11f1d4eaac491fbaa530f75facaab1796/cluster-autoscaler/estimator/binpacking_estimator.go#L102-L106
 
So I add a metrics to expose these.

Here is the time functions take to complete:

![709d8dda-8a45-4b87-8250-d12ecad9464f](https://github.com/kubernetes/autoscaler/assets/5654791/0ca8f647-4660-4243-90e7-d47ab2cf9138)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
