### PR TITLE
Explicitly create and remove buildx builders for VPA components

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -83,9 +83,16 @@ build-in-docker-%: clean docker-builder
 	echo '=============== bulding from the above ==============='
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/admission-controller'
 
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
 
 .PHONY: release
-release: build-in-docker docker-build docker-push
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -83,7 +83,15 @@ build-in-docker-%: clean docker-builder
 	echo '=============== bulding from the above ==============='
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/recommender'
 
-release: build-in-docker docker-build docker-push
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
+
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -83,8 +83,16 @@ build-in-docker-%: clean docker-builder
 	echo '=============== bulding from the above ==============='
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/updater'
 
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
+
 .PHONY: release
-release: build-in-docker docker-build docker-push
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
Explicitly create a `builder` to be used with `docker buildx` and configure it for use during the build. Previously, the build would take whichever builder was currently configured on the machine, which could lead to inconsistencies with the builder's `output` behavior. See [the discussion in the v0.14.0 release issue](https://github.com/kubernetes/autoscaler/issues/5851#issuecomment-1594502338) for more context.
The builder created here is of type `docker-container` and [needs and explicit `output` configured](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver) – the flag [`--load` is a shorthand for `--output=type=docker`](https://docs.docker.com/engine/reference/commandline/buildx_build/#load).

#### Special notes for your reviewer:
Additional make target were created, such that we can re-use the builder across the different platforms. Creating and tearing down a builder takes time, which we want to avoid doing too often.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

