### PR TITLE
Add support for scaling up with ZeroToMaxNodesScaling option

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -443,7 +443,7 @@ func (tng *TestNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	id := tng.id
 	tng.targetSize -= len(nodes)
 	tng.Unlock()
-	if tng.opts != nil && tng.opts.AtomicScaling && tng.targetSize != 0 {
+	if tng.opts != nil && tng.opts.ZeroOrMaxNodeScaling && tng.targetSize != 0 {
 		return fmt.Errorf("TestNodeGroup: attempted to partially scale down a node group that should be scaled down atomically")
 	}
 	for _, node := range nodes {

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -46,8 +46,8 @@ type NodeGroupAutoscalingOptions struct {
 	ScaleDownUnreadyTime time.Duration
 	// Maximum time CA waits for node to be provisioned
 	MaxNodeProvisionTime time.Duration
-	// AtomicScaling means that all nodes should be provisioned and brought down all at once instead of one-by-one
-	AtomicScaling bool
+	// AtomicScaleUp means that a node group should be scaled up to maximum size in a scale up.
+	AtomicScaleUp bool
 }
 
 // GCEOptions contain autoscaling options specific to GCE cloud provider.

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -46,8 +46,8 @@ type NodeGroupAutoscalingOptions struct {
 	ScaleDownUnreadyTime time.Duration
 	// Maximum time CA waits for node to be provisioned
 	MaxNodeProvisionTime time.Duration
-	// AtomicScaleUp means that a node group should be scaled up to maximum size in a scale up.
-	AtomicScaleUp bool
+	// AtomicScaling means that a node group should be scaled up or down all at once instead of one-by-one
+	AtomicScaling bool
 }
 
 // GCEOptions contain autoscaling options specific to GCE cloud provider.

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -46,8 +46,8 @@ type NodeGroupAutoscalingOptions struct {
 	ScaleDownUnreadyTime time.Duration
 	// Maximum time CA waits for node to be provisioned
 	MaxNodeProvisionTime time.Duration
-	// AtomicScaling means that a node group should be scaled up or down all at once instead of one-by-one
-	AtomicScaling bool
+	// ZeroOrMaxNodeScaling means that a node group should be scaled up to maximum size or down to zero nodes all at once instead of one-by-one.
+	ZeroOrMaxNodeScaling bool
 }
 
 // GCEOptions contain autoscaling options specific to GCE cloud provider.

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -1103,7 +1103,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 func sizedNodeGroup(id string, size int, atomic bool) cloudprovider.NodeGroup {
 	ng := testprovider.NewTestNodeGroup(id, 10000, 0, size, true, false, "n1-standard-2", nil, nil)
 	ng.SetOptions(&config.NodeGroupAutoscalingOptions{
-		AtomicScaling: atomic,
+		ZeroOrMaxNodeScaling: atomic,
 	})
 	return ng
 }

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
@@ -79,7 +79,7 @@ func (ds *GroupDeletionScheduler) ScheduleDeletion(nodeInfo *framework.NodeInfo,
 		return
 	}
 
-	ds.addToBatcher(nodeInfo, nodeGroup, batchSize, drain, opts.AtomicScaling)
+	ds.addToBatcher(nodeInfo, nodeGroup, batchSize, drain, opts.ZeroOrMaxNodeScaling)
 }
 
 // prepareNodeForDeletion is a long-running operation, so it needs to avoid locking the AtomicDeletionScheduler object

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -173,7 +173,7 @@ func (bp *ScaleDownBudgetProcessor) categorize(groups []*NodeGroupView) (individ
 			klog.Errorf("Failed to get autoscaling options for node group %s: %v", view.Group.Id(), err)
 			continue
 		}
-		if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 			atomic = append(atomic, view)
 		} else {
 			individual = append(individual, view)
@@ -196,7 +196,7 @@ func (bp *ScaleDownBudgetProcessor) groupByNodeGroup(nodes []*apiv1.Node) (indiv
 			klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
 			continue
 		}
-		if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 			if idx, ok := atomicGroup[nodeGroup]; ok {
 				atomic[idx].Nodes = append(atomic[idx].Nodes, node)
 			} else {

--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -361,7 +361,7 @@ var transformNodeGroupView = cmp.Transformer("transformNodeGroupView", func(b No
 func sizedNodeGroup(id string, size int, atomic bool) cloudprovider.NodeGroup {
 	ng := testprovider.NewTestNodeGroup(id, 10000, 0, size, true, false, "n1-standard-2", nil, nil)
 	ng.SetOptions(&config.NodeGroupAutoscalingOptions{
-		AtomicScaling: atomic,
+		ZeroOrMaxNodeScaling: atomic,
 	})
 	return ng
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -795,7 +795,7 @@ func TestNodesToDelete(t *testing.T) {
 func sizedNodeGroup(id string, size int, atomic bool) cloudprovider.NodeGroup {
 	ng := testprovider.NewTestNodeGroup(id, 10000, 0, size, true, false, "n1-standard-2", nil, nil)
 	ng.SetOptions(&config.NodeGroupAutoscalingOptions{
-		AtomicScaling: atomic,
+		ZeroOrMaxNodeScaling: atomic,
 	})
 	return ng
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -448,7 +448,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 		}
 		if autoscalingOptions != nil && autoscalingOptions.AtomicScaleUp {
 			if o.autoscalingContext.MaxNodesTotal != 0 && currentNodeCount+nodeGroup.MaxSize() > o.autoscalingContext.MaxNodesTotal {
-				klog.Errorf("Skipping node group %s - atomic scale-up exceetds cluster node count limit", nodeGroup.Id())
+				klog.V(4).Infof("Skipping node group %s - atomic scale-up exceetds cluster node count limit", nodeGroup.Id())
 				skippedNodeGroups[nodeGroup.Id()] = NewSkippedReasons("atomic scale-up exceeds cluster node count limit")
 				continue
 			}
@@ -505,7 +505,6 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 		estimator := estimator.NewBinpackingNodeEstimator(o.autoscalingContext.PredicateChecker, o.autoscalingContext.ClusterSnapshot, limiter, estimator.NewDecreasingPodOrderer())
 		option.NodeCount, option.Pods = estimator.Estimate(pods, nodeInfo, nodeGroup)
 		if option.NodeCount != nodeGroup.MaxSize() {
-			klog.Warningf("Estimator NodeCount: %d setting to %d", option.NodeCount, nodeGroup.MaxSize())
 			option.NodeCount = nodeGroup.MaxSize()
 		}
 		return option

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -446,7 +446,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 			klog.Errorf("Couldn't get autoscaling options for ng: %v", nodeGroup.Id())
 		}
 		numNodes := 1
-		if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 			numNodes = nodeGroup.MaxSize() - currentTargetSize
 			if o.autoscalingContext.MaxNodesTotal != 0 && currentNodeCount+numNodes > o.autoscalingContext.MaxNodesTotal {
 				klog.V(4).Infof("Skipping node group %s - atomic scale-up exceeds cluster node count limit", nodeGroup.Id())
@@ -495,7 +495,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 	if err != nil {
 		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
 	}
-	if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 		if option.NodeCount > 0 && option.NodeCount != nodeGroup.MaxSize() {
 			option.NodeCount = nodeGroup.MaxSize()
 		}
@@ -633,7 +633,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 	if err != nil {
 		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
 	}
-	if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 		return nil
 	}
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -124,6 +124,223 @@ func TestMixedScaleUp(t *testing.T) {
 	simpleScaleUpTest(t, config, expectedResults)
 }
 
+func TestAtomicScaleUpOK(t *testing.T) {
+	options := defaultOptions
+	options.NodeGroupDefaults.AtomicScaleUp = true
+
+	n := BuildTestNode("n", 1000, 1000)
+	SetNodeReadyState(n, true, time.Time{})
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(n)
+
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 5},
+			{Name: "ng2", MaxSize: 5},
+		},
+		Nodes: []NodeConfig{
+			{Name: "n1", Cpu: 900, Memory: 900, Gpu: 0, Ready: true, Group: "ng1"},
+		},
+		Pods: []PodConfig{
+			{Name: "p1", Cpu: 900, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p-new", Cpu: 1000, Memory: 1000, Gpu: 0, Node: "", ToleratesGpu: false},
+		},
+		// ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 2},
+		Options: &options,
+		NodeTemplateConfig: &NodeTemplateConfig{
+			NodeGroupName: "ng2",
+			MachineType:   "ct4p",
+			NodeInfo:      nodeInfo,
+		},
+	}
+	expectedResults := &ScaleTestResults{
+		FinalOption: GroupSizeChange{GroupName: "ng2", SizeChange: 5},
+		ScaleUpStatus: ScaleUpStatusInfo{
+			PodsTriggeredScaleUp: []string{"p-new"},
+		},
+	}
+	simpleScaleUpTest(t, config, expectedResults)
+}
+
+func TestAtomicScaleUpMixed(t *testing.T) {
+	options := defaultOptions
+	options.NodeGroupDefaults.AtomicScaleUp = true
+
+	n := BuildTestNode("n", 700, 700)
+	SetNodeReadyState(n, true, time.Time{})
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(n)
+
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 5},
+			{Name: "ng2", MaxSize: 5},
+			{Name: "ng3", MaxSize: 5},
+		},
+		Nodes: []NodeConfig{
+			{Name: "n1", Cpu: 500, Memory: 1000, Gpu: 0, Ready: true, Group: "ng1"},
+			{Name: "n2", Cpu: 1000, Memory: 500, Gpu: 0, Ready: true, Group: "ng2"},
+		},
+		Pods: []PodConfig{
+			{Name: "p1", Cpu: 400, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+			{Name: "p2", Cpu: 900, Memory: 400, Gpu: 0, Node: "n2", ToleratesGpu: false},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p-triggering", Cpu: 650, Memory: 650, Gpu: 0, Node: "", ToleratesGpu: false},
+			{Name: "p-remaining", Cpu: 2000, Memory: 2000, Gpu: 0, Node: "", ToleratesGpu: false},
+			{Name: "p-awaiting", Cpu: 100, Memory: 800, Gpu: 0, Node: "", ToleratesGpu: false},
+		},
+		ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng3", SizeChange: 5},
+		Options:                 &options,
+		NodeTemplateConfig: &NodeTemplateConfig{
+			NodeGroupName: "ng3",
+			MachineType:   "ct4p",
+			NodeInfo:      nodeInfo,
+		},
+	}
+	expectedResults := &ScaleTestResults{
+		FinalOption: GroupSizeChange{GroupName: "ng3", SizeChange: 5},
+		ScaleUpStatus: ScaleUpStatusInfo{
+			PodsTriggeredScaleUp:    []string{"p-triggering"},
+			PodsRemainUnschedulable: []string{"p-remaining"},
+			PodsAwaitEvaluation:     []string{"p-awaiting"},
+		},
+	}
+	simpleScaleUpTest(t, config, expectedResults)
+}
+
+func TestAtomicScaleUpMaxCoresLimitHit(t *testing.T) {
+	options := defaultOptions
+	options.MaxCoresTotal = 9
+	options.NodeGroupDefaults.AtomicScaleUp = true
+
+	n := BuildTestNode("n", 4500, 4500)
+	SetNodeReadyState(n, true, time.Time{})
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(n)
+
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 5},
+			{Name: "ng2", MaxSize: 3},
+		},
+		Nodes: []NodeConfig{
+			{Name: "n1", Cpu: 900, Memory: 900, Gpu: 0, Ready: true, Group: "ng1"},
+		},
+		Pods: []PodConfig{
+			{Name: "p1", Cpu: 900, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p-new-1", Cpu: 4200, Memory: 4200, Gpu: 0, Node: "", ToleratesGpu: false},
+			{Name: "p-new-2", Cpu: 4200, Memory: 4200, Gpu: 0, Node: "", ToleratesGpu: false},
+		},
+		// ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 2},
+		Options: &options,
+		NodeTemplateConfig: &NodeTemplateConfig{
+			NodeGroupName: "ng2",
+			MachineType:   "ct4p",
+			NodeInfo:      nodeInfo,
+		},
+	}
+	expectedResults := &ScaleTestResults{
+		NoScaleUpReason: "max cluster cpu limit reached",
+		ScaleUpStatus: ScaleUpStatusInfo{
+			PodsRemainUnschedulable: []string{"p-new-1", "p-new-2"},
+		},
+	}
+	simpleNoScaleUpTest(t, config, expectedResults)
+}
+
+func TestAtomicScaleUpMaxMemoryLimitHit(t *testing.T) {
+	options := defaultOptions
+	options.MaxMemoryTotal = 10000
+	options.NodeGroupDefaults.AtomicScaleUp = true
+
+	n := BuildTestNode("n", 5000, 5000)
+	SetNodeReadyState(n, true, time.Time{})
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(n)
+
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 5},
+			{Name: "ng2", MaxSize: 3},
+		},
+		Nodes: []NodeConfig{
+			{Name: "n1", Cpu: 900, Memory: 900, Gpu: 0, Ready: true, Group: "ng1"},
+		},
+		Pods: []PodConfig{
+			{Name: "p1", Cpu: 900, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p-new-1", Cpu: 4900, Memory: 4900, Gpu: 0, Node: "", ToleratesGpu: false},
+			{Name: "p-new-2", Cpu: 4900, Memory: 4900, Gpu: 0, Node: "", ToleratesGpu: false},
+		},
+		// ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 2},
+		Options: &options,
+		NodeTemplateConfig: &NodeTemplateConfig{
+			NodeGroupName: "ng2",
+			MachineType:   "ct4p",
+			NodeInfo:      nodeInfo,
+		},
+	}
+	expectedResults := &ScaleTestResults{
+		NoScaleUpReason: "max cluster memory limit reached",
+		ScaleUpStatus: ScaleUpStatusInfo{
+			PodsRemainUnschedulable: []string{"p-new-1", "p-new-2"},
+		},
+	}
+	simpleNoScaleUpTest(t, config, expectedResults)
+}
+
+// Test with memory and cpu in limit
+
+func TestAtomicScaleUpNodeLimitHit(t *testing.T) {
+	options := defaultOptions
+	options.MaxNodesTotal = 5
+	options.NodeGroupDefaults.AtomicScaleUp = true
+
+	n := BuildTestNode("n", 5000, 5000)
+	SetNodeReadyState(n, true, time.Time{})
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(n)
+
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 2},
+			{Name: "ng2", MaxSize: 5},
+		},
+		Nodes: []NodeConfig{
+			{Name: "n1", Cpu: 900, Memory: 900, Gpu: 0, Ready: true, Group: "ng1"},
+			{Name: "n2", Cpu: 900, Memory: 900, Gpu: 0, Ready: true, Group: "ng1"},
+		},
+		Pods: []PodConfig{
+			{Name: "p1", Cpu: 900, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+			{Name: "p2", Cpu: 900, Memory: 900, Gpu: 0, Node: "n1", ToleratesGpu: false},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p-new-1", Cpu: 4900, Memory: 4900, Gpu: 0, Node: "", ToleratesGpu: false},
+			{Name: "p-new-2", Cpu: 4900, Memory: 4900, Gpu: 0, Node: "", ToleratesGpu: false},
+		},
+		// ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 2},
+		Options: &options,
+		NodeTemplateConfig: &NodeTemplateConfig{
+			NodeGroupName: "ng2",
+			MachineType:   "ct4p",
+			NodeInfo:      nodeInfo,
+		},
+	}
+	expectedResults := &ScaleTestResults{
+		NoScaleUpReason: "atomic scale-up exceeds cluster node count limit",
+		ScaleUpStatus: ScaleUpStatusInfo{
+			PodsRemainUnschedulable: []string{"p-new-1", "p-new-2"},
+		},
+	}
+	simpleNoScaleUpTest(t, config, expectedResults)
+}
+
 func TestScaleUpMaxCoresLimitHit(t *testing.T) {
 	options := defaultOptions
 	options.MaxCoresTotal = 9
@@ -634,11 +851,7 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 	// build nodes
 	nodes := make([]*apiv1.Node, 0, len(config.Nodes))
 	for _, n := range config.Nodes {
-		node := BuildTestNode(n.Name, n.Cpu, n.Memory)
-		if n.Gpu > 0 {
-			AddGpusToNode(node, n.Gpu)
-		}
-		SetNodeReadyState(node, n.Ready, now.Add(-2*time.Minute))
+		node := buildTestNode(n, now)
 		nodes = append(nodes, node)
 		if n.Group != "" {
 			groupNodes[n.Group] = append(groupNodes[n.Group], node)
@@ -658,13 +871,19 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil, nil)
 
 	// setup node groups
-	provider := testprovider.NewTestCloudProvider(func(nodeGroup string, increase int) error {
+	var provider *testprovider.TestCloudProvider
+	onScaleUpFunc := func(nodeGroup string, increase int) error {
 		groupSizeChangesChannel <- GroupSizeChange{GroupName: nodeGroup, SizeChange: increase}
 		if config.OnScaleUp != nil {
 			return config.OnScaleUp(nodeGroup, increase)
 		}
 		return nil
-	}, nil)
+	}
+	if config.NodeTemplateConfig != nil {
+		provider = testprovider.NewTestAutoprovisioningCloudProvider(onScaleUpFunc, nil, nil, nil, []string{config.NodeTemplateConfig.MachineType}, map[string]*schedulerframework.NodeInfo{config.NodeTemplateConfig.NodeGroupName: config.NodeTemplateConfig.NodeInfo})
+	} else {
+		provider = testprovider.NewTestCloudProvider(onScaleUpFunc, nil)
+	}
 	options := defaultOptions
 	if config.Options != nil {
 		options = *config.Options
@@ -692,6 +911,13 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 		}
 	}
 
+	// Build node groups without any nodes
+	for name, ng := range groupConfigs {
+		if provider.GetNodeGroup(name) == nil {
+			tng := provider.BuildNodeGroup(name, ng.MinSize, ng.MaxSize, 0, false, config.NodeTemplateConfig.MachineType, &options.NodeGroupDefaults)
+			provider.InsertNodeGroup(tng)
+		}
+	}
 	// build orchestrator
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
@@ -740,6 +966,15 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 		GroupTargetSizes: targetSizes,
 		ExpansionOptions: expander.LastInputOptions(),
 	}
