### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/responses/response.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/responses/response.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/errors"
+	"io"
 	"net/http"
 	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/errors"
 )
 
 // AcsResponse interface
@@ -113,7 +114,7 @@ func (baseResponse *BaseResponse) IsSuccess() bool {
 
 func (baseResponse *BaseResponse) parseFromHttpResponse(httpResponse *http.Response) (err error) {
 	defer httpResponse.Body.Close()
-	body, err := ioutil.ReadAll(httpResponse.Body)
+	body, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return
 	}

--- a/cluster-autoscaler/cloudprovider/alicloud/metadata/metadata.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/metadata/metadata.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -424,7 +423,7 @@ func (vpc *MetaDataRequest) send() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/awsutil/copy_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/awsutil/copy_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
@@ -231,7 +230,7 @@ func TestCopyReader(t *testing.T) {
 	var buf io.Reader = bytes.NewReader([]byte("hello world"))
 	var r io.Reader
 	awsutil.Copy(&r, buf)
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -240,7 +239,7 @@ func TestCopyReader(t *testing.T) {
 	}
 
 	// empty bytes because this is not a deep copy
-	b, err = ioutil.ReadAll(buf)
+	b, err = io.ReadAll(buf)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/logger.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httputil"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
@@ -160,7 +159,7 @@ func logResponse(r *request.Request) {
 			req.ClientInfo.ServiceName, req.Operation.Name, string(b)))
 
 		if logBody {
-			b, err := ioutil.ReadAll(lw.buf)
+			b, err := io.ReadAll(lw.buf)
 			if err != nil {
 				lw.Logger.Log(fmt.Sprintf(logRespErrMsg,
 					req.ClientInfo.ServiceName, req.Operation.Name, err))

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/logger_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/logger_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -117,7 +116,7 @@ func TestLogRequest(t *testing.T) {
 
 		logRequest(req)
 
-		b, err := ioutil.ReadAll(req.HTTPRequest.Body)
+		b, err := io.ReadAll(req.HTTPRequest.Body)
 		if err != nil {
 			t.Fatalf("%d, expect to read SDK request Body", i)
 		}
@@ -181,7 +180,7 @@ func TestLogResponse(t *testing.T) {
 			Header: http.Header{
 				"ABC": []string{"123"},
 			},
-			Body: ioutil.NopCloser(c.Body),
+			Body: io.NopCloser(c.Body),
 		}
 
 		logResponse(req)
@@ -199,7 +198,7 @@ func TestLogResponse(t *testing.T) {
 			t.Errorf("%d, expect no log, got,\n%v", i, logW.String())
 		}
 
-		b, err := ioutil.ReadAll(req.HTTPResponse.Body)
+		b, err := io.ReadAll(req.HTTPResponse.Body)
 		if err != nil {
 			t.Fatalf("%d, expect to read SDK request Body", i)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -3,7 +3,7 @@ package corehandlers
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -145,7 +145,7 @@ func handleSendError(r *request.Request, err error) {
 			r.HTTPResponse = &http.Response{
 				StatusCode: int(code),
 				Status:     http.StatusText(int(code)),
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}
 			return
 		}
@@ -156,7 +156,7 @@ func handleSendError(r *request.Request, err error) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       i.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	// Catch all request errors, and let the default retrier determine

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -156,7 +156,7 @@ func handleSendError(r *request.Request, err error) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       i.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	// Catch all request errors, and let the default retrier determine

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/corehandlers/handlers_test.go
@@ -3,7 +3,7 @@ package corehandlers_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -108,7 +108,7 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 			Resp: &http.Response{
 				StatusCode: 403,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte{})),
+				Body:       io.NopCloser(bytes.NewBuffer([]byte{})),
 			},
 			Err: awserr.New("ExpiredToken", "", nil),
 		},
@@ -116,7 +116,7 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 			Resp: &http.Response{
 				StatusCode: 403,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte{})),
+				Body:       io.NopCloser(bytes.NewBuffer([]byte{})),
 			},
 			Err: awserr.New("ExpiredToken", "", nil),
 		},
@@ -124,7 +124,7 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 			Resp: &http.Response{
 				StatusCode: 200,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte{})),
+				Body:       io.NopCloser(bytes.NewBuffer([]byte{})),
 			},
 		},
 	}
@@ -366,7 +366,7 @@ func setupContentLengthTestServer(t *testing.T, hasContentLength bool, contentLe
 			}
 		}
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("expect no error, got %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/processcreds/provider.go
@@ -81,7 +81,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -416,7 +415,7 @@ func executeCommand(cmd exec.Cmd, exec chan error) {
 func readInput(r io.Reader, w io.Writer, read chan error) {
 	tee := io.TeeReader(r, w)
 
-	_, err := ioutil.ReadAll(tee)
+	_, err := io.ReadAll(tee)
 
 	if err == io.EOF {
 		err = nil

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/processcreds/provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/processcreds/provider_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -387,7 +386,7 @@ func TestProcessProviderNotExpired(t *testing.T) {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_expiring")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "tmp_expiring")
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
@@ -428,7 +427,7 @@ func TestProcessProviderExpired(t *testing.T) {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_expired")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "tmp_expired")
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
@@ -470,7 +469,7 @@ func TestProcessProviderForceExpire(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_force_expire")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "tmp_force_expire")
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/ssocreds/provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/ssocreds/provider.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -159,7 +159,7 @@ func loadTokenFile(startURL string) (t token, err error) {
 		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, err)
 	}
 
-	fileBytes, err := ioutil.ReadFile(filepath.Join(defaultCacheLocation(), key))
+	fileBytes, err := os.ReadFile(filepath.Join(defaultCacheLocation(), key))
 	if err != nil {
 		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/stscreds/web_identity_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/credentials/stscreds/web_identity_provider.go
@@ -2,7 +2,7 @@ package stscreds
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"time"
 
@@ -38,7 +38,7 @@ type FetchTokenPath string
 
 // FetchToken returns a token by reading from the filesystem
 func (f FetchTokenPath) FetchToken(ctx credentials.Context) ([]byte, error) {
-	data, err := ioutil.ReadFile(string(f))
+	data, err := os.ReadFile(string(f))
 	if err != nil {
 		errMsg := fmt.Sprintf("unable to read file at %s", f)
 		return nil, awserr.New(ErrCodeWebIdentity, errMsg, err)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/ec2metadata/api_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/ec2metadata/api_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -670,7 +669,7 @@ func TestMetadataNotAvailable(t *testing.T) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 		r.Error = awserr.New(request.ErrCodeRequestError, "send request failed", nil)
 		r.Retryable = aws.Bool(true) // network errors are retryable
@@ -688,7 +687,7 @@ func TestMetadataErrorResponse(t *testing.T) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: http.StatusBadRequest,
 			Status:     http.StatusText(http.StatusBadRequest),
-			Body:       ioutil.NopCloser(strings.NewReader("error message text")),
+			Body:       io.NopCloser(strings.NewReader("error message text")),
 		}
 		r.Retryable = aws.Bool(false) // network errors are retryable
 	})

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/endpoints/v3model_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/endpoints/v3model_test.go
@@ -6,7 +6,6 @@ package endpoints
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -884,7 +883,7 @@ func TestEndpointVariants(t *testing.T) {
 		Endpoint  string `json:"Endpoint"`
 	}
 
-	casesBytes, err := ioutil.ReadFile(filepath.Join("testdata", "variants_cases.json"))
+	casesBytes, err := os.ReadFile(filepath.Join("testdata", "variants_cases.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/http_request_copy_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/http_request_copy_test.go
@@ -2,7 +2,7 @@ package request
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -17,10 +17,10 @@ func TestRequestCopyRace(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			req := copyHTTPRequest(origReq, ioutil.NopCloser(&bytes.Buffer{}))
+			req := copyHTTPRequest(origReq, io.NopCloser(&bytes.Buffer{}))
 			req.Header.Set("Header", "Value")
 			go func() {
-				req2 := copyHTTPRequest(req, ioutil.NopCloser(&bytes.Buffer{}))
+				req2 := copyHTTPRequest(req, io.NopCloser(&bytes.Buffer{}))
 				req2.Header.Add("Header", "Value2")
 			}()
 			_ = req.Header.Get("Header")

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/request.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/request.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -531,7 +530,7 @@ func (r *Request) Send() error {
 		if r.HTTPResponse == nil {
 			r.HTTPResponse = &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(&bytes.Buffer{}),
+				Body:   io.NopCloser(&bytes.Buffer{}),
 			}
 		}
 		// Regardless of success or failure of the request trigger the Complete

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/timeout_read_closer_benchmark_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/timeout_read_closer_benchmark_test.go
@@ -2,7 +2,7 @@ package request_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -10,7 +10,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/metadata"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4"
+	v4 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/unit"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
@@ -27,7 +27,7 @@ func BenchmarkTimeoutReadCloser(b *testing.B) {
 	handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(resp))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte(resp))),
 		}
 	})
 	handlers.Sign.PushBackNamed(v4.SignRequestHandler)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/timeout_read_closer_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/timeout_read_closer_test.go
@@ -3,7 +3,6 @@ package request
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
@@ -66,7 +65,7 @@ func TestWithResponseReadTimeout(t *testing.T) {
 			URL: &url.URL{},
 		},
 		HTTPResponse: &http.Response{
-			Body: ioutil.NopCloser(bytes.NewReader(nil)),
+			Body: io.NopCloser(bytes.NewReader(nil)),
 		},
 	}
 	r.ApplyOptions(WithResponseReadTimeout(time.Second))

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/waiter_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request/waiter_test.go
@@ -3,7 +3,7 @@ package request_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -323,7 +323,7 @@ func TestWaiterError(t *testing.T) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: code,
 			Status:     http.StatusText(code),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	})
 	svc.Handlers.Unmarshal.PushBack(func(r *request.Request) {
@@ -408,7 +408,7 @@ func TestWaiterStatus(t *testing.T) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: code,
 			Status:     http.StatusText(code),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	})
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session/credentials_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session/credentials_test.go
@@ -5,7 +5,6 @@ package session
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -866,7 +865,7 @@ func TestSessionAssumeRoleWithWebIdentity_Options(t *testing.T) {
 }
 
 func ssoTestSetup() (func(), error) {
-	dir, err := ioutil.TempDir("", "sso-test")
+	dir, err := os.MkdirTemp("", "sso-test")
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session/session.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session/session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -659,7 +658,7 @@ func loadCustomCABundle(client *http.Client, bundle io.Reader) error {
 }
 
 func loadCertPool(r io.Reader) (*x509.CertPool, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New(ErrCodeLoadCustomCABundle,
 			"failed to read custom CA bundle PEM file", err)
@@ -681,13 +680,13 @@ func loadClientTLSCert(client *http.Client, certFile, keyFile io.Reader) error {
 			"unable to get usable HTTP transport from client", err)
 	}
 
-	cert, err := ioutil.ReadAll(certFile)
+	cert, err := io.ReadAll(certFile)
 	if err != nil {
 		return awserr.New(ErrCodeLoadClientTLSCert,
 			"unable to get read client TLS cert file", err)
 	}
 
-	key, err := ioutil.ReadAll(keyFile)
+	key, err := io.ReadAll(keyFile)
 	if err != nil {
 		return awserr.New(ErrCodeLoadClientTLSCert,
 			"unable to get read client TLS key file", err)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -60,7 +60,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
@@ -360,7 +359,7 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 		if body != nil {
 			var ok bool
 			if reader, ok = body.(io.ReadCloser); !ok {
-				reader = ioutil.NopCloser(body)
+				reader = io.NopCloser(body)
 			}
 		}
 		r.Body = reader

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4/v4_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4/v4_test.go
@@ -3,7 +3,6 @@ package v4
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -554,7 +553,7 @@ func TestSignWithRequestBody(t *testing.T) {
 	expectBody := []byte("abc123")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		if err != nil {
 			t.Errorf("expect no error, got %v", err)
@@ -592,7 +591,7 @@ func TestSignWithRequestBody_Overwrite(t *testing.T) {
 	var expectBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		if err != nil {
 			t.Errorf("expect not no error, got %v", err)
@@ -648,7 +647,7 @@ func TestBuildCanonicalRequest(t *testing.T) {
 func TestSignWithBody_ReplaceRequestBody(t *testing.T) {
 	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
 	req, seekerBody := buildRequest("dynamodb", "us-east-1", "{}")
-	req.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	req.Body = io.NopCloser(bytes.NewReader([]byte{}))
 
 	s := NewSigner(creds)
 	origBody := req.Body
@@ -670,7 +669,7 @@ func TestSignWithBody_ReplaceRequestBody(t *testing.T) {
 func TestSignWithBody_NoReplaceRequestBody(t *testing.T) {
 	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
 	req, seekerBody := buildRequest("dynamodb", "us-east-1", "{}")
-	req.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	req.Body = io.NopCloser(bytes.NewReader([]byte{}))
 
 	s := NewSigner(creds, func(signer *Signer) {
 		signer.DisableRequestBodyOverwrite = true

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/certificate_utils.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/certificate_utils.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -269,7 +268,7 @@ func CleanupTLSBundleFiles(files ...string) error {
 }
 
 func createTmpFile(b []byte) (string, error) {
-	bundleFile, err := ioutil.TempFile(os.TempDir(), "aws-sdk-go-session-test")
+	bundleFile, err := os.CreateTemp(os.TempDir(), "aws-sdk-go-session-test")
 	if err != nil {
 		return "", err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/integration/integration.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/integration/integration.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
@@ -45,7 +44,7 @@ func UniqueID() string {
 
 // CreateFileOfSize will return an *os.File that is of size bytes
 func CreateFileOfSize(dir string, size int64) (*os.File, error) {
-	file, err := ioutil.TempFile(dir, "s3Bench")
+	file, err := os.CreateTemp(dir, "s3Bench")
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/integration/performance/s3GetObject/main.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/integration/performance/s3GetObject/main.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"time"
@@ -132,7 +131,7 @@ func doRequest(ctx context.Context, id int64, svc *s3.S3, config Config) *Reques
 	}
 	defer resp.Body.Close()
 
-	if n, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if n, err := io.Copy(io.Discard, resp.Body); err != nil {
 		traceCtx.AppendError(fmt.Errorf("read request body failed, read %v, %v", n, err))
 		return traceCtx
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/internal/ini/ini_lexer.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/internal/ini/ini_lexer.go
@@ -3,7 +3,6 @@ package ini
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/awserr"
 )
@@ -57,7 +56,7 @@ type iniLexer struct{}
 // Tokenize will return a list of tokens during lexical analysis of the
 // io.Reader.
 func (l *iniLexer) Tokenize(r io.Reader) ([]Token, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New(ErrCodeUnableToReadFile, "unable to read file", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/internal/ini/walker_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/internal/ini/walker_test.go
@@ -5,7 +5,6 @@ package ini
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func TestValidDataFiles(t *testing.T) {
 		expectedPath := path + "_expected"
 		e := map[string]interface{}{}
 
-		b, err := ioutil.ReadFile(expectedPath)
+		b, err := os.ReadFile(expectedPath)
 		if err != nil {
 			// ignore files that do not have an expected file
 			return nil

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -8,7 +8,7 @@ package restjsonservice
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -184,7 +184,7 @@ func BenchmarkEmptyStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},
@@ -386,7 +386,7 @@ func BenchmarkGetEventStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
@@ -8,7 +8,7 @@ package restxmlservice
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -184,7 +184,7 @@ func BenchmarkEmptyStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},
@@ -386,7 +386,7 @@ func BenchmarkGetEventStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -8,7 +8,7 @@ package rpcservice
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -188,7 +188,7 @@ func BenchmarkEmptyStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},
@@ -414,7 +414,7 @@ func BenchmarkGetEventStream_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/customization_passes.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/customization_passes.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -404,8 +404,19 @@ func mergeServicesCustomizations(a *API) error {
 
 	if info.serviceVersion != "" {
 		index := strings.LastIndex(p, string(filepath.Separator))
-		files, _ := ioutil.ReadDir(p[:index])
-		if len(files) > 1 {
+		entries, err := os.ReadDir(p[:index])
+		if err != nil {
+			return err
+		}
+		infos := make([]fs.FileInfo, 0, len(entries))
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			infos = append(infos, info)
+		}
+		if len(infos) > 1 {
 			panic("New version was introduced")
 		}
 		p = p[:index] + "/" + info.serviceVersion

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/eventstream_tmpl_readertests.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/eventstream_tmpl_readertests.go
@@ -236,7 +236,7 @@ func (c *loopReader) Read(p []byte) (int, error) {
 						Status:     "200 OK",
 						StatusCode: 200,
 						Header:     http.Header{},
-						Body:       ioutil.NopCloser(stream),
+						Body:       io.NopCloser(stream),
 					}
 				},
 			},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/eventstream_tmpl_tests.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/api/eventstream_tmpl_tests.go
@@ -15,7 +15,7 @@ func (a *API) APIEventStreamTestGoCode() string {
 
 	a.resetImports()
 	a.AddImport("bytes")
-	a.AddImport("io/ioutil")
+	a.AddImport("io")
 	a.AddImport("net/http")
 	a.AddImport("reflect")
 	a.AddImport("testing")

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/cli/gen-api/main.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/cli/gen-api/main.go
@@ -10,7 +10,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -205,7 +205,7 @@ package %s
 `
 
 func writeGoFile(file string, layout string, args ...interface{}) error {
-	return ioutil.WriteFile(file, []byte(util.GoFmt(fmt.Sprintf(layout, args...))), 0664)
+	return os.WriteFile(file, []byte(util.GoFmt(fmt.Sprintf(layout, args...))), 0664)
 }
 
 // writeServiceDocFile generates the documentation for service package.

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/cli/gen-protocol-tests/main.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/model/cli/gen-protocol-tests/main.go
@@ -87,7 +87,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -114,7 +114,7 @@ var extraImports = []string{
 	"encoding/xml",
 	"fmt",
 	"io",
-	"io/ioutil",
+	"io",
 	"net/http",
 	"testing",
 	"time",
@@ -236,7 +236,7 @@ func (t tplInputTestCaseData) BodyAssertions() string {
 	protocol := t.TestCase.TestSuite.API.Metadata.Protocol
 
 	// Extract the body bytes
-	fmt.Fprintln(code, "body, _ := ioutil.ReadAll(r.Body)")
+	fmt.Fprintln(code, "body, _ := io.ReadAll(r.Body)")
 
 	// Generate the body verification code
 	expectedBody := util.Trim(t.TestCase.InputTest.Body)
@@ -289,7 +289,7 @@ func Test{{ .OpName }}(t *testing.T) {
 
 	buf := bytes.NewReader([]byte({{ .Body }}))
 	req, out := svc.{{ .TestCase.Given.ExportedName }}Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	{{ range $k, $v := .TestCase.OutputTest.Headers }}req.HTTPResponse.Header.Set("{{ $k }}", "{{ $v }}")

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
@@ -8,18 +8,17 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
 	"time"
 
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/metadata"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/unit"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -2122,7 +2121,7 @@ func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2157,7 +2156,7 @@ func TestInputService2ProtocolTestStructureWithLocationNameAndQueryNameAppliedTo
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&BarLocationName=val2&Foo=val1&Version=2014-01-01&yuckQueryName=val3`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2192,7 +2191,7 @@ func TestInputService3ProtocolTestNestedStructureMembersCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Struct.Scalar=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2244,7 +2243,7 @@ func TestInputService4ProtocolTestListTypesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListBools.1=true&ListBools.2=false&ListBools.3=false&ListFloats.1=1.1&ListFloats.2=2.718&ListFloats.3=3.14&ListIntegers.1=0&ListIntegers.2=1&ListIntegers.3=2&ListStrings.1=foo&ListStrings.2=bar&ListStrings.3=baz&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2281,7 +2280,7 @@ func TestInputService5ProtocolTestListWithLocationNameAppliedToMemberCase1(t *te
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListMemberName.1=a&ListMemberName.2=b&ListMemberName.3=c&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2318,7 +2317,7 @@ func TestInputService6ProtocolTestListWithLocationNameAndQueryNameCase1(t *testi
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListQueryName.1=a&ListQueryName.2=b&ListQueryName.3=c&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2351,7 +2350,7 @@ func TestInputService7ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&BlobArg=Zm9v&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2386,7 +2385,7 @@ func TestInputService8ProtocolTestTimestampValuesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&TimeArg=2015-01-25T08%3A00%3A00Z&TimeCustom=1422172800&TimeFormat=1422172800&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2419,7 +2418,7 @@ func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Token=abc123&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2450,7 +2449,7 @@ func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Token=00000000-0000-4000-8000-000000000000&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2487,7 +2486,7 @@ func TestInputService10ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListEnums.1=foo&ListEnums.2=&ListEnums.3=bar&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2518,7 +2517,7 @@ func TestInputService10ProtocolTestEnumCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2551,7 +2550,7 @@ func TestInputService11ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=StaticOp&Name=myname&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2584,7 +2583,7 @@ func TestInputService11ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=MemberRefOp&Name=myname&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
-	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/client/metadata"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/signer/v4"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/awstesting/unit"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol"

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/unmarshal_error_test.go
@@ -4,7 +4,7 @@
 package ec2query
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -25,7 +25,7 @@ func TestUnmarshalError(t *testing.T) {
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<Response>
 							<Errors>
 								<Error>
@@ -45,7 +45,7 @@ func TestUnmarshalError(t *testing.T) {
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<Hello>
 							<World>.</World>
 						</Hello>`)),

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/ec2query/unmarshal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -1842,7 +1841,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><RequestId>request-id</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService1TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1889,7 +1888,7 @@ func TestOutputService2ProtocolTestBlobCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Blob>dmFsdWU=</Blob><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService2TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1915,7 +1914,7 @@ func TestOutputService3ProtocolTestListsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><ListMember><member>abc</member><member>123</member></ListMember><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService3TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1944,7 +1943,7 @@ func TestOutputService4ProtocolTestListWithCustomMemberNameCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><ListMember><item>abc</item><item>123</item></ListMember><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService4TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1973,7 +1972,7 @@ func TestOutputService5ProtocolTestFlattenedListCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><ListMember>abc</ListMember><ListMember>123</ListMember><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService5TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2002,7 +2001,7 @@ func TestOutputService6ProtocolTestNormalMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService6TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2031,7 +2030,7 @@ func TestOutputService7ProtocolTestFlattenedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService7TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2060,7 +2059,7 @@ func TestOutputService8ProtocolTestNamedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Map><foo>qux</foo><bar>bar</bar></Map><Map><foo>baz</foo><bar>bam</bar></Map><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService8TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2089,7 +2088,7 @@ func TestOutputService9ProtocolTestEmptyStringCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService9TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2115,7 +2114,7 @@ func TestOutputService10ProtocolTestTimestampMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService10TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2153,7 +2152,7 @@ func TestOutputService11ProtocolTestEnumOutputCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"))
 	req, out := svc.OutputService11TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/eventstream/decode_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/eventstream/decode_test.go
@@ -3,7 +3,6 @@ package eventstream
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -16,7 +15,7 @@ func TestWriteEncodedFromDecoded(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := ioutil.TempFile(os.TempDir(), "encoded_positive_"+c.Name)
+		f, err := os.CreateTemp(os.TempDir(), "encoded_positive_"+c.Name)
 		if err != nil {
 			t.Fatalf("failed to open %q, %v", c.Name, err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/eventstream/shared_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/eventstream/shared_test.go
@@ -5,7 +5,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -106,19 +107,27 @@ func readPositiveTests(root string) ([]testCase, error) {
 }
 
 func readTests(root string) (map[string][]byte, error) {
-	items, err := ioutil.ReadDir(root)
+	entries, err := os.ReadDir(root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read test suite %q dirs, %v", root, err)
+		return nil, err
+	}
+	infos := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, info)
 	}
 
 	cases := map[string][]byte{}
-	for _, item := range items {
+	for _, item := range infos {
 		if item.IsDir() {
 			continue
 		}
 
 		filename := filepath.Join(root, item.Name())
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read test_data file %q, %v", filename, err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/build_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -2339,7 +2338,7 @@ func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Name": "myname"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2382,7 +2381,7 @@ func TestInputService2ProtocolTestTimestampValuesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"TimeArg": 1422172800, "TimeCustom": "Sun, 25 Jan 2015 08:00:00 GMT", "TimeFormat": "Sun, 25 Jan 2015 08:00:00 GMT"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2423,7 +2422,7 @@ func TestInputService3ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"BlobArg": "Zm9v"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2467,7 +2466,7 @@ func TestInputService3ProtocolTestBase64EncodedBlobsCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"BlobMap": {"key1": "Zm9v", "key2": "YmFy"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2511,7 +2510,7 @@ func TestInputService4ProtocolTestNestedBlobsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"ListParam": ["Zm9v", "YmFy"]}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2554,7 +2553,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"NoRecurse": "foo"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2599,7 +2598,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveStruct": {"NoRecurse": "foo"}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2648,7 +2647,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveStruct": {"RecursiveStruct": {"RecursiveStruct": {"NoRecurse": "foo"}}}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2698,7 +2697,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveList": [{"NoRecurse": "foo"}, {"NoRecurse": "bar"}]}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2750,7 +2749,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveList": [{"NoRecurse": "foo"}, {"RecursiveStruct": {"NoRecurse": "bar"}}]}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2800,7 +2799,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveMap": {"foo": {"NoRecurse": "foo"}, "bar": {"NoRecurse": "bar"}}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2841,7 +2840,7 @@ func TestInputService6ProtocolTestEmptyMapsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Map": {}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2882,7 +2881,7 @@ func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Token": "abc123"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2913,7 +2912,7 @@ func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Token": "00000000-0000-4000-8000-000000000000"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -2951,7 +2950,7 @@ func TestInputService8ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"FooEnum": "foo", "ListEnums": ["foo", "", "bar"]}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3004,7 +3003,7 @@ func TestInputService9ProtocolTestEndpointHostTraitStaticPrefixCase1(t *testing.
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Name": "myname"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3045,7 +3044,7 @@ func TestInputService9ProtocolTestEndpointHostTraitStaticPrefixCase2(t *testing.
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Name": "myname"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_error.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_error.go
@@ -3,7 +3,6 @@ package jsonrpc
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -42,7 +41,7 @@ func (u *UnmarshalTypedError) UnmarshalError(
 	if err != nil {
 		return nil, err
 	}
-	body := ioutil.NopCloser(&buf)
+	body := io.NopCloser(&buf)
 
 	// Code may be separated by hash(#), with the last element being the code
 	// used by the SDK.

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_error_test.go
@@ -6,7 +6,7 @@ package jsonrpc
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -83,7 +83,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"simple error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(simpleErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(simpleErrJSON)),
 			},
 			Expect: &SimpleError{
 				Message2: aws.String("some message"),
@@ -93,7 +93,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"other error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(otherErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(otherErrJSON)),
 			},
 			Expect: &OtherError{
 				Message2: aws.String("some message"),
@@ -102,7 +102,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"other complex Code error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(complexCodeErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(complexCodeErrJSON)),
 			},
 			Expect: &OtherError{
 				Message2: aws.String("some message"),
@@ -111,7 +111,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"complex error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(complexErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(complexErrJSON)),
 			},
 			Expect: &ComplexError{
 				Message2: aws.String("some message"),
@@ -124,7 +124,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"unknown error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(unknownErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(unknownErrJSON)),
 			},
 			Expect: awserr.NewRequestFailure(
 				awserr.New("UnknownError", "error message", nil),
@@ -136,14 +136,14 @@ func TestUnmarshalTypedError(t *testing.T) {
 			Response: &http.Response{
 				StatusCode: 400,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(strings.NewReader(`{`)),
+				Body:       io.NopCloser(strings.NewReader(`{`)),
 			},
 			Err: "failed decoding",
 		},
 		"mixed case fields": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(simpleCasedErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(simpleCasedErrJSON)),
 			},
 			Expect: &SimpleError{
 				Message2: aws.String("some message"),
@@ -189,7 +189,7 @@ func TestUnmarshalError_SerializationError(t *testing.T) {
 					Header: http.Header{
 						"X-Amzn-Requestid": []string{"abc123"},
 					},
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						bytes.NewReader([]byte{}),
 					),
 				},
@@ -204,7 +204,7 @@ func TestUnmarshalError_SerializationError(t *testing.T) {
 					Header: http.Header{
 						"X-Amzn-Requestid": []string{"abc123"},
 					},
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						bytes.NewReader([]byte(`<html></html>`)),
 					),
 				},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -1665,7 +1664,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"Str\": \"myname\", \"Num\": 123, \"FalseBool\": false, \"TrueBool\": true, \"Float\": 1.2, \"Double\": 1.3, \"Long\": 200, \"Char\": \"a\"}"))
 	req, out := svc.OutputService1TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1712,7 +1711,7 @@ func TestOutputService2ProtocolTestBlobMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"BlobMember\": \"aGkh\", \"StructMember\": {\"foo\": \"dGhlcmUh\"}}"))
 	req, out := svc.OutputService2TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1741,7 +1740,7 @@ func TestOutputService3ProtocolTestTimestampMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38Z\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38Z\"}}"))
 	req, out := svc.OutputService3TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1779,7 +1778,7 @@ func TestOutputService4ProtocolTestListsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"ListMember\": [\"a\", \"b\"]}"))
 	req, out := svc.OutputService4TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1808,7 +1807,7 @@ func TestOutputService4ProtocolTestListsCase2(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"ListMember\": [\"a\", null], \"ListMemberMap\": [{}, null, null, {}], \"ListMemberStruct\": [{}, null, null, {}]}"))
 	req, out := svc.OutputService4TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1849,7 +1848,7 @@ func TestOutputService5ProtocolTestMapsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"MapMember\": {\"a\": [1, 2], \"b\": [3, 4]}}"))
 	req, out := svc.OutputService5TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1884,7 +1883,7 @@ func TestOutputService6ProtocolTestIgnoresExtraDataCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"foo\": \"bar\"}"))
 	req, out := svc.OutputService6TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1907,7 +1906,7 @@ func TestOutputService7ProtocolTestEnumOutputCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"bar\"]}"))
 	req, out := svc.OutputService7TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1939,7 +1938,7 @@ func TestOutputService8ProtocolTestunmodeledNonjsonResponsePayloadCase1(t *testi
 
 	buf := bytes.NewReader([]byte("success"))
 	req, out := svc.OutputService8TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1962,7 +1961,7 @@ func TestOutputService8ProtocolTestunmodeledNonjsonResponsePayloadCase2(t *testi
 
 	buf := bytes.NewReader([]byte("\"success\""))
 	req, out := svc.OutputService8TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -1985,7 +1984,7 @@ func TestOutputService8ProtocolTestunmodeledNonjsonResponsePayloadCase3(t *testi
 
 	buf := bytes.NewReader([]byte("{}"))
 	req, out := svc.OutputService8TestCaseOperation3Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/payload.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/payload.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
@@ -32,7 +31,7 @@ func (h HandlerPayloadUnmarshal) UnmarshalPayload(r io.Reader, v interface{}) er
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(r),
+			Body:       io.NopCloser(r),
 		},
 		Data: v,
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/build_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -3808,7 +3807,7 @@ func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3841,7 +3840,7 @@ func TestInputService1ProtocolTestScalarMembersCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Baz=true&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3874,7 +3873,7 @@ func TestInputService1ProtocolTestScalarMembersCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Baz=false&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3909,7 +3908,7 @@ func TestInputService2ProtocolTestNestedStructureMembersCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&StructArg.ScalarArg=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3946,7 +3945,7 @@ func TestInputService3ProtocolTestListTypesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListArg.member.1=foo&ListArg.member.2=bar&ListArg.member.3=baz&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -3979,7 +3978,7 @@ func TestInputService3ProtocolTestListTypesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListArg=&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4017,7 +4016,7 @@ func TestInputService4ProtocolTestFlattenedListCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListArg.1=a&ListArg.2=b&ListArg.3=c&ScalarArg=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4052,7 +4051,7 @@ func TestInputService4ProtocolTestFlattenedListCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Foo.1=a&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4088,7 +4087,7 @@ func TestInputService5ProtocolTestSerializeFlattenedMapTypeCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&MapArg.1.key=key1&MapArg.1.value=val1&MapArg.2.key=key2&MapArg.2.value=val2&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4125,7 +4124,7 @@ func TestInputService6ProtocolTestNonFlattenedListWithLocationNameCase1(t *testi
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListArg.item.1=a&ListArg.item.2=b&ListArg.item.3=c&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4163,7 +4162,7 @@ func TestInputService7ProtocolTestFlattenedListWithLocationNameCase1(t *testing.
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&ListArgLocation.1=a&ListArgLocation.2=b&ListArgLocation.3=c&ScalarArg=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4199,7 +4198,7 @@ func TestInputService8ProtocolTestSerializeMapTypeCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&MapArg.entry.1.key=key1&MapArg.entry.1.value=val1&MapArg.entry.2.key=key2&MapArg.entry.2.value=val2&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4235,7 +4234,7 @@ func TestInputService9ProtocolTestSerializeMapTypeWithLocationNameCase1(t *testi
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&MapArg.entry.1.TheKey=key1&MapArg.entry.1.TheValue=val1&MapArg.entry.2.TheKey=key2&MapArg.entry.2.TheValue=val2&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4268,7 +4267,7 @@ func TestInputService10ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&BlobArg=Zm9v&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4303,7 +4302,7 @@ func TestInputService11ProtocolTestBase64EncodedBlobsNestedCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&BlobArgs.1=Zm9v&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4338,7 +4337,7 @@ func TestInputService12ProtocolTestTimestampValuesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&TimeArg=2015-01-25T08%3A00%3A00Z&TimeCustom=1422172800&TimeFormat=1422172800&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4373,7 +4372,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.NoRecurse=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4410,7 +4409,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.RecursiveStruct.NoRecurse=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4451,7 +4450,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.RecursiveStruct.RecursiveStruct.RecursiveStruct.NoRecurse=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4493,7 +4492,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.RecursiveList.member.1.NoRecurse=foo&RecursiveStruct.RecursiveList.member.2.NoRecurse=bar&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4537,7 +4536,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.RecursiveList.member.1.NoRecurse=foo&RecursiveStruct.RecursiveList.member.2.RecursiveStruct.NoRecurse=bar&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4579,7 +4578,7 @@ func TestInputService13ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&RecursiveStruct.RecursiveMap.entry.1.key=foo&RecursiveStruct.RecursiveMap.entry.1.value.NoRecurse=foo&RecursiveStruct.RecursiveMap.entry.2.key=bar&RecursiveStruct.RecursiveMap.entry.2.value.NoRecurse=bar&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4612,7 +4611,7 @@ func TestInputService14ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Token=abc123&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4643,7 +4642,7 @@ func TestInputService14ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Token=00000000-0000-4000-8000-000000000000&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4681,7 +4680,7 @@ func TestInputService15ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&FooEnum=foo&ListEnums.member.1=foo&ListEnums.member.2=&ListEnums.member.3=bar&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4714,7 +4713,7 @@ func TestInputService15ProtocolTestEnumCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&FooEnum=foo&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4745,7 +4744,7 @@ func TestInputService15ProtocolTestEnumCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4778,7 +4777,7 @@ func TestInputService16ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=StaticOp&Name=myname&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -4811,7 +4810,7 @@ func TestInputService16ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=MemberRefOp&Name=myname&Version=2014-01-01`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/unmarshal_error_test.go
@@ -4,7 +4,7 @@
 package query
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -25,7 +25,7 @@ func TestUnmarshalError(t *testing.T) {
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<ErrorResponse>
 							<Error>
 								<Code>codeAbc</Code><Message>msg123</Message>
@@ -42,7 +42,7 @@ func TestUnmarshalError(t *testing.T) {
 				HTTPResponse: &http.Response{
 					StatusCode: 502,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<ServiceUnavailableException>
 							<Something>else</Something>
 						</ServiceUnavailableException>`)),
@@ -57,7 +57,7 @@ func TestUnmarshalError(t *testing.T) {
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<Hello>
 							<World>.</World>
 						</Hello>`)),

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/query/unmarshal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -2814,7 +2813,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService1TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2864,7 +2863,7 @@ func TestOutputService2ProtocolTestNotAllMembersInResponseCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Str>myname</Str></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService2TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2890,7 +2889,7 @@ func TestOutputService3ProtocolTestBlobCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Blob>dmFsdWU=</Blob></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService3TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2916,7 +2915,7 @@ func TestOutputService4ProtocolTestListsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><ListMember><member>abc</member><member>123</member></ListMember></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService4TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2945,7 +2944,7 @@ func TestOutputService5ProtocolTestListWithCustomMemberNameCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><ListMember><item>abc</item><item>123</item></ListMember></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService5TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2974,7 +2973,7 @@ func TestOutputService6ProtocolTestFlattenedListCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><ListMember>abc</ListMember><ListMember>123</ListMember></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService6TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3003,7 +3002,7 @@ func TestOutputService7ProtocolTestFlattenedSingleElementListCase1(t *testing.T)
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><ListMember>abc</ListMember></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService7TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3029,7 +3028,7 @@ func TestOutputService8ProtocolTestListOfStructuresCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><List><member><Foo>firstfoo</Foo><Bar>firstbar</Bar><Baz>firstbaz</Baz></member><member><Foo>secondfoo</Foo><Bar>secondbar</Bar><Baz>secondbaz</Baz></member></List></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService8TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3070,7 +3069,7 @@ func TestOutputService9ProtocolTestFlattenedListOfStructuresCase1(t *testing.T) 
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><List><Foo>firstfoo</Foo><Bar>firstbar</Bar><Baz>firstbaz</Baz></List><List><Foo>secondfoo</Foo><Bar>secondbar</Bar><Baz>secondbaz</Baz></List></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService9TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3111,7 +3110,7 @@ func TestOutputService10ProtocolTestFlattenedListWithLocationNameCase1(t *testin
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><NamedList>a</NamedList><NamedList>b</NamedList></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService10TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3140,7 +3139,7 @@ func TestOutputService11ProtocolTestNormalMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08\"><OperationNameResult><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService11TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3169,7 +3168,7 @@ func TestOutputService12ProtocolTestFlattenedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService12TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3198,7 +3197,7 @@ func TestOutputService13ProtocolTestFlattenedMapInShapeDefinitionCase1(t *testin
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Attribute><Name>qux</Name><Value>bar</Value></Attribute></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService13TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3224,7 +3223,7 @@ func TestOutputService14ProtocolTestNamedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Map><foo>qux</foo><bar>bar</bar></Map><Map><foo>baz</foo><bar>bam</bar></Map></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService14TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3253,7 +3252,7 @@ func TestOutputService15ProtocolTestEmptyStringCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Foo/></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService15TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3279,7 +3278,7 @@ func TestOutputService16ProtocolTestTimestampMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService16TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3317,7 +3316,7 @@ func TestOutputService17ProtocolTestEnumOutputCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"))
 	req, out := svc.OutputService17TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/rest/rest_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/rest/rest_test.go
@@ -5,7 +5,7 @@ package rest_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -55,7 +55,7 @@ func TestUnsetHeaders(t *testing.T) {
 	}{}
 
 	req := svc.NewRequest(op, input, output)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(nil)), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBuffer(nil)), Header: http.Header{}}
 	req.HTTPResponse.Header.Set("X-Amz-Foo", "e30=")
 
 	// unmarshal response
@@ -148,7 +148,7 @@ func TestNormalizedHeaders(t *testing.T) {
 			req := svc.NewRequest(op, input, output)
 			req.HTTPResponse = &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBuffer(nil)),
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
 				Header:     tt.outputValues,
 			}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -67,7 +66,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) error {
 					switch payload.Interface().(type) {
 					case []byte:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						}
@@ -76,7 +75,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) error {
 
 					case *string:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						}
@@ -90,15 +89,15 @@ func unmarshalBody(r *request.Request, v reflect.Value) error {
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 
 						case "io.ReadSeeker":
-							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+							b, err := io.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
 								return awserr.New(request.ErrCodeSerialization,
 									"failed to read response body", err)
 							}
-							payload.Set(reflect.ValueOf(ioutil.NopCloser(bytes.NewReader(b))))
+							payload.Set(reflect.ValueOf(io.NopCloser(bytes.NewReader(b))))
 
 						default:
-							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+							io.Copy(io.Discard, r.HTTPResponse.Body)
 							r.HTTPResponse.Body.Close()
 							return awserr.New(request.ErrCodeSerialization,
 								"failed to decode REST response",

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/build_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -7122,7 +7121,7 @@ func TestInputService9ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Config": {"A": "one", "B": "two"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7162,7 +7161,7 @@ func TestInputService10ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBo
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Config": {"A": "one", "B": "two"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7202,7 +7201,7 @@ func TestInputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "contents", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -7243,7 +7242,7 @@ func TestInputService12ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Bar": "QmxvYiBwYXJhbQ=="}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7276,7 +7275,7 @@ func TestInputService13ProtocolTestBlobPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -7333,7 +7332,7 @@ func TestInputService14ProtocolTestStructurePayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"baz": "bar"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7364,7 +7363,7 @@ func TestInputService14ProtocolTestStructurePayloadCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7441,7 +7440,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"NoRecurse": "foo"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7478,7 +7477,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveStruct": {"NoRecurse": "foo"}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7519,7 +7518,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveStruct": {"RecursiveStruct": {"RecursiveStruct": {"NoRecurse": "foo"}}}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7561,7 +7560,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveList": [{"NoRecurse": "foo"}, {"NoRecurse": "bar"}]}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7605,7 +7604,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveList": [{"NoRecurse": "foo"}, {"RecursiveStruct": {"NoRecurse": "bar"}}]}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7647,7 +7646,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"RecursiveStruct": {"RecursiveMap": {"foo": {"NoRecurse": "foo"}, "bar": {"NoRecurse": "bar"}}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7688,7 +7687,7 @@ func TestInputService17ProtocolTestTimestampValuesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"TimeArg": 1422172800, "TimeCustom": "2015-01-25T08:00:00Z", "TimeFormat": "Sun, 25 Jan 2015 08:00:00 GMT"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7732,7 +7731,7 @@ func TestInputService18ProtocolTestNamedLocationsInJSONBodyCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"timestamp_location": 1422172800}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7765,7 +7764,7 @@ func TestInputService19ProtocolTestStringPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -7800,7 +7799,7 @@ func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Token": "abc123"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7831,7 +7830,7 @@ func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Token": "00000000-0000-4000-8000-000000000000"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7874,7 +7873,7 @@ func TestInputService21ProtocolTestJSONValueTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"BodyField":"{\"Foo\":\"Bar\"}"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7925,7 +7924,7 @@ func TestInputService21ProtocolTestJSONValueTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"BodyListField":["{\"Foo\":\"Bar\"}"]}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7961,7 +7960,7 @@ func TestInputService21ProtocolTestJSONValueTraitCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8011,7 +8010,7 @@ func TestInputService22ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"FooEnum": "foo", "ListEnums": ["foo", "", "bar"]}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8069,7 +8068,7 @@ func TestInputService23ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Name": "myname"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8102,7 +8101,7 @@ func TestInputService23ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"Name": "myname"}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8137,7 +8136,7 @@ func TestInputService24ProtocolTestUnionTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"OneOf": {"a": "hi"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8172,7 +8171,7 @@ func TestInputService24ProtocolTestUnionTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"OneOf": {"b": "hi"}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8209,7 +8208,7 @@ func TestInputService24ProtocolTestUnionTraitCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"OneOf": {"c": {"hello": "hi"}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8246,7 +8245,7 @@ func TestInputService24ProtocolTestUnionTraitCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"OneOf": {"d": {"hello": "hi"}}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8285,7 +8284,7 @@ func TestInputService24ProtocolTestUnionTraitCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"OneOf": {"e": [{"hello": "hi"}]}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8321,7 +8320,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase1(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"testConfig": {"timeout": 10}}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8360,7 +8359,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase2(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8396,7 +8395,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase3(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8437,7 +8436,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase4(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{"data": 25}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8478,7 +8477,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase5(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertJSON(t, `{}`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -8520,7 +8519,7 @@ func TestInputService25ProtocolTestrestjsonContentTypeAndBodyCase6(t *testing.T)
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "1234", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_error.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_error.go
@@ -3,7 +3,6 @@ package restjson
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -56,7 +55,7 @@ func (u *UnmarshalTypedError) UnmarshalError(
 			return nil, err
 		}
 
-		body = ioutil.NopCloser(&buf)
+		body = io.NopCloser(&buf)
 		code = jsonErr.Code
 		msg = jsonErr.Message
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_error_test.go
@@ -6,7 +6,7 @@ package restjson
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -85,7 +85,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"simple error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(simpleErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(simpleErrJSON)),
 			},
 			Expect: &SimpleError{
 				Message2: aws.String("some message"),
@@ -95,7 +95,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"other error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(otherErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(otherErrJSON)),
 			},
 			Expect: &OtherError{
 				Message2: aws.String("some message"),
@@ -104,7 +104,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"other complex Code error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(complexCodeErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(complexCodeErrJSON)),
 			},
 			Expect: &OtherError{
 				Message2: aws.String("some message"),
@@ -116,7 +116,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 				Header: http.Header{
 					"Some-Header": []string{"headval"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader(complexErrJSON)),
+				Body: io.NopCloser(strings.NewReader(complexErrJSON)),
 			},
 			Expect: &ComplexError{
 				Message2:  aws.String("some message"),
@@ -131,7 +131,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 		"unknown error": {
 			Response: &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(strings.NewReader(unknownErrJSON)),
+				Body:   io.NopCloser(strings.NewReader(unknownErrJSON)),
 			},
 			Expect: awserr.NewRequestFailure(
 				awserr.New("UnknownError", "error message", nil),
@@ -143,7 +143,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 			Response: &http.Response{
 				StatusCode: 400,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(strings.NewReader(`{`)),
+				Body:       io.NopCloser(strings.NewReader(`{`)),
 			},
 			Err: "failed decoding",
 		},
@@ -153,7 +153,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 					errorTypeHeader:    []string{"UnknownError"},
 					errorMessageHeader: []string{"error message"},
 				},
-				Body: ioutil.NopCloser(nil),
+				Body: io.NopCloser(nil),
 			},
 			Expect: awserr.NewRequestFailure(
 				awserr.New("UnknownError", "error message", nil),
@@ -166,7 +166,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 				Header: http.Header{
 					errorTypeHeader: []string{"SimpleError"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader(simpleNoCodeJSON)),
+				Body: io.NopCloser(strings.NewReader(simpleNoCodeJSON)),
 			},
 			Expect: &SimpleError{
 				Message2: aws.String("some message"),
@@ -179,7 +179,7 @@ func TestUnmarshalTypedError(t *testing.T) {
 					errorTypeHeader:    []string{"SimpleError"},
 					errorMessageHeader: []string{"error message"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader(simpleNoCodeJSON)),
+				Body: io.NopCloser(strings.NewReader(simpleNoCodeJSON)),
 			},
 			Expect: &SimpleError{
 				Message2: aws.String("some message"),
@@ -225,7 +225,7 @@ func TestUnmarshalError_SerializationError(t *testing.T) {
 					Header: http.Header{
 						"X-Amzn-Requestid": []string{"abc123"},
 					},
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						bytes.NewReader([]byte{}),
 					),
 				},
@@ -240,7 +240,7 @@ func TestUnmarshalError_SerializationError(t *testing.T) {
 					Header: http.Header{
 						"X-Amzn-Requestid": []string{"abc123"},
 					},
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						bytes.NewReader([]byte(`<html></html>`)),
 					),
 				},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restjson/unmarshal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -2647,7 +2646,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"Str\": \"myname\", \"Num\": 123, \"FalseBool\": false, \"TrueBool\": true, \"Float\": 1.2, \"Double\": 1.3, \"Long\": 200, \"Char\": \"a\", \"Timestamp\": \"2015-01-25T08:00:00Z\", \"Blob\": \"aGVsbG8=\"}"))
 	req, out := svc.OutputService1TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("BlobHeader", "aGVsbG8=")
@@ -2715,7 +2714,7 @@ func TestOutputService2ProtocolTestBlobMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"BlobMember\": \"aGkh\", \"StructMember\": {\"foo\": \"dGhlcmUh\"}}"))
 	req, out := svc.OutputService2TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2744,7 +2743,7 @@ func TestOutputService3ProtocolTestTimestampMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38Z\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38Z\"}}"))
 	req, out := svc.OutputService3TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("x-amz-timearg", "Tue, 29 Apr 2014 18:30:38 GMT")
@@ -2794,7 +2793,7 @@ func TestOutputService4ProtocolTestListsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"ListMember\": [\"a\", \"b\"]}"))
 	req, out := svc.OutputService4TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2823,7 +2822,7 @@ func TestOutputService5ProtocolTestListsWithStructureMemberCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"ListMember\": [{\"Foo\": \"a\"}, {\"Foo\": \"b\"}]}"))
 	req, out := svc.OutputService5TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2852,7 +2851,7 @@ func TestOutputService6ProtocolTestMapsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"MapMember\": {\"a\": [1, 2], \"b\": [3, 4]}}"))
 	req, out := svc.OutputService6TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2887,7 +2886,7 @@ func TestOutputService7ProtocolTestComplexMapValuesCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"MapMember\": {\"a\": 1398796238, \"b\": 1398796238}}"))
 	req, out := svc.OutputService7TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2916,7 +2915,7 @@ func TestOutputService8ProtocolTestIgnoresExtraDataCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"foo\": \"bar\"}"))
 	req, out := svc.OutputService8TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2939,7 +2938,7 @@ func TestOutputService9ProtocolTestIgnoresUndefinedOutputCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("OK"))
 	req, out := svc.OutputService9TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -2962,7 +2961,7 @@ func TestOutputService10ProtocolTestSupportsHeaderMapsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{}"))
 	req, out := svc.OutputService10TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("Content-Length", "10")
@@ -3003,7 +3002,7 @@ func TestOutputService11ProtocolTestJSONPayloadCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"Foo\": \"abc\"}"))
 	req, out := svc.OutputService11TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("X-Foo", "baz")
