### PR TITLE
Quote temp folder name parameter to avoid errors

### DIFF
--- a/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
+++ b/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # The following commands always returns an error because controller-gen does not accept keys other than strings.
-${CONTROLLER_GEN} ${CRD_OPTS} paths="${APIS_PATH}/..." output:crd:dir=${WORKSPACE} >& ${WORKSPACE}/errors.log ||:
+${CONTROLLER_GEN} ${CRD_OPTS} paths="${APIS_PATH}/..." output:crd:dir="\"${WORKSPACE}\"" >& ${WORKSPACE}/errors.log ||:
 grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'usage' ${WORKSPACE}/errors.log \
     && { echo "Failed to generate CRD YAMLs."; exit 1; }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
Add some quotes around the target directory parameter for `controller-gen`. Temporary folders can have all kinds of funny symbols in it, which can lead to unexpected results/errors. Here is what I got today when trying to re-generate the CRDs with `hack/generate-crd-yamls.sh`:

```
 ✗ ./hack/generate-crd-yaml.sh
Error: unable to parse option "output:crd:dir=/var/folders/4p/pbd3vmnj5_xfvcjh0pdxy8zw0000gn/T/tmp.eYi9W4D9v4": ['p' exponent requires hexadecimal mantissa (at <input>:1:14) exponent has no digits (at <input>:1:14)]
```

After adding the quotes, the script executed fine.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

