### PR TITLE
Replace `BuildTestContainer` with use of builder

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -144,7 +145,7 @@ func testRunOnceBase(
 
 	for i := range pods {
 		pods[i] = test.Pod().WithName("test_"+strconv.Itoa(i)).
-			AddContainer(test.BuildTestContainer(containerName, "1", "100M")).
+			AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).
 			WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
 			Get()
 

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
@@ -37,7 +38,7 @@ func TestGetUpdatePriority(t *testing.T) {
 	}{
 		{
 			name: "simple scale up",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -46,7 +47,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "simple scale down",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -55,7 +56,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "no resource diff",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -64,7 +65,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "scale up on milliquanitites",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "10m", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("10m")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("900m", "").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -73,7 +74,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "scale up outside recommended range",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("10", "").
 				WithLowerBound("6", "").
@@ -85,7 +86,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "scale down outside recommended range",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "8", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("8")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("2", "").
 				WithLowerBound("1", "").
@@ -97,7 +98,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "scale up with multiple quantities",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "2", "")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -106,7 +107,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple resources, both scale up",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "10M")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("3")).WithMemRequest(resource.MustParse("10M")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("6", "20M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -115,7 +116,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple resources, only one scale up",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "10M")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).WithMemRequest(resource.MustParse("10M")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "20M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -124,7 +125,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple resources, both scale down",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).WithMemRequest(resource.MustParse("20M")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "10M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
@@ -133,7 +134,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple resources, one outside recommended range",
-			pod:  test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "4", "20M")).Get(),
+			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).WithMemRequest(resource.MustParse("20M")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("2", "10M").
 				WithLowerBound("1", "5M").
@@ -145,8 +146,8 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple containers, both scale up",
-			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
-				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
+			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).
+				AddContainer(test.Container().WithName("test-container-2").WithCPURequest(resource.MustParse("2")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("4", "").AppendRecommendation(
 				test.Recommendation().
@@ -159,8 +160,8 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple containers, both scale down",
-			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "3", "")).
-				AddContainer(test.BuildTestContainer("test-container-2", "7", "")).Get(),
+			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("3")).Get()).
+				AddContainer(test.Container().WithName("test-container-2").WithCPURequest(resource.MustParse("7")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("1", "").AppendRecommendation(
 				test.Recommendation().
@@ -173,8 +174,8 @@ func TestGetUpdatePriority(t *testing.T) {
 			},
 		}, {
 			name: "multiple containers, both scale up, one outside range",
-			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).
-				AddContainer(test.BuildTestContainer("test-container-2", "2", "")).Get(),
+			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).
+				AddContainer(test.Container().WithName("test-container-2").WithCPURequest(resource.MustParse("2")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("4", "").
 				WithLowerBound("1", "").AppendRecommendation(
@@ -193,8 +194,8 @@ func TestGetUpdatePriority(t *testing.T) {
 			//   container1: request={6 CPU, 10 MB}, recommended={8 CPU, 20 MB}
 			//   container2: request={4 CPU, 30 MB}, recommended={7 CPU, 30 MB}
 			//   total:      request={10 CPU, 40 MB}, recommended={15 CPU, 50 MB}
-			pod: test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "6", "10M")).
-				AddContainer(test.BuildTestContainer("test-container-2", "4", "30M")).Get(),
+			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("6")).WithMemRequest(resource.MustParse("10M")).Get()).
+				AddContainer(test.Container().WithName("test-container-2").WithCPURequest(resource.MustParse("4")).WithMemRequest(resource.MustParse("30M")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
 				WithTarget("8", "20M").AppendRecommendation(
 				test.Recommendation().
@@ -221,7 +222,7 @@ func TestGetUpdatePriority(t *testing.T) {
 // recommendation for a container.
 func TestGetUpdatePriority_NoRecommendationForContainer(t *testing.T) {
 	p := NewProcessor()
-	pod := test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer("test-container", "5", "10")).Get()
+	pod := test.Pod().WithName("POD1").AddContainer(test.Container().WithName("test-container").WithCPURequest(resource.MustParse("5")).WithMemRequest(resource.MustParse("10")).Get()).Get()
 	vpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithContainer("test-container").Get()
 	result := p.GetUpdatePriority(pod, vpa, nil)
 	assert.NotNil(t, result)
@@ -245,28 +246,28 @@ func TestGetUpdatePriority_VpaObservedContainers(t *testing.T) {
 	}{
 		{
 			name:           "with no VpaObservedContainers annotation",
-			pod:            test.Pod().WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+			pod:            test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).Get(),
 			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
 			want:           optedInContainerDiff,
 		},
 		{
 			name: "with container listed in VpaObservedContainers annotation",
 			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: containerName}).
-				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+				WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).Get(),
 			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
 			want:           optedInContainerDiff,
 		},
 		{
 			name: "with container not listed in VpaObservedContainers annotation",
 			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: ""}).
-				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+				WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).Get(),
 			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
 			want:           optedOutContainerDiff,
 		},
 		{
 			name: "with incorrect VpaObservedContainers annotation",
 			pod: test.Pod().WithAnnotations(map[string]string{annotations.VpaObservedContainersLabel: "abcd;';"}).
-				WithName("POD1").AddContainer(test.BuildTestContainer(containerName, "1", "")).Get(),
+				WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).Get(),
 			recommendation: test.Recommendation().WithContainer(containerName).WithTarget("10", "").Get(),
 			want:           optedInContainerDiff,
 		},

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -30,7 +30,7 @@ import (
 	vpa_types_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	vpa_lister_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -38,22 +38,6 @@ var (
 	timeLayout       = "2006-01-02 15:04:05"
 	testTimestamp, _ = time.Parse(timeLayout, "2017-04-18 17:35:05")
 )
-
-// BuildTestContainer creates container with specified resources
-func BuildTestContainer(containerName, cpu, mem string) apiv1.Container {
-	// TODO: Use builder directly, remove this function.
-	builder := Container().WithName(containerName)
-
-	if len(cpu) > 0 {
-		cpuVal, _ := resource.ParseQuantity(cpu)
-		builder = builder.WithCPURequest(cpuVal)
-	}
-	if len(mem) > 0 {
-		memVal, _ := resource.ParseQuantity(mem)
-		builder = builder.WithMemRequest(memVal)
-	}
-	return builder.Get()
-}
 
 // BuildTestPolicy creates ResourcesPolicy with specified constraints
 func BuildTestPolicy(containerName, minCPU, maxCPU, minMemory, maxMemory string) *vpa_types.PodResourcePolicy {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -113,7 +113,7 @@ func TestPodMatchesVPA(t *testing.T) {
 		result          bool
 	}
 
-	pod := test.Pod().WithName("test-pod").AddContainer(test.BuildTestContainer(containerName, "1", "100M")).Get()
+	pod := test.Pod().WithName("test-pod").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).Get()
 	pod.Labels = map[string]string{"app": "testingApp"}
 
 	vpaBuilder := test.VerticalPodAutoscaler().
@@ -137,7 +137,7 @@ func TestPodMatchesVPA(t *testing.T) {
 }
 
 func TestGetControllingVPAForPod(t *testing.T) {
-	pod := test.Pod().WithName("test-pod").AddContainer(test.BuildTestContainer(containerName, "1", "100M")).Get()
+	pod := test.Pod().WithName("test-pod").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).Get()
 	pod.Labels = map[string]string{"app": "testingApp"}
 
 	vpaBuilder := test.VerticalPodAutoscaler().

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestRecommendationNotAvailable(t *testing.T) {
-	pod := test.Pod().WithName("pod1").AddContainer(test.BuildTestContainer("ctr-name", "", "")).Get()
+	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName("ctr-name").Get()).Get()
 	podRecommendation := vpa_types.RecommendedPodResources{
 		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 			{
@@ -48,7 +48,7 @@ func TestRecommendationNotAvailable(t *testing.T) {
 }
 
 func TestRecommendationToLimitCapping(t *testing.T) {
-	pod := test.Pod().WithName("pod1").AddContainer(test.BuildTestContainer("ctr-name", "", "")).Get()
+	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName("ctr-name").Get()).Get()
 	pod.Spec.Containers[0].Resources.Limits =
 		apiv1.ResourceList{
 			apiv1.ResourceCPU:    *resource.NewScaledQuantity(3, 1),
@@ -143,7 +143,7 @@ func TestRecommendationToLimitCapping(t *testing.T) {
 }
 
 func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
-	pod := test.Pod().WithName("pod1").AddContainer(test.BuildTestContainer("ctr-name", "", "")).Get()
+	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName("ctr-name").Get()).Get()
 	podRecommendation := vpa_types.RecommendedPodResources{
 		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 			{
@@ -238,7 +238,7 @@ var applyTestCases = []struct {
 }
 
 func TestApply(t *testing.T) {
-	pod := test.Pod().WithName("pod1").AddContainer(test.BuildTestContainer("ctr-name", "", "")).Get()
+	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName("ctr-name").Get()).Get()
 
 	for _, testCase := range applyTestCases {
 		res, _, err := NewCappingRecommendationProcessor(&fakeLimitRangeCalculator{}).Apply(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Resolves a code TODO by replacing uses of `BuildTestContainer` with use of the builder directly.

#### Which issue(s) this PR fixes:

Fixes code TODO

#### Special notes for your reviewer:

I was resolving the TODO and generally think it might have helped clean things up, but would like to get some feedback if we all agree this change makes sense.
I can see it both ways that having this helper made sense. If so we should just remove the TODO instead.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @jbartosik 