### PR TITLE
Explicitly create and remove buildx builders

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -78,9 +78,16 @@ build-in-docker: $(addprefix build-in-docker-,$(ALL_ARCHITECTURES))
 build-in-docker-%: clean docker-builder
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/admission-controller'
 
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
 
 .PHONY: release
-release: build-in-docker docker-build docker-push
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -78,7 +78,15 @@ build-in-docker: $(addprefix build-in-docker-,$(ALL_ARCHITECTURES))
 build-in-docker-%: clean docker-builder
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/recommender'
 
-release: build-in-docker docker-build docker-push
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
+
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -42,7 +42,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
 
 .PHONY: docker-push
 docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
@@ -78,8 +78,16 @@ build-in-docker: $(addprefix build-in-docker-,$(ALL_ARCHITECTURES))
 build-in-docker-%: clean docker-builder
 	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/updater'
 
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
+
 .PHONY: release
-release: build-in-docker docker-build docker-push
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry-picking fix from #5867 to release branch so it can be built from a clean state. We have a VPA release in progress (#5851) and I'd like to make sure that we follow the instructions precisely:
> Create a fresh clone of the repo and switch to the vpa-release-0.${minor} branch. This makes sure you have no local changes while building the images.

I verified already that with this c-p included everything builds fine and the images are pushed to GCR (my in this case).

