### PR TITLE
Mention logs from #5862 in release instructions

### DIFF
--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -25,6 +25,8 @@ We use the issue to communicate what is state of the release.
 1. [ ] Wait for all VPA changes that will be in the release to merge.
 2. [ ] Wait for [the end to end tests](https://k8s-testgrid.appspot.com/sig-autoscaling-vpa) to run with all VPA changes
    included.
+   To see what code was actually tested, look for `===== last commit =====`
+   entries in the full `build-log.txt` of a given test run.
 3. [ ] Make sure the end to end VPA tests are green.
 
 ### New minor release


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The promised follow-up to #5862, clarifies how to verify what state of the code repository was used as a basis for any given test run.

[Sample log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-autoscaling-vpa-actuation/1669586547378229248/build-log.txt) looks like:
```
I0616 06:13:30.554] =============== last commit ===============
I0616 06:13:30.554] git log -1
I0616 06:13:30.554] commit 231868ead734ce91a3b5d87fd471c1946d6a92c6
I0616 06:13:30.555] Merge: d7fa2d9d8 1944c821c
I0616 06:13:30.555] Author: Kubernetes Prow Robot <k8s-ci-robot@users.noreply.github.com>
I0616 06:13:30.555] Date:   Thu Jun 15 12:00:22 2023 -0700
I0616 06:13:30.555] 
I0616 06:13:30.555]     Merge pull request #5862 from kgolab/makefile-status
I0616 06:13:30.555]     
I0616 06:13:30.555]     Execute git commands to show the state of local clone of the repo.
```