@@ -3033,7 +3032,7 @@ func TestOutputService12ProtocolTestStreamingPayloadCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("abc"))
 	req, out := svc.OutputService12TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3059,7 +3058,7 @@ func TestOutputService13ProtocolTestJSONValueTraitCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"BodyField\":\"{\\\"Foo\\\":\\\"Bar\\\"}\"}"))
 	req, out := svc.OutputService13TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("X-Amz-Foo", "eyJGb28iOiJCYXIifQ==")
@@ -3085,7 +3084,7 @@ func TestOutputService13ProtocolTestJSONValueTraitCase2(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"BodyListField\":[\"{\\\"Foo\\\":\\\"Bar\\\"}\"]}"))
 	req, out := svc.OutputService13TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3109,7 +3108,7 @@ func TestOutputService14ProtocolTestEnumCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"bar\"]}"))
 	req, out := svc.OutputService14TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("x-amz-enum", "baz")
@@ -3145,7 +3144,7 @@ func TestOutputService14ProtocolTestEnumCase2(t *testing.T) {
 
 	buf := bytes.NewReader([]byte(""))
 	req, out := svc.OutputService14TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restxml/build_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restxml/build_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -6126,7 +6125,7 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Name>foo</Name><Description>bar</Description></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6160,7 +6159,7 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Name>foo</Name><Description>bar</Description></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6216,7 +6215,7 @@ func TestInputService2ProtocolTestSerializeOtherScalarTypesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><First>true</First><Second>false</Second><Third>1.2</Third><Fourth>3</Fourth></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6253,7 +6252,7 @@ func TestInputService3ProtocolTestNestedStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure><Foo>a</Foo><Bar>b</Bar></SubStructure><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6289,7 +6288,7 @@ func TestInputService3ProtocolTestNestedStructuresCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure><Foo>a</Foo></SubStructure><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6323,7 +6322,7 @@ func TestInputService4ProtocolTestNestedStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure /><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6360,7 +6359,7 @@ func TestInputService5ProtocolTestNonFlattenedListsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam><member>one</member><member>two</member><member>three</member></ListParam></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6397,7 +6396,7 @@ func TestInputService6ProtocolTestNonFlattenedListsWithLocationNameCase1(t *test
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><AlternateName><NotMember>one</NotMember><NotMember>two</NotMember><NotMember>three</NotMember></AlternateName></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6434,7 +6433,7 @@ func TestInputService7ProtocolTestFlattenedListsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam>one</ListParam><ListParam>two</ListParam><ListParam>three</ListParam></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6471,7 +6470,7 @@ func TestInputService8ProtocolTestFlattenedListsWithLocationNameCase1(t *testing
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item>one</item><item>two</item><item>three</item></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6514,7 +6513,7 @@ func TestInputService9ProtocolTestListOfStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item><value>one</value></item><item><value>two</value></item><item><value>three</value></item></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6549,7 +6548,7 @@ func TestInputService10ProtocolTestBlobShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><StructureParam><b>Zm9v</b></StructureParam></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6590,7 +6589,7 @@ func TestInputService11ProtocolTestTimestampShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<TimestampStructure xmlns="https://foo/"><TimeArg>2015-01-25T08:00:00Z</TimeArg><TimeCustom>Sun, 25 Jan 2015 08:00:00 GMT</TimeCustom><TimeFormat>Sun, 25 Jan 2015 08:00:00 GMT</TimeFormat></TimestampStructure>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6794,7 +6793,7 @@ func TestInputService17ProtocolTestStringPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6829,7 +6828,7 @@ func TestInputService18ProtocolTestBlobPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6886,7 +6885,7 @@ func TestInputService19ProtocolTestStructurePayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6939,7 +6938,7 @@ func TestInputService19ProtocolTestStructurePayloadCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<foo />`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -6997,7 +6996,7 @@ func TestInputService20ProtocolTestXMLAttributeCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7097,7 +7096,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7134,7 +7133,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7175,7 +7174,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveStruct><RecursiveStruct><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7217,7 +7216,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveList><member><NoRecurse>foo</NoRecurse></member><member><NoRecurse>bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7261,7 +7260,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveList><member><NoRecurse>foo</NoRecurse></member><member><RecursiveStruct><NoRecurse>bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7303,7 +7302,7 @@ func TestInputService23ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveMap><entry><key>bar</key><value><NoRecurse>bar</NoRecurse></value></entry><entry><key>foo</key><value><NoRecurse>foo</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7336,7 +7335,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7367,7 +7366,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7412,7 +7411,7 @@ func TestInputService25ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<InputShape><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></InputShape>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7472,7 +7471,7 @@ func TestInputService26ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<StaticOpRequest><Name>myname</Name></StaticOpRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {
@@ -7505,7 +7504,7 @@ func TestInputService26ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	awstesting.AssertXML(t, `<MemberRefOpRequest><Name>myname</Name></MemberRefOpRequest>`, util.Trim(string(body)))
 
 	if e, a := int64(len(body)), r.ContentLength; e != a {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restxml/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/restxml/unmarshal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -34,7 +33,7 @@ var _ json.Marshaler
 var _ time.Time
 var _ xmlutil.XMLNode
 var _ xml.Attr
-var _ = ioutil.Discard
+var _ = io.Discard
 var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
@@ -2945,7 +2944,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp><Blob>aGVsbG8=</Blob></OperationNameResponse>"))
 	req, out := svc.OutputService1TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("BlobHeader", "aGVsbG8=")
@@ -3010,7 +3009,7 @@ func TestOutputService1ProtocolTestScalarMembersCase2(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Str></Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp></OperationNameResponse>"))
 	req, out := svc.OutputService1TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("ImaHeader", "test")
@@ -3068,7 +3067,7 @@ func TestOutputService2ProtocolTestBlobCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><Blob>dmFsdWU=</Blob></OperationNameResult>"))
 	req, out := svc.OutputService2TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3094,7 +3093,7 @@ func TestOutputService3ProtocolTestListsCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><ListMember><member>abc</member><member>123</member></ListMember></OperationNameResult>"))
 	req, out := svc.OutputService3TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3123,7 +3122,7 @@ func TestOutputService4ProtocolTestListWithCustomMemberNameCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><ListMember><item>abc</item><item>123</item></ListMember></OperationNameResult>"))
 	req, out := svc.OutputService4TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3152,7 +3151,7 @@ func TestOutputService5ProtocolTestFlattenedListCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><ListMember>abc</ListMember><ListMember>123</ListMember></OperationNameResult>"))
 	req, out := svc.OutputService5TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3181,7 +3180,7 @@ func TestOutputService6ProtocolTestNormalMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map></OperationNameResult>"))
 	req, out := svc.OutputService6TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3210,7 +3209,7 @@ func TestOutputService7ProtocolTestFlattenedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map></OperationNameResult>"))
 	req, out := svc.OutputService7TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3239,7 +3238,7 @@ func TestOutputService8ProtocolTestNamedMapCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResult><Map><entry><foo>qux</foo><bar>bar</bar></entry><entry><foo>baz</foo><bar>bam</bar></entry></Map></OperationNameResult>"))
 	req, out := svc.OutputService8TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3268,7 +3267,7 @@ func TestOutputService9ProtocolTestXMLPayloadCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Foo>abc</Foo></OperationNameResponse>"))
 	req, out := svc.OutputService9TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("X-Foo", "baz")
@@ -3298,7 +3297,7 @@ func TestOutputService10ProtocolTestStreamingPayloadCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("abc"))
 	req, out := svc.OutputService10TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3324,7 +3323,7 @@ func TestOutputService11ProtocolTestScalarMembersInHeadersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte(""))
 	req, out := svc.OutputService11TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("x-char", "a")
@@ -3383,7 +3382,7 @@ func TestOutputService12ProtocolTestEmptyStringCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService12TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3409,7 +3408,7 @@ func TestOutputService13ProtocolTestTimestampMembersCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"))
 	req, out := svc.OutputService13TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("x-amz-timearg", "Tue, 29 Apr 2014 18:30:38 GMT")
@@ -3459,7 +3458,7 @@ func TestOutputService14ProtocolTestEnumCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>0</member><member>1</member></ListEnums></OperationNameResponse>"))
 	req, out := svc.OutputService14TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 	req.HTTPResponse.Header.Set("x-amz-enum", "baz")
@@ -3495,7 +3494,7 @@ func TestOutputService14ProtocolTestEnumCase2(t *testing.T) {
 
 	buf := bytes.NewReader([]byte(""))
 	req, out := svc.OutputService14TestCaseOperation2Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 
@@ -3518,7 +3517,7 @@ func TestOutputService15ProtocolTestXMLAttributesCase1(t *testing.T) {
 
 	buf := bytes.NewReader([]byte("<SomeOutputDoc xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><ItemsList><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type1\"><ID>id1</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type2\"><ID>id2</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type3\"><ID>id3</ID></ItemDetail></Item></ItemsList></SomeOutputDoc>"))
 	req, out := svc.OutputService15TestCaseOperation1Request(nil)
-	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: io.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/unmarshal.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/unmarshal.go
@@ -2,8 +2,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
-
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
 )
 
@@ -16,7 +14,7 @@ func UnmarshalDiscardBody(r *request.Request) {
 		return
 	}
 
-	io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	io.Copy(io.Discard, r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/unmarshal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/private/protocol/unmarshal_test.go
@@ -1,7 +1,7 @@
 package protocol_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -71,7 +71,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 				Data: &testOutput{},
 				HTTPResponse: &http.Response{
 					StatusCode: 502,
-					Body:       ioutil.NopCloser(strings.NewReader("invalid json")),
+					Body:       io.NopCloser(strings.NewReader("invalid json")),
 				},
 			},
 			unmarshalFn: jsonrpc.Unmarshal,
@@ -87,7 +87,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 				Data: &testOutput{},
 				HTTPResponse: &http.Response{
 					StatusCode: 111,
-					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+					Body:       io.NopCloser(strings.NewReader("<<>>>>>>")),
 				},
 			},
 			unmarshalFn: ec2query.Unmarshal,
@@ -106,7 +106,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 				Data: &testOutput{},
 				HTTPResponse: &http.Response{
 					StatusCode: 1,
-					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+					Body:       io.NopCloser(strings.NewReader("<<>>>>>>")),
 				},
 			},
 			unmarshalFn: query.Unmarshal,
@@ -122,7 +122,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 				Data: &testOutput{},
 				HTTPResponse: &http.Response{
 					StatusCode: 123,
-					Body:       ioutil.NopCloser(strings.NewReader("invalid json")),
+					Body:       io.NopCloser(strings.NewReader("invalid json")),
 				},
 			},
 			unmarshalFn: restjson.Unmarshal,
@@ -138,7 +138,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 				Data: &testOutput{},
 				HTTPResponse: &http.Response{
 					StatusCode: 456,
-					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+					Body:       io.NopCloser(strings.NewReader("<<>>>>>>")),
 				},
 			},
 			unmarshalFn: restxml.Unmarshal,

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/cloudfront/sign/privkey.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/cloudfront/sign/privkey.go
@@ -6,7 +6,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -51,7 +50,7 @@ func LoadEncryptedPEMPrivKey(reader io.Reader, password []byte) (*rsa.PrivateKey
 }
 
 func loadPem(reader io.Reader) (*pem.Block, error) {
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/docdb/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/docdb/customizations_test.go
@@ -5,7 +5,7 @@ package docdb
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"regexp"
 	"testing"
@@ -130,7 +130,7 @@ func TestPresignCrossRegionRequest(t *testing.T) {
 			if err := c.Req.Sign(); err != nil {
 				t.Fatalf("expect no error, got %v", err)
 			}
-			b, _ := ioutil.ReadAll(c.Req.HTTPRequest.Body)
+			b, _ := io.ReadAll(c.Req.HTTPRequest.Body)
 			q, _ := url.ParseQuery(string(b))
 
 			u, _ := url.QueryUnescape(q.Get("PreSignedUrl"))

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/dynamodb/customizations.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/dynamodb/customizations.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"time"
 
@@ -85,7 +84,7 @@ func validateCRC32(r *request.Request) {
 	}
 
 	// Reset body for subsequent reads
-	r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+	r.HTTPResponse.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 
 	// Compute the CRC checksum
 	crc := crc32.ChecksumIEEE(buf.Bytes())

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/dynamodb/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/dynamodb/customizations_test.go
@@ -2,7 +2,7 @@ package dynamodb_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -37,7 +37,7 @@ func mockCRCResponse(svc *dynamodb.DynamoDB, status int, body, crc string) (req 
 		req.HTTPResponse = &http.Response{
 			ContentLength: int64(len(body)),
 			StatusCode:    status,
-			Body:          ioutil.NopCloser(bytes.NewReader([]byte(body))),
+			Body:          io.NopCloser(bytes.NewReader([]byte(body))),
 			Header:        header,
 		}
 	})

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/ec2/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/ec2/customizations_test.go
@@ -6,7 +6,7 @@ package ec2_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -39,7 +39,7 @@ func TestCopySnapshotPresignedURL(t *testing.T) {
 	})
 	req.Sign()
 
-	b, _ := ioutil.ReadAll(req.HTTPRequest.Body)
+	b, _ := io.ReadAll(req.HTTPRequest.Body)
 	q, _ := url.ParseQuery(string(b))
 	u, _ := url.QueryUnescape(q.Get("PresignedUrl"))
 	if e, a := "us-west-2", q.Get("DestinationRegion"); e != a {
@@ -101,7 +101,7 @@ func checkRetryerMaxRetries(t *testing.T, maxRetries int) func(*request.Request)
 			rr.HTTPResponse = &http.Response{
 				StatusCode: 200,
 				Header:     http.Header{},
-				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+				Body:       io.NopCloser(&bytes.Buffer{}),
 			}
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/kinesis/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/kinesis/customizations_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -105,14 +104,14 @@ func TestKinesisCustomRetryErrorCodes(t *testing.T) {
 		{
 			StatusCode: 400,
 			Header:     http.Header{},
-			Body: ioutil.NopCloser(bytes.NewReader(
+			Body: io.NopCloser(bytes.NewReader(
 				[]byte(fmt.Sprintf(jsonErr, ErrCodeLimitExceededException)),
 			)),
 		},
 		{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/kinesis/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/kinesis/eventstream_test.go
@@ -8,7 +8,7 @@ package kinesis
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -198,7 +198,7 @@ func BenchmarkSubscribeToShard_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/lexruntimeservice/cust_jsonvalue_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/lexruntimeservice/cust_jsonvalue_test.go
@@ -6,7 +6,7 @@ package lexruntimeservice_test
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -42,7 +42,7 @@ func TestLexRunTimeService_suppressedJSONValue(t *testing.T) {
 						return h
 					}(),
 					ContentLength: 2,
-					Body:          ioutil.NopCloser(strings.NewReader(`{}`)),
+					Body:          io.NopCloser(strings.NewReader(`{}`)),
 				}
 			})
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/lexruntimev2/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/lexruntimev2/eventstream_test.go
@@ -8,7 +8,7 @@ package lexruntimev2
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -194,7 +194,7 @@ func BenchmarkStartConversation_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/machinelearning/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/machinelearning/customizations_test.go
@@ -2,7 +2,7 @@ package machinelearning_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -19,7 +19,7 @@ func TestPredictEndpoint(t *testing.T) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+			Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
 		}
 	})
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/neptune/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/neptune/customizations_test.go
@@ -5,7 +5,7 @@ package neptune
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"regexp"
 	"testing"
@@ -124,7 +124,7 @@ func TestPresignCrossRegionRequest(t *testing.T) {
 			if err := c.Req.Sign(); err != nil {
 				t.Fatalf("expect no error, got %v", err)
 			}
-			b, _ := ioutil.ReadAll(c.Req.HTTPRequest.Body)
+			b, _ := io.ReadAll(c.Req.HTTPRequest.Body)
 			q, _ := url.ParseQuery(string(b))
 
 			u, _ := url.QueryUnescape(q.Get("PreSignedUrl"))

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/rds/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/rds/customizations_test.go
@@ -5,7 +5,7 @@ package rds
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"regexp"
 	"testing"
@@ -231,7 +231,7 @@ func TestPresignCrossRegionRequest(t *testing.T) {
 			if err := c.Req.Sign(); err != nil {
 				t.Fatalf("expect no error, got %v", err)
 			}
-			b, _ := ioutil.ReadAll(c.Req.HTTPRequest.Body)
+			b, _ := io.ReadAll(c.Req.HTTPRequest.Body)
 			q, _ := url.ParseQuery(string(b))
 
 			u, _ := url.QueryUnescape(q.Get("PreSignedUrl"))

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/route53/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/route53/unmarshal_error_test.go
@@ -4,7 +4,7 @@
 package route53
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ but it already exists
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<?xml version="1.0" encoding="UTF-8"?>
 <ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
   <Error>
@@ -53,7 +53,7 @@ but it already exists
 				HTTPResponse: &http.Response{
 					StatusCode: 400,
 					Header:     http.Header{},
-					Body: ioutil.NopCloser(strings.NewReader(
+					Body: io.NopCloser(strings.NewReader(
 						`<?xml version="1.0" encoding="UTF-8"?>
 <InvalidChangeBatch xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
   <Messages>

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/body_hash_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/body_hash_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -258,7 +257,7 @@ func TestUseMD5ValidationReader(t *testing.T) {
 					}(),
 				},
 				Data: &GetObjectOutput{
-					Body:          ioutil.NopCloser(bytes.NewReader(bodyWithSum)),
+					Body:          io.NopCloser(bytes.NewReader(bodyWithSum)),
 					ContentLength: aws.Int64(int64(len(bodyWithSum))),
 				},
 			},
@@ -297,7 +296,7 @@ func TestUseMD5ValidationReader(t *testing.T) {
 					}(),
 				},
 				Data: &GetObjectOutput{
-					Body:          ioutil.NopCloser(bytes.NewReader(emptyBodySum[:])),
+					Body:          io.NopCloser(bytes.NewReader(emptyBodySum[:])),
 					ContentLength: aws.Int64(int64(len(emptyBodySum[:]))),
 				},
 			},
