### PR TITLE
Implement configurable thresholds for threshold based estimator

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -115,7 +115,17 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 		opts.ExpanderStrategy = expanderStrategy
 	}
 	if opts.EstimatorBuilder == nil {
-		estimatorBuilder, err := estimator.NewEstimatorBuilder(opts.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(opts.MaxNodesPerScaleUp, opts.MaxNodeGroupBinpackingDuration), estimator.NewDecreasingPodOrderer())
+		thresholds := []estimator.Threshold{
+			estimator.NewStaticThreshold(opts.MaxNodesPerScaleUp, opts.MaxNodeGroupBinpackingDuration),
+			estimator.NewSngCapacityThreshold(),
+			estimator.NewClusterCapacityThreshold(),
+		}
+		estimatorBuilder, err := estimator.NewEstimatorBuilder(
+			opts.EstimatorName,
+			estimator.NewThresholdBasedEstimationLimiter(thresholds),
+			estimator.NewDecreasingPodOrderer(),
+			estimator.NewEstimationContext(opts.MaxNodesTotal),
+		)
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -124,7 +124,6 @@ func initializeDefaultOptions(opts *AutoscalerOptions) error {
 			opts.EstimatorName,
 			estimator.NewThresholdBasedEstimationLimiter(thresholds),
 			estimator.NewDecreasingPodOrderer(),
-			estimator.NewEstimationContext(opts.MaxNodesTotal),
 		)
 		if err != nil {
 			return err

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -208,7 +208,12 @@ func NewScaleTestAutoscalingContext(
 	}
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
-	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0), estimator.NewDecreasingPodOrderer())
+	estimatorBuilder, _ := estimator.NewEstimatorBuilder(
+		options.EstimatorName,
+		estimator.NewThresholdBasedEstimationLimiter(nil),
+		estimator.NewDecreasingPodOrderer(),
+		&estimator.EstimationContext{},
+	)
 	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	if err != nil {
 		return context.AutoscalingContext{}, err

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -212,7 +212,6 @@ func NewScaleTestAutoscalingContext(
 		options.EstimatorName,
 		estimator.NewThresholdBasedEstimationLimiter(nil),
 		estimator.NewDecreasingPodOrderer(),
-		&estimator.EstimationContext{},
 	)
 	predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 	if err != nil {

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -34,6 +34,7 @@ type BinpackingNodeEstimator struct {
 	clusterSnapshot  clustersnapshot.ClusterSnapshot
 	limiter          EstimationLimiter
 	podOrderer       EstimationPodOrderer
+	context          *EstimationContext
 }
 
 // NewBinpackingNodeEstimator builds a new BinpackingNodeEstimator.
@@ -41,12 +42,15 @@ func NewBinpackingNodeEstimator(
 	predicateChecker predicatechecker.PredicateChecker,
 	clusterSnapshot clustersnapshot.ClusterSnapshot,
 	limiter EstimationLimiter,
-	podOrderer EstimationPodOrderer) *BinpackingNodeEstimator {
+	podOrderer EstimationPodOrderer,
+	context *EstimationContext,
+) *BinpackingNodeEstimator {
 	return &BinpackingNodeEstimator{
 		predicateChecker: predicateChecker,
 		clusterSnapshot:  clusterSnapshot,
 		limiter:          limiter,
 		podOrderer:       podOrderer,
+		context:          context,
 	}
 }
 
@@ -65,7 +69,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 	nodeTemplate *schedulerframework.NodeInfo,
 	nodeGroup cloudprovider.NodeGroup) (int, []*apiv1.Pod) {
 
-	e.limiter.StartEstimation(pods, nodeGroup)
+	e.limiter.StartEstimation(pods, nodeGroup, e.context)
 	defer e.limiter.EndEstimation()
 
 	pods = e.podOrderer.Order(pods, nodeTemplate, nodeGroup)

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -34,7 +34,7 @@ type BinpackingNodeEstimator struct {
 	clusterSnapshot  clustersnapshot.ClusterSnapshot
 	limiter          EstimationLimiter
 	podOrderer       EstimationPodOrderer
-	context          *EstimationContext
+	context          EstimationContext
 }
 
 // NewBinpackingNodeEstimator builds a new BinpackingNodeEstimator.
@@ -43,7 +43,7 @@ func NewBinpackingNodeEstimator(
 	clusterSnapshot clustersnapshot.ClusterSnapshot,
 	limiter EstimationLimiter,
 	podOrderer EstimationPodOrderer,
-	context *EstimationContext,
+	context EstimationContext,
 ) *BinpackingNodeEstimator {
 	return &BinpackingNodeEstimator{
 		predicateChecker: predicateChecker,

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -185,9 +185,9 @@ func TestBinpackingEstimate(t *testing.T) {
 
 			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
 			assert.NoError(t, err)
-			limiter := NewThresholdBasedEstimationLimiter(tc.maxNodes, time.Duration(0))
+			limiter := NewThresholdBasedEstimationLimiter([]Threshold{NewStaticThreshold(tc.maxNodes, time.Duration(0))})
 			processor := NewDecreasingPodOrderer()
-			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, processor)
+			estimator := NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, processor, nil)
 
 			node := makeNode(tc.millicores, tc.memory, "template", "zone-mars")
 			nodeInfo := schedulerframework.NewNodeInfo()

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+type clusterCapacityThreshold struct {
+}
+
+// GetNodeLimit returns available capacity of the cluster. Return value of 0 means that no limit is set.
+func (l *clusterCapacityThreshold) GetNodeLimit(_ cloudprovider.NodeGroup, context *EstimationContext) int {
+	if context == nil || (context.clusterMaxNodeLimit <= 0) || (context.clusterMaxNodeLimit < context.currentNodeCount) {
+		return 0
+	}
+	return context.clusterMaxNodeLimit - context.currentNodeCount
+}
+
+// GetDurationLimit always returns 0 for this threshold, i.e. no limit is set.
+func (l *clusterCapacityThreshold) GetDurationLimit() time.Duration {
+	return 0
+}
+
+// NewClusterCapacityThreshold returns a variable Threshold to limit
+// maximum nodes in binpacking. Value of the limit depends on maximum number of nodes
+// allowed and total number of nodes currently running in the cluster
+func NewClusterCapacityThreshold() Threshold {
+	return &clusterCapacityThreshold{}
+}

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
@@ -30,33 +30,39 @@ func TestNewClusterCapacityThreshold(t *testing.T) {
 		contextCurrentNodes int
 	}{
 		{
-			name:                "computes available capacity",
-			wantThreshold:       5,
+			name:                "returns available capacity",
 			contextMaxNodes:     10,
 			contextCurrentNodes: 5,
+			wantThreshold:       5,
 		},
 		{
-			name:                "for not defined cluster max nodes returns 0",
-			wantThreshold:       0,
+			name:                "no threshold is set if cluster capacity is unlimited",
 			contextMaxNodes:     0,
 			contextCurrentNodes: 10,
+			wantThreshold:       0,
 		},
 		{
-			name:                "for negative total capacity returns 0",
-			wantThreshold:       0,
+			name:                "threshold is negative if cluster has no capacity",
 			contextMaxNodes:     5,
 			contextCurrentNodes: 10,
+			wantThreshold:       -1,
+		},
+		{
+			name:                "threshold is negative if cluster node limit is negative",
+			contextMaxNodes:     -5,
+			contextCurrentNodes: 0,
+			wantThreshold:       -1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			context := &EstimationContext{
+			context := &estimationContext{
 				similarNodeGroups:   nil,
 				currentNodeCount:    tt.contextCurrentNodes,
 				clusterMaxNodeLimit: tt.contextMaxNodes,
 			}
-			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().GetNodeLimit(nil, context))
-			assert.True(t, NewClusterCapacityThreshold().GetDurationLimit() == 0)
+			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().NodeLimit(nil, context))
+			assert.True(t, NewClusterCapacityThreshold().DurationLimit(nil, nil) == 0)
 		})
 	}
 }

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClusterCapacityThreshold(t *testing.T) {
+	tests := []struct {
+		name                string
+		wantThreshold       int
+		contextMaxNodes     int
+		contextCurrentNodes int
+	}{
+		{
+			name:                "computes available capacity",
+			wantThreshold:       5,
+			contextMaxNodes:     10,
+			contextCurrentNodes: 5,
+		},
+		{
+			name:                "for not defined cluster max nodes returns 0",
+			wantThreshold:       0,
+			contextMaxNodes:     0,
+			contextCurrentNodes: 10,
+		},
+		{
+			name:                "for negative total capacity returns 0",
+			wantThreshold:       0,
+			contextMaxNodes:     5,
+			contextCurrentNodes: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context := &EstimationContext{
+				similarNodeGroups:   nil,
+				currentNodeCount:    tt.contextCurrentNodes,
+				nodeGroupCapacity:   0,
+				clusterMaxNodeLimit: tt.contextMaxNodes,
+			}
+			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().GetNodeLimit(nil, context))
+			assert.True(t, NewClusterCapacityThreshold().GetDurationLimit() == 0)
+		})
+	}
+}

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
@@ -53,7 +53,6 @@ func TestNewClusterCapacityThreshold(t *testing.T) {
 			context := &EstimationContext{
 				similarNodeGroups:   nil,
 				currentNodeCount:    tt.contextCurrentNodes,
-				nodeGroupCapacity:   0,
 				clusterMaxNodeLimit: tt.contextMaxNodes,
 			}
 			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().GetNodeLimit(nil, context))

