### PR TITLE
Cluster Autoscaler: add more logging for balancing similar node groups

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -224,6 +224,17 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	// Recompute similar node groups in case they need to be updated
 	bestOption.SimilarNodeGroups = o.ComputeSimilarNodeGroups(bestOption.NodeGroup, nodeInfos, schedulablePods, now)
+	if bestOption.SimilarNodeGroups != nil {
+		// if similar node groups are found, log about them
+		similarNodeGroupIds := make([]string, 0)
+		for _, sng := range bestOption.SimilarNodeGroups {
+			similarNodeGroupIds = append(similarNodeGroupIds, sng.Id())
+		}
+		klog.V(2).Infof("Found %d similar node groups: %v", len(bestOption.SimilarNodeGroups), similarNodeGroupIds)
+	} else if o.autoscalingContext.BalanceSimilarNodeGroups {
+		// if no similar node groups are found and the flag is enabled, log about it
+		klog.V(2).Info("No similar node groups found")
+	}
 
 	nodeInfo, found := nodeInfos[bestOption.NodeGroup.Id()]
 	if !found {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

this change adds some logging at verbosity levels 2 and 3 to help diagnose why the cluster-autoscaler does not consider 2 or more node groups to be similar.

#### Which issue(s) this PR fixes:

Fixes #5834 

#### Special notes for your reviewer:

must enable `--balance-similar-node-groups` and `-v=3` to see the results of this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When using the `--balance-similar-node-groups` flag of the Cluster Autoscaler, more logging is now available at verbosity levels 2 and 3 to help diagnose balancing failures.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
