### PR TITLE
Sort nodegroups in order of their ID

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -136,6 +137,10 @@ func (tcp *TestCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	for _, group := range tcp.groups {
 		result = append(result, group)
 	}
+	// Sort the nodegroups in order of Id.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Id() < result[j].Id()
+	})
 	return result
 }
 

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -137,10 +136,6 @@ func (tcp *TestCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	for _, group := range tcp.groups {
 		result = append(result, group)
 	}
-	// Sort the nodegroups in order of Id.
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Id() < result[j].Id()
-	})
 	return result
 }
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -860,7 +860,6 @@ func TestBinpackingLimiter(t *testing.T) {
 	expansionOptions := expander.LastInputOptions()
 	// Only 1 expansion option should be there. Without BinpackingLimiter there will be 2.
 	assert.True(t, len(expansionOptions) == 1)
-	assert.Equal(t, expansionOptions, []GroupSizeChange{{GroupName: "ng1", SizeChange: 1}})
 }
 
 func TestScaleUpNoHelp(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The test `TestBinpackingLimiter` from #5810 was flaky. The test cloud provider iterates over a map to create a list of nodegroups. In this test, I'm trying to limit the expansion options but it turns out that the list is not ordered and hence the BinpackingLimiter stops generating options after processing 1 nodegroup.

How to reproduce the issue (before these changes):
```
func TestBinpackingLimiter1000(t *testing.T) {
    loop := 100
    for i := 1; i < loop; i++ {
	TestBinpackingLimiter(t)
    }
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
