### PR TITLE
Fix: Do not inject fakeNode for instance which has errors on create

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -479,7 +479,12 @@ func (tng *TestNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	instances := make([]cloudprovider.Instance, 0)
 	for node, nodegroup := range tng.cloudProvider.nodes {
 		if nodegroup == tng.id {
-			instances = append(instances, cloudprovider.Instance{Id: node})
+			instances = append(instances, cloudprovider.Instance{
+				Id: node,
+				Status: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceRunning,
+				},
+			})
 		}
 	}
 	return instances, nil

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
@@ -29,20 +29,20 @@ import (
 func TestCloudProviderNodeInstancesCache(t *testing.T) {
 	// Fresh entry for node group in cache.
 	nodeNg1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	instanceNg1_1 := cloudprovider.Instance{Id: nodeNg1_1.Name}
+	instanceNg1_1 := buildRunningInstance(nodeNg1_1.Name)
 	// Fresh entry for node group in cache - checks Invalidate function.
 	nodeNg2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	instanceNg2_1 := cloudprovider.Instance{Id: nodeNg2_1.Name}
+	instanceNg2_1 := buildRunningInstance(nodeNg2_1.Name)
 	nodeNg2_2 := BuildTestNode("ng2-2", 1000, 1000)
-	instanceNg2_2 := cloudprovider.Instance{Id: nodeNg2_2.Name}
+	instanceNg2_2 := buildRunningInstance(nodeNg2_2.Name)
 	// Stale entry for node group in cache - check Refresh function.
 	nodeNg3_1 := BuildTestNode("ng3-1", 1000, 1000)
-	instanceNg3_1 := cloudprovider.Instance{Id: nodeNg3_1.Name}
+	instanceNg3_1 := buildRunningInstance(nodeNg3_1.Name)
 	nodeNg3_2 := BuildTestNode("ng3-2", 1000, 1000)
-	instanceNg3_2 := cloudprovider.Instance{Id: nodeNg3_2.Name}
+	instanceNg3_2 := buildRunningInstance(nodeNg3_2.Name)
 	// Removed node group.
 	nodeNg4_1 := BuildTestNode("ng4-1", 1000, 1000)
-	instanceNg4_1 := cloudprovider.Instance{Id: nodeNg4_1.Name}
+	instanceNg4_1 := buildRunningInstance(nodeNg4_1.Name)
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 1)
@@ -89,4 +89,13 @@ func TestCloudProviderNodeInstancesCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]cloudprovider.Instance{"ng1": {instanceNg1_1}, "ng2": {instanceNg2_2}, "ng3": {instanceNg3_2}}, results)
 	assert.Equal(t, 3, len(cache.cloudProviderNodeInstances))
+}
+
+func buildRunningInstance(name string) cloudprovider.Instance {
+	return cloudprovider.Instance{
+		Id: name,
+		Status: &cloudprovider.InstanceStatus{
+			State: cloudprovider.InstanceRunning,
+		},
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

CA doesn't handle well situation when instance is in error state (thus no pods can schedule on to it) and node pool is at min size, so it cannot scale down the faulty node.

In this situation the node is considered to be still upcoming, so CA still registers the fake "upcoming node" and CA doesn't trigger scale up immediately, only after 15 minutes (when the node passes the timeout for registration). In order to fix this, we should not inject the fake upcoming node, if we already detected it's in error state.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```