+}
+
+func buildTestNode(n NodeConfig, now time.Time) *apiv1.Node {
+	node := BuildTestNode(n.Name, n.Cpu, n.Memory)
+	if n.Gpu > 0 {
+		AddGpusToNode(node, n.Gpu)
+	}
+	SetNodeReadyState(node, n.Ready, now.Add(-2*time.Minute))
+	return node
 }
 
 func buildTestPod(p PodConfig) *apiv1.Pod {

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -126,7 +126,7 @@ func TestMixedScaleUp(t *testing.T) {
 
 func TestAtomicScaleUp(t *testing.T) {
 	options := defaultOptions
-	options.NodeGroupDefaults.AtomicScaleUp = true
+	options.NodeGroupDefaults.AtomicScaling = true
 
 	optionsWithLimitedMaxCores := options
 	optionsWithLimitedMaxCores.MaxCoresTotal = 3

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -124,9 +124,9 @@ func TestMixedScaleUp(t *testing.T) {
 	simpleScaleUpTest(t, config, expectedResults)
 }
 
-func TestAtomicScaleUp(t *testing.T) {
+func TestZeroOrMaxNodeScaling(t *testing.T) {
 	options := defaultOptions
-	options.NodeGroupDefaults.AtomicScaling = true
+	options.NodeGroupDefaults.ZeroOrMaxNodeScaling = true
 
 	optionsWithLimitedMaxCores := options
 	optionsWithLimitedMaxCores.MaxCoresTotal = 3

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -125,7 +125,7 @@ type ScaleUpTestConfig struct {
 	OnScaleUp               testcloudprovider.OnScaleUpFunc
 	ExpansionOptionToChoose *GroupSizeChange
 	Options                 *config.AutoscalingOptions
-	NodeTemplateConfig      *NodeTemplateConfig
+	NodeTemplateConfigs     map[string]*NodeTemplateConfig
 }
 
 // ScaleUpTestResult represents a node groups scale up result

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -109,6 +109,13 @@ type NodeGroupConfig struct {
 	MaxSize int
 }
 
+// NodeTemplateConfig is a structure to provide node info in tests
+type NodeTemplateConfig struct {
+	MachineType   string
+	NodeInfo      *schedulerframework.NodeInfo
+	NodeGroupName string
+}
+
 // ScaleUpTestConfig represents a config of a scale test
 type ScaleUpTestConfig struct {
 	Groups                  []NodeGroupConfig
@@ -118,6 +125,7 @@ type ScaleUpTestConfig struct {
 	OnScaleUp               testcloudprovider.OnScaleUpFunc
 	ExpansionOptionToChoose *GroupSizeChange
 	Options                 *config.AutoscalingOptions
+	NodeTemplateConfig      *NodeTemplateConfig
 }
 
 // ScaleUpTestResult represents a node groups scale up result

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -47,6 +47,7 @@ type Option struct {
 	NodeCount         int
 	Debug             string
 	Pods              []*apiv1.Pod
+	IsAtomic          bool
 }
 
 // Strategy describes an interface for selecting the best option when scaling up

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -47,7 +47,6 @@ type Option struct {
 	NodeCount         int
 	Debug             string
 	Pods              []*apiv1.Pod
-	IsAtomic          bool
 }
 
 // Strategy describes an interface for selecting the best option when scaling up

--- a/cluster-autoscaler/processors/nodes/post_filtering_processor.go
+++ b/cluster-autoscaler/processors/nodes/post_filtering_processor.go
@@ -59,7 +59,7 @@ func (p *PostFilteringScaleDownNodeProcessor) filterOutIncompleteAtomicNodeGroup
 			klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
 			continue
 		}
-		if autoscalingOptions != nil && autoscalingOptions.AtomicScaling {
+		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 			klog.V(2).Infof("Considering node %s for atomic scale down", node.Node.Name)
 			nodesByGroup[nodeGroup] = append(nodesByGroup[nodeGroup], node)
 		} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a node group AtomicScaleUp option, that allows for all-or-nothing scale up of the node group.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add AtomicScaleUp option that allows all-or-nothing scale up of node groups.
In atomic scale-ups, the node group should be scaled up to max size (without partial scale-ups).
```
