### PR TITLE
Revert "Add subresource status for vpa"

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -44,6 +44,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - "autoscaling.k8s.io"
     resources:
@@ -52,18 +53,6 @@ rules:
       - get
       - list
       - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:vpa-status-actor
-rules:
-  - apiGroups:
-      - "autoscaling.k8s.io"
-    resources:
-      - verticalpodautoscalers/status
-    verbs:
-      - get
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -147,19 +136,6 @@ subjects:
     namespace: kube-system
   - kind: ServiceAccount
     name: vpa-updater
-    namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:vpa-status-actor
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:vpa-status-actor
-subjects:
-  - kind: ServiceAccount
-    name: vpa-recommender
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -513,8 +513,7 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
   - deprecated: true
     deprecationWarning: autoscaling.k8s.io/v1beta2 API is deprecated
     name: v1beta2

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -372,23 +372,6 @@ func InstallVPA(f *framework.Framework, vpa *vpa_types.VerticalPodAutoscaler) {
 	vpaClientSet := getVpaClientSet(f)
 	_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Create(context.TODO(), vpa, metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error creating VPA")
-	// apiserver ignore status in vpa create, so need to update status
-	if !isStatusEmpty(&vpa.Status) {
-		if vpa.Status.Recommendation != nil {
-			PatchVpaRecommendation(f, vpa, vpa.Status.Recommendation)
-		}
-	}
-}
-
-func isStatusEmpty(status *vpa_types.VerticalPodAutoscalerStatus) bool {
-	if status == nil {
-		return true
-	}
-
-	if len(status.Conditions) == 0 && status.Recommendation == nil {
-		return true
-	}
-	return false
 }
 
 // InstallRawVPA installs a VPA object passed in as raw json in the test cluster.
@@ -413,7 +396,7 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 		Value: *newStatus,
 	}})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = getVpaClientSet(f).AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
+	_, err = getVpaClientSet(f).AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -360,23 +360,6 @@ func InstallVPA(f *framework.Framework, vpa *vpa_types.VerticalPodAutoscaler) {
 	vpaClientSet := getVpaClientSet(f)
 	_, err := vpaClientSet.AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Create(context.TODO(), vpa, metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error creating VPA")
-	// apiserver ignore status in vpa create, so need to update status
-	if !isStatusEmpty(&vpa.Status) {
-		if vpa.Status.Recommendation != nil {
-			PatchVpaRecommendation(f, vpa, vpa.Status.Recommendation)
-		}
-	}
-}
-
-func isStatusEmpty(status *vpa_types.VerticalPodAutoscalerStatus) bool {
-	if status == nil {
-		return true
-	}
-
-	if len(status.Conditions) == 0 && status.Recommendation == nil {
-		return true
-	}
-	return false
 }
 
 // InstallRawVPA installs a VPA object passed in as raw json in the test cluster.
@@ -401,7 +384,7 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 		Value: *newStatus,
 	}})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = getVpaClientSet(f).AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
+	_, err = getVpaClientSet(f).AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -40,7 +40,6 @@ type VerticalPodAutoscalerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vpa
-// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type="string",JSONPath=".spec.updatePolicy.updateMode"
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.cpu"
 // +kubebuilder:printcolumn:name="Mem",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.memory"

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -49,14 +49,14 @@ type patchRecord struct {
 	Value interface{} `json:"value"`
 }
 
-func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord) (result *vpa_types.VerticalPodAutoscaler, err error) {
+func patchVpa(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord) (result *vpa_types.VerticalPodAutoscaler, err error) {
 	bytes, err := json.Marshal(patches)
 	if err != nil {
 		klog.Errorf("Cannot marshal VPA status patches %+v. Reason: %+v", patches, err)
 		return
 	}
 
-	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{}, "status")
+	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{})
 }
 
 // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
@@ -69,7 +69,7 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 	}}
 
 	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
-		return patchVpaStatus(vpaClient, vpaName, patches)
+		return patchVpa(vpaClient, vpaName, patches)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
/kind bug
/kind failing-test

#5766 merged on 2023-06-27 10:48 GMT+2

* [actuation](https://k8s-testgrid.appspot.com/sig-autoscaling-vpa#autoscaling-vpa-actuation) e2e had last successful run at 08:47 CET, first failing run at 11:03 CET
* [admission controller](https://k8s-testgrid.appspot.com/sig-autoscaling-vpa#autoscaling-vpa-admission-controller) e2e had last successful run at 09:46 CET, first failing run at 11:46 CET
* [actuation](https://k8s-testgrid.appspot.com/sig-autoscaling-vpa#autoscaling-vpa-actuation) e2e had last successful run at 08:47 CET, first failing run at 11:03 CET

Failures sound like they're caused by the PR. From [actuation run logs](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-autoscaling-vpa-actuation/1673617900889444352):

```
I0627 09:23:04.238] Jun 27 09:23:04.238: FAIL: Failed to patch VPA.
I0627 09:23:04.239] Unexpected error:
I0627 09:23:04.239]     <*errors.StatusError | 0xc000b66e60>: {
I0627 09:23:04.239]         ErrStatus: {
I0627 09:23:04.239]             TypeMeta: {Kind: "", APIVersion: ""},
I0627 09:23:04.239]             ListMeta: {
I0627 09:23:04.239]                 SelfLink: "",
push_pin
I0627 09:23:04.239]                 ResourceVersion: "",
I0627 09:23:04.239]                 Continue: "",
I0627 09:23:04.239]                 RemainingItemCount: nil,
I0627 09:23:04.239]             },
I0627 09:23:04.239]             Status: "Failure",
I0627 09:23:04.239]             Message: "verticalpodautoscalers.autoscaling.k8s.io \"hamster-vpa\" not found",
I0627 09:23:04.239]             Reason: "NotFound",
I0627 09:23:04.239]             Details: {
I0627 09:23:04.239]                 Name: "hamster-vpa",
I0627 09:23:04.239]                 Group: "autoscaling.k8s.io",
I0627 09:23:04.239]                 Kind: "verticalpodautoscalers",
I0627 09:23:04.240]                 UID: "",
I0627 09:23:04.240]                 Causes: nil,
I0627 09:23:04.240]                 RetryAfterSeconds: 0,
I0627 09:23:04.240]             },
I0627 09:23:04.240]             Code: 404,
I0627 09:23:04.240]         },
I0627 09:23:04.240]     }
I0627 09:23:04.240]     verticalpodautoscalers.autoscaling.k8s.io "hamster-vpa" not found
I0627 09:23:04.240] occurred
```

I see similar errors (Failed to patch VPA.) in other test runs I checked.

@wowqing FYI