@@ -332,7 +331,7 @@ func TestUseMD5ValidationReader(t *testing.T) {
 					Header: http.Header{},
 				},
 				Data: &GetObjectOutput{
-					Body:          ioutil.NopCloser(bytes.NewReader(body)),
+					Body:          io.NopCloser(bytes.NewReader(body)),
 					ContentLength: aws.Int64(int64(len(body))),
 				},
 			},
@@ -384,7 +383,7 @@ func TestUseMD5ValidationReader(t *testing.T) {
 					}(),
 				},
 				Data: &GetObjectOutput{
-					Body:          ioutil.NopCloser(bytes.NewReader(bodyWithSum)),
+					Body:          io.NopCloser(bytes.NewReader(bodyWithSum)),
 					ContentLength: aws.Int64(-1),
 				},
 			},
@@ -410,7 +409,7 @@ func TestUseMD5ValidationReader(t *testing.T) {
 					}(),
 				},
 				Data: &GetObjectOutput{
-					Body:          ioutil.NopCloser(bytes.NewReader(make([]byte, 5))),
+					Body:          io.NopCloser(bytes.NewReader(make([]byte, 5))),
 					ContentLength: aws.Int64(5),
 				},
 			},
@@ -485,7 +484,7 @@ func TestReaderMD5Validation(t *testing.T) {
 			Error:      "unexpected EOF",
 		},
 		{
-			ContentReader: ioutil.NopCloser(errorReader{}),
+			ContentReader: io.NopCloser(errorReader{}),
 			PayloadLen:    int64(len(body)),
 			Error:         "errorReader error",
 		},
