### PR TITLE
Update VPA scripts to use v1.

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -41,6 +41,9 @@ fi
 
 ACTION=$1
 COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
+case ${ACTION} in
+delete|diff) COMPONENTS+=" vpa-beta2-crd" ;;
+esac
 
 if [ $# -gt 1 ]; then
   COMPONENTS="$2-deployment"

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -41,9 +41,6 @@ fi
 
 ACTION=$1
 COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
-case ${ACTION} in
-delete|diff|print) COMPONENTS+=" vpa-beta2-crd" ;;
-esac
 
 if [ $# -gt 1 ]; then
   COMPONENTS="$2-deployment"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR update the [vpa-process-yamls.sh](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/hack/vpa-process-yamls.sh) script to print the VPA  V1 CRD data.
#### Which issue(s) this PR fixes:

Fixes #5832

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
