### PR TITLE
Added the RBAC Permission to Linode.

### DIFF
--- a/cluster-autoscaler/cloudprovider/linode/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/linode/examples/cluster-autoscaler-autodiscover.yaml
@@ -51,7 +51,7 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR added the missing RBAC permission in the [examples](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/linode/examples/cluster-autoscaler-autodiscover.yaml) mentioned under the Linode Cloud Provider.

#### Which issue(s) this PR fixes:

Fixes #5815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