@@ -494,7 +493,7 @@ func TestReaderMD5Validation(t *testing.T) {
 	for i, c := range cases {
 		reader := c.ContentReader
 		if reader == nil {
-			reader = ioutil.NopCloser(bytes.NewReader(c.Content))
+			reader = io.NopCloser(bytes.NewReader(c.Content))
 		}
 		v := newMD5ValidationReader(reader, c.PayloadLen)
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/bucket_location.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/bucket_location.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"io/ioutil"
+	"io"
 	"regexp"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
@@ -78,7 +78,7 @@ func WithNormalizeBucketLocation(r *request.Request) {
 func buildGetBucketLocation(r *request.Request) {
 	if r.DataFilled() {
 		out := r.Data.(*GetBucketLocationOutput)
-		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+		b, err := io.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
 			r.Error = awserr.New(request.ErrCodeSerialization,
 				"failed reading response body", err)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/bucket_location_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/bucket_location_test.go
@@ -2,7 +2,7 @@ package s3_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -26,7 +26,7 @@ func TestGetBucketLocation(t *testing.T) {
 		s := s3.New(unit.Session)
 		s.Handlers.Send.Clear()
 		s.Handlers.Send.PushBack(func(r *request.Request) {
-			reader := ioutil.NopCloser(bytes.NewReader([]byte(test.body)))
+			reader := io.NopCloser(bytes.NewReader([]byte(test.body)))
 			r.HTTPResponse = &http.Response{StatusCode: 200, Body: reader}
 		})
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/content_md5_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/content_md5_test.go
@@ -3,7 +3,7 @@ package s3_test
 import (
 	"crypto/md5"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
@@ -18,7 +18,7 @@ func assertMD5(t *testing.T, req *request.Request) {
 		t.Errorf("expected no error, but received %v", err)
 	}
 
-	b, _ := ioutil.ReadAll(req.HTTPRequest.Body)
+	b, _ := io.ReadAll(req.HTTPRequest.Body)
 	out := md5.Sum(b)
 	if len(b) == 0 {
 		t.Error("expected non-empty value")

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/cust_integ_shared_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/cust_integ_shared_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -326,7 +325,7 @@ func testWriteToObject(t *testing.T, bucket string, opts ...request.Option) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 	if e, a := []byte("hello world"), b; !bytes.Equal(e, a) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -388,7 +387,7 @@ func testPresignedGetPut(t *testing.T, bucket string, opts ...request.Option) {
 
 	var b []byte
 	defer getresp.Body.Close()
-	b, err = ioutil.ReadAll(getresp.Body)
+	b, err = io.ReadAll(getresp.Body)
 	if e, a := "hello world", string(b); e != a {
 		t.Fatalf("expect %v, got %v", e, a)
 	}
@@ -426,7 +425,7 @@ func testCopyObject(t *testing.T, sourceBucket string, targetBucket string, opts
 		t.Fatalf("expect no error, got %v", err)
 	}
 
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 	if e, a := []byte("hello world"), b; !reflect.DeepEqual(e, a) {
 		t.Errorf("expect %v, got %v", e, a)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/endpoint_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/endpoint_test.go
@@ -6,7 +6,7 @@ package s3
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -745,7 +745,7 @@ func runValidations(t *testing.T, cases map[string]testCase) {
 					r.HTTPResponse = &http.Response{
 						StatusCode:    200,
 						ContentLength: 0,
-						Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+						Body:          io.NopCloser(bytes.NewReader(nil)),
 					}
 				}()
 				if len(c.expectedErr) != 0 {
@@ -850,7 +850,7 @@ func TestWriteGetObjectResponse_UpdateEndpoint(t *testing.T) {
 					r.HTTPResponse = &http.Response{
 						StatusCode:    200,
 						ContentLength: 0,
-						Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+						Body:          io.NopCloser(bytes.NewReader(nil)),
 					}
 				}()
 				if len(c.expectedErr) != 0 {
@@ -935,7 +935,7 @@ func TestWriteGetObjectResponse(t *testing.T) {
 						t.Errorf("expect %v, got %v", e, a)
 					}
 
-					all, err := ioutil.ReadAll(request.Body)
+					all, err := io.ReadAll(request.Body)
 					if err != nil {
 						t.Errorf("expect no error, got %v", err)
 					}
@@ -968,7 +968,7 @@ func TestWriteGetObjectResponse(t *testing.T) {
 						t.Errorf("expect %v, got %v", e, a)
 					}
 
-					all, err := ioutil.ReadAll(request.Body)
+					all, err := io.ReadAll(request.Body)
 					if err != nil {
 						t.Errorf("expect no error, got %v", err)
 					}
@@ -1001,7 +1001,7 @@ func TestWriteGetObjectResponse(t *testing.T) {
 						t.Errorf("expect %v, got %v", e, a)
 					}
 
-					all, err := ioutil.ReadAll(request.Body)
+					all, err := io.ReadAll(request.Body)
 					if err != nil {
 						t.Errorf("expect no error, got %v", err)
 					}
@@ -1039,7 +1039,7 @@ func TestWriteGetObjectResponse(t *testing.T) {
 						t.Errorf("expect %v, got %v", e, a)
 					}
 
-					all, err := ioutil.ReadAll(request.Body)
+					all, err := io.ReadAll(request.Body)
 					if err != nil {
 						t.Errorf("expect no error, got %v", err)
 					}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/eventstream_test.go
@@ -8,7 +8,7 @@ package s3
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -194,7 +194,7 @@ func BenchmarkSelectObjectContent_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/aes_gcm.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/aes_gcm.go
@@ -5,7 +5,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"io"
-	"io/ioutil"
 )
 
 // AESGCM Symmetric encryption algorithm. Since Golang designed this
@@ -60,7 +59,7 @@ type gcmEncryptReader struct {
 
 func (reader *gcmEncryptReader) Read(data []byte) (int, error) {
 	if reader.buf == nil {
-		b, err := ioutil.ReadAll(reader.src)
+		b, err := io.ReadAll(reader.src)
 		if err != nil {
 			return 0, err
 		}
@@ -89,7 +88,7 @@ type gcmDecryptReader struct {
 
 func (reader *gcmDecryptReader) Read(data []byte) (int, error) {
 	if reader.buf == nil {
-		b, err := ioutil.ReadAll(reader.src)
+		b, err := io.ReadAll(reader.src)
 		if err != nil {
 			return 0, err
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/aes_gcm_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/aes_gcm_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -61,7 +61,7 @@ type KAT struct {
 }
 
 func TestAES_GCM_KATS(t *testing.T) {
-	fileContents, err := ioutil.ReadFile("testdata/aes_gcm.json")
+	fileContents, err := os.ReadFile("testdata/aes_gcm.json")
 	if err != nil {
 		t.Fatalf("failed to read KAT file: %v", err)
 	}
@@ -173,7 +173,7 @@ func aesgcmTest(t *testing.T, iv, key, plaintext, expected, tag []byte) {
 
 	cipherdata := gcm.Encrypt(bytes.NewReader(plaintext))
 
-	ciphertext, err := ioutil.ReadAll(cipherdata)
+	ciphertext, err := io.ReadAll(cipherdata)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -188,7 +188,7 @@ func aesgcmTest(t *testing.T, iv, key, plaintext, expected, tag []byte) {
 	}
 
 	data := gcm.Decrypt(bytes.NewReader(ciphertext))
-	text, err := ioutil.ReadAll(data)
+	text, err := io.ReadAll(data)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/cipher_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/cipher_test.go
@@ -1,7 +1,7 @@
 package s3crypto_test
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -11,9 +11,9 @@ import (
 func TestCryptoReadCloserRead(t *testing.T) {
 	expectedStr := "HELLO WORLD "
 	str := strings.NewReader(expectedStr)
-	rc := &s3crypto.CryptoReadCloser{Body: ioutil.NopCloser(str), Decrypter: str}
+	rc := &s3crypto.CryptoReadCloser{Body: io.NopCloser(str), Decrypter: str}
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -27,10 +27,10 @@ func TestCryptoReadCloserClose(t *testing.T) {
 	expectedStr := ""
 
 	str := strings.NewReader(data)
-	rc := &s3crypto.CryptoReadCloser{Body: ioutil.NopCloser(str), Decrypter: str}
+	rc := &s3crypto.CryptoReadCloser{Body: io.NopCloser(str), Decrypter: str}
 	rc.Close()
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/decryption_client_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/decryption_client_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -68,14 +68,14 @@ func TestGetObjectGCM(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{s3crypto.AESGCMNoPadding},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-tag-len"):  []string{"128"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err := req.Send()
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
-	b, err := ioutil.ReadAll(out.Body)
+	b, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -135,14 +135,14 @@ func TestGetObjectCBC(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{strings.Join([]string{s3crypto.AESCBC, s3crypto.AESCBCPadder.Name()}, "/")},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err := req.Send()
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
-	b, err := ioutil.ReadAll(out.Body)
+	b, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -198,14 +198,14 @@ func TestGetObjectCBC2(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{strings.Join([]string{s3crypto.AESCBC, s3crypto.AESCBCPadder.Name()}, "/")},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err := req.Send()
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
-	b, err := ioutil.ReadAll(out.Body)
+	b, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -273,7 +273,7 @@ func TestDecryptionClient_GetObject_V2Artifact(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSContextWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{"AES/GCM/NoPadding"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err := req.Send()
@@ -281,7 +281,7 @@ func TestDecryptionClient_GetObject_V2Artifact(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	actual, err := ioutil.ReadAll(out.Body)
+	actual, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/decryption_client_v2_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/decryption_client_v2_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -87,7 +87,7 @@ func TestDecryptionClientV2_GetObject(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSContextWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{"AES/GCM/NoPadding"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err = req.Send()
@@ -95,7 +95,7 @@ func TestDecryptionClientV2_GetObject(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	actual, err := ioutil.ReadAll(out.Body)
+	actual, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDecryptionClientV2_GetObject_V1Interop_KMS_AESCBC(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{"AES/CBC/PKCS5Padding"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err = req.Send()
@@ -161,7 +161,7 @@ func TestDecryptionClientV2_GetObject_V1Interop_KMS_AESCBC(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	actual, err := ioutil.ReadAll(out.Body)
+	actual, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -219,7 +219,7 @@ func TestDecryptionClientV2_GetObject_V1Interop_KMS_AESGCM(t *testing.T) {
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{"AES/GCM/NoPadding"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	})
 	err = req.Send()
@@ -227,7 +227,7 @@ func TestDecryptionClientV2_GetObject_V1Interop_KMS_AESGCM(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	actual, err := ioutil.ReadAll(out.Body)
+	actual, err := io.ReadAll(out.Body)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -258,7 +258,7 @@ func TestDecryptionClientV2_GetObject_OnlyDecryptsRegisteredAlgorithms(t *testin
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-wrap-alg"): []string{s3crypto.KMSWrap},
 				http.CanonicalHeaderKey("x-amz-meta-x-amz-cek-alg"):  []string{"AES/CBC/PKCS5Padding"},
 			},
-			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			Body: io.NopCloser(bytes.NewBuffer(b)),
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/encryption_client_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/encryption_client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -72,7 +72,7 @@ func TestPutObject(t *testing.T) {
 	if e, a := "stop", err.Error(); e != a {
 		t.Errorf("expected %s error, but received %s", e, a)
 	}
-	b, err := ioutil.ReadAll(req.HTTPRequest.Body)
+	b, err := io.ReadAll(req.HTTPRequest.Body)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/encryption_client_v2_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/encryption_client_v2_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -177,7 +176,7 @@ func TestEncryptionClientV2_PutObject_KMSCONTEXT_AESGCM(t *testing.T) {
 
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushFront(func(r *request.Request) {
-		all, err := ioutil.ReadAll(r.Body)
+		all, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/hash_io_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/hash_io_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -62,7 +61,7 @@ func TestContentLengthReader(t *testing.T) {
 
 	for _, tt := range cases {
 		reader := newContentLengthReader(tt.reader)
-		_, err := ioutil.ReadAll(reader)
+		_, err := io.ReadAll(reader)
 		if err != nil {
 			if len(tt.expectedErr) == 0 {
 				t.Errorf("expected no error, got %v", err)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/helper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/helper.go
@@ -3,7 +3,6 @@ package s3crypto
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
@@ -14,7 +13,7 @@ func getWriterStore(req *request.Request, path string, useTempFile bool) (io.Rea
 		return &bytesReadWriteSeeker{}, nil
 	}
 	// Create temp file to be used later for calculating the SHA256 header
-	f, err := ioutil.TempFile(path, "")
+	f, err := os.CreateTemp(path, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/helper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/helper_test.go
@@ -2,7 +2,7 @@ package s3crypto
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -121,8 +121,8 @@ func TestGetWriterStore_TempFile(t *testing.T) {
 
 func TestGetWriterStore_TempFileWithRetry(t *testing.T) {
 	responses := []*http.Response{
-		{StatusCode: 500, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
-		{StatusCode: 200, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
+		{StatusCode: 500, Header: http.Header{}, Body: io.NopCloser(&bytes.Buffer{})},
+		{StatusCode: 200, Header: http.Header{}, Body: io.NopCloser(&bytes.Buffer{})},
 	}
 	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/integ_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/integ_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -132,7 +132,7 @@ func getFixtures(t *testing.T, s3Client *s3.S3, cekAlg, bucket string) testFixtu
 			t.Fatalf("unable to get fixture object %s, %v", *obj.Key, err)
 		}
 		caseKey := strings.TrimPrefix(*obj.Key, baseFolder+"/"+prefix)
-		plaintext, err := ioutil.ReadAll(ptObj.Body)
+		plaintext, err := io.ReadAll(ptObj.Body)
 		if err != nil {
 			t.Fatalf("unable to read fixture object %s, %v", *obj.Key, err)
 		}
@@ -245,7 +245,7 @@ func decryptFixtures(t *testing.T, decClient *s3crypto.DecryptionClient, s3Clien
 			t.Fatalf("failed to get encrypted object %v", err)
 		}
 
-		ciphertext, err := ioutil.ReadAll(ctObj.Body)
+		ciphertext, err := io.ReadAll(ctObj.Body)
 		if err != nil {
 			t.Fatalf("failed to read object data %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/integration/main_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/integration/main_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -201,7 +200,7 @@ func getObjectAndCompare(t *testing.T, client Decryptor, key string, expected []
 		t.Fatalf("failed to get object: %v", err)
 	}
 
-	actual, err := ioutil.ReadAll(output.Body)
+	actual, err := io.ReadAll(output.Body)
 	if err != nil {
 		t.Fatalf("failed to read body response: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/kms_context_key_handler_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/kms_context_key_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -20,7 +20,7 @@ import (
 
 func TestKmsContextKeyHandler_GenerateCipherDataWithCEKAlg(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(500)
 			return
@@ -96,7 +96,7 @@ func TestKmsContextKeyHandler_DecryptKey(t *testing.T) {
 	key, _ := hex.DecodeString("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22")
 	keyB64 := base64.URLEncoding.EncodeToString(key)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 			w.WriteHeader(500)
@@ -193,7 +193,7 @@ func TestKmsContextKeyHandler_DecryptKey_WithCMK(t *testing.T) {
 	key, _ := hex.DecodeString("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22")
 	keyB64 := base64.URLEncoding.EncodeToString(key)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 			w.WriteHeader(500)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/kms_key_handler_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/kms_key_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -80,7 +80,7 @@ func TestKmsKeyHandler_DecryptKey(t *testing.T) {
 	key, _ := hex.DecodeString("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22")
 	keyB64 := base64.URLEncoding.EncodeToString(key)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 			w.WriteHeader(500)
@@ -119,7 +119,7 @@ func TestKmsKeyHandler_DecryptKey_WithCMK(t *testing.T) {
 	key, _ := hex.DecodeString("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22")
 	keyB64 := base64.URLEncoding.EncodeToString(key)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 			w.WriteHeader(500)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/migrations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/migrations_test.go
@@ -3,7 +3,7 @@ package s3crypto_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session"
@@ -148,7 +148,7 @@ func ExampleNewDecryptionClientV2_migration00() {
 		return
 	}
 
-	_, err = ioutil.ReadAll(getObject.Body)
+	_, err = io.ReadAll(getObject.Body)
 	if err != nil {
 		fmt.Printf("error reading object: %v\n", err)
 	}
@@ -197,7 +197,7 @@ func ExampleNewDecryptionClientV2_migration01() {
 		return
 	}
 
-	_, err = ioutil.ReadAll(getObject.Body)
+	_, err = io.ReadAll(getObject.Body)
 	if err != nil {
 		fmt.Printf("error reading object: %v\n", err)
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/mock_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/mock_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/kms/kmsiface"
@@ -92,7 +91,7 @@ func (cipher *mockContentCipher) GetCipherData() CipherData {
 }
 
 func (cipher *mockContentCipher) EncryptContents(src io.Reader) (io.Reader, error) {
-	b, err := ioutil.ReadAll(src)
+	b, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +101,12 @@ func (cipher *mockContentCipher) EncryptContents(src io.Reader) (io.Reader, erro
 }
 
 func (cipher *mockContentCipher) DecryptContents(src io.ReadCloser) (io.ReadCloser, error) {
-	b, err := ioutil.ReadAll(src)
+	b, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err
 	}
 	size := len(b)
-	return ioutil.NopCloser(bytes.NewReader(make([]byte, size))), nil
+	return io.NopCloser(bytes.NewReader(make([]byte, size))), nil
 }
 
 type mockKMS struct {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/strategy.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/strategy.go
@@ -3,7 +3,7 @@ package s3crypto
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -98,7 +98,7 @@ func (load S3LoadStrategy) Load(req *request.Request) (Envelope, error) {
 		return env, err
 	}
 
-	b, err := ioutil.ReadAll(out.Body)
+	b, err := io.ReadAll(out.Body)
 	if err != nil {
 		return env, err
 	}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/strategy_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3crypto/strategy_test.go
@@ -3,7 +3,7 @@ package s3crypto_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -142,11 +142,11 @@ func TestS3SaveStrategy(t *testing.T) {
 		client.Handlers.UnmarshalMeta.Clear()
 		client.Handlers.UnmarshalError.Clear()
 		client.Handlers.Send.PushBack(func(r *request.Request) {
-			bodyBytes, err := ioutil.ReadAll(r.Body)
+			bodyBytes, err := io.ReadAll(r.Body)
 			if err != nil {
 				r.HTTPResponse = &http.Response{
 					StatusCode: 500,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(err.Error()))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(err.Error()))),
 				}
 				return
 			}
@@ -156,7 +156,7 @@ func TestS3SaveStrategy(t *testing.T) {
 			if err != nil {
 				r.HTTPResponse = &http.Response{
 					StatusCode: 500,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(err.Error()))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(err.Error()))),
 				}
 				return
 			}
@@ -167,7 +167,7 @@ func TestS3SaveStrategy(t *testing.T) {
 
 			r.HTTPResponse = &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}
 		})
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/batch_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/batch_test.go
@@ -3,7 +3,7 @@ package s3manager
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -733,7 +733,7 @@ func TestBatchUpload(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		urlParts := strings.Split(r.URL.String(), "/")
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/download_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/download_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -57,7 +56,7 @@ func dlLoggingSvc(data []byte) (*s3.S3, *[]string, *[]string) {
 		bodyBytes := data[start:fin]
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(bodyBytes)),
+			Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
 			Header:     http.Header{},
 		}
 		r.HTTPResponse.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d",
@@ -82,7 +81,7 @@ func dlLoggingSvcNoChunk(data []byte) (*s3.S3, *[]string) {
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(data[:])),
+			Body:       io.NopCloser(bytes.NewReader(data[:])),
 			Header:     http.Header{},
 		}
 		r.HTTPResponse.Header.Set("Content-Length", fmt.Sprintf("%d", len(data)))
@@ -116,7 +115,7 @@ func dlLoggingSvcNoContentRangeLength(data []byte, states []int) (*s3.S3, *[]str
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: states[index],
-			Body:       ioutil.NopCloser(body),
+			Body:       io.NopCloser(body),
 			Header:     http.Header{},
 		}
 		index++
@@ -161,7 +160,7 @@ func dlLoggingSvcContentRangeTotalAny(data []byte, states []int) (*s3.S3, *[]str
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: states[index],
-			Body:       ioutil.NopCloser(bytes.NewReader(bodyBytes)),
+			Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
 			Header:     http.Header{},
 		}
 		r.HTTPResponse.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/*",
@@ -191,7 +190,7 @@ func dlLoggingSvcWithErrReader(cases []testErrReader) (*s3.S3, *[]string) {
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(&c),
+			Body:       io.NopCloser(&c),
 			Header:     http.Header{},
 		}
 		r.HTTPResponse.Header.Set("Content-Range",
@@ -302,7 +301,7 @@ func TestDownloadError(t *testing.T) {
 		num++
 		if num > 1 {
 			r.HTTPResponse.StatusCode = 400
-			r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+			r.HTTPResponse.Body = io.NopCloser(bytes.NewReader([]byte{}))
 		}
 	})
 
@@ -602,7 +601,7 @@ func TestDownload_WithFailure(t *testing.T) {
 
 			r.HTTPResponse = &http.Response{
 				Header: http.Header{},
-				Body:   ioutil.NopCloser(&bytes.Buffer{}),
+				Body:   io.NopCloser(&bytes.Buffer{}),
 			}
 			r.Error = awserr.New("ConnectionError", "some connection error", nil)
 			r.Retryable = aws.Bool(false)
@@ -613,7 +612,7 @@ func TestDownload_WithFailure(t *testing.T) {
 				StatusCode:    http.StatusOK,
 				Status:        http.StatusText(http.StatusOK),
 				ContentLength: int64(body.Len()),
-				Body:          ioutil.NopCloser(body),
+				Body:          io.NopCloser(body),
 				Header:        http.Header{},
 			}
 			r.HTTPResponse.Header.Set("Content-Length", strconv.Itoa(body.Len()))
@@ -775,7 +774,7 @@ func TestDownloadBufferStrategy_Errors(t *testing.T) {
 		start, _ := strconv.ParseInt(rng[1], 10, 64)
 		fin, _ := strconv.ParseInt(rng[2], 10, 64)
 
-		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 		r.HTTPResponse = &http.Response{
 			StatusCode:    200,
 			Body:          aws.ReadSeekCloser(&badReader{err: io.ErrUnexpectedEOF}),

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/upload_internal_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/s3manager/upload_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	random "math/rand"
 	"net/http"
 	"strconv"
@@ -87,12 +86,12 @@ func TestUploadByteSlicePool(t *testing.T) {
 			svc.Handlers.Send.Clear()
 			svc.Handlers.Send.PushFront(func(r *request.Request) {
 				if r.Body != nil {
-					io.Copy(ioutil.Discard, r.Body)
+					io.Copy(io.Discard, r.Body)
 				}
 
 				r.HTTPResponse = &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(respBody))),
 				}
 
 				switch data := r.Data.(type) {
@@ -181,7 +180,7 @@ func TestUploadByteSlicePool_Failures(t *testing.T) {
 					svc.Handlers.Send.Clear()
 					svc.Handlers.Send.PushFront(func(r *request.Request) {
 						if r.Body != nil {
-							io.Copy(ioutil.Discard, r.Body)
+							io.Copy(io.Discard, r.Body)
 						}
 
 						if r.Operation.Name == operation {
@@ -189,14 +188,14 @@ func TestUploadByteSlicePool_Failures(t *testing.T) {
 							r.Error = fmt.Errorf("request error")
 							r.HTTPResponse = &http.Response{
 								StatusCode: 500,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+								Body:       io.NopCloser(bytes.NewReader([]byte{})),
 							}
 							return
 						}
 
 						r.HTTPResponse = &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
+							Body:       io.NopCloser(bytes.NewReader([]byte(respBody))),
 						}
 
 						switch data := r.Data.(type) {
@@ -259,12 +258,12 @@ func TestUploadByteSlicePoolConcurrentMultiPartSize(t *testing.T) {
 	svc.Handlers.Send.Clear()
 	svc.Handlers.Send.PushFront(func(r *request.Request) {
 		if r.Body != nil {
-			io.Copy(ioutil.Discard, r.Body)
+			io.Copy(io.Discard, r.Body)
 		}
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(respBody))),
 		}
 
 		switch data := r.Data.(type) {
@@ -370,12 +369,12 @@ func BenchmarkPools(b *testing.B) {
 	svc.Handlers.Send.Clear()
 	svc.Handlers.Send.PushFront(func(r *request.Request) {
 		if r.Body != nil {
-			io.Copy(ioutil.Discard, r.Body)
+			io.Copy(io.Discard, r.Body)
 		}
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 
 		switch data := r.Data.(type) {

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/statusok_error.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/statusok_error.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/awserr"
@@ -12,7 +11,7 @@ import (
 )
 
 func copyMultipartStatusOKUnmarshalError(r *request.Request) {
-	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	b, err := io.ReadAll(r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
@@ -22,12 +21,12 @@ func copyMultipartStatusOKUnmarshalError(r *request.Request) {
 		)
 		// Note, some middleware later in the stack like restxml.Unmarshal expect a valid, non-closed Body
 		// even in case of an error, so we replace it with an empty Reader.
-		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
+		r.HTTPResponse.Body = io.NopCloser(bytes.NewBuffer(nil))
 		return
 	}
 
 	body := bytes.NewReader(b)
-	r.HTTPResponse.Body = ioutil.NopCloser(body)
+	r.HTTPResponse.Body = io.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)
 
 	unmarshalError(r)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/statusok_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/statusok_error_test.go
@@ -6,7 +6,6 @@ package s3_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -208,7 +207,7 @@ func newCopyTestSvc(errMsg string, responseBodyClosed *bool) *s3.S3 {
 		request.NamedHandler{
 			Name: "newCopyTestSvc",
 			Fn: func(r *request.Request) {
-				io.Copy(ioutil.Discard, r.HTTPRequest.Body)
+				io.Copy(io.Discard, r.HTTPRequest.Body)
 				r.HTTPRequest.Body.Close()
 				r.HTTPResponse = &http.Response{
 					Status:     http.StatusText(statusCode),

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/unmarshal_error.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/unmarshal_error.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -23,7 +22,7 @@ type xmlErrorResponse struct {
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
-	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	defer io.Copy(io.Discard, r.HTTPResponse.Body)
 
 	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/unmarshal_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3/unmarshal_error_test.go
@@ -3,7 +3,7 @@ package s3_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -32,7 +32,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: -1,
 			}
 		},
@@ -48,7 +48,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: 0,
 			}
 		},
@@ -64,7 +64,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: 0,
 			}
 		},
@@ -80,7 +80,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: 0,
 			}
 		},
@@ -99,7 +99,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"taken-request-id"},
 					"X-Amz-Id-2":       []string{"taken-host-id"},
 				},
-				Body:          ioutil.NopCloser(strings.NewReader(body)),
+				Body:          io.NopCloser(strings.NewReader(body)),
 				ContentLength: int64(len(body)),
 			}
 		},
@@ -115,7 +115,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: -1,
 			}
 		},
@@ -131,7 +131,7 @@ var testUnmarshalCases = []testErrorCase{
 					"X-Amz-Request-Id": []string{"abc123"},
 					"X-Amz-Id-2":       []string{"321cba"},
 				},
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 				ContentLength: -1,
 			}
 		},
@@ -193,7 +193,7 @@ func Test200NoErrorUnmarshalError(t *testing.T) {
 				"X-Amz-Request-Id": []string{"abc123"},
 				"X-Amz-Id-2":       []string{"321cba"},
 			},
-			Body:          ioutil.NopCloser(strings.NewReader(completeMultiResp)),
+			Body:          io.NopCloser(strings.NewReader(completeMultiResp)),
 			ContentLength: -1,
 		}
 		r.HTTPResponse.Status = http.StatusText(r.HTTPResponse.StatusCode)
@@ -231,7 +231,7 @@ func Test200WithErrorUnmarshalError(t *testing.T) {
 				"X-Amz-Request-Id": []string{"abc123"},
 				"X-Amz-Id-2":       []string{"321cba"},
 			},
-			Body:          ioutil.NopCloser(strings.NewReader(completeMultiErrResp)),
+			Body:          io.NopCloser(strings.NewReader(completeMultiErrResp)),
 			ContentLength: -1,
 		}
 		r.HTTPResponse.Status = http.StatusText(r.HTTPResponse.StatusCode)

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3control/endpoint_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/s3control/endpoint_test.go
@@ -6,7 +6,7 @@ package s3control
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -439,7 +439,7 @@ func runValidations(t *testing.T, cases map[string]testParams) {
 					r.HTTPResponse = &http.Response{
 						StatusCode:    200,
 						ContentLength: 0,
-						Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+						Body:          io.NopCloser(bytes.NewReader(nil)),
 					}
 				}()
 				if len(c.expectedErr) != 0 {
@@ -836,7 +836,7 @@ func runValidationsWithRequestFn(t *testing.T, c testParamsWithRequestFn) {
 			r.HTTPResponse = &http.Response{
 				StatusCode:    200,
 				ContentLength: 0,
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 			}
 		}()
 		if len(c.expectedErr) != 0 {
@@ -896,7 +896,7 @@ func TestInputIsNotModified(t *testing.T) {
 			r.HTTPResponse = &http.Response{
 				StatusCode:    200,
 				ContentLength: 0,
-				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+				Body:          io.NopCloser(bytes.NewReader(nil)),
 			}
 		}()
 	})

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/simpledb/unmarshall_error.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/simpledb/unmarshall_error.go
@@ -3,7 +3,6 @@ package simpledb
 import (
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/awserr"
@@ -49,7 +48,7 @@ func (r *xmlErrorResponse) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
-	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	defer io.Copy(io.Discard, r.HTTPResponse.Body)
 
 	if r.HTTPResponse.ContentLength == int64(0) {
 		// No body, use status code to generate an awserr.Error

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/simpledb/unmarshall_error_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/simpledb/unmarshall_error_test.go
@@ -2,7 +2,7 @@ package simpledb_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestStatusCodeError(t *testing.T) {
 		s := simpledb.New(unit.Session)
 		s.Handlers.Send.Clear()
 		s.Handlers.Send.PushBack(func(r *request.Request) {
-			body := ioutil.NopCloser(bytes.NewReader([]byte{}))
+			body := io.NopCloser(bytes.NewReader([]byte{}))
 			r.HTTPResponse = &http.Response{
 				ContentLength: 0,
 				StatusCode:    test.scode,
@@ -103,7 +103,7 @@ func TestResponseError(t *testing.T) {
 		s.Handlers.Send.Clear()
 		s.Handlers.Send.PushBack(func(r *request.Request) {
 			xml := createXMLResponse(test.requestID, test.errors)
-			body := ioutil.NopCloser(bytes.NewReader([]byte(xml)))
+			body := io.NopCloser(bytes.NewReader([]byte(xml)))
 			r.HTTPResponse = &http.Response{
 				ContentLength: int64(len(xml)),
 				StatusCode:    test.scode,

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/sqs/checksums_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/sqs/checksums_test.go
@@ -2,7 +2,7 @@ package sqs_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -27,7 +27,7 @@ func TestSendMessageChecksum(t *testing.T) {
 		MessageBody: aws.String("test"),
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
 			MD5OfMessageBody: aws.String("098f6bcd4621d373cade4e832627b4f6"),
@@ -45,7 +45,7 @@ func TestSendMessageChecksumInvalid(t *testing.T) {
 		MessageBody: aws.String("test"),
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
 			MD5OfMessageBody: aws.String("000"),
@@ -76,7 +76,7 @@ func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 		MessageBody: aws.String("test"),
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
 			MD5OfMessageBody: aws.String("000"),
@@ -92,7 +92,7 @@ func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 func TestSendMessageChecksumNoInput(t *testing.T) {
 	req, _ := svc.SendMessageRequest(&sqs.SendMessageInput{})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{}
 	})
@@ -114,7 +114,7 @@ func TestSendMessageChecksumNoOutput(t *testing.T) {
 		MessageBody: aws.String("test"),
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{}
 	})
@@ -135,7 +135,7 @@ func TestRecieveMessageChecksum(t *testing.T) {
 	req, _ := svc.ReceiveMessageRequest(&sqs.ReceiveMessageInput{})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{
@@ -156,7 +156,7 @@ func TestRecieveMessageChecksumInvalid(t *testing.T) {
 	req, _ := svc.ReceiveMessageRequest(&sqs.ReceiveMessageInput{})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{
@@ -192,7 +192,7 @@ func TestSendMessageBatchChecksum(t *testing.T) {
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageBatchOutput{
 			Successful: []*sqs.SendMessageBatchResultEntry{
@@ -219,7 +219,7 @@ func TestSendMessageBatchChecksumFailed(t *testing.T) {
 		},
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageBatchOutput{
 			Failed: []*sqs.BatchResultErrorEntry{
@@ -266,7 +266,7 @@ func TestSendMessageBatchChecksumInvalid(t *testing.T) {
 	})
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
-		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+		body := io.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageBatchOutput{
 			Successful: []*sqs.SendMessageBatchResultEntry{

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/sts/customizations_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/sts/customizations_test.go
@@ -3,7 +3,7 @@ package sts_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -62,14 +62,14 @@ func TestSTSCustomRetryErrorCodes(t *testing.T) {
 		{
 			StatusCode: 400,
 			Header:     http.Header{},
-			Body: ioutil.NopCloser(bytes.NewReader(
+			Body: io.NopCloser(bytes.NewReader(
 				[]byte(fmt.Sprintf(xmlErr, sts.ErrCodeIDPCommunicationErrorException)),
 			)),
 		},
 		{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/transcribestreamingservice/eventstream_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/transcribestreamingservice/eventstream_test.go
@@ -8,7 +8,7 @@ package transcribestreamingservice
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -194,7 +194,7 @@ func BenchmarkStartMedicalStreamTranscription_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},
@@ -992,7 +992,7 @@ func BenchmarkStartStreamTranscription_Read(b *testing.B) {
 					Status:     "200 OK",
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(stream),
+					Body:       io.NopCloser(stream),
 				}
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/transcribestreamingservice/unit_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/transcribestreamingservice/unit_test.go
@@ -5,7 +5,7 @@ package transcribestreamingservice
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ func TestStartStreamTranscription_Error(t *testing.T) {
 		HTTPClient: newTestClient(func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("{ \"code\" : \"BadRequestException\" }"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("{ \"code\" : \"BadRequestException\" }"))),
 				Header:     http.Header{},
 			}
 		}),

--- a/cluster-autoscaler/cloudprovider/azure/azure_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_client.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -204,7 +203,7 @@ func newServicePrincipalTokenFromCredentials(config *Config, env *azure.Environm
 
 	if len(config.AADClientCertPath) > 0 && len(config.AADClientCertPassword) > 0 {
 		klog.V(2).Infoln("azure: using jwt client_assertion (client_cert+client_private_key) to retrieve access token")
-		certData, err := ioutil.ReadFile(config.AADClientCertPath)
+		certData, err := os.ReadFile(config.AADClientCertPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading the client certificate from file %s: %v", config.AADClientCertPath, err)
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"strconv"
@@ -148,7 +147,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg := &Config{}
 
 	if configReader != nil {
-		body, err := ioutil.ReadAll(configReader)
+		body, err := io.ReadAll(configReader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read config: %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_instance_types/gen.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_instance_types/gen.go
@@ -22,7 +22,7 @@ package main
 import (
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -96,7 +96,7 @@ func getAllAzureVirtualMachineTypes() (result map[string]*azure.InstanceType, er
 	if err = cmd.Start(); err != nil {
 		return nil, err
 	}
-	bytes, err := ioutil.ReadAll(stdout)
+	bytes, err := io.ReadAll(stdout)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -22,9 +22,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -510,7 +510,7 @@ func getLastSegment(ID string) (string, error) {
 
 // readDeploymentParameters gets deployment parameters from paramFilePath.
 func readDeploymentParameters(paramFilePath string) (map[string]interface{}, error) {
-	contents, err := ioutil.ReadFile(paramFilePath)
+	contents, err := os.ReadFile(paramFilePath)
 	if err != nil {
 		klog.Errorf("Failed to read deployment parameters from file %q: %v", paramFilePath, err)
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/core.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/core.go
@@ -21,11 +21,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -74,7 +74,7 @@ func NewCredentials(AccessKeyID, secretAccessKey string) *Credentials {
 
 // NewCredentialsFromFile returns Credentials
 func NewCredentialsFromFile(filePath string) (*Credentials, error) {
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func NewConfigWithParams(accessKeyID, secretAccessKey, region string) *Config {
 
 // NewConfigFromFile create a new config from cloud config.
 func NewConfigFromFile(filePath string) (*Config, error) {
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +527,7 @@ func (c *Client) SendRequest(req *Request, option *SignOption) (bceResponse *Res
 	}
 	var buf []byte
 	if req.Body != nil {
-		buf, _ = ioutil.ReadAll(req.Body)
+		buf, _ = os.ReadAll(req.Body)
 	}
 
 	for i := 0; ; i++ {
@@ -542,7 +542,7 @@ func (c *Client) SendRequest(req *Request, option *SignOption) (bceResponse *Res
 				req.Method, req.URL.String(), req.Header))
 		}
 		t0 := time.Now()
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		req.Body = os.NopCloser(bytes.NewBuffer(buf))
 		resp, httpError := c.httpClient.Do(req.raw())
 		t1 := time.Now()
 		bceResponse = NewResponse(resp)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/core.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/core.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -527,7 +528,7 @@ func (c *Client) SendRequest(req *Request, option *SignOption) (bceResponse *Res
 	}
 	var buf []byte
 	if req.Body != nil {
-		buf, _ = os.ReadAll(req.Body)
+		buf, _ = io.ReadAll(req.Body)
 	}
 
 	for i := 0; ; i++ {
@@ -542,7 +543,7 @@ func (c *Client) SendRequest(req *Request, option *SignOption) (bceResponse *Res
 				req.Method, req.URL.String(), req.Header))
 		}
 		t0 := time.Now()
-		req.Body = os.NopCloser(bytes.NewBuffer(buf))
+		req.Body = io.NopCloser(bytes.NewBuffer(buf))
 		resp, httpError := c.httpClient.Do(req.raw())
 		t1 := time.Now()
 		bceResponse = NewResponse(resp)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/response.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce/response.go
@@ -17,7 +17,7 @@ limitations under the License.
 package bce
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -41,7 +41,7 @@ func (res *Response) GetBodyContent() ([]byte, error) {
 			}
 		}()
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 
 		if err != nil {
 			return nil, err

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
@@ -448,7 +448,7 @@ func TempFile(content []byte, dir, prefix string) (*os.File, error) {
 		}
 	}
 
-	tmpfile, err := ioutil.TempFile(dir, prefix)
+	tmpfile, err := os.CreateTemp(dir, prefix)
 
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_manager.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"time"
 
@@ -72,7 +71,7 @@ type asgTemplate struct {
 func CreateBaiducloudManager(configReader io.Reader) (*BaiducloudManager, error) {
 	cfg := &CloudConfig{}
 	if configReader != nil {
-		configContents, err := ioutil.ReadAll(configReader)
+		configContents, err := io.ReadAll(configReader)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_manager_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +33,7 @@ import (
 func newManagerTest(configReader io.Reader) (*Manager, error) {
 	cfg := &Config{}
 	if configReader != nil {
-		body, err := ioutil.ReadAll(configReader)
+		body, err := io.ReadAll(configReader)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/alert.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/alert.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -372,7 +371,7 @@ func (a *agents) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -502,7 +501,7 @@ func (a *alarms) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -620,7 +619,7 @@ func (r *receivers) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -641,7 +640,7 @@ func (r *receivers) ResendVerificationLink(ctx context.Context, id string, rType
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -773,7 +772,7 @@ func (s *secrets) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/autoscaling.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/autoscaling.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -917,7 +916,7 @@ func (asg *autoScalingGroup) Delete(ctx context.Context, clusterID string) error
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -931,7 +930,7 @@ func (lc *launchConfiguration) Delete(ctx context.Context, profileID string) err
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -946,7 +945,7 @@ func (p *policy) Delete(ctx context.Context, clusterID, PolicyID string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -961,7 +960,7 @@ func (n *node) Delete(ctx context.Context, clusterID string, asnd *AutoScalingNo
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -976,7 +975,7 @@ func (s *schedule) Delete(ctx context.Context, clusterID, scheduleID string) err
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/cdn.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/cdn.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -202,7 +201,7 @@ func (c *cdnService) Delete(ctx context.Context, domainID string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -215,6 +214,6 @@ func (c *cdnService) DeleteCache(ctx context.Context, domainID string, files *Fi
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/client.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/client.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -237,7 +237,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (resp *http.Response
 	if resp.StatusCode == http.StatusUnauthorized {
 		tok, tokErr := c.Token.Refresh(ctx)
 		if tokErr != nil {
-			buf, _ := ioutil.ReadAll(resp.Body)
+			buf, _ := io.ReadAll(resp.Body)
 			err = fmt.Errorf("%s : %w", string(buf), tokErr)
 			return
 		}
@@ -247,7 +247,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (resp *http.Response
 	}
 	if resp.StatusCode >= http.StatusBadRequest {
 		defer resp.Body.Close()
-		buf, _ := ioutil.ReadAll(resp.Body)
+		buf, _ := io.ReadAll(resp.Body)
 		err = errorFromStatus(resp.StatusCode, string(buf))
 
 	}

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/container_registry.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/container_registry.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -133,7 +132,7 @@ func (c *containerRegistry) Delete(ctx context.Context, repositoryName string) e
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/kubernetes.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/kubernetes.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -216,7 +215,7 @@ func (c *kubernetesEngineService) Delete(ctx context.Context, id string) error {
 		fmt.Println("error send req")
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -248,7 +247,7 @@ func (c *kubernetesEngineService) RecycleNode(ctx context.Context, clusterUID st
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -261,7 +260,7 @@ func (c *kubernetesEngineService) DeleteClusterWorkerPool(ctx context.Context, c
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -291,7 +290,7 @@ func (c *kubernetesEngineService) UpdateClusterWorkerPool(ctx context.Context, c
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -304,7 +303,7 @@ func (c *kubernetesEngineService) DeleteClusterWorkerPoolNode(ctx context.Contex
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 
@@ -318,7 +317,7 @@ func (c *kubernetesEngineService) GetKubeConfig(ctx context.Context, clusterUID 
 		return "", nil
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/loadbalancer.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/loadbalancer.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -190,7 +189,7 @@ func (l *loadbalancer) Delete(ctx context.Context, lbdr *LoadBalancerDeleteReque
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -375,7 +374,7 @@ func (l *listener) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -518,7 +517,7 @@ func (m *member) Delete(ctx context.Context, poolID, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -716,7 +715,7 @@ func (p *pool) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }
@@ -842,7 +841,7 @@ func (h *healthmonitor) Delete(ctx context.Context, hmID string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/server.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/server.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -301,7 +300,7 @@ func (s *server) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/snapshot.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/snapshot.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -88,7 +87,7 @@ func (s *snapshot) Delete(ctx context.Context, id string) error {
 		fmt.Println("error send req")
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/volume.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/volume.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -151,7 +150,7 @@ func (v *volume) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/brightbox/gobrightbox/brightbox.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/gobrightbox/brightbox.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -217,7 +216,7 @@ func (c *Client) MakeApiRequest(method string, path string, reqBody interface{},
 		StatusCode: res.StatusCode,
 		Status:     res.Status,
 	}
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 	err = json.Unmarshal(body, &apierr)
 	apierr.ResponseBody = body
 	return res, apierr

--- a/cluster-autoscaler/cloudprovider/brightbox/k8ssdk/testing.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/k8ssdk/testing.go
@@ -15,7 +15,7 @@
 package k8ssdk
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -68,7 +68,7 @@ func GetAuthEnvTokenHandler(t *testing.T) *httptest.Server {
 		if r.URL.String() != expected {
 			t.Errorf("URL = %q; want %q", r.URL, expected)
 		}
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -271,7 +270,7 @@ func (mgr *cherryManagerRest) request(ctx context.Context, method, pathUrl strin
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/cluster-autoscaler/cloudprovider/civo/civo-cloud-sdk-go/client.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo-cloud-sdk-go/client.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -103,13 +103,13 @@ func NewAdvancedClientForTesting(responses map[string]map[string]string) (*Clien
 	var responseSent bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			log.Printf("Error reading body: %v", err)
 			return
 		}
 
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		for url, criteria := range responses {
 			if strings.Contains(req.URL.String(), url) &&
@@ -199,7 +199,7 @@ func (c *Client) sendRequest(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.LastJSONResponse = string(body)
 
 	if resp.StatusCode >= 300 {

--- a/cluster-autoscaler/cloudprovider/civo/civo_manager.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_manager.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -71,7 +70,7 @@ type Config struct {
 func newManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*Manager, error) {
 	cfg := &Config{}
 	if configReader != nil {
-		body, err := ioutil.ReadAll(configReader)
+		body, err := io.ReadAll(configReader)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/cloudstack/service/client.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/service/client.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -174,7 +174,7 @@ func (client *client) newRequest(api string, args map[string]string, async bool,
 	}
 	klog.Info("NewAPIRequest response status code:", response.StatusCode)
 
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	var data map[string]interface{}
 	_ = json.Unmarshal([]byte(body), &data)
 

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -75,7 +75,7 @@ type Config struct {
 func newManager(configReader io.Reader) (*Manager, error) {
 	cfg := &Config{}
 	if configReader != nil {
-		body, err := ioutil.ReadAll(configReader)
+		body, err := io.ReadAll(configReader)
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +96,7 @@ func newManager(configReader io.Reader) (*Manager, error) {
 	}
 
 	if cfg.TokenFile != "" {
-		tokenData, err := ioutil.ReadFile(cfg.TokenFile)
+		tokenData, err := os.ReadFile(cfg.TokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read token file: %s", err)
 		}

--- a/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/api/middleware.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/api/middleware.go
@@ -19,7 +19,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -56,7 +56,7 @@ func (m *ErrorHandlerMiddleware) RoundTrip(req *http.Request) (*http.Response, e
 			Message string `json:"message"`
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading response body: %s", err)
 		}

--- a/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/api/security.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/api/security.go
@@ -24,7 +24,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -78,7 +78,7 @@ func (s *SecurityProviderExoscale) signRequest(req *http.Request, expiration tim
 	// Request body if present
 	body := ""
 	if req.Body != nil {
-		data, err := ioutil.ReadAll(req.Body)
+		data, err := io.ReadAll(req.Body)
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func (s *SecurityProviderExoscale) signRequest(req *http.Request, expiration tim
 			return err
 		}
 		body = string(data)
-		req.Body = ioutil.NopCloser(bytes.NewReader(data))
+		req.Body = io.NopCloser(bytes.NewReader(data))
 	}
 	sigParts = append(sigParts, body)
 

--- a/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18978,7 +18977,7 @@ func (c *ClientWithResponses) ListZonesWithResponse(ctx context.Context, reqEdit
 
 // ParseListAccessKeysResponse parses an HTTP response from a ListAccessKeysWithResponse call
 func ParseListAccessKeysResponse(rsp *http.Response) (*ListAccessKeysResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19006,7 +19005,7 @@ func ParseListAccessKeysResponse(rsp *http.Response) (*ListAccessKeysResponse, e
 
 // ParseCreateAccessKeyResponse parses an HTTP response from a CreateAccessKeyWithResponse call
 func ParseCreateAccessKeyResponse(rsp *http.Response) (*CreateAccessKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19032,7 +19031,7 @@ func ParseCreateAccessKeyResponse(rsp *http.Response) (*CreateAccessKeyResponse,
 
 // ParseListAccessKeyKnownOperationsResponse parses an HTTP response from a ListAccessKeyKnownOperationsWithResponse call
 func ParseListAccessKeyKnownOperationsResponse(rsp *http.Response) (*ListAccessKeyKnownOperationsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19060,7 +19059,7 @@ func ParseListAccessKeyKnownOperationsResponse(rsp *http.Response) (*ListAccessK
 
 // ParseListAccessKeyOperationsResponse parses an HTTP response from a ListAccessKeyOperationsWithResponse call
 func ParseListAccessKeyOperationsResponse(rsp *http.Response) (*ListAccessKeyOperationsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19088,7 +19087,7 @@ func ParseListAccessKeyOperationsResponse(rsp *http.Response) (*ListAccessKeyOpe
 
 // ParseRevokeAccessKeyResponse parses an HTTP response from a RevokeAccessKeyWithResponse call
 func ParseRevokeAccessKeyResponse(rsp *http.Response) (*RevokeAccessKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19114,7 +19113,7 @@ func ParseRevokeAccessKeyResponse(rsp *http.Response) (*RevokeAccessKeyResponse,
 
 // ParseGetAccessKeyResponse parses an HTTP response from a GetAccessKeyWithResponse call
 func ParseGetAccessKeyResponse(rsp *http.Response) (*GetAccessKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19140,7 +19139,7 @@ func ParseGetAccessKeyResponse(rsp *http.Response) (*GetAccessKeyResponse, error
 
 // ParseListAntiAffinityGroupsResponse parses an HTTP response from a ListAntiAffinityGroupsWithResponse call
 func ParseListAntiAffinityGroupsResponse(rsp *http.Response) (*ListAntiAffinityGroupsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19168,7 +19167,7 @@ func ParseListAntiAffinityGroupsResponse(rsp *http.Response) (*ListAntiAffinityG
 
 // ParseCreateAntiAffinityGroupResponse parses an HTTP response from a CreateAntiAffinityGroupWithResponse call
 func ParseCreateAntiAffinityGroupResponse(rsp *http.Response) (*CreateAntiAffinityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19194,7 +19193,7 @@ func ParseCreateAntiAffinityGroupResponse(rsp *http.Response) (*CreateAntiAffini
 
 // ParseDeleteAntiAffinityGroupResponse parses an HTTP response from a DeleteAntiAffinityGroupWithResponse call
 func ParseDeleteAntiAffinityGroupResponse(rsp *http.Response) (*DeleteAntiAffinityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19220,7 +19219,7 @@ func ParseDeleteAntiAffinityGroupResponse(rsp *http.Response) (*DeleteAntiAffini
 
 // ParseGetAntiAffinityGroupResponse parses an HTTP response from a GetAntiAffinityGroupWithResponse call
 func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19246,7 +19245,7 @@ func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGrou
 
 // ParseGetDbaasCaCertificateResponse parses an HTTP response from a GetDbaasCaCertificateWithResponse call
 func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertificateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19274,7 +19273,7 @@ func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertific
 
 // ParseGetDbaasServiceKafkaResponse parses an HTTP response from a GetDbaasServiceKafkaWithResponse call
 func ParseGetDbaasServiceKafkaResponse(rsp *http.Response) (*GetDbaasServiceKafkaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19300,7 +19299,7 @@ func ParseGetDbaasServiceKafkaResponse(rsp *http.Response) (*GetDbaasServiceKafk
 
 // ParseCreateDbaasServiceKafkaResponse parses an HTTP response from a CreateDbaasServiceKafkaWithResponse call
 func ParseCreateDbaasServiceKafkaResponse(rsp *http.Response) (*CreateDbaasServiceKafkaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19326,7 +19325,7 @@ func ParseCreateDbaasServiceKafkaResponse(rsp *http.Response) (*CreateDbaasServi
 
 // ParseUpdateDbaasServiceKafkaResponse parses an HTTP response from a UpdateDbaasServiceKafkaWithResponse call
 func ParseUpdateDbaasServiceKafkaResponse(rsp *http.Response) (*UpdateDbaasServiceKafkaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19352,7 +19351,7 @@ func ParseUpdateDbaasServiceKafkaResponse(rsp *http.Response) (*UpdateDbaasServi
 
 // ParseGetDbaasMigrationStatusResponse parses an HTTP response from a GetDbaasMigrationStatusWithResponse call
 func ParseGetDbaasMigrationStatusResponse(rsp *http.Response) (*GetDbaasMigrationStatusResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19378,7 +19377,7 @@ func ParseGetDbaasMigrationStatusResponse(rsp *http.Response) (*GetDbaasMigratio
 
 // ParseGetDbaasServiceMysqlResponse parses an HTTP response from a GetDbaasServiceMysqlWithResponse call
 func ParseGetDbaasServiceMysqlResponse(rsp *http.Response) (*GetDbaasServiceMysqlResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19404,7 +19403,7 @@ func ParseGetDbaasServiceMysqlResponse(rsp *http.Response) (*GetDbaasServiceMysq
 
 // ParseCreateDbaasServiceMysqlResponse parses an HTTP response from a CreateDbaasServiceMysqlWithResponse call
 func ParseCreateDbaasServiceMysqlResponse(rsp *http.Response) (*CreateDbaasServiceMysqlResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19430,7 +19429,7 @@ func ParseCreateDbaasServiceMysqlResponse(rsp *http.Response) (*CreateDbaasServi
 
 // ParseUpdateDbaasServiceMysqlResponse parses an HTTP response from a UpdateDbaasServiceMysqlWithResponse call
 func ParseUpdateDbaasServiceMysqlResponse(rsp *http.Response) (*UpdateDbaasServiceMysqlResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19456,7 +19455,7 @@ func ParseUpdateDbaasServiceMysqlResponse(rsp *http.Response) (*UpdateDbaasServi
 
 // ParseGetDbaasServiceOpensearchResponse parses an HTTP response from a GetDbaasServiceOpensearchWithResponse call
 func ParseGetDbaasServiceOpensearchResponse(rsp *http.Response) (*GetDbaasServiceOpensearchResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19482,7 +19481,7 @@ func ParseGetDbaasServiceOpensearchResponse(rsp *http.Response) (*GetDbaasServic
 
 // ParseCreateDbaasServiceOpensearchResponse parses an HTTP response from a CreateDbaasServiceOpensearchWithResponse call
 func ParseCreateDbaasServiceOpensearchResponse(rsp *http.Response) (*CreateDbaasServiceOpensearchResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19508,7 +19507,7 @@ func ParseCreateDbaasServiceOpensearchResponse(rsp *http.Response) (*CreateDbaas
 
 // ParseUpdateDbaasServiceOpensearchResponse parses an HTTP response from a UpdateDbaasServiceOpensearchWithResponse call
 func ParseUpdateDbaasServiceOpensearchResponse(rsp *http.Response) (*UpdateDbaasServiceOpensearchResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19534,7 +19533,7 @@ func ParseUpdateDbaasServiceOpensearchResponse(rsp *http.Response) (*UpdateDbaas
 
 // ParseGetDbaasServicePgResponse parses an HTTP response from a GetDbaasServicePgWithResponse call
 func ParseGetDbaasServicePgResponse(rsp *http.Response) (*GetDbaasServicePgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19560,7 +19559,7 @@ func ParseGetDbaasServicePgResponse(rsp *http.Response) (*GetDbaasServicePgRespo
 
 // ParseCreateDbaasServicePgResponse parses an HTTP response from a CreateDbaasServicePgWithResponse call
 func ParseCreateDbaasServicePgResponse(rsp *http.Response) (*CreateDbaasServicePgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19586,7 +19585,7 @@ func ParseCreateDbaasServicePgResponse(rsp *http.Response) (*CreateDbaasServiceP
 
 // ParseUpdateDbaasServicePgResponse parses an HTTP response from a UpdateDbaasServicePgWithResponse call
 func ParseUpdateDbaasServicePgResponse(rsp *http.Response) (*UpdateDbaasServicePgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19612,7 +19611,7 @@ func ParseUpdateDbaasServicePgResponse(rsp *http.Response) (*UpdateDbaasServiceP
 
 // ParseGetDbaasServiceRedisResponse parses an HTTP response from a GetDbaasServiceRedisWithResponse call
 func ParseGetDbaasServiceRedisResponse(rsp *http.Response) (*GetDbaasServiceRedisResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19638,7 +19637,7 @@ func ParseGetDbaasServiceRedisResponse(rsp *http.Response) (*GetDbaasServiceRedi
 
 // ParseCreateDbaasServiceRedisResponse parses an HTTP response from a CreateDbaasServiceRedisWithResponse call
 func ParseCreateDbaasServiceRedisResponse(rsp *http.Response) (*CreateDbaasServiceRedisResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19664,7 +19663,7 @@ func ParseCreateDbaasServiceRedisResponse(rsp *http.Response) (*CreateDbaasServi
 
 // ParseUpdateDbaasServiceRedisResponse parses an HTTP response from a UpdateDbaasServiceRedisWithResponse call
 func ParseUpdateDbaasServiceRedisResponse(rsp *http.Response) (*UpdateDbaasServiceRedisResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19690,7 +19689,7 @@ func ParseUpdateDbaasServiceRedisResponse(rsp *http.Response) (*UpdateDbaasServi
 
 // ParseListDbaasServicesResponse parses an HTTP response from a ListDbaasServicesWithResponse call
 func ParseListDbaasServicesResponse(rsp *http.Response) (*ListDbaasServicesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19718,7 +19717,7 @@ func ParseListDbaasServicesResponse(rsp *http.Response) (*ListDbaasServicesRespo
 
 // ParseGetDbaasServiceLogsResponse parses an HTTP response from a GetDbaasServiceLogsWithResponse call
 func ParseGetDbaasServiceLogsResponse(rsp *http.Response) (*GetDbaasServiceLogsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19744,7 +19743,7 @@ func ParseGetDbaasServiceLogsResponse(rsp *http.Response) (*GetDbaasServiceLogsR
 
 // ParseGetDbaasServiceMetricsResponse parses an HTTP response from a GetDbaasServiceMetricsWithResponse call
 func ParseGetDbaasServiceMetricsResponse(rsp *http.Response) (*GetDbaasServiceMetricsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19772,7 +19771,7 @@ func ParseGetDbaasServiceMetricsResponse(rsp *http.Response) (*GetDbaasServiceMe
 
 // ParseListDbaasServiceTypesResponse parses an HTTP response from a ListDbaasServiceTypesWithResponse call
 func ParseListDbaasServiceTypesResponse(rsp *http.Response) (*ListDbaasServiceTypesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19800,7 +19799,7 @@ func ParseListDbaasServiceTypesResponse(rsp *http.Response) (*ListDbaasServiceTy
 
 // ParseGetDbaasServiceTypeResponse parses an HTTP response from a GetDbaasServiceTypeWithResponse call
 func ParseGetDbaasServiceTypeResponse(rsp *http.Response) (*GetDbaasServiceTypeResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19826,7 +19825,7 @@ func ParseGetDbaasServiceTypeResponse(rsp *http.Response) (*GetDbaasServiceTypeR
 
 // ParseDeleteDbaasServiceResponse parses an HTTP response from a DeleteDbaasServiceWithResponse call
 func ParseDeleteDbaasServiceResponse(rsp *http.Response) (*DeleteDbaasServiceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19852,7 +19851,7 @@ func ParseDeleteDbaasServiceResponse(rsp *http.Response) (*DeleteDbaasServiceRes
 
 // ParseGetDbaasSettingsKafkaResponse parses an HTTP response from a GetDbaasSettingsKafkaWithResponse call
 func ParseGetDbaasSettingsKafkaResponse(rsp *http.Response) (*GetDbaasSettingsKafkaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19912,7 +19911,7 @@ func ParseGetDbaasSettingsKafkaResponse(rsp *http.Response) (*GetDbaasSettingsKa
 
 // ParseGetDbaasSettingsMysqlResponse parses an HTTP response from a GetDbaasSettingsMysqlWithResponse call
 func ParseGetDbaasSettingsMysqlResponse(rsp *http.Response) (*GetDbaasSettingsMysqlResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19948,7 +19947,7 @@ func ParseGetDbaasSettingsMysqlResponse(rsp *http.Response) (*GetDbaasSettingsMy
 
 // ParseGetDbaasSettingsOpensearchResponse parses an HTTP response from a GetDbaasSettingsOpensearchWithResponse call
 func ParseGetDbaasSettingsOpensearchResponse(rsp *http.Response) (*GetDbaasSettingsOpensearchResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -19984,7 +19983,7 @@ func ParseGetDbaasSettingsOpensearchResponse(rsp *http.Response) (*GetDbaasSetti
 
 // ParseGetDbaasSettingsPgResponse parses an HTTP response from a GetDbaasSettingsPgWithResponse call
 func ParseGetDbaasSettingsPgResponse(rsp *http.Response) (*GetDbaasSettingsPgResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20044,7 +20043,7 @@ func ParseGetDbaasSettingsPgResponse(rsp *http.Response) (*GetDbaasSettingsPgRes
 
 // ParseGetDbaasSettingsRedisResponse parses an HTTP response from a GetDbaasSettingsRedisWithResponse call
 func ParseGetDbaasSettingsRedisResponse(rsp *http.Response) (*GetDbaasSettingsRedisResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20080,7 +20079,7 @@ func ParseGetDbaasSettingsRedisResponse(rsp *http.Response) (*GetDbaasSettingsRe
 
 // ParseListDeployTargetsResponse parses an HTTP response from a ListDeployTargetsWithResponse call
 func ParseListDeployTargetsResponse(rsp *http.Response) (*ListDeployTargetsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20108,7 +20107,7 @@ func ParseListDeployTargetsResponse(rsp *http.Response) (*ListDeployTargetsRespo
 
 // ParseGetDeployTargetResponse parses an HTTP response from a GetDeployTargetWithResponse call
 func ParseGetDeployTargetResponse(rsp *http.Response) (*GetDeployTargetResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20134,7 +20133,7 @@ func ParseGetDeployTargetResponse(rsp *http.Response) (*GetDeployTargetResponse,
 
 // ParseListDnsDomainsResponse parses an HTTP response from a ListDnsDomainsWithResponse call
 func ParseListDnsDomainsResponse(rsp *http.Response) (*ListDnsDomainsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20162,7 +20161,7 @@ func ParseListDnsDomainsResponse(rsp *http.Response) (*ListDnsDomainsResponse, e
 
 // ParseGetDnsDomainResponse parses an HTTP response from a GetDnsDomainWithResponse call
 func ParseGetDnsDomainResponse(rsp *http.Response) (*GetDnsDomainResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20188,7 +20187,7 @@ func ParseGetDnsDomainResponse(rsp *http.Response) (*GetDnsDomainResponse, error
 
 // ParseListDnsDomainRecordsResponse parses an HTTP response from a ListDnsDomainRecordsWithResponse call
 func ParseListDnsDomainRecordsResponse(rsp *http.Response) (*ListDnsDomainRecordsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20216,7 +20215,7 @@ func ParseListDnsDomainRecordsResponse(rsp *http.Response) (*ListDnsDomainRecord
 
 // ParseGetDnsDomainRecordResponse parses an HTTP response from a GetDnsDomainRecordWithResponse call
 func ParseGetDnsDomainRecordResponse(rsp *http.Response) (*GetDnsDomainRecordResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20242,7 +20241,7 @@ func ParseGetDnsDomainRecordResponse(rsp *http.Response) (*GetDnsDomainRecordRes
 
 // ParseListElasticIpsResponse parses an HTTP response from a ListElasticIpsWithResponse call
 func ParseListElasticIpsResponse(rsp *http.Response) (*ListElasticIpsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20270,7 +20269,7 @@ func ParseListElasticIpsResponse(rsp *http.Response) (*ListElasticIpsResponse, e
 
 // ParseCreateElasticIpResponse parses an HTTP response from a CreateElasticIpWithResponse call
 func ParseCreateElasticIpResponse(rsp *http.Response) (*CreateElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20296,7 +20295,7 @@ func ParseCreateElasticIpResponse(rsp *http.Response) (*CreateElasticIpResponse,
 
 // ParseDeleteElasticIpResponse parses an HTTP response from a DeleteElasticIpWithResponse call
 func ParseDeleteElasticIpResponse(rsp *http.Response) (*DeleteElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20322,7 +20321,7 @@ func ParseDeleteElasticIpResponse(rsp *http.Response) (*DeleteElasticIpResponse,
 
 // ParseGetElasticIpResponse parses an HTTP response from a GetElasticIpWithResponse call
 func ParseGetElasticIpResponse(rsp *http.Response) (*GetElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20348,7 +20347,7 @@ func ParseGetElasticIpResponse(rsp *http.Response) (*GetElasticIpResponse, error
 
 // ParseUpdateElasticIpResponse parses an HTTP response from a UpdateElasticIpWithResponse call
 func ParseUpdateElasticIpResponse(rsp *http.Response) (*UpdateElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20374,7 +20373,7 @@ func ParseUpdateElasticIpResponse(rsp *http.Response) (*UpdateElasticIpResponse,
 
 // ParseResetElasticIpFieldResponse parses an HTTP response from a ResetElasticIpFieldWithResponse call
 func ParseResetElasticIpFieldResponse(rsp *http.Response) (*ResetElasticIpFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20400,7 +20399,7 @@ func ParseResetElasticIpFieldResponse(rsp *http.Response) (*ResetElasticIpFieldR
 
 // ParseAttachInstanceToElasticIpResponse parses an HTTP response from a AttachInstanceToElasticIpWithResponse call
 func ParseAttachInstanceToElasticIpResponse(rsp *http.Response) (*AttachInstanceToElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20426,7 +20425,7 @@ func ParseAttachInstanceToElasticIpResponse(rsp *http.Response) (*AttachInstance
 
 // ParseDetachInstanceFromElasticIpResponse parses an HTTP response from a DetachInstanceFromElasticIpWithResponse call
 func ParseDetachInstanceFromElasticIpResponse(rsp *http.Response) (*DetachInstanceFromElasticIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20452,7 +20451,7 @@ func ParseDetachInstanceFromElasticIpResponse(rsp *http.Response) (*DetachInstan
 
 // ParseListEventsResponse parses an HTTP response from a ListEventsWithResponse call
 func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20478,7 +20477,7 @@ func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
 
 // ParseListInstancesResponse parses an HTTP response from a ListInstancesWithResponse call
 func ParseListInstancesResponse(rsp *http.Response) (*ListInstancesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20506,7 +20505,7 @@ func ParseListInstancesResponse(rsp *http.Response) (*ListInstancesResponse, err
 
 // ParseCreateInstanceResponse parses an HTTP response from a CreateInstanceWithResponse call
 func ParseCreateInstanceResponse(rsp *http.Response) (*CreateInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20532,7 +20531,7 @@ func ParseCreateInstanceResponse(rsp *http.Response) (*CreateInstanceResponse, e
 
 // ParseListInstancePoolsResponse parses an HTTP response from a ListInstancePoolsWithResponse call
 func ParseListInstancePoolsResponse(rsp *http.Response) (*ListInstancePoolsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20560,7 +20559,7 @@ func ParseListInstancePoolsResponse(rsp *http.Response) (*ListInstancePoolsRespo
 
 // ParseCreateInstancePoolResponse parses an HTTP response from a CreateInstancePoolWithResponse call
 func ParseCreateInstancePoolResponse(rsp *http.Response) (*CreateInstancePoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20586,7 +20585,7 @@ func ParseCreateInstancePoolResponse(rsp *http.Response) (*CreateInstancePoolRes
 
 // ParseDeleteInstancePoolResponse parses an HTTP response from a DeleteInstancePoolWithResponse call
 func ParseDeleteInstancePoolResponse(rsp *http.Response) (*DeleteInstancePoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20612,7 +20611,7 @@ func ParseDeleteInstancePoolResponse(rsp *http.Response) (*DeleteInstancePoolRes
 
 // ParseGetInstancePoolResponse parses an HTTP response from a GetInstancePoolWithResponse call
 func ParseGetInstancePoolResponse(rsp *http.Response) (*GetInstancePoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20638,7 +20637,7 @@ func ParseGetInstancePoolResponse(rsp *http.Response) (*GetInstancePoolResponse,
 
 // ParseUpdateInstancePoolResponse parses an HTTP response from a UpdateInstancePoolWithResponse call
 func ParseUpdateInstancePoolResponse(rsp *http.Response) (*UpdateInstancePoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20664,7 +20663,7 @@ func ParseUpdateInstancePoolResponse(rsp *http.Response) (*UpdateInstancePoolRes
 
 // ParseResetInstancePoolFieldResponse parses an HTTP response from a ResetInstancePoolFieldWithResponse call
 func ParseResetInstancePoolFieldResponse(rsp *http.Response) (*ResetInstancePoolFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20690,7 +20689,7 @@ func ParseResetInstancePoolFieldResponse(rsp *http.Response) (*ResetInstancePool
 
 // ParseEvictInstancePoolMembersResponse parses an HTTP response from a EvictInstancePoolMembersWithResponse call
 func ParseEvictInstancePoolMembersResponse(rsp *http.Response) (*EvictInstancePoolMembersResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20716,7 +20715,7 @@ func ParseEvictInstancePoolMembersResponse(rsp *http.Response) (*EvictInstancePo
 
 // ParseScaleInstancePoolResponse parses an HTTP response from a ScaleInstancePoolWithResponse call
 func ParseScaleInstancePoolResponse(rsp *http.Response) (*ScaleInstancePoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20742,7 +20741,7 @@ func ParseScaleInstancePoolResponse(rsp *http.Response) (*ScaleInstancePoolRespo
 
 // ParseListInstanceTypesResponse parses an HTTP response from a ListInstanceTypesWithResponse call
 func ParseListInstanceTypesResponse(rsp *http.Response) (*ListInstanceTypesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20770,7 +20769,7 @@ func ParseListInstanceTypesResponse(rsp *http.Response) (*ListInstanceTypesRespo
 
 // ParseGetInstanceTypeResponse parses an HTTP response from a GetInstanceTypeWithResponse call
 func ParseGetInstanceTypeResponse(rsp *http.Response) (*GetInstanceTypeResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20796,7 +20795,7 @@ func ParseGetInstanceTypeResponse(rsp *http.Response) (*GetInstanceTypeResponse,
 
 // ParseDeleteInstanceResponse parses an HTTP response from a DeleteInstanceWithResponse call
 func ParseDeleteInstanceResponse(rsp *http.Response) (*DeleteInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20822,7 +20821,7 @@ func ParseDeleteInstanceResponse(rsp *http.Response) (*DeleteInstanceResponse, e
 
 // ParseGetInstanceResponse parses an HTTP response from a GetInstanceWithResponse call
 func ParseGetInstanceResponse(rsp *http.Response) (*GetInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20848,7 +20847,7 @@ func ParseGetInstanceResponse(rsp *http.Response) (*GetInstanceResponse, error) 
 
 // ParseUpdateInstanceResponse parses an HTTP response from a UpdateInstanceWithResponse call
 func ParseUpdateInstanceResponse(rsp *http.Response) (*UpdateInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20874,7 +20873,7 @@ func ParseUpdateInstanceResponse(rsp *http.Response) (*UpdateInstanceResponse, e
 
 // ParseResetInstanceFieldResponse parses an HTTP response from a ResetInstanceFieldWithResponse call
 func ParseResetInstanceFieldResponse(rsp *http.Response) (*ResetInstanceFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20900,7 +20899,7 @@ func ParseResetInstanceFieldResponse(rsp *http.Response) (*ResetInstanceFieldRes
 
 // ParseCreateSnapshotResponse parses an HTTP response from a CreateSnapshotWithResponse call
 func ParseCreateSnapshotResponse(rsp *http.Response) (*CreateSnapshotResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20926,7 +20925,7 @@ func ParseCreateSnapshotResponse(rsp *http.Response) (*CreateSnapshotResponse, e
 
 // ParseRebootInstanceResponse parses an HTTP response from a RebootInstanceWithResponse call
 func ParseRebootInstanceResponse(rsp *http.Response) (*RebootInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20952,7 +20951,7 @@ func ParseRebootInstanceResponse(rsp *http.Response) (*RebootInstanceResponse, e
 
 // ParseResetInstanceResponse parses an HTTP response from a ResetInstanceWithResponse call
 func ParseResetInstanceResponse(rsp *http.Response) (*ResetInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -20978,7 +20977,7 @@ func ParseResetInstanceResponse(rsp *http.Response) (*ResetInstanceResponse, err
 
 // ParseResizeInstanceDiskResponse parses an HTTP response from a ResizeInstanceDiskWithResponse call
 func ParseResizeInstanceDiskResponse(rsp *http.Response) (*ResizeInstanceDiskResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21004,7 +21003,7 @@ func ParseResizeInstanceDiskResponse(rsp *http.Response) (*ResizeInstanceDiskRes
 
 // ParseScaleInstanceResponse parses an HTTP response from a ScaleInstanceWithResponse call
 func ParseScaleInstanceResponse(rsp *http.Response) (*ScaleInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21030,7 +21029,7 @@ func ParseScaleInstanceResponse(rsp *http.Response) (*ScaleInstanceResponse, err
 
 // ParseStartInstanceResponse parses an HTTP response from a StartInstanceWithResponse call
 func ParseStartInstanceResponse(rsp *http.Response) (*StartInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21056,7 +21055,7 @@ func ParseStartInstanceResponse(rsp *http.Response) (*StartInstanceResponse, err
 
 // ParseStopInstanceResponse parses an HTTP response from a StopInstanceWithResponse call
 func ParseStopInstanceResponse(rsp *http.Response) (*StopInstanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21082,7 +21081,7 @@ func ParseStopInstanceResponse(rsp *http.Response) (*StopInstanceResponse, error
 
 // ParseRevertInstanceToSnapshotResponse parses an HTTP response from a RevertInstanceToSnapshotWithResponse call
 func ParseRevertInstanceToSnapshotResponse(rsp *http.Response) (*RevertInstanceToSnapshotResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21108,7 +21107,7 @@ func ParseRevertInstanceToSnapshotResponse(rsp *http.Response) (*RevertInstanceT
 
 // ParseListLoadBalancersResponse parses an HTTP response from a ListLoadBalancersWithResponse call
 func ParseListLoadBalancersResponse(rsp *http.Response) (*ListLoadBalancersResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21136,7 +21135,7 @@ func ParseListLoadBalancersResponse(rsp *http.Response) (*ListLoadBalancersRespo
 
 // ParseCreateLoadBalancerResponse parses an HTTP response from a CreateLoadBalancerWithResponse call
 func ParseCreateLoadBalancerResponse(rsp *http.Response) (*CreateLoadBalancerResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21162,7 +21161,7 @@ func ParseCreateLoadBalancerResponse(rsp *http.Response) (*CreateLoadBalancerRes
 
 // ParseDeleteLoadBalancerResponse parses an HTTP response from a DeleteLoadBalancerWithResponse call
 func ParseDeleteLoadBalancerResponse(rsp *http.Response) (*DeleteLoadBalancerResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21188,7 +21187,7 @@ func ParseDeleteLoadBalancerResponse(rsp *http.Response) (*DeleteLoadBalancerRes
 
 // ParseGetLoadBalancerResponse parses an HTTP response from a GetLoadBalancerWithResponse call
 func ParseGetLoadBalancerResponse(rsp *http.Response) (*GetLoadBalancerResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21214,7 +21213,7 @@ func ParseGetLoadBalancerResponse(rsp *http.Response) (*GetLoadBalancerResponse,
 
 // ParseUpdateLoadBalancerResponse parses an HTTP response from a UpdateLoadBalancerWithResponse call
 func ParseUpdateLoadBalancerResponse(rsp *http.Response) (*UpdateLoadBalancerResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21240,7 +21239,7 @@ func ParseUpdateLoadBalancerResponse(rsp *http.Response) (*UpdateLoadBalancerRes
 
 // ParseAddServiceToLoadBalancerResponse parses an HTTP response from a AddServiceToLoadBalancerWithResponse call
 func ParseAddServiceToLoadBalancerResponse(rsp *http.Response) (*AddServiceToLoadBalancerResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21266,7 +21265,7 @@ func ParseAddServiceToLoadBalancerResponse(rsp *http.Response) (*AddServiceToLoa
 
 // ParseDeleteLoadBalancerServiceResponse parses an HTTP response from a DeleteLoadBalancerServiceWithResponse call
 func ParseDeleteLoadBalancerServiceResponse(rsp *http.Response) (*DeleteLoadBalancerServiceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21292,7 +21291,7 @@ func ParseDeleteLoadBalancerServiceResponse(rsp *http.Response) (*DeleteLoadBala
 
 // ParseGetLoadBalancerServiceResponse parses an HTTP response from a GetLoadBalancerServiceWithResponse call
 func ParseGetLoadBalancerServiceResponse(rsp *http.Response) (*GetLoadBalancerServiceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21318,7 +21317,7 @@ func ParseGetLoadBalancerServiceResponse(rsp *http.Response) (*GetLoadBalancerSe
 
 // ParseUpdateLoadBalancerServiceResponse parses an HTTP response from a UpdateLoadBalancerServiceWithResponse call
 func ParseUpdateLoadBalancerServiceResponse(rsp *http.Response) (*UpdateLoadBalancerServiceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21344,7 +21343,7 @@ func ParseUpdateLoadBalancerServiceResponse(rsp *http.Response) (*UpdateLoadBala
 
 // ParseResetLoadBalancerServiceFieldResponse parses an HTTP response from a ResetLoadBalancerServiceFieldWithResponse call
 func ParseResetLoadBalancerServiceFieldResponse(rsp *http.Response) (*ResetLoadBalancerServiceFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21370,7 +21369,7 @@ func ParseResetLoadBalancerServiceFieldResponse(rsp *http.Response) (*ResetLoadB
 
 // ParseResetLoadBalancerFieldResponse parses an HTTP response from a ResetLoadBalancerFieldWithResponse call
 func ParseResetLoadBalancerFieldResponse(rsp *http.Response) (*ResetLoadBalancerFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21396,7 +21395,7 @@ func ParseResetLoadBalancerFieldResponse(rsp *http.Response) (*ResetLoadBalancer
 
 // ParseGetOperationResponse parses an HTTP response from a GetOperationWithResponse call
 func ParseGetOperationResponse(rsp *http.Response) (*GetOperationResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21422,7 +21421,7 @@ func ParseGetOperationResponse(rsp *http.Response) (*GetOperationResponse, error
 
 // ParseListPrivateNetworksResponse parses an HTTP response from a ListPrivateNetworksWithResponse call
 func ParseListPrivateNetworksResponse(rsp *http.Response) (*ListPrivateNetworksResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21450,7 +21449,7 @@ func ParseListPrivateNetworksResponse(rsp *http.Response) (*ListPrivateNetworksR
 
 // ParseCreatePrivateNetworkResponse parses an HTTP response from a CreatePrivateNetworkWithResponse call
 func ParseCreatePrivateNetworkResponse(rsp *http.Response) (*CreatePrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21476,7 +21475,7 @@ func ParseCreatePrivateNetworkResponse(rsp *http.Response) (*CreatePrivateNetwor
 
 // ParseDeletePrivateNetworkResponse parses an HTTP response from a DeletePrivateNetworkWithResponse call
 func ParseDeletePrivateNetworkResponse(rsp *http.Response) (*DeletePrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21502,7 +21501,7 @@ func ParseDeletePrivateNetworkResponse(rsp *http.Response) (*DeletePrivateNetwor
 
 // ParseGetPrivateNetworkResponse parses an HTTP response from a GetPrivateNetworkWithResponse call
 func ParseGetPrivateNetworkResponse(rsp *http.Response) (*GetPrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21528,7 +21527,7 @@ func ParseGetPrivateNetworkResponse(rsp *http.Response) (*GetPrivateNetworkRespo
 
 // ParseUpdatePrivateNetworkResponse parses an HTTP response from a UpdatePrivateNetworkWithResponse call
 func ParseUpdatePrivateNetworkResponse(rsp *http.Response) (*UpdatePrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21554,7 +21553,7 @@ func ParseUpdatePrivateNetworkResponse(rsp *http.Response) (*UpdatePrivateNetwor
 
 // ParseResetPrivateNetworkFieldResponse parses an HTTP response from a ResetPrivateNetworkFieldWithResponse call
 func ParseResetPrivateNetworkFieldResponse(rsp *http.Response) (*ResetPrivateNetworkFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21580,7 +21579,7 @@ func ParseResetPrivateNetworkFieldResponse(rsp *http.Response) (*ResetPrivateNet
 
 // ParseAttachInstanceToPrivateNetworkResponse parses an HTTP response from a AttachInstanceToPrivateNetworkWithResponse call
 func ParseAttachInstanceToPrivateNetworkResponse(rsp *http.Response) (*AttachInstanceToPrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21606,7 +21605,7 @@ func ParseAttachInstanceToPrivateNetworkResponse(rsp *http.Response) (*AttachIns
 
 // ParseDetachInstanceFromPrivateNetworkResponse parses an HTTP response from a DetachInstanceFromPrivateNetworkWithResponse call
 func ParseDetachInstanceFromPrivateNetworkResponse(rsp *http.Response) (*DetachInstanceFromPrivateNetworkResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21632,7 +21631,7 @@ func ParseDetachInstanceFromPrivateNetworkResponse(rsp *http.Response) (*DetachI
 
 // ParseUpdatePrivateNetworkInstanceIpResponse parses an HTTP response from a UpdatePrivateNetworkInstanceIpWithResponse call
 func ParseUpdatePrivateNetworkInstanceIpResponse(rsp *http.Response) (*UpdatePrivateNetworkInstanceIpResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21658,7 +21657,7 @@ func ParseUpdatePrivateNetworkInstanceIpResponse(rsp *http.Response) (*UpdatePri
 
 // ParseListQuotasResponse parses an HTTP response from a ListQuotasWithResponse call
 func ParseListQuotasResponse(rsp *http.Response) (*ListQuotasResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21686,7 +21685,7 @@ func ParseListQuotasResponse(rsp *http.Response) (*ListQuotasResponse, error) {
 
 // ParseGetQuotaResponse parses an HTTP response from a GetQuotaWithResponse call
 func ParseGetQuotaResponse(rsp *http.Response) (*GetQuotaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21712,7 +21711,7 @@ func ParseGetQuotaResponse(rsp *http.Response) (*GetQuotaResponse, error) {
 
 // ParseListSecurityGroupsResponse parses an HTTP response from a ListSecurityGroupsWithResponse call
 func ParseListSecurityGroupsResponse(rsp *http.Response) (*ListSecurityGroupsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21740,7 +21739,7 @@ func ParseListSecurityGroupsResponse(rsp *http.Response) (*ListSecurityGroupsRes
 
 // ParseCreateSecurityGroupResponse parses an HTTP response from a CreateSecurityGroupWithResponse call
 func ParseCreateSecurityGroupResponse(rsp *http.Response) (*CreateSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21766,7 +21765,7 @@ func ParseCreateSecurityGroupResponse(rsp *http.Response) (*CreateSecurityGroupR
 
 // ParseDeleteSecurityGroupResponse parses an HTTP response from a DeleteSecurityGroupWithResponse call
 func ParseDeleteSecurityGroupResponse(rsp *http.Response) (*DeleteSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21792,7 +21791,7 @@ func ParseDeleteSecurityGroupResponse(rsp *http.Response) (*DeleteSecurityGroupR
 
 // ParseGetSecurityGroupResponse parses an HTTP response from a GetSecurityGroupWithResponse call
 func ParseGetSecurityGroupResponse(rsp *http.Response) (*GetSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21818,7 +21817,7 @@ func ParseGetSecurityGroupResponse(rsp *http.Response) (*GetSecurityGroupRespons
 
 // ParseAddRuleToSecurityGroupResponse parses an HTTP response from a AddRuleToSecurityGroupWithResponse call
 func ParseAddRuleToSecurityGroupResponse(rsp *http.Response) (*AddRuleToSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21844,7 +21843,7 @@ func ParseAddRuleToSecurityGroupResponse(rsp *http.Response) (*AddRuleToSecurity
 
 // ParseDeleteRuleFromSecurityGroupResponse parses an HTTP response from a DeleteRuleFromSecurityGroupWithResponse call
 func ParseDeleteRuleFromSecurityGroupResponse(rsp *http.Response) (*DeleteRuleFromSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21870,7 +21869,7 @@ func ParseDeleteRuleFromSecurityGroupResponse(rsp *http.Response) (*DeleteRuleFr
 
 // ParseAddExternalSourceToSecurityGroupResponse parses an HTTP response from a AddExternalSourceToSecurityGroupWithResponse call
 func ParseAddExternalSourceToSecurityGroupResponse(rsp *http.Response) (*AddExternalSourceToSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21896,7 +21895,7 @@ func ParseAddExternalSourceToSecurityGroupResponse(rsp *http.Response) (*AddExte
 
 // ParseAttachInstanceToSecurityGroupResponse parses an HTTP response from a AttachInstanceToSecurityGroupWithResponse call
 func ParseAttachInstanceToSecurityGroupResponse(rsp *http.Response) (*AttachInstanceToSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21922,7 +21921,7 @@ func ParseAttachInstanceToSecurityGroupResponse(rsp *http.Response) (*AttachInst
 
 // ParseDetachInstanceFromSecurityGroupResponse parses an HTTP response from a DetachInstanceFromSecurityGroupWithResponse call
 func ParseDetachInstanceFromSecurityGroupResponse(rsp *http.Response) (*DetachInstanceFromSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21948,7 +21947,7 @@ func ParseDetachInstanceFromSecurityGroupResponse(rsp *http.Response) (*DetachIn
 
 // ParseRemoveExternalSourceFromSecurityGroupResponse parses an HTTP response from a RemoveExternalSourceFromSecurityGroupWithResponse call
 func ParseRemoveExternalSourceFromSecurityGroupResponse(rsp *http.Response) (*RemoveExternalSourceFromSecurityGroupResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -21974,7 +21973,7 @@ func ParseRemoveExternalSourceFromSecurityGroupResponse(rsp *http.Response) (*Re
 
 // ParseListSksClustersResponse parses an HTTP response from a ListSksClustersWithResponse call
 func ParseListSksClustersResponse(rsp *http.Response) (*ListSksClustersResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22002,7 +22001,7 @@ func ParseListSksClustersResponse(rsp *http.Response) (*ListSksClustersResponse,
 
 // ParseCreateSksClusterResponse parses an HTTP response from a CreateSksClusterWithResponse call
 func ParseCreateSksClusterResponse(rsp *http.Response) (*CreateSksClusterResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22028,7 +22027,7 @@ func ParseCreateSksClusterResponse(rsp *http.Response) (*CreateSksClusterRespons
 
 // ParseListSksClusterDeprecatedResourcesResponse parses an HTTP response from a ListSksClusterDeprecatedResourcesWithResponse call
 func ParseListSksClusterDeprecatedResourcesResponse(rsp *http.Response) (*ListSksClusterDeprecatedResourcesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22054,7 +22053,7 @@ func ParseListSksClusterDeprecatedResourcesResponse(rsp *http.Response) (*ListSk
 
 // ParseGenerateSksClusterKubeconfigResponse parses an HTTP response from a GenerateSksClusterKubeconfigWithResponse call
 func ParseGenerateSksClusterKubeconfigResponse(rsp *http.Response) (*GenerateSksClusterKubeconfigResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22082,7 +22081,7 @@ func ParseGenerateSksClusterKubeconfigResponse(rsp *http.Response) (*GenerateSks
 
 // ParseListSksClusterVersionsResponse parses an HTTP response from a ListSksClusterVersionsWithResponse call
 func ParseListSksClusterVersionsResponse(rsp *http.Response) (*ListSksClusterVersionsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22110,7 +22109,7 @@ func ParseListSksClusterVersionsResponse(rsp *http.Response) (*ListSksClusterVer
 
 // ParseDeleteSksClusterResponse parses an HTTP response from a DeleteSksClusterWithResponse call
 func ParseDeleteSksClusterResponse(rsp *http.Response) (*DeleteSksClusterResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22136,7 +22135,7 @@ func ParseDeleteSksClusterResponse(rsp *http.Response) (*DeleteSksClusterRespons
 
 // ParseGetSksClusterResponse parses an HTTP response from a GetSksClusterWithResponse call
 func ParseGetSksClusterResponse(rsp *http.Response) (*GetSksClusterResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22162,7 +22161,7 @@ func ParseGetSksClusterResponse(rsp *http.Response) (*GetSksClusterResponse, err
 
 // ParseUpdateSksClusterResponse parses an HTTP response from a UpdateSksClusterWithResponse call
 func ParseUpdateSksClusterResponse(rsp *http.Response) (*UpdateSksClusterResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22188,7 +22187,7 @@ func ParseUpdateSksClusterResponse(rsp *http.Response) (*UpdateSksClusterRespons
 
 // ParseGetSksClusterAuthorityCertResponse parses an HTTP response from a GetSksClusterAuthorityCertWithResponse call
 func ParseGetSksClusterAuthorityCertResponse(rsp *http.Response) (*GetSksClusterAuthorityCertResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22216,7 +22215,7 @@ func ParseGetSksClusterAuthorityCertResponse(rsp *http.Response) (*GetSksCluster
 
 // ParseCreateSksNodepoolResponse parses an HTTP response from a CreateSksNodepoolWithResponse call
 func ParseCreateSksNodepoolResponse(rsp *http.Response) (*CreateSksNodepoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22242,7 +22241,7 @@ func ParseCreateSksNodepoolResponse(rsp *http.Response) (*CreateSksNodepoolRespo
 
 // ParseDeleteSksNodepoolResponse parses an HTTP response from a DeleteSksNodepoolWithResponse call
 func ParseDeleteSksNodepoolResponse(rsp *http.Response) (*DeleteSksNodepoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22268,7 +22267,7 @@ func ParseDeleteSksNodepoolResponse(rsp *http.Response) (*DeleteSksNodepoolRespo
 
 // ParseGetSksNodepoolResponse parses an HTTP response from a GetSksNodepoolWithResponse call
 func ParseGetSksNodepoolResponse(rsp *http.Response) (*GetSksNodepoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22294,7 +22293,7 @@ func ParseGetSksNodepoolResponse(rsp *http.Response) (*GetSksNodepoolResponse, e
 
 // ParseUpdateSksNodepoolResponse parses an HTTP response from a UpdateSksNodepoolWithResponse call
 func ParseUpdateSksNodepoolResponse(rsp *http.Response) (*UpdateSksNodepoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22320,7 +22319,7 @@ func ParseUpdateSksNodepoolResponse(rsp *http.Response) (*UpdateSksNodepoolRespo
 
 // ParseResetSksNodepoolFieldResponse parses an HTTP response from a ResetSksNodepoolFieldWithResponse call
 func ParseResetSksNodepoolFieldResponse(rsp *http.Response) (*ResetSksNodepoolFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22346,7 +22345,7 @@ func ParseResetSksNodepoolFieldResponse(rsp *http.Response) (*ResetSksNodepoolFi
 
 // ParseEvictSksNodepoolMembersResponse parses an HTTP response from a EvictSksNodepoolMembersWithResponse call
 func ParseEvictSksNodepoolMembersResponse(rsp *http.Response) (*EvictSksNodepoolMembersResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22372,7 +22371,7 @@ func ParseEvictSksNodepoolMembersResponse(rsp *http.Response) (*EvictSksNodepool
 
 // ParseScaleSksNodepoolResponse parses an HTTP response from a ScaleSksNodepoolWithResponse call
 func ParseScaleSksNodepoolResponse(rsp *http.Response) (*ScaleSksNodepoolResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22398,7 +22397,7 @@ func ParseScaleSksNodepoolResponse(rsp *http.Response) (*ScaleSksNodepoolRespons
 
 // ParseRotateSksCcmCredentialsResponse parses an HTTP response from a RotateSksCcmCredentialsWithResponse call
 func ParseRotateSksCcmCredentialsResponse(rsp *http.Response) (*RotateSksCcmCredentialsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22424,7 +22423,7 @@ func ParseRotateSksCcmCredentialsResponse(rsp *http.Response) (*RotateSksCcmCred
 
 // ParseRotateSksOperatorsCaResponse parses an HTTP response from a RotateSksOperatorsCaWithResponse call
 func ParseRotateSksOperatorsCaResponse(rsp *http.Response) (*RotateSksOperatorsCaResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22450,7 +22449,7 @@ func ParseRotateSksOperatorsCaResponse(rsp *http.Response) (*RotateSksOperatorsC
 
 // ParseUpgradeSksClusterResponse parses an HTTP response from a UpgradeSksClusterWithResponse call
 func ParseUpgradeSksClusterResponse(rsp *http.Response) (*UpgradeSksClusterResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22476,7 +22475,7 @@ func ParseUpgradeSksClusterResponse(rsp *http.Response) (*UpgradeSksClusterRespo
 
 // ParseUpgradeSksClusterServiceLevelResponse parses an HTTP response from a UpgradeSksClusterServiceLevelWithResponse call
 func ParseUpgradeSksClusterServiceLevelResponse(rsp *http.Response) (*UpgradeSksClusterServiceLevelResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22502,7 +22501,7 @@ func ParseUpgradeSksClusterServiceLevelResponse(rsp *http.Response) (*UpgradeSks
 
 // ParseResetSksClusterFieldResponse parses an HTTP response from a ResetSksClusterFieldWithResponse call
 func ParseResetSksClusterFieldResponse(rsp *http.Response) (*ResetSksClusterFieldResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22528,7 +22527,7 @@ func ParseResetSksClusterFieldResponse(rsp *http.Response) (*ResetSksClusterFiel
 
 // ParseListSnapshotsResponse parses an HTTP response from a ListSnapshotsWithResponse call
 func ParseListSnapshotsResponse(rsp *http.Response) (*ListSnapshotsResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22556,7 +22555,7 @@ func ParseListSnapshotsResponse(rsp *http.Response) (*ListSnapshotsResponse, err
 
 // ParseDeleteSnapshotResponse parses an HTTP response from a DeleteSnapshotWithResponse call
 func ParseDeleteSnapshotResponse(rsp *http.Response) (*DeleteSnapshotResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22582,7 +22581,7 @@ func ParseDeleteSnapshotResponse(rsp *http.Response) (*DeleteSnapshotResponse, e
 
 // ParseGetSnapshotResponse parses an HTTP response from a GetSnapshotWithResponse call
 func ParseGetSnapshotResponse(rsp *http.Response) (*GetSnapshotResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22608,7 +22607,7 @@ func ParseGetSnapshotResponse(rsp *http.Response) (*GetSnapshotResponse, error) 
 
 // ParseExportSnapshotResponse parses an HTTP response from a ExportSnapshotWithResponse call
 func ParseExportSnapshotResponse(rsp *http.Response) (*ExportSnapshotResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22634,7 +22633,7 @@ func ParseExportSnapshotResponse(rsp *http.Response) (*ExportSnapshotResponse, e
 
 // ParsePromoteSnapshotToTemplateResponse parses an HTTP response from a PromoteSnapshotToTemplateWithResponse call
 func ParsePromoteSnapshotToTemplateResponse(rsp *http.Response) (*PromoteSnapshotToTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22660,7 +22659,7 @@ func ParsePromoteSnapshotToTemplateResponse(rsp *http.Response) (*PromoteSnapsho
 
 // ParseGetSosPresignedUrlResponse parses an HTTP response from a GetSosPresignedUrlWithResponse call
 func ParseGetSosPresignedUrlResponse(rsp *http.Response) (*GetSosPresignedUrlResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22688,7 +22687,7 @@ func ParseGetSosPresignedUrlResponse(rsp *http.Response) (*GetSosPresignedUrlRes
 
 // ParseListSshKeysResponse parses an HTTP response from a ListSshKeysWithResponse call
 func ParseListSshKeysResponse(rsp *http.Response) (*ListSshKeysResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22716,7 +22715,7 @@ func ParseListSshKeysResponse(rsp *http.Response) (*ListSshKeysResponse, error) 
 
 // ParseRegisterSshKeyResponse parses an HTTP response from a RegisterSshKeyWithResponse call
 func ParseRegisterSshKeyResponse(rsp *http.Response) (*RegisterSshKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22742,7 +22741,7 @@ func ParseRegisterSshKeyResponse(rsp *http.Response) (*RegisterSshKeyResponse, e
 
 // ParseDeleteSshKeyResponse parses an HTTP response from a DeleteSshKeyWithResponse call
 func ParseDeleteSshKeyResponse(rsp *http.Response) (*DeleteSshKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22768,7 +22767,7 @@ func ParseDeleteSshKeyResponse(rsp *http.Response) (*DeleteSshKeyResponse, error
 
 // ParseGetSshKeyResponse parses an HTTP response from a GetSshKeyWithResponse call
 func ParseGetSshKeyResponse(rsp *http.Response) (*GetSshKeyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22794,7 +22793,7 @@ func ParseGetSshKeyResponse(rsp *http.Response) (*GetSshKeyResponse, error) {
 
 // ParseListTemplatesResponse parses an HTTP response from a ListTemplatesWithResponse call
 func ParseListTemplatesResponse(rsp *http.Response) (*ListTemplatesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22822,7 +22821,7 @@ func ParseListTemplatesResponse(rsp *http.Response) (*ListTemplatesResponse, err
 
 // ParseRegisterTemplateResponse parses an HTTP response from a RegisterTemplateWithResponse call
 func ParseRegisterTemplateResponse(rsp *http.Response) (*RegisterTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22848,7 +22847,7 @@ func ParseRegisterTemplateResponse(rsp *http.Response) (*RegisterTemplateRespons
 
 // ParseDeleteTemplateResponse parses an HTTP response from a DeleteTemplateWithResponse call
 func ParseDeleteTemplateResponse(rsp *http.Response) (*DeleteTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22874,7 +22873,7 @@ func ParseDeleteTemplateResponse(rsp *http.Response) (*DeleteTemplateResponse, e
 
 // ParseGetTemplateResponse parses an HTTP response from a GetTemplateWithResponse call
 func ParseGetTemplateResponse(rsp *http.Response) (*GetTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22900,7 +22899,7 @@ func ParseGetTemplateResponse(rsp *http.Response) (*GetTemplateResponse, error) 
 
 // ParseCopyTemplateResponse parses an HTTP response from a CopyTemplateWithResponse call
 func ParseCopyTemplateResponse(rsp *http.Response) (*CopyTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22926,7 +22925,7 @@ func ParseCopyTemplateResponse(rsp *http.Response) (*CopyTemplateResponse, error
 
 // ParseUpdateTemplateResponse parses an HTTP response from a UpdateTemplateWithResponse call
 func ParseUpdateTemplateResponse(rsp *http.Response) (*UpdateTemplateResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
@@ -22952,7 +22951,7 @@ func ParseUpdateTemplateResponse(rsp *http.Response) (*UpdateTemplateResponse, e
 
 // ParseListZonesResponse parses an HTTP response from a ListZonesWithResponse call
 func ParseListZonesResponse(rsp *http.Response) (*ListZonesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/main.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/main.go
@@ -20,8 +20,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -96,7 +96,7 @@ func main() {
 			klog.Fatalf("failed to read certificate files: %s", err)
 		}
 		certPool := x509.NewCertPool()
-		bs, err := ioutil.ReadFile(*cacert)
+		bs, err := os.ReadFile(*cacert)
 		if err != nil {
 			klog.Fatalf("failed to read client ca cert: %s", err)
 		}

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -310,7 +310,7 @@ func BuildExternalGrpc(
 	if opts.CloudConfig == "" {
 		klog.Fatal("No config file provided, please specify it via the --cloud-config flag")
 	}
-	config, err := ioutil.ReadFile(opts.CloudConfig)
+	config, err := os.ReadFile(opts.CloudConfig)
 	if err != nil {
 		klog.Fatalf("Could not open cloud provider configuration file %q: %v", opts.CloudConfig, err)
 	}
@@ -344,15 +344,15 @@ func newExternalGrpcCloudProviderClient(config []byte) (protos.CloudProviderClie
 		klog.V(5).Info("No certs specified in external gRPC provider config, using insecure mode")
 		dialOpt = grpc.WithInsecure()
 	} else {
-		certFile, err := ioutil.ReadFile(yamlConfig.Cert)
+		certFile, err := os.ReadFile(yamlConfig.Cert)
 		if err != nil {
 			return nil, fmt.Errorf("could not open Cert configuration file %q: %v", yamlConfig.Cert, err)
 		}
-		keyFile, err := ioutil.ReadFile(yamlConfig.Key)
+		keyFile, err := os.ReadFile(yamlConfig.Key)
 		if err != nil {
 			return nil, fmt.Errorf("could not open Key configuration file %q: %v", yamlConfig.Key, err)
 		}
-		cacertFile, err := ioutil.ReadFile(yamlConfig.Cacert)
+		cacertFile, err := os.ReadFile(yamlConfig.Cacert)
 		if err != nil {
 			return nil, fmt.Errorf("could not open Cacert configuration file %q: %v", yamlConfig.Cacert, err)
 		}

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/auth/iam/iam_service.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/auth/iam/iam_service.go
@@ -3,7 +3,7 @@ package iam
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"reflect"
 
 	jsoniter "github.com/json-iterator/go"
@@ -114,7 +114,7 @@ func GetResponseBody(resp *response.DefaultHttpResponse) ([]byte, error) {
 		return nil, sdkerr.NewServiceResponseError(resp.Response)
 	}
 
-	data, err := ioutil.ReadAll(resp.Response.Body)
+	data, err := io.ReadAll(resp.Response.Body)
 
 	if err != nil {
 		if closeErr := resp.Response.Body.Close(); closeErr != nil {
@@ -126,7 +126,7 @@ func GetResponseBody(resp *response.DefaultHttpResponse) ([]byte, error) {
 	if err := resp.Response.Body.Close(); err != nil {
 		return nil, err
 	} else {
-		resp.Response.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		resp.Response.Body = io.NopCloser(bytes.NewBuffer(data))
 	}
 
 	return data, nil

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/hc_http_client.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/hc_http_client.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 
@@ -228,7 +228,7 @@ func (hc *HcHttpClient) deserializeResponse(resp *response.DefaultHttpResponse, 
 		return nil
 	}
 
-	data, err := ioutil.ReadAll(resp.Response.Body)
+	data, err := io.ReadAll(resp.Response.Body)
 	if err != nil {
 		if closeErr := resp.Response.Body.Close(); closeErr != nil {
 			return err
@@ -238,7 +238,7 @@ func (hc *HcHttpClient) deserializeResponse(resp *response.DefaultHttpResponse, 
 	if err := resp.Response.Body.Close(); err != nil {
 		return err
 	} else {
-		resp.Response.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		resp.Response.Body = io.NopCloser(bytes.NewBuffer(data))
 	}
 
 	hasBody := false

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/impl/default_http_client.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/impl/default_http_client.go
@@ -22,7 +22,7 @@ package impl
 import (
 	"bytes"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -85,7 +85,7 @@ func (client *DefaultHttpClient) SyncInvokeHttp(request *request.DefaultHttpRequ
 			return nil, err
 		}
 		reqClone := req.Clone(req.Context())
-		reqClone.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		reqClone.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		defer reqClone.Body.Close()
 		client.httpHandler.RequestHandlers(*reqClone)
 	}
@@ -111,7 +111,7 @@ func (client *DefaultHttpClient) SyncInvokeHttp(request *request.DefaultHttpRequ
 			return nil, err
 		}
 		respClone := http.Response{
-			Body:             ioutil.NopCloser(bytes.NewBuffer(bodyBytes)),
+			Body:             io.NopCloser(bytes.NewBuffer(bodyBytes)),
 			Status:           resp.Status,
 			StatusCode:       resp.StatusCode,
 			Proto:            resp.Proto,

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/response/default_http_response.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/response/default_http_response.go
@@ -21,7 +21,7 @@ package response
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -49,12 +49,12 @@ func (r *DefaultHttpResponse) GetHeaders() map[string]string {
 }
 
 func (r *DefaultHttpResponse) GetBody() string {
-	body, err := ioutil.ReadAll(r.Response.Body)
+	body, err := io.ReadAll(r.Response.Body)
 	if err != nil {
 		return ""
 	}
 	if err := r.Response.Body.Close(); err == nil {
-		r.Response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		r.Response.Body = io.NopCloser(bytes.NewBuffer(body))
 	}
 	return string(body)
 }

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr/types.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr/types.go
@@ -22,7 +22,7 @@ package sdkerr
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
@@ -88,7 +88,7 @@ func NewServiceResponseError(resp *http.Response) *ServiceResponseError {
 		RequestId:  resp.Header.Get("X-Request-Id"),
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err == nil {
 		dataBuf := make(map[string]string)
 		err := jsoniter.Unmarshal(data, &dataBuf)
@@ -122,7 +122,7 @@ func NewServiceResponseError(resp *http.Response) *ServiceResponseError {
 	}
 
 	if err := resp.Body.Close(); err == nil {
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		resp.Body = io.NopCloser(bytes.NewBuffer(data))
 	}
 
 	return sr

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_.go
@@ -181,7 +181,7 @@ func (a *DefaultApiService) ApiInfoGetExecute(r ApiApiInfoGetRequest) (Info, *AP
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_backup_units.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_backup_units.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -168,7 +168,7 @@ func (a *BackupUnitsApiService) BackupunitsDeleteExecute(r ApiBackupunitsDeleteR
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -331,7 +331,7 @@ func (a *BackupUnitsApiService) BackupunitsFindByIdExecute(r ApiBackupunitsFindB
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -536,7 +536,7 @@ func (a *BackupUnitsApiService) BackupunitsGetExecute(r ApiBackupunitsGetRequest
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -719,7 +719,7 @@ func (a *BackupUnitsApiService) BackupunitsPatchExecute(r ApiBackupunitsPatchReq
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -898,7 +898,7 @@ func (a *BackupUnitsApiService) BackupunitsPostExecute(r ApiBackupunitsPostReque
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1081,7 +1081,7 @@ func (a *BackupUnitsApiService) BackupunitsPutExecute(r ApiBackupunitsPutRequest
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1277,7 +1277,7 @@ func (a *BackupUnitsApiService) BackupunitsSsourlGetExecute(r ApiBackupunitsSsou
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_contract_resources.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_contract_resources.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -195,7 +195,7 @@ func (a *ContractResourcesApiService) ContractsGetExecute(r ApiContractsGetReque
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_data_centers.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_data_centers.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *DataCentersApiService) DatacentersDeleteExecute(r ApiDatacentersDeleteR
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *DataCentersApiService) DatacentersFindByIdExecute(r ApiDatacentersFindB
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -556,7 +556,7 @@ func (a *DataCentersApiService) DatacentersGetExecute(r ApiDatacentersGetRequest
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -739,7 +739,7 @@ func (a *DataCentersApiService) DatacentersPatchExecute(r ApiDatacentersPatchReq
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -920,7 +920,7 @@ func (a *DataCentersApiService) DatacentersPostExecute(r ApiDatacentersPostReque
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1103,7 +1103,7 @@ func (a *DataCentersApiService) DatacentersPutExecute(r ApiDatacentersPutRequest
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_firewall_rules.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_firewall_rules.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -174,7 +174,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesDeleteExecu
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -349,7 +349,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesFindByIdExe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -592,7 +592,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesGetExecute(
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -787,7 +787,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesPatchExecut
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -978,7 +978,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesPostExecute
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1173,7 +1173,7 @@ func (a *FirewallRulesApiService) DatacentersServersNicsFirewallrulesPutExecute(
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_flow_logs.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_flow_logs.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsDeleteExecute(r ApiDa
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsFindByIdExecute(r Api
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -568,7 +568,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsGetExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -755,7 +755,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsPatchExecute(r ApiDat
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -938,7 +938,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsPostExecute(r ApiData
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1125,7 +1125,7 @@ func (a *FlowLogsApiService) DatacentersServersNicsFlowlogsPutExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_images.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_images.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *ImagesApiService) ImagesDeleteExecute(r ApiImagesDeleteRequest) (*APIRe
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *ImagesApiService) ImagesFindByIdExecute(r ApiImagesFindByIdRequest) (Im
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -530,7 +530,7 @@ func (a *ImagesApiService) ImagesGetExecute(r ApiImagesGetRequest) (Images, *API
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -713,7 +713,7 @@ func (a *ImagesApiService) ImagesPatchExecute(r ApiImagesPatchRequest) (Image, *
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -896,7 +896,7 @@ func (a *ImagesApiService) ImagesPutExecute(r ApiImagesPutRequest) (Image, *APIR
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_ip_blocks.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_ip_blocks.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *IPBlocksApiService) IpblocksDeleteExecute(r ApiIpblocksDeleteRequest) (
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *IPBlocksApiService) IpblocksFindByIdExecute(r ApiIpblocksFindByIdReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -556,7 +556,7 @@ func (a *IPBlocksApiService) IpblocksGetExecute(r ApiIpblocksGetRequest) (IpBloc
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -739,7 +739,7 @@ func (a *IPBlocksApiService) IpblocksPatchExecute(r ApiIpblocksPatchRequest) (Ip
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -918,7 +918,7 @@ func (a *IPBlocksApiService) IpblocksPostExecute(r ApiIpblocksPostRequest) (IpBl
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1101,7 +1101,7 @@ func (a *IPBlocksApiService) IpblocksPutExecute(r ApiIpblocksPutRequest) (IpBloc
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_kubernetes.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_kubernetes.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *KubernetesApiService) K8sDeleteExecute(r ApiK8sDeleteRequest) (*APIResp
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *KubernetesApiService) K8sFindByClusterIdExecute(r ApiK8sFindByClusterId
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -530,7 +530,7 @@ func (a *KubernetesApiService) K8sGetExecute(r ApiK8sGetRequest) (KubernetesClus
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -739,7 +739,7 @@ func (a *KubernetesApiService) K8sKubeconfigGetExecute(r ApiK8sKubeconfigGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -914,7 +914,7 @@ func (a *KubernetesApiService) K8sNodepoolsDeleteExecute(r ApiK8sNodepoolsDelete
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1081,7 +1081,7 @@ func (a *KubernetesApiService) K8sNodepoolsFindByIdExecute(r ApiK8sNodepoolsFind
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1290,7 +1290,7 @@ func (a *KubernetesApiService) K8sNodepoolsGetExecute(r ApiK8sNodepoolsGetReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1469,7 +1469,7 @@ func (a *KubernetesApiService) K8sNodepoolsNodesDeleteExecute(r ApiK8sNodepoolsN
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1640,7 +1640,7 @@ func (a *KubernetesApiService) K8sNodepoolsNodesFindByIdExecute(r ApiK8sNodepool
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1853,7 +1853,7 @@ func (a *KubernetesApiService) K8sNodepoolsNodesGetExecute(r ApiK8sNodepoolsNode
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2034,7 +2034,7 @@ func (a *KubernetesApiService) K8sNodepoolsNodesReplacePostExecute(r ApiK8sNodep
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2207,7 +2207,7 @@ func (a *KubernetesApiService) K8sNodepoolsPostExecute(r ApiK8sNodepoolsPostRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2394,7 +2394,7 @@ func (a *KubernetesApiService) K8sNodepoolsPutExecute(r ApiK8sNodepoolsPutReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2573,7 +2573,7 @@ func (a *KubernetesApiService) K8sPostExecute(r ApiK8sPostRequest) (KubernetesCl
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2756,7 +2756,7 @@ func (a *KubernetesApiService) K8sPutExecute(r ApiK8sPutRequest) (KubernetesClus
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2926,7 +2926,7 @@ func (a *KubernetesApiService) K8sVersionsDefaultGetExecute(r ApiK8sVersionsDefa
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3096,7 +3096,7 @@ func (a *KubernetesApiService) K8sVersionsGetExecute(r ApiK8sVersionsGetRequest)
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_labels.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_labels.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *LabelsApiService) DatacentersLabelsDeleteExecute(r ApiDatacentersLabels
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *LabelsApiService) DatacentersLabelsFindByKeyExecute(r ApiDatacentersLab
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -542,7 +542,7 @@ func (a *LabelsApiService) DatacentersLabelsGetExecute(r ApiDatacentersLabelsGet
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -725,7 +725,7 @@ func (a *LabelsApiService) DatacentersLabelsPostExecute(r ApiDatacentersLabelsPo
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -912,7 +912,7 @@ func (a *LabelsApiService) DatacentersLabelsPutExecute(r ApiDatacentersLabelsPut
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1091,7 +1091,7 @@ func (a *LabelsApiService) DatacentersServersLabelsDeleteExecute(r ApiDatacenter
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1262,7 +1262,7 @@ func (a *LabelsApiService) DatacentersServersLabelsFindByKeyExecute(r ApiDatacen
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1475,7 +1475,7 @@ func (a *LabelsApiService) DatacentersServersLabelsGetExecute(r ApiDatacentersSe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1662,7 +1662,7 @@ func (a *LabelsApiService) DatacentersServersLabelsPostExecute(r ApiDatacentersS
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1853,7 +1853,7 @@ func (a *LabelsApiService) DatacentersServersLabelsPutExecute(r ApiDatacentersSe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2032,7 +2032,7 @@ func (a *LabelsApiService) DatacentersVolumesLabelsDeleteExecute(r ApiDatacenter
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2203,7 +2203,7 @@ func (a *LabelsApiService) DatacentersVolumesLabelsFindByKeyExecute(r ApiDatacen
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2416,7 +2416,7 @@ func (a *LabelsApiService) DatacentersVolumesLabelsGetExecute(r ApiDatacentersVo
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2603,7 +2603,7 @@ func (a *LabelsApiService) DatacentersVolumesLabelsPostExecute(r ApiDatacentersV
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2794,7 +2794,7 @@ func (a *LabelsApiService) DatacentersVolumesLabelsPutExecute(r ApiDatacentersVo
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2969,7 +2969,7 @@ func (a *LabelsApiService) IpblocksLabelsDeleteExecute(r ApiIpblocksLabelsDelete
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3136,7 +3136,7 @@ func (a *LabelsApiService) IpblocksLabelsFindByKeyExecute(r ApiIpblocksLabelsFin
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3345,7 +3345,7 @@ func (a *LabelsApiService) IpblocksLabelsGetExecute(r ApiIpblocksLabelsGetReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3528,7 +3528,7 @@ func (a *LabelsApiService) IpblocksLabelsPostExecute(r ApiIpblocksLabelsPostRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3715,7 +3715,7 @@ func (a *LabelsApiService) IpblocksLabelsPutExecute(r ApiIpblocksLabelsPutReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3892,7 +3892,7 @@ func (a *LabelsApiService) LabelsFindByUrnExecute(r ApiLabelsFindByUrnRequest) (
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4097,7 +4097,7 @@ func (a *LabelsApiService) LabelsGetExecute(r ApiLabelsGetRequest) (Labels, *API
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4272,7 +4272,7 @@ func (a *LabelsApiService) SnapshotsLabelsDeleteExecute(r ApiSnapshotsLabelsDele
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4439,7 +4439,7 @@ func (a *LabelsApiService) SnapshotsLabelsFindByKeyExecute(r ApiSnapshotsLabelsF
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4648,7 +4648,7 @@ func (a *LabelsApiService) SnapshotsLabelsGetExecute(r ApiSnapshotsLabelsGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4831,7 +4831,7 @@ func (a *LabelsApiService) SnapshotsLabelsPostExecute(r ApiSnapshotsLabelsPostRe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -5018,7 +5018,7 @@ func (a *LabelsApiService) SnapshotsLabelsPutExecute(r ApiSnapshotsLabelsPutRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_lans.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_lans.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *LANsApiService) DatacentersLansDeleteExecute(r ApiDatacentersLansDelete
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *LANsApiService) DatacentersLansFindByIdExecute(r ApiDatacentersLansFind
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -568,7 +568,7 @@ func (a *LANsApiService) DatacentersLansGetExecute(r ApiDatacentersLansGetReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -749,7 +749,7 @@ func (a *LANsApiService) DatacentersLansNicsFindByIdExecute(r ApiDatacentersLans
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -988,7 +988,7 @@ func (a *LANsApiService) DatacentersLansNicsGetExecute(r ApiDatacentersLansNicsG
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1175,7 +1175,7 @@ func (a *LANsApiService) DatacentersLansNicsPostExecute(r ApiDatacentersLansNics
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1362,7 +1362,7 @@ func (a *LANsApiService) DatacentersLansPatchExecute(r ApiDatacentersLansPatchRe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1545,7 +1545,7 @@ func (a *LANsApiService) DatacentersLansPostExecute(r ApiDatacentersLansPostRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1732,7 +1732,7 @@ func (a *LANsApiService) DatacentersLansPutExecute(r ApiDatacentersLansPutReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_load_balancers.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_load_balancers.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -170,7 +170,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersBalancednicsDeleteExec
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -341,7 +341,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersBalancednicsFindByNicI
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -554,7 +554,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersBalancednicsGetExecute
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -741,7 +741,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersBalancednicsPostExecut
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -916,7 +916,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersDeleteExecute(r ApiDat
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1083,7 +1083,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersFindByIdExecute(r ApiD
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1318,7 +1318,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersGetExecute(r ApiDatace
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1505,7 +1505,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersPatchExecute(r ApiData
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1688,7 +1688,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersPostExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1875,7 +1875,7 @@ func (a *LoadBalancersApiService) DatacentersLoadbalancersPutExecute(r ApiDatace
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_locations.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_locations.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -164,7 +164,7 @@ func (a *LocationsApiService) LocationsFindByRegionIdExecute(r ApiLocationsFindB
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -341,7 +341,7 @@ func (a *LocationsApiService) LocationsFindByRegionIdAndIdExecute(r ApiLocations
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -546,7 +546,7 @@ func (a *LocationsApiService) LocationsGetExecute(r ApiLocationsGetRequest) (Loc
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_nat_gateways.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_nat_gateways.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysDeleteExecute(r ApiDatacen
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFindByNatGatewayIdExecute(
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -504,7 +504,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsDeleteExecute(r Ap
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -667,7 +667,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsFindByFlowLogIdExe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -898,7 +898,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsGetExecute(r ApiDa
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1081,7 +1081,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsPatchExecute(r Api
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1260,7 +1260,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsPostExecute(r ApiD
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1443,7 +1443,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysFlowlogsPutExecute(r ApiDa
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1652,7 +1652,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysGetExecute(r ApiDatacenter
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1839,7 +1839,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysPatchExecute(r ApiDatacent
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2024,7 +2024,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysPostExecute(r ApiDatacente
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2211,7 +2211,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysPutExecute(r ApiDatacenter
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2390,7 +2390,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesDeleteExecute(r ApiDa
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2561,7 +2561,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesFindByNatGatewayRuleI
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2774,7 +2774,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesGetExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2965,7 +2965,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesPatchExecute(r ApiDat
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3152,7 +3152,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesPostExecute(r ApiData
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3343,7 +3343,7 @@ func (a *NATGatewaysApiService) DatacentersNatgatewaysRulesPutExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_network_interfaces.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_network_interfaces.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -170,7 +170,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsDeleteExecute(r ApiD
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -341,7 +341,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsFindByIdExecute(r Ap
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -580,7 +580,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsGetExecute(r ApiData
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -771,7 +771,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsPatchExecute(r ApiDa
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -958,7 +958,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsPostExecute(r ApiDat
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1149,7 +1149,7 @@ func (a *NetworkInterfacesApiService) DatacentersServersNicsPutExecute(r ApiData
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_network_load_balancers.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_network_load_balancers.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersDeleteEx
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFindByNe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -512,7 +512,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -683,7 +683,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -896,7 +896,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1087,7 +1087,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1274,7 +1274,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1465,7 +1465,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersFlowlogs
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1644,7 +1644,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1815,7 +1815,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2028,7 +2028,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2219,7 +2219,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2406,7 +2406,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2597,7 +2597,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersForwardi
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2832,7 +2832,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersGetExecu
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3019,7 +3019,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersPatchExe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3202,7 +3202,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersPostExec
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3389,7 +3389,7 @@ func (a *NetworkLoadBalancersApiService) DatacentersNetworkloadbalancersPutExecu
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_private_cross_connects.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_private_cross_connects.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *PrivateCrossConnectsApiService) PccsDeleteExecute(r ApiPccsDeleteReques
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *PrivateCrossConnectsApiService) PccsFindByIdExecute(r ApiPccsFindByIdRe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -530,7 +530,7 @@ func (a *PrivateCrossConnectsApiService) PccsGetExecute(r ApiPccsGetRequest) (Pr
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -713,7 +713,7 @@ func (a *PrivateCrossConnectsApiService) PccsPatchExecute(r ApiPccsPatchRequest)
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -892,7 +892,7 @@ func (a *PrivateCrossConnectsApiService) PccsPostExecute(r ApiPccsPostRequest) (
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_requests.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_requests.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -164,7 +164,7 @@ func (a *RequestsApiService) RequestsFindByIdExecute(r ApiRequestsFindByIdReques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -483,7 +483,7 @@ func (a *RequestsApiService) RequestsGetExecute(r ApiRequestsGetRequest) (Reques
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -692,7 +692,7 @@ func (a *RequestsApiService) RequestsStatusGetExecute(r ApiRequestsStatusGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_servers.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_servers.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -170,7 +170,7 @@ func (a *ServersApiService) DatacentersServersCdromsDeleteExecute(r ApiDatacente
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -341,7 +341,7 @@ func (a *ServersApiService) DatacentersServersCdromsFindByIdExecute(r ApiDatacen
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -580,7 +580,7 @@ func (a *ServersApiService) DatacentersServersCdromsGetExecute(r ApiDatacentersS
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -767,7 +767,7 @@ func (a *ServersApiService) DatacentersServersCdromsPostExecute(r ApiDatacenters
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -942,7 +942,7 @@ func (a *ServersApiService) DatacentersServersDeleteExecute(r ApiDatacentersServ
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1109,7 +1109,7 @@ func (a *ServersApiService) DatacentersServersFindByIdExecute(r ApiDatacentersSe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1352,7 +1352,7 @@ func (a *ServersApiService) DatacentersServersGetExecute(r ApiDatacentersServers
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1539,7 +1539,7 @@ func (a *ServersApiService) DatacentersServersPatchExecute(r ApiDatacentersServe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1722,7 +1722,7 @@ func (a *ServersApiService) DatacentersServersPostExecute(r ApiDatacentersServer
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1911,7 +1911,7 @@ func (a *ServersApiService) DatacentersServersPutExecute(r ApiDatacentersServers
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2086,7 +2086,7 @@ func (a *ServersApiService) DatacentersServersRebootPostExecute(r ApiDatacenters
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2289,7 +2289,7 @@ func (a *ServersApiService) DatacentersServersRemoteConsoleGetExecute(r ApiDatac
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2466,7 +2466,7 @@ func (a *ServersApiService) DatacentersServersResumePostExecute(r ApiDatacenters
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2631,7 +2631,7 @@ func (a *ServersApiService) DatacentersServersStartPostExecute(r ApiDatacentersS
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2798,7 +2798,7 @@ func (a *ServersApiService) DatacentersServersStopPostExecute(r ApiDatacentersSe
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2965,7 +2965,7 @@ func (a *ServersApiService) DatacentersServersSuspendPostExecute(r ApiDatacenter
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3168,7 +3168,7 @@ func (a *ServersApiService) DatacentersServersTokenGetExecute(r ApiDatacentersSe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3345,7 +3345,7 @@ func (a *ServersApiService) DatacentersServersUpgradePostExecute(r ApiDatacenter
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3514,7 +3514,7 @@ func (a *ServersApiService) DatacentersServersVolumesDeleteExecute(r ApiDatacent
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3685,7 +3685,7 @@ func (a *ServersApiService) DatacentersServersVolumesFindByIdExecute(r ApiDatace
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3924,7 +3924,7 @@ func (a *ServersApiService) DatacentersServersVolumesGetExecute(r ApiDatacenters
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4115,7 +4115,7 @@ func (a *ServersApiService) DatacentersServersVolumesPostExecute(r ApiDatacenter
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_snapshots.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_snapshots.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *SnapshotsApiService) SnapshotsDeleteExecute(r ApiSnapshotsDeleteRequest
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *SnapshotsApiService) SnapshotsFindByIdExecute(r ApiSnapshotsFindByIdReq
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -530,7 +530,7 @@ func (a *SnapshotsApiService) SnapshotsGetExecute(r ApiSnapshotsGetRequest) (Sna
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -713,7 +713,7 @@ func (a *SnapshotsApiService) SnapshotsPatchExecute(r ApiSnapshotsPatchRequest) 
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -896,7 +896,7 @@ func (a *SnapshotsApiService) SnapshotsPutExecute(r ApiSnapshotsPutRequest) (Sna
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_templates.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_templates.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -145,7 +145,7 @@ func (a *TemplatesApiService) TemplatesFindByIdExecute(r ApiTemplatesFindByIdReq
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -331,7 +331,7 @@ func (a *TemplatesApiService) TemplatesGetExecute(r ApiTemplatesGetRequest) (Tem
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_user_management.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_user_management.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (a *UserManagementApiService) UmGroupsDeleteExecute(r ApiUmGroupsDeleteRequ
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -325,7 +325,7 @@ func (a *UserManagementApiService) UmGroupsFindByIdExecute(r ApiUmGroupsFindById
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -530,7 +530,7 @@ func (a *UserManagementApiService) UmGroupsGetExecute(r ApiUmGroupsGetRequest) (
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -709,7 +709,7 @@ func (a *UserManagementApiService) UmGroupsPostExecute(r ApiUmGroupsPostRequest)
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -892,7 +892,7 @@ func (a *UserManagementApiService) UmGroupsPutExecute(r ApiUmGroupsPutRequest) (
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1101,7 +1101,7 @@ func (a *UserManagementApiService) UmGroupsResourcesGetExecute(r ApiUmGroupsReso
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1276,7 +1276,7 @@ func (a *UserManagementApiService) UmGroupsSharesDeleteExecute(r ApiUmGroupsShar
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1443,7 +1443,7 @@ func (a *UserManagementApiService) UmGroupsSharesFindByResourceIdExecute(r ApiUm
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1652,7 +1652,7 @@ func (a *UserManagementApiService) UmGroupsSharesGetExecute(r ApiUmGroupsSharesG
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1839,7 +1839,7 @@ func (a *UserManagementApiService) UmGroupsSharesPostExecute(r ApiUmGroupsShares
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2026,7 +2026,7 @@ func (a *UserManagementApiService) UmGroupsSharesPutExecute(r ApiUmGroupsSharesP
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2201,7 +2201,7 @@ func (a *UserManagementApiService) UmGroupsUsersDeleteExecute(r ApiUmGroupsUsers
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2400,7 +2400,7 @@ func (a *UserManagementApiService) UmGroupsUsersGetExecute(r ApiUmGroupsUsersGet
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2583,7 +2583,7 @@ func (a *UserManagementApiService) UmGroupsUsersPostExecute(r ApiUmGroupsUsersPo
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2760,7 +2760,7 @@ func (a *UserManagementApiService) UmResourcesFindByTypeExecute(r ApiUmResources
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -2941,7 +2941,7 @@ func (a *UserManagementApiService) UmResourcesFindByTypeAndIdExecute(r ApiUmReso
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3146,7 +3146,7 @@ func (a *UserManagementApiService) UmResourcesGetExecute(r ApiUmResourcesGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3317,7 +3317,7 @@ func (a *UserManagementApiService) UmUsersDeleteExecute(r ApiUmUsersDeleteReques
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3480,7 +3480,7 @@ func (a *UserManagementApiService) UmUsersFindByIdExecute(r ApiUmUsersFindByIdRe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3711,7 +3711,7 @@ func (a *UserManagementApiService) UmUsersGetExecute(r ApiUmUsersGetRequest) (Us
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -3920,7 +3920,7 @@ func (a *UserManagementApiService) UmUsersGroupsGetExecute(r ApiUmUsersGroupsGet
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4129,7 +4129,7 @@ func (a *UserManagementApiService) UmUsersOwnsGetExecute(r ApiUmUsersOwnsGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4308,7 +4308,7 @@ func (a *UserManagementApiService) UmUsersPostExecute(r ApiUmUsersPostRequest) (
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -4491,7 +4491,7 @@ func (a *UserManagementApiService) UmUsersPutExecute(r ApiUmUsersPutRequest) (Us
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_user_s3_keys.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_user_s3_keys.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -166,7 +166,7 @@ func (a *UserS3KeysApiService) UmUsersS3keysDeleteExecute(r ApiUmUsersS3keysDele
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -333,7 +333,7 @@ func (a *UserS3KeysApiService) UmUsersS3keysFindByKeyIdExecute(r ApiUmUsersS3key
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -542,7 +542,7 @@ func (a *UserS3KeysApiService) UmUsersS3keysGetExecute(r ApiUmUsersS3keysGetRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -715,7 +715,7 @@ func (a *UserS3KeysApiService) UmUsersS3keysPostExecute(r ApiUmUsersS3keysPostRe
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -902,7 +902,7 @@ func (a *UserS3KeysApiService) UmUsersS3keysPutExecute(r ApiUmUsersS3keysPutRequ
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1098,7 +1098,7 @@ func (a *UserS3KeysApiService) UmUsersS3ssourlGetExecute(r ApiUmUsersS3ssourlGet
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_volumes.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_volumes.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_io "i"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_volumes.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/api_volumes.go
@@ -13,7 +13,7 @@ package ionoscloud
 import (
 	_context "context"
 	"fmt"
-	_ioutil "io/ioutil"
+	_io "i"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -200,7 +200,7 @@ func (a *VolumesApiService) DatacentersVolumesCreateSnapshotPostExecute(r ApiDat
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -375,7 +375,7 @@ func (a *VolumesApiService) DatacentersVolumesDeleteExecute(r ApiDatacentersVolu
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -542,7 +542,7 @@ func (a *VolumesApiService) DatacentersVolumesFindByIdExecute(r ApiDatacentersVo
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -777,7 +777,7 @@ func (a *VolumesApiService) DatacentersVolumesGetExecute(r ApiDatacentersVolumes
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -964,7 +964,7 @@ func (a *VolumesApiService) DatacentersVolumesPatchExecute(r ApiDatacentersVolum
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1147,7 +1147,7 @@ func (a *VolumesApiService) DatacentersVolumesPostExecute(r ApiDatacentersVolume
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1334,7 +1334,7 @@ func (a *VolumesApiService) DatacentersVolumesPutExecute(r ApiDatacentersVolumes
 		return localVarReturnValue, localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {
@@ -1517,7 +1517,7 @@ func (a *VolumesApiService) DatacentersVolumesRestoreSnapshotPostExecute(r ApiDa
 		return localVarAPIResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := _io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarAPIResponse.Payload = localVarBody
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/client.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go/client.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -562,7 +561,7 @@ func (c *APIClient) GetRequestStatus(ctx context.Context, path string) (*Request
 	var responseBody = make([]byte, 0)
 	if resp != nil {
 		var errRead error
-		responseBody, errRead = ioutil.ReadAll(resp.Body)
+		responseBody, errRead = io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		if errRead != nil {
 			return nil, nil, errRead
@@ -622,7 +621,7 @@ func (c *APIClient) WaitForRequest(ctx context.Context, path string) (*APIRespon
 		var localVarBody = make([]byte, 0)
 		if resp != nil {
 			var errRead error
-			localVarBody, errRead = ioutil.ReadAll(resp.Body)
+			localVarBody, errRead = io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
 			if errRead != nil {
 				return nil, errRead

--- a/cluster-autoscaler/cloudprovider/linode/linodego/linode_api_client_rest.go
+++ b/cluster-autoscaler/cloudprovider/linode/linodego/linode_api_client_rest.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -135,7 +135,7 @@ func (c *Client) request(ctx context.Context, method, url string, jsonData []byt
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/doc.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/doc.go
@@ -42,7 +42,7 @@ Example to Create an Stack
 
 	// Create Template
 	t := make(map[string]interface{})
-	f, err := ioutil.ReadFile("template.yaml")
+	f, err := os.ReadFile("template.yaml")
 	if err != nil {
 	    panic(err)
 	}
@@ -57,7 +57,7 @@ Example to Create an Stack
 	}
 	// Create Environment if needed
 	t_env := make(map[string]interface{})
-	f_env, err := ioutil.ReadFile("env.yaml")
+	f_env, err := os.ReadFile("env.yaml")
 	if err != nil {
 	    panic(err)
 	}
@@ -155,7 +155,7 @@ raw_template value.
 Example to Update a Stack Using the Update (PUT) Method
 
 	t := make(map[string]interface{})
-	f, err := ioutil.ReadFile("template.yaml")
+	f, err := os.ReadFile("template.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
@@ -3,7 +3,7 @@ package stacks
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -77,7 +77,7 @@ func (t *TE) Fetch() error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination/http.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination/http.go
@@ -2,7 +2,7 @@ package pagination
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,7 +22,7 @@ func PageResultFrom(resp *http.Response) (PageResult, error) {
 	var parsedBody interface{}
 
 	defer resp.Body.Close()
-	rawBody, err := ioutil.ReadAll(resp.Body)
+	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return PageResult{}, err
 	}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/provider_client.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/provider_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -411,7 +410,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	}
 
 	if !ok {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{
 			URL:      url,

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/http_responses.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/http_responses.go
@@ -2,7 +2,7 @@ package testhelper
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -63,7 +63,7 @@ func TestHeader(t *testing.T, r *http.Request, header string, expected string) {
 
 // TestBody verifies that the request body matches an expected body.
 func TestBody(t *testing.T, r *http.Request, expected string) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Errorf("Unable to read body: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestBody(t *testing.T, r *http.Request, expected string) {
 // TestJSONRequest verifies that the JSON payload of a request matches an expected structure, without asserting things about
 // whitespace or ordering.
 func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Errorf("Unable to read request body: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"os"
@@ -104,7 +103,7 @@ func newFileBasedFederationClient(securityTokenPath string, supplier sessionKeyS
 		SessionKeySupplier: supplier,
 		RefreshSecurityToken: func() (token securityToken, err error) {
 			var content []byte
-			if content, err = ioutil.ReadFile(securityTokenPath); err != nil {
+			if content, err = os.ReadFile(securityTokenPath); err != nil {
 				return nil, fmt.Errorf("failed to read security token from :%s. Due to: %s", securityTokenPath, err.Error())
 			}
 
@@ -421,13 +420,13 @@ func newFileBasedKeySessionSupplier(privateKeyPemPath string, passphrasePath *st
 			var err error
 			var passContent []byte
 			if passphrasePath != nil {
-				if passContent, err = ioutil.ReadFile(*passphrasePath); err != nil {
+				if passContent, err = os.ReadFile(*passphrasePath); err != nil {
 					return nil, nil, fmt.Errorf("can not read passphrase from file: %s, due to %s", *passphrasePath, err.Error())
 				}
 			}
 
 			var keyPemContent []byte
-			if keyPemContent, err = ioutil.ReadFile(privateKeyPemPath); err != nil {
+			if keyPemContent, err = os.ReadFile(privateKeyPemPath); err != nil {
 				return nil, nil, fmt.Errorf("can not read private privateKey pem from file: %s, due to %s", privateKeyPemPath, err.Error())
 			}
 

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/resouce_principal_key_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/resouce_principal_key_provider.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -104,14 +103,14 @@ func OkeWorkloadIdentityConfigurationProvider() (ConfigurationProviderWithClaimA
 	}
 
 	if version == ResourcePrincipalVersion1_1 || version == ResourcePrincipalVersion2_2 {
-		kubernetesServiceAccountToken, err := ioutil.ReadFile(KubernetesServiceAccountTokenPath)
+		kubernetesServiceAccountToken, err := os.ReadFile(KubernetesServiceAccountTokenPath)
 		if err != nil {
 			err = fmt.Errorf("can not create resource principal, error getting Kubernetes Service Account Token at %s",
 				KubernetesServiceAccountTokenPath)
 			return nil, resourcePrincipalError{err: err}
 		}
 
-		kubernetesServiceAccountCertRaw, err := ioutil.ReadFile(KubernetesServiceAccountCertPath)
+		kubernetesServiceAccountCertRaw, err := os.ReadFile(KubernetesServiceAccountCertPath)
 		if err != nil {
 			err = fmt.Errorf("can not create resource principal, error getting Kubernetes Service Account Token at %s",
 				KubernetesServiceAccountCertPath)

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_token_path_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_token_path_provider.go
@@ -5,7 +5,7 @@ package auth
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -129,7 +129,7 @@ func getInstanceIDFromMetadata() (instanceID string, err error) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/common.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/common.go
@@ -6,7 +6,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -264,7 +264,7 @@ func setRegionMetadataFromCfgFile(region *string) bool {
 
 func readAndParseConfigFile(configFileName *string) (fileContent []map[string]string, ok bool) {
 
-	if content, err := ioutil.ReadFile(*configFileName); err == nil {
+	if content, err := os.ReadFile(*configFileName); err == nil {
 		Debugf("Raw content of region metadata config file content:", string(content[:]))
 		if err := json.Unmarshal(content, &fileContent); err != nil {
 			Debugf("Can't unmarshal config file, the error info is", err)
@@ -381,7 +381,7 @@ func getRegionInfoFromInstanceMetadataServiceProd() ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get region information from response body. Error: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/configuration.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/configuration.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -161,7 +160,7 @@ func (p environmentConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, 
 	}
 
 	expandedPath := expandPath(value)
-	pemFileContent, err := ioutil.ReadFile(expandedPath)
+	pemFileContent, err := os.ReadFile(expandedPath)
 	if err != nil {
 		Debugln("Can not read PrivateKey location from environment variable: " + environmentVariable)
 		return
@@ -392,7 +391,7 @@ func expandPath(filepath string) (expandedPath string) {
 
 func openConfigFile(configFilePath string) (data []byte, err error) {
 	expandedPath := expandPath(configFilePath)
-	data, err = ioutil.ReadFile(expandedPath)
+	data, err = os.ReadFile(expandedPath)
 	if err != nil {
 		err = fmt.Errorf("can not read config file: %s due to: %s", configFilePath, err.Error())
 	}
@@ -522,7 +521,7 @@ func (p fileConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err err
 	}
 
 	expandedPath := expandPath(filePath)
-	pemFileContent, err := ioutil.ReadFile(expandedPath)
+	pemFileContent, err := os.ReadFile(expandedPath)
 	if err != nil {
 		err = fileConfigurationProviderError{err: fmt.Errorf("can not read PrivateKey  from configuration file due to: %s", err.Error())}
 		return
@@ -585,7 +584,7 @@ func (p fileConfigurationProvider) AuthType() (AuthConfig, error) {
 
 func getTokenContent(filePath string) (string, error) {
 	expandedPath := expandPath(filePath)
-	tokenFileContent, err := ioutil.ReadFile(expandedPath)
+	tokenFileContent, err := os.ReadFile(expandedPath)
 	if err != nil {
 		err = fileConfigurationProviderError{err: fmt.Errorf("can not read token content from configuration file due to: %s", err.Error())}
 		return "", err

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/errors.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/errors.go
@@ -6,7 +6,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -110,7 +110,7 @@ func newServiceFailureFromResponse(response *http.Response) error {
 	}
 
 	//If there is an error consume the body, entirely
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		se.Message = fmt.Sprintf("The body of the response was not readable, due to :%s", err.Error())
 		return se

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/helpers.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/helpers.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/textproto"
 	"os"
 	"reflect"
@@ -299,7 +298,7 @@ func IsEnvVarTrue(envVarKey string) bool {
 
 // Reads the certs from pem file pointed by the R1_CERT_PEM env variable
 func readCertPem(path string) []byte {
-	pem, err := ioutil.ReadFile(path)
+	pem, err := os.ReadFile(path)
 	if err != nil {
 		panic("can not read cert " + err.Error())
 	}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/http_signer.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/http_signer.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -179,7 +178,7 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	if err = b.Close(); err != nil {
 		return nil, b, err
 	}
-	return ioutil.NopCloser(&buf), ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 func hashAndEncode(data []byte) string {
@@ -203,7 +202,7 @@ func GetBodyHash(request *http.Request) (hashString string, err error) {
 		return "", fmt.Errorf("can not read body of request while calculating body hash: %s", err.Error())
 	}
 
-	data, err = ioutil.ReadAll(bReader)
+	data, err = io.ReadAll(bReader)
 	if err != nil {
 		return "", fmt.Errorf("can not read body of request while calculating body hash: %s", err.Error())
 	}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/log.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common/log.go
@@ -6,7 +6,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -76,7 +75,7 @@ func NewSDKLogger() (DefaultSDKLogger, error) {
 	logger.verboseLogger = log.New(os.Stderr, "VERBOSE ", log.Ldate|log.Lmicroseconds|log.Lshortfile)
 	logger.debugLogger = log.New(os.Stderr, "DEBUG ", log.Ldate|log.Lmicroseconds|log.Lshortfile)
 	logger.infoLogger = log.New(os.Stderr, "INFO ", log.Ldate|log.Lmicroseconds|log.Lshortfile)
-	logger.nullLogger = log.New(ioutil.Discard, "", log.Ldate|log.Lmicroseconds|log.Lshortfile)
+	logger.nullLogger = log.New(io.Discard, "", log.Ldate|log.Lmicroseconds|log.Lshortfile)
 
 	configured, isLogEnabled := os.LookupEnv("OCI_GO_SDK_DEBUG")
 

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/sony/gobreaker/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/sony/gobreaker/README.md
@@ -104,7 +104,7 @@ func Get(url string) ([]byte, error) {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/sony/gobreaker/example/http_breaker.go
+++ b/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/sony/gobreaker/example/http_breaker.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/sony/gobreaker"
 	"log"
 	"net/http"
@@ -30,7 +30,7 @@ func Get(url string) ([]byte, error) {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -236,7 +235,7 @@ func (m *OvhCloudManager) ReAuthenticate() error {
 func readConfig(configFile io.Reader) (*Config, error) {
 	cfg := &Config{}
 	if configFile != nil {
-		body, err := ioutil.ReadAll(configFile)
+		body, err := io.ReadAll(configFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read content: %w", err)
 		}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -469,7 +469,7 @@ func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, re
 func (c *Client) UnmarshalResponse(response *http.Response, result interface{}) error {
 	// Read all the response body
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/packet/packet_manager_rest.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_manager_rest.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -373,7 +372,7 @@ func (mgr *packetManagerRest) request(ctx context.Context, method, url string, j
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"time"
@@ -53,7 +52,7 @@ type scalewayCloudProvider struct {
 }
 
 func readConf(config *scalewaygo.Config, configFile io.Reader) error {
-	body, err := ioutil.ReadAll(configFile)
+	body, err := io.ReadAll(configFile)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/cvm_role_provider.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/cvm_role_provider.go
@@ -19,7 +19,7 @@ package common
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -67,7 +67,7 @@ func get(url string) ([]byte, error) {
 		return nil, roleNotBound
 	}
 
-	body, err := ioutil.ReadAll(rsp.Body)
+	body, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/response.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http/response.go
@@ -19,7 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	//"log"
 	"net/http"
@@ -98,7 +98,7 @@ func ParseErrorFromHTTPResponse(body []byte) (err error) {
 
 func ParseFromHttpResponse(hr *http.Response, response Response) (err error) {
 	defer hr.Body.Close()
-	body, err := ioutil.ReadAll(hr.Body)
+	body, err := io.ReadAll(hr.Body)
 	if err != nil {
 		msg := fmt.Sprintf("Fail to read response body because %s", err)
 		return errors.NewTencentCloudSDKError("ClientError.IOError", msg, "")

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/ini.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/ini.go
@@ -18,7 +18,7 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	tcerr "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
@@ -30,7 +30,7 @@ var (
 )
 
 func openFile(path string) (data []byte, err error) {
-	data, err = ioutil.ReadFile(path)
+	data, err = os.ReadFile(path)
 	if err != nil {
 		err = tcerr.NewTencentCloudSDKError(iniErr, err.Error(), "")
 	}

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/ratelimitretry.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/ratelimitretry.go
@@ -19,7 +19,6 @@ package common
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -66,9 +65,9 @@ func (c *Client) sendWithRateLimitRetry(req *http.Request, retryable bool) (resp
 }
 
 func shadowRead(reader io.ReadCloser) (io.ReadCloser, []byte) {
-	val, err := ioutil.ReadAll(reader)
+	val, err := io.ReadAll(reader)
 	if err != nil {
 		return reader, nil
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(val)), val
+	return io.NopCloser(bytes.NewBuffer(val)), val
 }

--- a/cluster-autoscaler/cloudprovider/volcengine/volc-sdk-golang/base/client.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volc-sdk-golang/base/client.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -71,7 +70,7 @@ func NewClient(info *ServiceInfo, apiInfoList map[string]*ApiInfo) *Client {
 		client.ServiceInfo.Credentials.AccessKeyID = os.Getenv(accessKey)
 		client.ServiceInfo.Credentials.SecretAccessKey = os.Getenv(secretKey)
 	} else if _, err := os.Stat(os.Getenv("HOME") + "/.volc/config"); err == nil {
-		if content, err := ioutil.ReadFile(os.Getenv("HOME") + "/.volc/config"); err == nil {
+		if content, err := os.ReadFile(os.Getenv("HOME") + "/.volc/config"); err == nil {
 			m := make(map[string]string)
 			json.Unmarshal(content, &m)
 			if accessKey, ok := m["ak"]; ok {
@@ -288,7 +287,7 @@ func (client *Client) makeRequest(inputContext context.Context, api string, req 
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []byte(""), resp.StatusCode, err, false
 	}
@@ -344,7 +343,7 @@ func (client *Client) request(ctx context.Context, api string, query url.Values,
 			// if seek failed, stop retry.
 			return backoff.Permanent(err)
 		}
-		req.Body = ioutil.NopCloser(requestBody)
+		req.Body = io.NopCloser(requestBody)
 		var needRetry bool
 		resp, code, err, needRetry = client.makeRequest(ctx, api, req, timeout)
 		if needRetry {

--- a/cluster-autoscaler/cloudprovider/volcengine/volc-sdk-golang/base/sign.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volc-sdk-golang/base/sign.go
@@ -24,7 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -283,8 +283,8 @@ func readAndReplaceBody(request *http.Request) []byte {
 	if request.Body == nil {
 		return []byte{}
 	}
-	payload, _ := ioutil.ReadAll(request.Body)
-	request.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	payload, _ := io.ReadAll(request.Body)
+	request.Body = io.NopCloser(bytes.NewReader(payload))
 	return payload
 }
 

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/internal/ini/ini_lexer.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/internal/ini/ini_lexer.go
@@ -22,7 +22,6 @@ package ini
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/volcengineerr"
 )
@@ -76,7 +75,7 @@ type iniLexer struct{}
 // Tokenize will return a list of tokens during lexical analysis of the
 // io.Reader.
 func (l *iniLexer) Tokenize(r io.Reader) ([]Token, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, volcengineerr.New(ErrCodeUnableToReadFile, "unable to read file", err)
 	}

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/payload.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/payload.go
@@ -21,7 +21,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine"
@@ -51,7 +50,7 @@ func (h HandlerPayloadUnmarshal) UnmarshalPayload(r io.Reader, v interface{}) er
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(r),
+			Body:       io.NopCloser(r),
 		},
 		Data: v,
 	}

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/rest/unmarshal.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/rest/unmarshal.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -74,7 +73,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 					switch payload.Interface().(type) {
 					case []byte:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = volcengineerr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						} else {
@@ -82,7 +81,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						}
 					case *string:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = volcengineerr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						} else {
@@ -94,15 +93,15 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						case "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 						case "io.ReadSeeker":
-							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+							b, err := io.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
 								r.Error = volcengineerr.New(request.ErrCodeSerialization,
 									"failed to read response volcenginebody", err)
 								return
 							}
-							payload.Set(reflect.ValueOf(ioutil.NopCloser(bytes.NewReader(b))))
+							payload.Set(reflect.ValueOf(io.NopCloser(bytes.NewReader(b))))
 						default:
-							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+							io.Copy(io.Discard, r.HTTPResponse.Body)
 							defer r.HTTPResponse.Body.Close()
 							r.Error = volcengineerr.New(request.ErrCodeSerialization,
 								"failed to decode REST response",

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/unmarshal.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/private/protocol/unmarshal.go
@@ -21,7 +21,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/request"
 )
@@ -35,6 +34,6 @@ func UnmarshalDiscardBody(r *request.Request) {
 		return
 	}
 
-	io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	io.Copy(io.Discard, r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 }

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/client/logger.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/client/logger.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httputil"
 	"strings"
 
@@ -238,7 +237,7 @@ func logResponse(r *request.Request) {
 			req.ClientInfo.ServiceName, req.Operation.Name, string(b)))
 
 		if logBody {
-			b, err := ioutil.ReadAll(lw.buf)
+			b, err := io.ReadAll(lw.buf)
 			if err != nil {
 				lw.Logger.Log(fmt.Sprintf(logRespErrMsg,
 					req.ClientInfo.ServiceName, req.Operation.Name, err))

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/corehandlers/handlers.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/corehandlers/handlers.go
@@ -22,7 +22,7 @@ package corehandlers
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -164,7 +164,7 @@ func handleSendError(r *request.Request, err error) {
 			r.HTTPResponse = &http.Response{
 				StatusCode: int(code),
 				Status:     http.StatusText(int(code)),
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}
 			return
 		}
@@ -175,7 +175,7 @@ func handleSendError(r *request.Request, err error) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	// Catch all request errors, and let the default retrier determine

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/credentials/processcreds/provider.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/credentials/processcreds/provider.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -358,7 +357,7 @@ func executeCommand(cmd exec.Cmd, exec chan error) {
 func readInput(r io.Reader, w io.Writer, read chan error) {
 	tee := io.TeeReader(r, w)
 
-	_, err := ioutil.ReadAll(tee)
+	_, err := io.ReadAll(tee)
 
 	if err == io.EOF {
 		err = nil

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/session/session.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/session/session.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -475,7 +474,7 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 }
 
 func loadCertPool(r io.Reader) (*x509.CertPool, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, volcengineerr.New("LoadCustomCABundleError",
 			"failed to read custom CA bundle PEM file", err)

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/volcenginequery/unmarshal.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/volcenginequery/unmarshal.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -44,7 +44,7 @@ var UnmarshalMetaHandler = request.NamedHandler{Name: "volcenginesdk.volcengineq
 func Unmarshal(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	if r.DataFilled() {
-		body, err := ioutil.ReadAll(r.HTTPResponse.Body)
+		body, err := io.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
 			fmt.Printf("read volcenginebody err, %v\n", err)
 			r.Error = err

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/volcenginequery/unmarshal_error.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/volcenginequery/unmarshal_error.go
@@ -22,7 +22,7 @@ package volcenginequery
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/custom"
@@ -58,7 +58,7 @@ func processUnmarshalError(info unmarshalErrorInfo) {
 	if info.Response == nil && info.Body == nil {
 		info.Response = &response.VolcengineResponse{}
 		if r.DataFilled() {
-			body, err = ioutil.ReadAll(r.HTTPResponse.Body)
+			body, err = io.ReadAll(r.HTTPResponse.Body)
 			if err != nil {
 				fmt.Printf("read volcenginebody err, %v\n", err)
 				r.Error = err

--- a/cluster-autoscaler/cloudprovider/vultr/govultr/vultr_rest_client.go
+++ b/cluster-autoscaler/cloudprovider/vultr/govultr/vultr_rest_client.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -97,7 +97,7 @@ func (c *Client) doWithContext(ctx context.Context, r *http.Request, data interf
 	//todo handle this
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_manager.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_manager.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -52,7 +51,7 @@ func newManager(config io.Reader) (*manager, error) {
 	cfg := &Config{}
 
 	if config != nil {
-		body, err := ioutil.ReadAll(config)
+		body, err := io.ReadAll(config)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