--- a/cluster-autoscaler/estimator/estimation_context.go
+++ b/cluster-autoscaler/estimator/estimation_context.go
@@ -21,48 +21,39 @@ import (
 )
 
 // EstimationContext stores static and runtime state of autoscaling, used by Estimator
-type EstimationContext struct {
+type EstimationContext interface {
+	SimilarNodeGroups() []cloudprovider.NodeGroup
+	ClusterMaxNodeLimit() int
+	CurrentNodeCount() int
+}
+
+type estimationContext struct {
 	similarNodeGroups   []cloudprovider.NodeGroup
 	currentNodeCount    int
 	clusterMaxNodeLimit int
 }
 
-// NewEstimationContext creates new estimation context with static properties
-func NewEstimationContext(clusterMaxNodeLimit int) *EstimationContext {
-	return &EstimationContext{clusterMaxNodeLimit: clusterMaxNodeLimit}
-}
-
-// NewEstimationContextUpdate creates a patch for estimation context with runtime properties.
+// NewEstimationContext creates a patch for estimation context with runtime properties.
 // This patch is used to update existing context.
-func NewEstimationContextUpdate(similarNodeGroups []cloudprovider.NodeGroup, currentNodeCount int) *EstimationContext {
-	return &EstimationContext{
-		similarNodeGroups: similarNodeGroups,
-		currentNodeCount:  currentNodeCount,
+func NewEstimationContext(clusterMaxNodeLimit int, similarNodeGroups []cloudprovider.NodeGroup, currentNodeCount int) EstimationContext {
+	return &estimationContext{
+		similarNodeGroups:   similarNodeGroups,
+		currentNodeCount:    currentNodeCount,
+		clusterMaxNodeLimit: clusterMaxNodeLimit,
 	}
 }
 
-// GetSimilarNodeGroups returns array of similar node groups
-func (c *EstimationContext) GetSimilarNodeGroups() []cloudprovider.NodeGroup {
+// SimilarNodeGroups returns array of similar node groups
+func (c *estimationContext) SimilarNodeGroups() []cloudprovider.NodeGroup {
 	return c.similarNodeGroups
 }
 
-// GetClusterMaxNodeLimit returns maximum node number allowed for the cluster
-func (c *EstimationContext) GetClusterMaxNodeLimit() int {
+// ClusterMaxNodeLimit returns maximum node number allowed for the cluster
+func (c *estimationContext) ClusterMaxNodeLimit() int {
 	return c.clusterMaxNodeLimit
 }
 
-// GetCurrentNodeCount returns current number of nodes in the cluster
-func (c *EstimationContext) GetCurrentNodeCount() int {
+// CurrentNodeCount returns current number of nodes in the cluster
+func (c *estimationContext) CurrentNodeCount() int {
 	return c.currentNodeCount
-}
-
-func updateContext(baseContext *EstimationContext, otherContext *EstimationContext) *EstimationContext {
-	if baseContext == nil {
-		return otherContext
-	} else if otherContext == nil {
-		return baseContext
-	}
-	baseContext.similarNodeGroups = otherContext.similarNodeGroups
-	baseContext.currentNodeCount = otherContext.currentNodeCount
-	return baseContext
 }

--- a/cluster-autoscaler/estimator/estimation_context.go
+++ b/cluster-autoscaler/estimator/estimation_context.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+// EstimationContext stores static and runtime state of autoscaling, used by Estimator
+type EstimationContext struct {
+	similarNodeGroups   []cloudprovider.NodeGroup
+	currentNodeCount    int
+	clusterMaxNodeLimit int
+}
+
+// NewEstimationContext creates new estimation context with static properties
+func NewEstimationContext(clusterMaxNodeLimit int) *EstimationContext {
+	return &EstimationContext{clusterMaxNodeLimit: clusterMaxNodeLimit}
+}
+
+// NewEstimationContextUpdate creates a patch for estimation context with runtime properties.
+// This patch is used to update existing context.
+func NewEstimationContextUpdate(similarNodeGroups []cloudprovider.NodeGroup, currentNodeCount int) *EstimationContext {
+	return &EstimationContext{
+		similarNodeGroups: similarNodeGroups,
+		currentNodeCount:  currentNodeCount,
+	}
+}
+
+// GetSimilarNodeGroups returns array of similar node groups
+func (c *EstimationContext) GetSimilarNodeGroups() []cloudprovider.NodeGroup {
+	return c.similarNodeGroups
+}
+
+// GetClusterMaxNodeLimit returns maximum node number allowed for the cluster
+func (c *EstimationContext) GetClusterMaxNodeLimit() int {
+	return c.clusterMaxNodeLimit
+}
+
+// GetCurrentNodeCount returns current number of nodes in the cluster
+func (c *EstimationContext) GetCurrentNodeCount() int {
+	return c.currentNodeCount
+}
+
+func updateContext(baseContext *EstimationContext, otherContext *EstimationContext) *EstimationContext {
+	if baseContext == nil {
+		return otherContext
+	} else if otherContext == nil {
+		return baseContext
+	}
+	baseContext.similarNodeGroups = otherContext.similarNodeGroups
+	baseContext.currentNodeCount = otherContext.currentNodeCount
+	return baseContext
+}

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -43,17 +43,17 @@ type Estimator interface {
 }
 
 // EstimatorBuilder creates a new estimator object.
-type EstimatorBuilder func(predicatechecker.PredicateChecker, clustersnapshot.ClusterSnapshot, *EstimationContext) Estimator
+type EstimatorBuilder func(predicatechecker.PredicateChecker, clustersnapshot.ClusterSnapshot, EstimationContext) Estimator
 
 // NewEstimatorBuilder creates a new estimator object from flag.
-func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer EstimationPodOrderer, context *EstimationContext) (EstimatorBuilder, error) {
+func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer EstimationPodOrderer) (EstimatorBuilder, error) {
 	switch name {
 	case BinpackingEstimatorName:
 		return func(
 			predicateChecker predicatechecker.PredicateChecker,
 			clusterSnapshot clustersnapshot.ClusterSnapshot,
-			runtimeContext *EstimationContext) Estimator {
-			return NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, orderer, updateContext(context, runtimeContext))
+			context EstimationContext) Estimator {
+			return NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, orderer, context)
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown estimator: %s", name)
@@ -64,7 +64,7 @@ func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer Estimat
 // scale-up is limited by external factors.
 type EstimationLimiter interface {
 	// StartEstimation is called at the start of estimation.
-	StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup, *EstimationContext)
+	StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup, EstimationContext)
 	// EndEstimation is called at the end of estimation.
 	EndEstimation()
 	// PermissionToAddNode is called by an estimator when it wants to add additional

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -43,16 +43,17 @@ type Estimator interface {
 }
 
 // EstimatorBuilder creates a new estimator object.
-type EstimatorBuilder func(predicatechecker.PredicateChecker, clustersnapshot.ClusterSnapshot) Estimator
+type EstimatorBuilder func(predicatechecker.PredicateChecker, clustersnapshot.ClusterSnapshot, *EstimationContext) Estimator
 
 // NewEstimatorBuilder creates a new estimator object from flag.
-func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer EstimationPodOrderer) (EstimatorBuilder, error) {
+func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer EstimationPodOrderer, context *EstimationContext) (EstimatorBuilder, error) {
 	switch name {
 	case BinpackingEstimatorName:
 		return func(
 			predicateChecker predicatechecker.PredicateChecker,
-			clusterSnapshot clustersnapshot.ClusterSnapshot) Estimator {
-			return NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, orderer)
+			clusterSnapshot clustersnapshot.ClusterSnapshot,
+			runtimeContext *EstimationContext) Estimator {
+			return NewBinpackingNodeEstimator(predicateChecker, clusterSnapshot, limiter, orderer, updateContext(context, runtimeContext))
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown estimator: %s", name)
@@ -63,7 +64,7 @@ func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer Estimat
 // scale-up is limited by external factors.
 type EstimationLimiter interface {
 	// StartEstimation is called at the start of estimation.
-	StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup)
+	StartEstimation([]*apiv1.Pod, cloudprovider.NodeGroup, *EstimationContext)
 	// EndEstimation is called at the end of estimation.
 	EndEstimation()
 	// PermissionToAddNode is called by an estimator when it wants to add additional

--- a/cluster-autoscaler/estimator/sng_capacity_threshold.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/klog/v2"
+)
+
+type sngCapacityThreshold struct {
+}
+
+func (l *sngCapacityThreshold) GetNodeLimit(_ cloudprovider.NodeGroup, context *EstimationContext) int {
+	var totalCapacity int
+	for _, nodeGroup := range context.GetSimilarNodeGroups() {
+		nodeGroupTargetSize, err := nodeGroup.TargetSize()
+		// Should not ever happen as only valid node groups are passed to estimator
+		if err != nil {
+			klog.Errorf("Error while computing available capacity of a node group %v: can't get target size of the group", nodeGroup.Id(), err)
+			continue
+		}
+		groupCapacity := nodeGroup.MaxSize() - nodeGroupTargetSize
+		if groupCapacity > 0 {
+			totalCapacity += groupCapacity
+		}
+	}
+	return totalCapacity
+}
+
+func (l *sngCapacityThreshold) GetDurationLimit() time.Duration {
+	return 0
+}
+
+// NewSngCapacityThreshold returns a Threshold that should be used to limit
+// result and duration of binpacking by given static values
+func NewSngCapacityThreshold() Threshold {
+	return &sngCapacityThreshold{}
+}

--- a/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+)
+
+func TestSngCapacityThreshold(t *testing.T) {
+	type nodeGroupConfig struct {
+		name       string
+		maxNodes   int
+		nodesCount int
+	}
+	tests := []struct {
+		name             string
+		nodeGroupsConfig []nodeGroupConfig
+		wantThreshold    int
+	}{
+		{
+			"Computes capacity correctly",
+			[]nodeGroupConfig{
+				{"ng1", 10, 5},
+				{"ng2", 100, 50},
+				{"ng3", 5, 3},
+			},
+			57,
+		},
+		{
+			"For empty capacity returns 0",
+			[]nodeGroupConfig{
+				{"ng1", 10, 10},
+				{"ng2", 100, 100},
+			},
+			0,
+		},
+		{
+			"Skips over-provisioned groups",
+			[]nodeGroupConfig{
+				{"ng1", 10, 5},
+				{"ng3", 10, 11},
+				{"ng3", 0, 5},
+			},
+			5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProvider(func(string, int) error { return nil }, nil)
+			for _, ng := range tt.nodeGroupsConfig {
+				provider.AddNodeGroup(ng.name, 0, ng.maxNodes, ng.nodesCount)
+			}
+			context := EstimationContext{similarNodeGroups: provider.NodeGroups()}
+			assert.Equalf(t, tt.wantThreshold, NewSngCapacityThreshold().GetNodeLimit(nil, &context), "NewSngCapacityThreshold()")
+			assert.True(t, NewClusterCapacityThreshold().GetDurationLimit() == 0)
+		})
+	}
+}

--- a/cluster-autoscaler/estimator/static_threshold.go
+++ b/cluster-autoscaler/estimator/static_threshold.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+type staticThreshold struct {
+	maxNodes    int
+	maxDuration time.Duration
+}
+
+func (l *staticThreshold) GetNodeLimit(cloudprovider.NodeGroup, *EstimationContext) int {
+	return l.maxNodes
+}
+
+func (l *staticThreshold) GetDurationLimit() time.Duration {
+	return l.maxDuration
+}
+
+// NewStaticThreshold returns a Threshold that should be used to limit
+// result and duration of binpacking by given static values
+func NewStaticThreshold(maxNodes int, maxDuration time.Duration) Threshold {
+	return &staticThreshold{
+		maxNodes:    maxNodes,
+		maxDuration: maxDuration,
+	}
+}

--- a/cluster-autoscaler/estimator/static_threshold.go
+++ b/cluster-autoscaler/estimator/static_threshold.go
@@ -27,11 +27,11 @@ type staticThreshold struct {
 	maxDuration time.Duration
 }
 
-func (l *staticThreshold) GetNodeLimit(cloudprovider.NodeGroup, *EstimationContext) int {
+func (l *staticThreshold) NodeLimit(cloudprovider.NodeGroup, EstimationContext) int {
 	return l.maxNodes
 }
 
-func (l *staticThreshold) GetDurationLimit() time.Duration {
+func (l *staticThreshold) DurationLimit(cloudprovider.NodeGroup, EstimationContext) time.Duration {
 	return l.maxDuration
 }
 

--- a/cluster-autoscaler/estimator/threshold.go
+++ b/cluster-autoscaler/estimator/threshold.go
@@ -25,6 +25,6 @@ import (
 // Threshold provides resources configuration for threshold based estimation limiter.
 // Return value of 0 means that no limit is set.
 type Threshold interface {
-	GetNodeLimit(cloudprovider.NodeGroup, *EstimationContext) int
-	GetDurationLimit() time.Duration
+	NodeLimit(cloudprovider.NodeGroup, EstimationContext) int
+	DurationLimit(cloudprovider.NodeGroup, EstimationContext) time.Duration
 }

--- a/cluster-autoscaler/estimator/threshold.go
+++ b/cluster-autoscaler/estimator/threshold.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+// Threshold provides resources configuration for threshold based estimation limiter.
+// Return value of 0 means that no limit is set.
+type Threshold interface {
+	GetNodeLimit(cloudprovider.NodeGroup, *EstimationContext) int
+	GetDurationLimit() time.Duration
+}

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -61,7 +61,7 @@ func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode() bool {
 		return false
 	}
 	timeDefined := tbel.maxDuration > 0 && tbel.start != time.Time{}
-	if timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration)) {
+	if tbel.maxDuration < 0 || (timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration))) {
 		klog.V(4).Infof("Capping binpacking after exceeding max duration of %v", tbel.maxDuration)
 		return false
 	}

--- a/cluster-autoscaler/estimator/threshold_based_limiter_test.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter_test.go
@@ -95,7 +95,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 			thresholds:      []Threshold{NewStaticThreshold(3, 0)},
 		},
 		{
-			name: "binpacking is stopped if at least one threshold is negative",
+			name: "binpacking is stopped if at least one threshold has negative max nodes limit",
 			operations: []limiterOperation{
 				expectDeny,
 			},
@@ -103,6 +103,17 @@ func TestThresholdBasedLimiter(t *testing.T) {
 			thresholds: []Threshold{
 				NewStaticThreshold(-1, 0),
 				NewStaticThreshold(10, 0),
+			},
+		},
+		{
+			name: "binpacking is stopped if at least one threshold has negative max duration limit",
+			operations: []limiterOperation{
+				expectDeny,
+			},
+			expectNodeCount: 0,
+			thresholds: []Threshold{
+				NewStaticThreshold(100, -1),
+				NewStaticThreshold(10, 60*time.Minute),
 			},
 		},
 		{
@@ -171,7 +182,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 			for _, op := range tc.operations {
 				op(t, limiter)
 			}
-			assert.Equal(t, tc.expectNodeCount, limiter.nodes)
+			assert.Equalf(t, tc.expectNodeCount, limiter.nodes, "Number of allowed nodes does not match expectation")
 			limiter.EndEstimation()
 		})
 	}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -97,6 +97,8 @@ const (
 	ScaleDownMiscOperations    FunctionLabel = "scaleDown:miscOperations"
 	ScaleDownSoftTaintUnneeded FunctionLabel = "scaleDown:softTaintUnneeded"
 	ScaleUp                    FunctionLabel = "scaleUp"
+	BuildPodEquivalenceGroups  FunctionLabel = "scaleUp:buildPodEquivalenceGroups"
+	Estimate                   FunctionLabel = "scaleUp:estimate"
 	FindUnneeded               FunctionLabel = "findUnneeded"
 	UpdateState                FunctionLabel = "updateClusterState"
 	FilterOutSchedulable       FunctionLabel = "filterOutSchedulable"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Introduce new binpacking limit (`Threshold`) interface for threshold based limiter.

Instead of static node cap, we can have an array of thresholds, that compute estimation limits based on parameters set both at construction and runtime. It will give us the ability to tune the performance of the binpacking in future.

This PR implements 3 thresholds:

1. Static maximum node & maximum duration
2. Static cluster-wide node number limit
3. Similar node groups capacity threshold

#### Special notes for your reviewer:

It is alternative implementation of #5883, but having orchestrator populating `EstimationContext` instead of constructing limits/thresholds, which gives us ability to inject thresholds outside of orchestrator if context has enough data for them.

@BigDarkClown @x13n 