### PR TITLE
Include short unregistered nodes in calculation of incorrect node group

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -648,8 +648,9 @@ func (csr *ClusterStateRegistry) updateIncorrectNodeGroupSizes(currentTime time.
 			}
 			continue
 		}
-		if len(readiness.Registered) > acceptableRange.MaxNodes ||
-			len(readiness.Registered) < acceptableRange.MinNodes {
+		unregisteredNodes := len(readiness.Unregistered) + len(readiness.LongUnregistered)
+		if len(readiness.Registered) > acceptableRange.CurrentTarget ||
+			len(readiness.Registered) < acceptableRange.CurrentTarget-unregisteredNodes {
 			incorrect := IncorrectNodeGroupSize{
 				CurrentSize:   len(readiness.Registered),
 				ExpectedSize:  acceptableRange.CurrentTarget,

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1064,3 +1064,319 @@ func newBackoff() backoff.Backoff {
 	return backoff.NewIdBasedExponentialBackoff(5*time.Minute, /*InitialNodeGroupBackoffDuration*/
 		30*time.Minute /*MaxNodeGroupBackoffDuration*/, 3*time.Hour /*NodeGroupBackoffResetTimeout*/)
 }
+
+func TestUpdateAcceptableRanges(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		targetSizes      map[string]int
+		readiness        map[string]Readiness
+		scaleUpRequests  map[string]*ScaleUpRequest
+		scaledDownGroups []string
+
+		wantAcceptableRanges map[string]AcceptableRange
+	}{
+		{
+			name: "No scale-ups/scale-downs",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 10)},
+				"ng2": {Ready: make([]string, 20)},
+			},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 10, MaxNodes: 10, CurrentTarget: 10},
+				"ng2": {MinNodes: 20, MaxNodes: 20, CurrentTarget: 20},
+			},
+		},
+		{
+			name: "Ongoing scale-ups",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 10)},
+				"ng2": {Ready: make([]string, 20)},
+			},
+			scaleUpRequests: map[string]*ScaleUpRequest{
+				"ng1": {Increase: 3},
+				"ng2": {Increase: 5},
+			},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 7, MaxNodes: 10, CurrentTarget: 10},
+				"ng2": {MinNodes: 15, MaxNodes: 20, CurrentTarget: 20},
+			},
+		},
+		{
+			name: "Ongoing scale-downs",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 10)},
+				"ng2": {Ready: make([]string, 20)},
+			},
+			scaledDownGroups: []string{"ng1", "ng1", "ng2", "ng2", "ng2"},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 10, MaxNodes: 12, CurrentTarget: 10},
+				"ng2": {MinNodes: 20, MaxNodes: 23, CurrentTarget: 20},
+			},
+		},
+		{
+			name: "Some short unregistered nodes",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 8), Unregistered: make([]string, 2)},
+				"ng2": {Ready: make([]string, 17), Unregistered: make([]string, 3)},
+			},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 10, MaxNodes: 10, CurrentTarget: 10},
+				"ng2": {MinNodes: 20, MaxNodes: 20, CurrentTarget: 20},
+			},
+		},
+		{
+			name: "Some long unregistered nodes",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 8), LongUnregistered: make([]string, 2)},
+				"ng2": {Ready: make([]string, 17), LongUnregistered: make([]string, 3)},
+			},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 8, MaxNodes: 10, CurrentTarget: 10},
+				"ng2": {MinNodes: 17, MaxNodes: 20, CurrentTarget: 20},
+			},
+		},
+		{
+			name: "Everything together",
+			targetSizes: map[string]int{
+				"ng1": 10,
+				"ng2": 20,
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Ready: make([]string, 8), Unregistered: make([]string, 1), LongUnregistered: make([]string, 2)},
+				"ng2": {Ready: make([]string, 17), Unregistered: make([]string, 3), LongUnregistered: make([]string, 4)},
+			},
+			scaleUpRequests: map[string]*ScaleUpRequest{
+				"ng1": {Increase: 3},
+				"ng2": {Increase: 5},
+			},
+			scaledDownGroups: []string{"ng1", "ng1", "ng2", "ng2", "ng2"},
+			wantAcceptableRanges: map[string]AcceptableRange{
+				"ng1": {MinNodes: 5, MaxNodes: 12, CurrentTarget: 10},
+				"ng2": {MinNodes: 11, MaxNodes: 23, CurrentTarget: 20},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProvider(nil, nil)
+			for nodeGroupName, targetSize := range tc.targetSizes {
+				provider.AddNodeGroup(nodeGroupName, 0, 1000, targetSize)
+			}
+			var scaleDownRequests []*ScaleDownRequest
+			for _, nodeGroupName := range tc.scaledDownGroups {
+				scaleDownRequests = append(scaleDownRequests, &ScaleDownRequest{
+					NodeGroup: provider.GetNodeGroup(nodeGroupName),
+				})
+			}
+
+			clusterState := &ClusterStateRegistry{
+				cloudProvider:         provider,
+				perNodeGroupReadiness: tc.readiness,
+				scaleUpRequests:       tc.scaleUpRequests,
+				scaleDownRequests:     scaleDownRequests,
+			}
+
+			clusterState.updateAcceptableRanges(tc.targetSizes)
+			assert.Equal(t, tc.wantAcceptableRanges, clusterState.acceptableRanges)
+		})
+	}
+}
+
+func TestUpdateIncorrectNodeGroupSizes(t *testing.T) {
+	timeNow := time.Now()
+	testCases := []struct {
+		name string
+
+		acceptableRanges map[string]AcceptableRange
+		readiness        map[string]Readiness
+		incorrectSizes   map[string]IncorrectNodeGroupSize
+
+		wantIncorrectSizes map[string]IncorrectNodeGroupSize
+	}{
+		{
+			name: "node groups with correct sizes",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 10)},
+				"ng2": {Registered: make([]string, 20)},
+			},
+			incorrectSizes:     map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{},
+		},
+		{
+			name: "node groups with correct sizes after not being correct sized",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 10)},
+				"ng2": {Registered: make([]string, 20)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 8, ExpectedSize: 10, FirstObserved: timeNow.Add(-time.Hour)},
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow.Add(-time.Minute)},
+			},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{},
+		},
+		{
+			name: "node groups below the target size",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8)},
+				"ng2": {Registered: make([]string, 15)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 8, ExpectedSize: 10, FirstObserved: timeNow},
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+		{
+			name: "node groups above the target size",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 12)},
+				"ng2": {Registered: make([]string, 25)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 12, ExpectedSize: 10, FirstObserved: timeNow},
+				"ng2": {CurrentSize: 25, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+		{
+			name: "node groups below the target size with changed delta",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8)},
+				"ng2": {Registered: make([]string, 15)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 7, ExpectedSize: 10, FirstObserved: timeNow.Add(-time.Hour)},
+				"ng2": {CurrentSize: 14, ExpectedSize: 20, FirstObserved: timeNow.Add(-time.Minute)},
+			},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 8, ExpectedSize: 10, FirstObserved: timeNow},
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+		{
+			name: "node groups below the target size with the same delta",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8)},
+				"ng2": {Registered: make([]string, 15)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 8, ExpectedSize: 10, FirstObserved: timeNow.Add(-time.Hour)},
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow.Add(-time.Minute)},
+			},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng1": {CurrentSize: 8, ExpectedSize: 10, FirstObserved: timeNow.Add(-time.Hour)},
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow.Add(-time.Minute)},
+			},
+		},
+		{
+			name: "node groups below the target size with short unregistered nodes",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8), Unregistered: make([]string, 2)},
+				"ng2": {Registered: make([]string, 15), Unregistered: make([]string, 3)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+		{
+			name: "node groups below the target size with long unregistered nodes",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8), LongUnregistered: make([]string, 2)},
+				"ng2": {Registered: make([]string, 15), LongUnregistered: make([]string, 3)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+		{
+			name: "node groups below the target size with various unregistered nodes",
+			acceptableRanges: map[string]AcceptableRange{
+				"ng1": {CurrentTarget: 10},
+				"ng2": {CurrentTarget: 20},
+			},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 8), Unregistered: make([]string, 1), LongUnregistered: make([]string, 1)},
+				"ng2": {Registered: make([]string, 15), Unregistered: make([]string, 2), LongUnregistered: make([]string, 2)},
+			},
+			incorrectSizes: map[string]IncorrectNodeGroupSize{},
+			wantIncorrectSizes: map[string]IncorrectNodeGroupSize{
+				"ng2": {CurrentSize: 15, ExpectedSize: 20, FirstObserved: timeNow},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProvider(nil, nil)
+			for nodeGroupName, acceptableRange := range tc.acceptableRanges {
+				provider.AddNodeGroup(nodeGroupName, 0, 1000, acceptableRange.CurrentTarget)
+			}
+
+			clusterState := &ClusterStateRegistry{
+				cloudProvider:           provider,
+				acceptableRanges:        tc.acceptableRanges,
+				perNodeGroupReadiness:   tc.readiness,
+				incorrectNodeGroupSizes: tc.incorrectSizes,
+			}
+
+			clusterState.updateIncorrectNodeGroupSizes(timeNow)
+			assert.Equal(t, tc.wantIncorrectSizes, clusterState.incorrectNodeGroupSizes)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There are 2 mechanisms used to fix the incorrect node group size:
- Unregistered nodes are removed after the default time of 15 minutes.
- Node group is resized to the number of registered nodes if this number is smaller than the target size after the default time of 15 minutes.

Both these mechanisms use the same time threshold, so there can occur race conditions between them. For example in the following situation:

Node group with:
- 1 registered node
- 1 unregistered node
- target size of 2

In this instance it is better to remove the unregistered node rather than resizing the node group. The issue with the second approach is that we don't have a guarantee which node will be removed - it can be either the unregistered one (desired) or the registered one (undesired).

To prevent this the second logic takes the nodes unregistered for > 15 minutes into account when deciding if it should resize the node group. It however does not take the nodes unready for < 15 minutes, which can result in the second mechanism being triggered.

This change takes all the unregistered nodes into account when deciding on the trigger condition for the second mechanism. This should prevent the race condition I've described here from happening. 

#### Does this PR introduce a user-facing change?
```
Because of this change some cloud providers may trigger the "fixNodeGroupSize" 
logic more frequently in their clusters than they did before. This can happen if the 
scale-ups take a long time to create nodes and can result in the CA treating the 
node groups as incorrectly sized and scaling them down. This can be prevented 
by increasing the max node provisioning time parameter of Cluster Autoscaler.

You can check if your cluster is experiencing this issue by looking for the following log line:
"Decreasing size of <node group name>, expected=X current=Y delta=Z"
``` 