### PR TITLE
Record all vpa api versions in recommender metrics

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -279,6 +279,7 @@ func (cluster *ClusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	vpa.Recommendation = currentRecommendation
 	vpa.SetUpdateMode(apiObject.Spec.UpdatePolicy)
 	vpa.SetResourcePolicy(apiObject.Spec.ResourcePolicy)
+	vpa.SetAPIVersion(apiObject.GetObjectKind().GroupVersionKind().Version)
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -104,8 +104,8 @@ type Vpa struct {
 	Created time.Time
 	// CheckpointWritten indicates when last checkpoint for the VPA object was stored.
 	CheckpointWritten time.Time
-	// IsV1Beta1API is set to true if VPA object has labelSelector defined as in v1beta1 api.
-	IsV1Beta1API bool
+	// APIVersion of the VPA object.
+	APIVersion string
 	// TargetRef points to the controller managing the set of pods.
 	TargetRef *autoscaling.CrossVersionObjectReference
 	// PodCount contains number of live Pods matching a given VPA object.
@@ -123,10 +123,25 @@ func NewVpa(id VpaID, selector labels.Selector, created time.Time) *Vpa {
 		Created:                         created,
 		Annotations:                     make(vpaAnnotationsMap),
 		Conditions:                      make(vpaConditionsMap),
-		IsV1Beta1API:                    false,
-		PodCount:                        0,
+		// APIVersion defaults to the version of the client used to read resources.
+		// If a new version is introduced that needs to be differentiated beyond the
+		// client conversion, this needs to be done based on the resource content.
+		// The K8s client will not return the resource apiVersion as it's converted
+		// to the version requested by the client server side.
+		APIVersion: vpa_types.SchemeGroupVersion.Version,
+		PodCount:   0,
 	}
 	return vpa
+}
+
+// SetAPIVersion to the version of the VPA API object.
+// Default API Version is the API version of the VPA client.
+// If the provided version is empty, no change is made.
+func (vpa *Vpa) SetAPIVersion(to string) {
+	if to == "" {
+		return
+	}
+	vpa.APIVersion = to
 }
 
 // UseAggregationIfMatching checks if the given aggregation matches (contributes to) this VPA

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
@@ -33,7 +33,14 @@ const (
 )
 
 var (
-	modes = []string{string(vpa_types.UpdateModeOff), string(vpa_types.UpdateModeInitial), string(vpa_types.UpdateModeRecreate), string(vpa_types.UpdateModeAuto)}
+	// TODO: unify this list with the types defined in the VPA handler to avoid
+	// drift if one file is changed and the other one is missed.
+	modes = []string{
+		string(vpa_types.UpdateModeOff),
+		string(vpa_types.UpdateModeInitial),
+		string(vpa_types.UpdateModeRecreate),
+		string(vpa_types.UpdateModeAuto),
+	}
 )
 
 type apiVersion string
@@ -150,20 +157,15 @@ func NewObjectCounter() *ObjectCounter {
 
 // Add updates the helper state to include the given VPA object
 func (oc *ObjectCounter) Add(vpa *model.Vpa) {
-	mode := string(vpa_types.UpdateModeAuto)
+	mode := vpa_types.UpdateModeAuto
 	if vpa.UpdateMode != nil && string(*vpa.UpdateMode) != "" {
-		mode = string(*vpa.UpdateMode)
-	}
-	// TODO: Maybe report v1 version as well.
-	api := v1beta2
-	if vpa.IsV1Beta1API {
-		api = v1beta1
+		mode = *vpa.UpdateMode
 	}
 
 	key := objectCounterKey{
-		mode:              mode,
+		mode:              string(mode),
 		has:               vpa.HasRecommendation(),
-		apiVersion:        api,
+		apiVersion:        apiVersion(vpa.APIVersion),
 		matchesPods:       vpa.HasMatchedPods(),
 		unsupportedConfig: vpa.Conditions.ConditionActive(vpa_types.ConfigUnsupported),
 	}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recommender
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	apiv1 "k8s.io/api/core/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+)
+
+func TestObjectCounter(t *testing.T) {
+	updateModeOff := vpa_types.UpdateModeOff
+	updateModeInitial := vpa_types.UpdateModeInitial
+	updateModeRecreate := vpa_types.UpdateModeRecreate
+	updateModeAuto := vpa_types.UpdateModeAuto
+	// We verify that other update modes are handled correctly as validation
+	// may not happen if there are issues with the admission controller.
+	updateModeUserDefined := vpa_types.UpdateMode("userDefined")
+
+	cases := []struct {
+		name        string
+		add         []*model.Vpa
+		wantMetrics map[string]float64
+	}{
+		{
+			name: "set empty api on metric if it is missing on the VPA",
+			add: []*model.Vpa{
+				{
+					APIVersion: "",
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report api version v1beta1",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1beta1",
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1beta1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report api version v1beta2",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1beta2",
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1beta2,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report api version v1",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "default update mode to auto",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: nil,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report update mode auto",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &updateModeAuto,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report update mode initial",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &updateModeInitial,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Initial,": 1,
+			},
+		},
+		{
+			name: "report update mode recreate",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &updateModeRecreate,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
+			},
+		},
+		{
+			name: "report update mode off",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &updateModeOff,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Off,": 1,
+			},
+		},
+		{
+			name: "report update mode user defined",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &updateModeUserDefined,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=userDefined,": 1,
+			},
+		},
+		{
+			name: "report has recommendation as false on missing recommendations",
+			add: []*model.Vpa{
+				{
+					APIVersion:     "v1",
+					Recommendation: nil,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report has recommendation as false on missing container recommendations",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Recommendation: &vpa_types.RecommendedPodResources{
+						ContainerRecommendations: nil,
+					},
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report has recommendation as true on existing container recommendations",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Recommendation: &vpa_types.RecommendedPodResources{
+						ContainerRecommendations: []vpa_types.RecommendedContainerResources{{}},
+					},
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=true,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report has matches pods as true on missing condition",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Conditions: nil,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report has matches pods as false on NoPodsMatched condition",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Conditions: map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types.VerticalPodAutoscalerCondition{
+						vpa_types.NoPodsMatched: {
+							Status: apiv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=false,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report unsupported config as false on missing condition",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Conditions: nil,
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+			},
+		},
+		{
+			name: "report unsupported config as true on ConfigUnsupported condition",
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					Conditions: map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types.VerticalPodAutoscalerCondition{
+						vpa_types.ConfigUnsupported: {
+							Status: apiv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantMetrics: map[string]float64{
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=true,update_mode=Auto,": 1,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			counter := NewObjectCounter()
+			for _, add := range tc.add {
+				counter.Add(add)
+			}
+
+			t.Cleanup(func() {
+				// Reset the metric after the test to avoid collisions.
+				vpaObjectCount.Reset()
+			})
+			counter.Observe()
+
+			metrics := make(chan prometheus.Metric)
+
+			go func() {
+				vpaObjectCount.Collect(metrics)
+				close(metrics)
+			}()
+
+			gotMetrics := make(map[string]float64)
+			for metric := range metrics {
+				var metricProto dto.Metric
+				if err := metric.Write(&metricProto); err != nil {
+					t.Errorf("failed to write metric: %v", err)
+				}
+
+				key := labelsToKey(metricProto.GetLabel())
+				gotMetrics[key] = *metricProto.GetGauge().Value
+			}
+
+			for wantKey, wantValue := range tc.wantMetrics {
+				gotValue, gotKey := gotMetrics[wantKey]
+				if !gotKey {
+					t.Errorf("missing metrics sample %q, want value %f", wantKey, wantValue)
+				}
+				if gotValue != wantValue {
+					t.Errorf("incorrect metrics sample %q, want value %f, got value %f", wantKey, wantValue, gotValue)
+				}
+			}
+
+			// If a test case only covers specific metric cases we expect all other metrics to be 0.
+			for gotKey, gotValue := range gotMetrics {
+				_, wantKey := tc.wantMetrics[gotKey]
+				if wantKey {
+					continue
+				}
+				if gotValue != 0 {
+					t.Errorf("incorrect metrics sample %q, want value %f, got value %f", gotKey, 0.0, gotValue)
+				}
+			}
+		})
+	}
+}
+
+func labelsToKey(labels []*dto.LabelPair) string {
+	key := strings.Builder{}
+	for _, label := range labels {
+		key.WriteString(*label.Name)
+		key.WriteRune('=')
+		key.WriteString(*label.Value)
+		key.WriteRune(',')
+	}
+	return key.String()
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Change the tracking of APIVersion from a boolean
indicating if the VPA is v1beta1
to the version string
and make sure it gets exported
in metrics.

Add tests for the recommender metrics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
* VPA API Versions reported in the `vpa_objects_count` metric now include `v1` VPAs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @jbartosik