### PR TITLE
fix: don't clean `CriticalAddonsOnly` taint from template nodes

### DIFF
--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -41,8 +41,6 @@ const (
 	// DeletionCandidateTaint is a taint used to mark unneeded node as preferably unschedulable.
 	DeletionCandidateTaint = "DeletionCandidateOfClusterAutoscaler"
 
-	// ReschedulerTaintKey is the name of the taint created by rescheduler.
-	ReschedulerTaintKey = "CriticalAddonsOnly"
 	// IgnoreTaintPrefix any taint starting with it will be filtered out from autoscaler template node.
 	IgnoreTaintPrefix = "ignore-taint.cluster-autoscaler.kubernetes.io/"
 
@@ -333,9 +331,6 @@ func SanitizeTaints(taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint
 		// New nodes will not have this taint and so we should strip it when creating
 		// template node.
 		switch taint.Key {
-		case ReschedulerTaintKey:
-			klog.V(4).Info("Removing rescheduler taint when creating template")
-			continue
 		case ToBeDeletedTaint:
 			klog.V(4).Infof("Removing autoscaler taint when creating template from node")
 			continue

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -327,9 +327,6 @@ func CleanAllTaints(nodes []*apiv1.Node, client kube_client.Interface, recorder 
 func SanitizeTaints(taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint {
 	var newTaints []apiv1.Taint
 	for _, taint := range taints {
-		// Rescheduler can put this taint on a node while evicting non-critical pods.
-		// New nodes will not have this taint and so we should strip it when creating
-		// template node.
 		switch taint.Key {
 		case ToBeDeletedTaint:
 			klog.V(4).Infof("Removing autoscaler taint when creating template from node")

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -486,11 +486,6 @@ func TestSanitizeTaints(t *testing.T) {
 					Effect: apiv1.TaintEffectNoSchedule,
 				},
 				{
-					Key:    ReschedulerTaintKey,
-					Value:  "test1",
-					Effect: apiv1.TaintEffectNoSchedule,
-				},
-				{
 					Key:    "test-taint",
 					Value:  "test2",
 					Effect: apiv1.TaintEffectNoSchedule,


### PR DESCRIPTION
- this taint leads to unexpected behavior
- users expect CA to consider the taint when autoscaling

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4097 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed: `CriticalAddonsOnly` taint will not be cleaned from template nodes anymore. This is a *backwards incompatible* change. Check https://github.com/kubernetes/autoscaler/issues/4097 for more information. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
