### PR TITLE
Re-introduce asynchronous node deletion and clean node deletion logic.

### DIFF
--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -145,7 +145,7 @@ func cropIndividualNodes(toDelete []*NodeGroupView, groups []*NodeGroupView, bud
 }
 
 func (bp *ScaleDownBudgetProcessor) group(nodes []*apiv1.Node) []*NodeGroupView {
-	groupMap := map[cloudprovider.NodeGroup]int{}
+	groupMap := map[string]int{}
 	grouped := []*NodeGroupView{}
 	for _, node := range nodes {
 		nodeGroup, err := bp.ctx.CloudProvider.NodeGroupForNode(node)
@@ -153,10 +153,10 @@ func (bp *ScaleDownBudgetProcessor) group(nodes []*apiv1.Node) []*NodeGroupView 
 			klog.Errorf("Failed to find node group for %s: %v", node.Name, err)
 			continue
 		}
-		if idx, ok := groupMap[nodeGroup]; ok {
+		if idx, ok := groupMap[nodeGroup.Id()]; ok {
 			grouped[idx].Nodes = append(grouped[idx].Nodes, node)
 		} else {
-			groupMap[nodeGroup] = len(grouped)
+			groupMap[nodeGroup.Id()] = len(grouped)
 			grouped = append(grouped, &NodeGroupView{
 				Group: nodeGroup,
 				Nodes: []*apiv1.Node{node},


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind bug
-->

#### What this PR does / why we need it:
This PR fixes a bug where node deletions could sequentially even if parallelism is used. This changes AddNodes function from NodeDeletionBatcher to only add nodes synchronously, but continue with processing them in a goroutine.

Additionally the PR removes some dead code and changes map keys from NodeGroups to their IDs to make it less error prone for the future.

Shoutout to @krzysied who found this bug.
