### PR TITLE
update agnhost image to pull from registry.k8s.io

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -299,9 +299,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 
 	ginkgo.It("does not act on injected sidecars", func() {
 		const (
-			// TODO(krzysied): Update the image url when the agnhost:2.10 image
-			// is promoted to the k8s-e2e-test-images repository.
-			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
+			agnhostImage  = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 			sidecarParam  = "--sidecar-image=registry.k8s.io/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)

--- a/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/actuation.go
@@ -287,9 +287,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 
 	ginkgo.It("does not act on injected sidecars", func() {
 		const (
-			// TODO(krzysied): Update the image url when the agnhost:2.10 image
-			// is promoted to the k8s-e2e-test-images repository.
-			agnhostImage  = "gcr.io/k8s-staging-e2e-test-images/agnhost:2.10"
+			agnhostImage  = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 			sidecarParam  = "--sidecar-image=registry.k8s.io/pause:3.1"
 			sidecarName   = "webhook-added-sidecar"
 			servicePort   = int32(8443)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move the agnhost image in e2e tests from the staging repo to be pulled from `registry.k8s.io/e2e-test-images/agnhost:2.40` instead.

#### Which issue(s) this PR fixes:

Fixes a code TODO.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @jbartosik 