### PR TITLE
Clarify and simplify the "build and stage images" step.

### DIFF
--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -45,8 +45,20 @@ We use the issue to communicate what is state of the release.
 
 ## Build and stage images
 
+Create a fresh clone of the repo and switch to the `vpa-release-0.${minor}`
+branch. This makes sure you have no local changes while building the images.
+
+For example:
 ```sh
-for component in recommender updater admission-controller ; do REGISTRY=gcr.io/k8s-staging-autoscaling TAG=[*vpa-version*] make release --directory=pkg/${component}; done
+git clone git@github.com:kubernetes/autoscaler.git
+git switch vpa-release-0.14
+```
+
+Once in the freshly cloned repo, build and stage the images.
+
+```sh
+cd vertical-pod-autoscaler/
+for component in recommender updater admission-controller ; do TAG=`grep 'const VerticalPodAutoscalerVersion = ' common/version.go | cut -d '"' -f 2` REGISTRY=gcr.io/k8s-staging-autoscaling make release --directory=pkg/${component}; done
 ```
 
 ## Test the release


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The goal is twofold:
* clarify the release process for people who are not accustomed to it (like me, for example) - by saying where to run the scripts,
* make the process less error-prone by getting the `TAG` value automatically
