### PR TITLE
Fixed `go:build` tags for ovhcloud

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
@@ -1,5 +1,5 @@
-//go:build exoscale
-// +build exoscale
+//go:build ovhcloud
+// +build ovhcloud
 
 /*
 Copyright 2020 The Kubernetes Authors.
@@ -24,7 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
-// AvailableCloudProviders supported by the Hetzner cloud provider builder.
+// AvailableCloudProviders supported by the OVHcloud cloud provider builder.
 var AvailableCloudProviders = []string{
 	cloudprovider.OVHcloudProviderName,
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR fixed the `go:build` tags for ovhcloud in the [builder_ovhcloud.go](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go) file

#### Which issue(s) this PR fixes:

Fixes #5940

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
