### PR TITLE
Bump version to 0.14.0 as a preparation for release.

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "0.13.0"
+const VerticalPodAutoscalerVersion = "0.14.0"


### PR DESCRIPTION
#### What type of PR is this?

/kind release

#### What this PR does / why we need it:

Part of the release process, as documented [here](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/RELEASE.md).

Release tracker: #5851
