### PR TITLE
fix(cloudprovider/exteranlgrpc): properly handle unimplemented methods

### DIFF
--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,6 +115,9 @@ func (w *Wrapper) PricingNodePrice(_ context.Context, req *protos.PricingNodePri
 
 	model, err := w.provider.Pricing()
 	if err != nil {
+		if err == cloudprovider.ErrNotImplemented {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
 		return nil, err
 	}
 	reqNode := req.GetNode()
@@ -136,6 +141,9 @@ func (w *Wrapper) PricingPodPrice(_ context.Context, req *protos.PricingPodPrice
 
 	model, err := w.provider.Pricing()
 	if err != nil {
+		if err == cloudprovider.ErrNotImplemented {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
 		return nil, err
 	}
 	reqPod := req.GetPod()
@@ -326,6 +334,9 @@ func (w *Wrapper) NodeGroupTemplateNodeInfo(_ context.Context, req *protos.NodeG
 	}
 	info, err := ng.TemplateNodeInfo()
 	if err != nil {
+		if err == cloudprovider.ErrNotImplemented {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
 		return nil, err
 	}
 	return &protos.NodeGroupTemplateNodeInfoResponse{
@@ -355,6 +366,9 @@ func (w *Wrapper) NodeGroupGetOptions(_ context.Context, req *protos.NodeGroupAu
 	}
 	opts, err := ng.GetOptions(defaults)
 	if err != nil {
+		if err == cloudprovider.ErrNotImplemented {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
 		return nil, err
 	}
 	if opts == nil {

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -27,7 +27,9 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -158,6 +160,10 @@ func (m *pricingModel) NodePrice(node *apiv1.Node, startTime time.Time, endTime 
 		EndTime:   &end,
 	})
 	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.Unimplemented {
+			return 0, cloudprovider.ErrNotImplemented
+		}
 		klog.V(1).Infof("Error on gRPC call PricingNodePrice: %v", err)
 		return 0, err
 	}
@@ -178,6 +184,10 @@ func (m *pricingModel) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime tim
 		EndTime:   &end,
 	})
 	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.Unimplemented {
+			return 0, cloudprovider.ErrNotImplemented
+		}
 		klog.V(1).Infof("Error on gRPC call PricingPodPrice: %v", err)
 		return 0, err
 	}

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"sync"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -206,6 +208,10 @@ func (n *NodeGroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
 		Id: n.id,
 	})
 	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.Unimplemented {
+			return nil, cloudprovider.ErrNotImplemented
+		}
 		klog.V(1).Infof("Error on gRPC call NodeGroupTemplateNodeInfo: %v", err)
 		return nil, err
 	}
@@ -269,6 +275,10 @@ func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*co
 		},
 	})
 	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.Unimplemented {
+			return nil, cloudprovider.ErrNotImplemented
+		}
 		klog.V(1).Infof("Error on gRPC call NodeGroupGetOptions: %v", err)
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/externalgrpc/protos/externalgrpc.proto
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/protos/externalgrpc.proto
@@ -41,13 +41,13 @@ service CloudProvider {
 
   // PricingNodePrice returns a theoretical minimum price of running a node for
   // a given period of time on a perfectly matching machine.
-  // Implementation optional.
+  // Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
   rpc PricingNodePrice(PricingNodePriceRequest)
     returns (PricingNodePriceResponse) {}
 
   // PricingPodPrice returns a theoretical minimum price of running a pod for a given
   // period of time on a perfectly matching machine.
-  // Implementation optional.
+  // Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
   rpc PricingPodPrice(PricingPodPriceRequest)
     returns (PricingPodPriceResponse) {}
 
@@ -103,13 +103,13 @@ service CloudProvider {
   // NodeGroupTemplateNodeInfo returns a structure of an empty (as if just started) node,
   // with all of the labels, capacity and allocatable information. This will be used in
   // scale-up simulations to predict what would a new node look like if a node group was expanded.
-  // Implementation optional.
+  // Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
   rpc NodeGroupTemplateNodeInfo(NodeGroupTemplateNodeInfoRequest)
     returns (NodeGroupTemplateNodeInfoResponse) {}
 
   // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
-  // NodeGroup. Returning a grpc error will result in using default options.
-  // Implementation optional.
+  // NodeGroup.
+  // Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
   rpc NodeGroupGetOptions(NodeGroupAutoscalingOptionsRequest)
     returns (NodeGroupAutoscalingOptionsResponse) {}
 }
@@ -371,4 +371,3 @@ message NodeGroupAutoscalingOptionsResponse {
   // autoscaling options for the requested node.
   NodeGroupAutoscalingOptions nodeGroupAutoscalingOptions = 1;
 }
-

--- a/cluster-autoscaler/cloudprovider/externalgrpc/protos/externalgrpc_grpc.pb.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/protos/externalgrpc_grpc.pb.go
@@ -46,11 +46,11 @@ type CloudProviderClient interface {
 	NodeGroupForNode(ctx context.Context, in *NodeGroupForNodeRequest, opts ...grpc.CallOption) (*NodeGroupForNodeResponse, error)
 	// PricingNodePrice returns a theoretical minimum price of running a node for
 	// a given period of time on a perfectly matching machine.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	PricingNodePrice(ctx context.Context, in *PricingNodePriceRequest, opts ...grpc.CallOption) (*PricingNodePriceResponse, error)
 	// PricingPodPrice returns a theoretical minimum price of running a pod for a given
 	// period of time on a perfectly matching machine.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	PricingPodPrice(ctx context.Context, in *PricingPodPriceRequest, opts ...grpc.CallOption) (*PricingPodPriceResponse, error)
 	// GPULabel returns the label added to nodes with GPU resource.
 	GPULabel(ctx context.Context, in *GPULabelRequest, opts ...grpc.CallOption) (*GPULabelResponse, error)
@@ -84,11 +84,11 @@ type CloudProviderClient interface {
 	// NodeGroupTemplateNodeInfo returns a structure of an empty (as if just started) node,
 	// with all of the labels, capacity and allocatable information. This will be used in
 	// scale-up simulations to predict what would a new node look like if a node group was expanded.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	NodeGroupTemplateNodeInfo(ctx context.Context, in *NodeGroupTemplateNodeInfoRequest, opts ...grpc.CallOption) (*NodeGroupTemplateNodeInfoResponse, error)
 	// GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
-	// NodeGroup. Returning a grpc error will result in using default options.
-	// Implementation optional.
+	// NodeGroup.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	NodeGroupGetOptions(ctx context.Context, in *NodeGroupAutoscalingOptionsRequest, opts ...grpc.CallOption) (*NodeGroupAutoscalingOptionsResponse, error)
 }
 
@@ -247,11 +247,11 @@ type CloudProviderServer interface {
 	NodeGroupForNode(context.Context, *NodeGroupForNodeRequest) (*NodeGroupForNodeResponse, error)
 	// PricingNodePrice returns a theoretical minimum price of running a node for
 	// a given period of time on a perfectly matching machine.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	PricingNodePrice(context.Context, *PricingNodePriceRequest) (*PricingNodePriceResponse, error)
 	// PricingPodPrice returns a theoretical minimum price of running a pod for a given
 	// period of time on a perfectly matching machine.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	PricingPodPrice(context.Context, *PricingPodPriceRequest) (*PricingPodPriceResponse, error)
 	// GPULabel returns the label added to nodes with GPU resource.
 	GPULabel(context.Context, *GPULabelRequest) (*GPULabelResponse, error)
@@ -285,11 +285,11 @@ type CloudProviderServer interface {
 	// NodeGroupTemplateNodeInfo returns a structure of an empty (as if just started) node,
 	// with all of the labels, capacity and allocatable information. This will be used in
 	// scale-up simulations to predict what would a new node look like if a node group was expanded.
-	// Implementation optional.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	NodeGroupTemplateNodeInfo(context.Context, *NodeGroupTemplateNodeInfoRequest) (*NodeGroupTemplateNodeInfoResponse, error)
 	// GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
-	// NodeGroup. Returning a grpc error will result in using default options.
-	// Implementation optional.
+	// NodeGroup.
+	// Implementation optional: if unimplemented return error code 12 (for `Unimplemented`)
 	NodeGroupGetOptions(context.Context, *NodeGroupAutoscalingOptionsRequest) (*NodeGroupAutoscalingOptionsResponse, error)
 	mustEmbedUnimplementedCloudProviderServer()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

Some `CloudProvider` and `nodeGroup` methods are optional: if a cloud provider does not implemented an optional method, it should return the `cloudprovider.ErrNotImplemented` error, this error is expected and the CA gracefully handles it.

Currently there is no way to pass this specific error from a grpc based cloud provider: The protobuf definition incorrectly states that an rpc is optional or a grpc error will result in using defaults, but this is not correct at the moment: in case of grpc errors, the client passes a generic error that is not correctly handled by the CA, so currently all rpc must be implemented.

This PR allows grpc cloud providers to not implement optional methods: a not implemented method should pass the grpc error code 12 `Unimplemented`, if so, the CA grpc client will transform this to the go `cloudprovider.ErrNotImplemented` error that is then correctly handled.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
externalgrpc cloud provider: grpc based cloud providers can now pass the grpc error code 12, Unimplemented, to signal they do not implement optional methods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
