### PR TITLE
clusterapi: refresh kubeconfig bearer tokens for management and workload kubeconfigs dynamically

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -165,6 +165,10 @@ cluster-autoscaler --cloud-provider=clusterapi \
                    --kubeconfig=/mnt/workload.kubeconfig
 ```
 
+### A note on kubeconfig credentials
+
+When the cluster autoscaler is configured to read kubeconfig(s) from a path, by passing a `--kubeconfig` or `--cloud-config` option, the autoscaler will re-read the contents of the kubeconfig file after it detects the file was modified by it's modtime. This was added to support EKS clusters with the Cluster API Provider for AWS, where CAPA would provide the cluster with a kubernetes secret resource populated with a short-lived EKS kubeconfig credential, but may be useful for other Cluster API providers as well. In the past, it was not possible to use the Cluster API's kubeconfig credential directly as a secret volume, because when the short-lived contents were refreshed by the CAPA controller, the cluster autoscaler would not re-read the secret mount. There were various work arounds, for example manually creating a longer-lived kubeconfig from a service account. This is no longer necessary, cluster autoscaler will automatically refresh the kubeconfig credentials as needed.
+
 ## Enabling Autoscaling
 
 To enable the automatic scaling of components in your cluster-api managed

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -373,11 +373,14 @@ func getKubeConfig() *rest.Config {
 	if *kubeConfigFile != "" {
 		klog.V(1).Infof("Using kubeconfig file: %s", *kubeConfigFile)
 		// use the current context in kubeconfig
-		config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
+		kubeConfig, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
 		if err != nil {
 			klog.Fatalf("Failed to build config: %v", err)
 		}
-		return config
+		kubeConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			return config.NewDynamicKubeConfigRoundTripper(*kubeConfigFile, rt)
+		})
+		return kubeConfig
 	}
 	url, err := url.Parse(*kubernetes)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Continuously update the bearer token provided by a kube config file for the clusterapi provider.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/4784

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
