### PR TITLE
Fix TestBinpackingLimiter flake

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -849,7 +849,7 @@ func TestBinpackingLimiter(t *testing.T) {
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&context, processors, clusterState, taints.TaintConfig{})
 
-	expander := NewMockRepotingStrategy(t, &GroupSizeChange{GroupName: "ng1", SizeChange: 1})
+	expander := NewMockRepotingStrategy(t, nil)
 	context.ExpanderStrategy = expander
 
 	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{extraPod}, nodes, []*appsv1.DaemonSet{}, nodeInfos)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

In the `TestBinpackingLimiter` test we assert the best option, despite the fact that it is undeterministic. This causes flake if the `ng2` is returned as a first node group.
