### PR TITLE
When comparing PodSpec semantically, drop projected volumes for init containers

### DIFF
--- a/cluster-autoscaler/utils/utils.go
+++ b/cluster-autoscaler/utils/utils.go
@@ -94,6 +94,16 @@ func dropProjectedVolumesAndMounts(podSpec *apiv1.PodSpec) {
 		}
 		podSpec.Containers[i].VolumeMounts = volumeMounts
 	}
+
+	for i := range podSpec.InitContainers {
+		var volumeMounts []apiv1.VolumeMount
+		for _, mount := range podSpec.InitContainers[i].VolumeMounts {
+			if ok := projectedVolumeNames[mount.Name]; !ok {
+				volumeMounts = append(volumeMounts, mount)
+			}
+		}
+		podSpec.InitContainers[i].VolumeMounts = volumeMounts
+	}
 }
 
 func dropHostname(podSpec *apiv1.PodSpec) {

--- a/cluster-autoscaler/utils/utils_test.go
+++ b/cluster-autoscaler/utils/utils_test.go
@@ -111,6 +111,8 @@ func TestSanitizePodSpec(t *testing.T) {
 				},
 				Containers: []apiv1.Container{
 					{Image: "foo/bar", Name: "foobar", VolumeMounts: []apiv1.VolumeMount{{Name: "projected1"}}},
+				},
+				InitContainers: []apiv1.Container{
 					{Image: "foo/baz", Name: "foobaz", VolumeMounts: []apiv1.VolumeMount{{Name: "projected2"}}},
 				},
 			},
@@ -118,6 +120,8 @@ func TestSanitizePodSpec(t *testing.T) {
 				NodeSelector: map[string]string{"foo": "bar"},
 				Containers: []apiv1.Container{
 					{Image: "foo/bar", Name: "foobar"},
+				},
+				InitContainers: []apiv1.Container{
 					{Image: "foo/baz", Name: "foobaz"},
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

CA groups pods based on their scheduling requirements. They are grouped based on pod spec and we assume that pods belonging to the same controller should have similar requirements. However, there are certain fields that differ between the pods controlled by the same controller. If we know that they do not affect scheduling we should drop those for grouping purposes.

One of such fields is projected volume mount. We drop them currently, but only for containers, while they can exist for init containers as well.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
