### PR TITLE
add cluster-autoscaler name and version to the user agent

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_sdk_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_sdk_provider.go
@@ -27,7 +27,9 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/ec2metadata"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/endpoints"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/request"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws/session"
+	"k8s.io/autoscaler/cluster-autoscaler/version"
 	provider_aws "k8s.io/cloud-provider-aws/pkg/providers/v1"
 	"k8s.io/klog/v2"
 )
@@ -61,10 +63,13 @@ func createAWSSDKProvider(configReader io.Reader) (*awsSDKProvider, error) {
 	}
 
 	sess, err := session.NewSession(config)
-
 	if err != nil {
 		return nil, err
 	}
+
+	// add cluster-autoscaler to the user-agent to make it easier to identify
+	agent := fmt.Sprintf("cluster-autoscaler/v%s", version.ClusterAutoscalerVersion)
+	sess.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler(agent))
 
 	provider := &awsSDKProvider{
 		session: sess,


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

This updates the user agent and makes it easier to distinguish between various users of the Go SDK.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

User-Agent for CAS requests prior to this change:
`aws-sdk-go/1.44.24 (go1.20.1; linux; amd64)`

After this change:
`aws-sdk-go/1.44.24 (go1.20.1; linux; amd64) cluster-autoscaler/v1.28.0-alpha.2`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
