### PR TITLE
Bump golang to the latest version (1.20.5)

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -22,7 +22,7 @@ ARCH ?= amd64
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 GOARM=7
-GOLANG_VERSION = 1.20.4
+GOLANG_VERSION = 1.20.5
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)


### PR DESCRIPTION
#### What type of PR is this?

/king bug

#### What this PR does / why we need it:

Need to fix GO-2023-1840

The govulncheck reports that:
```
Standard library
    Found in: runtime@go1.20.3
    Fixed in: runtime@go1.20.5
```

I'm not bumping the tag since the one from #5778 was actually never released.
