### PR TITLE
chore: remove unused func scaleFromZeroAnnotationsEnabled

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -172,16 +172,6 @@ func normalizedProviderString(s string) normalizedProviderID {
 	return normalizedProviderID(split[len(split)-1])
 }
 
-func scaleFromZeroAnnotationsEnabled(annotations map[string]string) bool {
-	cpu := annotations[cpuKey]
-	mem := annotations[memoryKey]
-
-	if cpu != "" && mem != "" {
-		return true
-	}
-	return false
-}
-
 func parseKey(annotations map[string]string, key string) (resource.Quantity, error) {
 	if val, exists := annotations[key]; exists && val != "" {
 		return resource.ParseQuantity(val)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -430,47 +430,6 @@ func TestUtilNormalizedProviderID(t *testing.T) {
 	}
 }
 
-func TestScaleFromZeroEnabled(t *testing.T) {
-	for _, tc := range []struct {
-		description string
-		enabled     bool
-		annotations map[string]string
-	}{{
-		description: "nil annotations",
-		enabled:     false,
-	}, {
-		description: "empty annotations",
-		annotations: map[string]string{},
-		enabled:     false,
-	}, {
-		description: "non-matching annotation",
-		annotations: map[string]string{"foo": "bar"},
-		enabled:     false,
-	}, {
-		description: "matching key, incomplete annotations",
-		annotations: map[string]string{
-			"foo":  "bar",
-			cpuKey: "1",
-		},
-		enabled: false,
-	}, {
-		description: "matching key, complete annotations",
-		annotations: map[string]string{
-			"foo":     "bar",
-			cpuKey:    "1",
-			memoryKey: "2Mi",
-		},
-		enabled: true,
-	}} {
-		t.Run(tc.description, func(t *testing.T) {
-			got := scaleFromZeroAnnotationsEnabled(tc.annotations)
-			if tc.enabled != got {
-				t.Errorf("expected %t, got %t", tc.enabled, got)
-			}
-		})
-	}
-}
-
 func TestParseCPUCapacity(t *testing.T) {
 	for _, tc := range []struct {
 		description      string


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I was trying to see the logic of `CanScaleFromZero` and found `func scaleFromZeroAnnotationsEnabled` as unused. So removed the unused func and it's test in this PR