### PR TITLE
add --load to docker buildx

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -33,7 +33,7 @@ test-unit: clean build
 docker-build: $(addprefix docker-build-,$(ALL_ARCHITECTURES))
 
 .PHONY: docker-build-*
-docker-build-%: 
+docker-build-%:
 ifndef REGISTRY
 	ERR = $(error REGISTRY is undefined)
 	$(ERR)

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -33,7 +33,7 @@ test-unit: clean build
 docker-build: $(addprefix docker-build-,$(ALL_ARCHITECTURES))
 
 .PHONY: docker-build-*
-docker-build-%: 
+docker-build-%:
 ifndef REGISTRY
 	ERR = $(error REGISTRY is undefined)
 	$(ERR)


### PR DESCRIPTION
to fix local e2e runs

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

In local runs of the e2e test they failed with errors like:

```
Successfully tagged vpa-autoscaling-builder:latest
docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-amd64 -C pkg/updater'
make: Entering directory '/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater'
CGO_ENABLED=0 LD_FLAGS=-s GO111MODULE=on GOARCH=amd64 GOOS=linux go build -mod vendor -o updater-amd64
make: Leaving directory '/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater'
docker buildx build --pull --platform linux/amd64 -t gcr.io/xxx/vpa-updater-amd64:latest --build-arg ARCH=amd64 .
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 2.7s (6/6) FINISHED                                                                                                                               
 => [internal] load .dockerignore                                                                                                                         0.1s
 => => transferring context: 2B                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                      0.1s
 => => transferring dockerfile: 836B                                                                                                                      0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                                                          0.3s
 => [internal] load build context                                                                                                                         1.0s
 => => transferring context: 55.79MB                                                                                                                      1.0s
 => CACHED [1/2] FROM gcr.io/distroless/static:latest@sha256:7198a357ff3a8ef750b041324873960cf2153c11cc50abb9d8d5f8bb089f6b4e                             0.0s
 => => resolve gcr.io/distroless/static:latest@sha256:7198a357ff3a8ef750b041324873960cf2153c11cc50abb9d8d5f8bb089f6b4e                                    0.0s
 => [2/2] COPY updater-amd64 /updater                                                                                                                     1.2s
docker push gcr.io/xxx/vpa-updater-amd64:latest
The push refers to repository [gcr.io/xxx/vpa-updater-amd64]
An image does not exist locally with the tag: gcr.io/xxx/vpa-updater-amd64
make: *** [Makefile:63: do-push-amd64] Error 1
make: Leaving directory '/home/kwiesmueller/go/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater'
```

This seems to be caused by the `docker buildx` command not storing the images in the local daemon.

I don't know if this is something specific to my local setup.

```
Server: Docker Engine - Community
 Engine:
  Version:          20.10.21
  API version:      1.41 (minimum version 1.12)
```

Adding the `--load` flag made the tests pass.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
