### PR TITLE
fix: CA on fargate causing log flood

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/autoscaling"
@@ -39,9 +40,9 @@ var testAwsManager = &AwsManager{
 	awsService: testAwsService,
 }
 
-func newTestAwsManagerWithMockServices(mockAutoScaling autoScalingI, mockEC2 ec2I, mockEKS eksI, autoDiscoverySpecs []asgAutoDiscoveryConfig) *AwsManager {
+func newTestAwsManagerWithMockServices(mockAutoScaling autoScalingI, mockEC2 ec2I, mockEKS eksI, autoDiscoverySpecs []asgAutoDiscoveryConfig, instanceStatus map[AwsInstanceRef]*string) *AwsManager {
 	awsService := awsWrapper{mockAutoScaling, mockEC2, mockEKS}
-	return &AwsManager{
+	mgr := &AwsManager{
 		awsService: awsService,
 		asgCache: &asgCache{
 			registeredAsgs:        make(map[AwsRef]*asg, 0),
@@ -55,16 +56,21 @@ func newTestAwsManagerWithMockServices(mockAutoScaling autoScalingI, mockEC2 ec2
 			autoscalingOptions:    make(map[AwsRef]map[string]string),
 		},
 	}
+
+	if instanceStatus != nil {
+		mgr.asgCache.instanceStatus = instanceStatus
+	}
+	return mgr
 }
 
 func newTestAwsManagerWithAsgs(t *testing.T, mockAutoScaling autoScalingI, mockEC2 ec2I, specs []string) *AwsManager {
-	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, nil)
+	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, nil, nil)
 	m.asgCache.parseExplicitAsgs(specs)
 	return m
 }
 
 func newTestAwsManagerWithAutoAsgs(t *testing.T, mockAutoScaling autoScalingI, mockEC2 ec2I, specs []string, autoDiscoverySpecs []asgAutoDiscoveryConfig) *AwsManager {
-	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, autoDiscoverySpecs)
+	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, autoDiscoverySpecs, nil)
 	m.asgCache.parseExplicitAsgs(specs)
 	return m
 }
@@ -592,7 +598,7 @@ func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
 func TestGetResourceLimiter(t *testing.T) {
 	mockAutoScaling := &autoScalingMock{}
 	mockEC2 := &ec2Mock{}
-	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, nil)
+	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, nil, nil)
 
 	provider := testProvider(t, m)
 	_, err := provider.GetResourceLimiter()
@@ -603,4 +609,65 @@ func TestCleanup(t *testing.T) {
 	provider := testProvider(t, testAwsManager)
 	err := provider.Cleanup()
 	assert.NoError(t, err)
+}
+
+func TestHasInstance(t *testing.T) {
+	nodeStatus := "Healthy"
+	mgr := &AwsManager{
+		asgCache: &asgCache{
+			registeredAsgs: make(map[AwsRef]*asg, 0),
+			asgToInstances: make(map[AwsRef][]AwsInstanceRef),
+			instanceToAsg:  make(map[AwsInstanceRef]*asg),
+			interrupt:      make(chan struct{}),
+			awsService:     &testAwsService,
+			instanceStatus: map[AwsInstanceRef]*string{
+				{
+					ProviderID: "aws:///us-east-1a/test-instance-id",
+					Name:       "test-instance-id",
+				}: &nodeStatus,
+			},
+		},
+		awsService: testAwsService,
+	}
+	provider := testProvider(t, mgr)
+
+	// Case 1: correct node - present in AWS
+	node1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-XXX",
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id",
+		},
+	}
+	present, err := provider.HasInstance(node1)
+	assert.NoError(t, err)
+	assert.True(t, present)
+
+	// Case 2: incorrect node - fargate is unsupported
+	node2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fargate-XXX",
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id",
+		},
+	}
+	present, err = provider.HasInstance(node2)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	assert.True(t, present)
+
+	// Case 3: correct node - not present in AWS
+	node3 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-XXX",
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id-2",
+		},
+	}
+	present, err = provider.HasInstance(node3)
+	assert.ErrorContains(t, err, nodeNotPresentErr)
+	assert.False(t, present)
+
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -634,7 +634,7 @@ func TestHasInstance(t *testing.T) {
 	// Case 1: correct node - present in AWS
 	node1 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-XXX",
+			Name: "node-1",
 		},
 		Spec: apiv1.NodeSpec{
 			ProviderID: "aws:///us-east-1a/test-instance-id",
@@ -647,7 +647,7 @@ func TestHasInstance(t *testing.T) {
 	// Case 2: incorrect node - fargate is unsupported
 	node2 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "fargate-XXX",
+			Name: "fargate-1",
 		},
 		Spec: apiv1.NodeSpec{
 			ProviderID: "aws:///us-east-1a/test-instance-id",
@@ -660,7 +660,7 @@ func TestHasInstance(t *testing.T) {
 	// Case 3: correct node - not present in AWS
 	node3 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-XXX",
+			Name: "node-2",
 		},
 		Spec: apiv1.NodeSpec{
 			ProviderID: "aws:///us-east-1a/test-instance-id-2",


### PR DESCRIPTION
- happens when CA tries to check if the unmanaged fargate node is a part of ASG (it isn't)
- and keeps on logging error
Signed-off-by: vadasambar <surajrbanakar@gmail.com>

#### What type of PR is this?


/kind bug




#### What this PR does / why we need it:
Fixes  #5842 (and adds tests)

* Scenario: EKS cluster running on fargate but uses CA to scale some non-fargate nodegroups
* Problem: CA reads all K8s nodes including fargate ones and checks if the instance is present in AWS (by calling [HasInstance](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go#L131)). This leads to error and causes log flooding (fargate is not a part of any ASG).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  #5842

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed: CA tries to check if unmanaged fargate node exists in AWS and keeps on logging error message
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
