### PR TITLE
Add subresource status for vpa

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -44,7 +44,6 @@ rules:
       - get
       - list
       - watch
-      - patch
   - apiGroups:
       - "autoscaling.k8s.io"
     resources:
@@ -53,6 +52,18 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-actor
+rules:
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers/status
+    verbs:
+      - get
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -136,6 +147,19 @@ subjects:
     namespace: kube-system
   - kind: ServiceAccount
     name: vpa-updater
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -513,7 +513,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
   - deprecated: true
     deprecationWarning: autoscaling.k8s.io/v1beta2 API is deprecated
     name: v1beta2
@@ -748,3 +749,5 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -372,6 +372,23 @@ func InstallVPA(f *framework.Framework, vpa *vpa_types.VerticalPodAutoscaler) {
 	vpaClientSet := getVpaClientSet(f)
 	_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Create(context.TODO(), vpa, metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error creating VPA")
+	// apiserver ignore status in vpa create, so need to update status
+	if !isStatusEmpty(&vpa.Status) {
+		if vpa.Status.Recommendation != nil {
+			PatchVpaRecommendation(f, vpa, vpa.Status.Recommendation)
+		}
+	}
+}
+
+func isStatusEmpty(status *vpa_types.VerticalPodAutoscalerStatus) bool {
+	if status == nil {
+		return true
+	}
+
+	if len(status.Conditions) == 0 && status.Recommendation == nil {
+		return true
+	}
+	return false
 }
 
 // InstallRawVPA installs a VPA object passed in as raw json in the test cluster.
@@ -396,7 +413,7 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 		Value: *newStatus,
 	}})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = getVpaClientSet(f).AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
+	_, err = getVpaClientSet(f).AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -360,6 +360,23 @@ func InstallVPA(f *framework.Framework, vpa *vpa_types.VerticalPodAutoscaler) {
 	vpaClientSet := getVpaClientSet(f)
 	_, err := vpaClientSet.AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Create(context.TODO(), vpa, metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error creating VPA")
+	// apiserver ignore status in vpa create, so need to update status
+	if !isStatusEmpty(&vpa.Status) {
+		if vpa.Status.Recommendation != nil {
+			PatchVpaRecommendation(f, vpa, vpa.Status.Recommendation)
+		}
+	}
+}
+
+func isStatusEmpty(status *vpa_types.VerticalPodAutoscalerStatus) bool {
+	if status == nil {
+		return true
+	}
+
+	if len(status.Conditions) == 0 && status.Recommendation == nil {
+		return true
+	}
+	return false
 }
 
 // InstallRawVPA installs a VPA object passed in as raw json in the test cluster.
@@ -384,7 +401,7 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 		Value: *newStatus,
 	}})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = getVpaClientSet(f).AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
+	_, err = getVpaClientSet(f).AutoscalingV1beta2().VerticalPodAutoscalers(f.Namespace.Name).Patch(context.TODO(), vpa.Name, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -40,6 +40,7 @@ type VerticalPodAutoscalerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=vpa
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type="string",JSONPath=".spec.updatePolicy.updateMode"
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.cpu"
 // +kubebuilder:printcolumn:name="Mem",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.memory"

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -39,6 +39,7 @@ type VerticalPodAutoscalerList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=vpa
+// +kubebuilder:subresource:status
 // +k8s:prerelease-lifecycle-gen=true
 
 // VerticalPodAutoscaler is the configuration for a vertical pod

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -49,14 +49,14 @@ type patchRecord struct {
 	Value interface{} `json:"value"`
 }
 
-func patchVpa(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord) (result *vpa_types.VerticalPodAutoscaler, err error) {
+func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord) (result *vpa_types.VerticalPodAutoscaler, err error) {
 	bytes, err := json.Marshal(patches)
 	if err != nil {
 		klog.Errorf("Cannot marshal VPA status patches %+v. Reason: %+v", patches, err)
 		return
 	}
 
-	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{})
+	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{}, "status")
 }
 
 // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
@@ -69,7 +69,7 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 	}}
 
 	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
-		return patchVpa(vpaClient, vpaName, patches)
+		return patchVpaStatus(vpaClient, vpaName, patches)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Add status field in subresource on crd yaml and add new ClusterRole system:vpa-actor to patch /status subresource. 
The `metadata.generation` only increase on vpa spec update. 
Fix e2e test for patch and create vpa

#### What type of PR is this?
/kind bug
/kind failing-test
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Current vpa crd has empty subresource field, that leads to metadata.generation increase on vpa status update.
The controller-runtime has [GenerationChangedPredicate](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.5/pkg/predicate#GenerationChangedPredicate) to filter out update status event for cr, but it not work for vpa.
This PR add status field in subresource on crd yaml and add new ClusterRole system:vpa-actor to patch /status subresource.
The metadata.generation only increase on vpa spec update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5675 

#### Special notes for your reviewer:
Previous pull request is #5680 #5766 and be revert #5738 #5897, because of e2e test failed #5727. 

This PR compare with previous PR  #5766, only add `subresources` in v1beta2.
https://github.com/kubernetes/autoscaler/compare/master...wu0407:autoscaler:add-status-subresource?expand=1#diff-b2539c9dfcc061e38b1961b5e52a8aed413750d74b71c018a3f6ca7dfc871efaR752-R753 
@kwiesmueller @jbartosik 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the /status subresource to VPA
action required: If you're installing VPA with different means than the `hack/vpa-up.sh` script, you need to add the ClusterRole `system:vpa-status-actor` and corresponding ClusterRoleBinding yourself. Otherwise VPA will no longer be able to update the recommendations!
If you create vpa with status,  status be ignored in apiserver, so need to update status after create vpa.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
