### PR TITLE
Backport #5776 [cluster-autoscaler] "Change magnum to use control-plane role" into CA1.25

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -117,6 +117,10 @@ func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; found {
 		return nil, nil
 	}
+	// Ignore control-plane nodes
+	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/control-plane"]; found {
+		return nil, nil
+	}
 
 	ngUUID, err := mcp.magnumManager.nodeGroupForNode(node)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR is cherry-picked, which backports https://github.com/kubernetes/autoscaler/pull/5776 in CA-1.25
#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/autoscaler/issues/5888

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
