### PR TITLE
chore(deps): update vendored hcloud-go to 2.0.0

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -2,7 +2,7 @@
 
 The cluster autoscaler for Hetzner Cloud scales worker nodes.
 
-# Configuration
+## Configuration
 
 `HCLOUD_TOKEN` Required Hetzner Cloud token.
 
@@ -31,10 +31,9 @@ Multiple flags will create multiple node pools. For example:
 
 You can find a deployment sample under [examples/cluster-autoscaler-run-on-master.yaml](examples/cluster-autoscaler-run-on-master.yaml). Please be aware that you should change the values within this deployment to reflect your cluster.
 
-# Development
+## Development
 
-Make sure you're inside the root path of the [autoscaler
-repository](https://github.com/kubernetes/autoscaler)
+Make sure you're inside the `cluster-autoscaler` root folder.
 
 1.) Build the `cluster-autoscaler` binary:
 
@@ -54,4 +53,14 @@ docker build -t hetzner/cluster-autoscaler:dev .
 
 ```
 docker push hetzner/cluster-autoscaler:dev
+```
+
+### Updating vendored hcloud-go
+
+To update the vendored `hcloud-go` code, navigate to the directory and run the `hack/update-vendor.sh` script:
+
+```
+cd cluster-autoscaler/cloudprovider/hetzner
+UPSTREAM_REF=v2.0.0 hack/update-vendor.sh
+git add hcloud-go/
 ```

--- a/cluster-autoscaler/cloudprovider/hetzner/hack/update-vendor.sh
+++ b/cluster-autoscaler/cloudprovider/hetzner/hack/update-vendor.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -o pipefail
+set -o nounset
+set -o errexit
+
+UPSTREAM_REPO=${UPSTREAM_REPO:-https://github.com/hetznercloud/hcloud-go.git}
+UPSTREAM_REF=${UPSTREAM_REF:-main}
+
+vendor_path=hcloud-go
+
+original_module_path="github.com/hetznercloud/hcloud-go/v2/"
+vendor_module_path=k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/
+
+
+echo "# Removing existing directory."
+rm -rf hcloud-go
+
+echo "# Cloning repo"
+git clone --depth=1 --branch "$UPSTREAM_REF" "$UPSTREAM_REPO" "$vendor_path"
+
+echo "# Removing unnecessary files"
+find "$vendor_path" -type f ! -name "*.go" ! -name "LICENSE" -delete
+find "$vendor_path" -type f -name "*_test.go" -delete
+find "$vendor_path" -type d -empty -delete
+
+echo "# Rewriting module path"
+find "$vendor_path" -type f -exec sed -i "s@${original_module_path}@${vendor_module_path}@g" {} +
+

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/LICENSE
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2020 Hetzner Cloud GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/architecture.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/architecture.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 // Architecture specifies the architecture of the CPU.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -66,7 +50,7 @@ const (
 
 // CertificateUsedByRef points to a resource that uses this certificate.
 type CertificateUsedByRef struct {
-	ID   int
+	ID   int64
 	Type CertificateUsedByRefType
 }
 
@@ -84,9 +68,9 @@ func (st *CertificateStatus) IsFailed() bool {
 	return st.Issuance == CertificateStatusTypeFailed || st.Renewal == CertificateStatusTypeFailed
 }
 
-// Certificate represents an certificate in the Hetzner Cloud.
+// Certificate represents a certificate in the Hetzner Cloud.
 type Certificate struct {
-	ID             int
+	ID             int64
 	Name           string
 	Labels         map[string]string
 	Type           CertificateType
@@ -112,7 +96,7 @@ type CertificateClient struct {
 }
 
 // GetByID retrieves a Certificate by its ID. If the Certificate does not exist, nil is returned.
-func (c *CertificateClient) GetByID(ctx context.Context, id int) (*Certificate, *Response, error) {
+func (c *CertificateClient) GetByID(ctx context.Context, id int64) (*Certificate, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/certificates/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -144,8 +128,8 @@ func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certif
 // Get retrieves a Certificate by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) Get(ctx context.Context, idOrName string) (*Certificate, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -158,7 +142,7 @@ type CertificateListOpts struct {
 }
 
 func (l CertificateListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -193,25 +177,7 @@ func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) 
 
 // All returns all Certificates.
 func (c *CertificateClient) All(ctx context.Context) ([]*Certificate, error) {
-	allCertificates := []*Certificate{}
-
-	opts := CertificateListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		Certificate, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allCertificates = append(allCertificates, Certificate...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allCertificates, nil
+	return c.AllWithOpts(ctx, CertificateListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all Certificates for the given options.
@@ -276,7 +242,7 @@ func (o CertificateCreateOpts) validateUploaded() error {
 	return nil
 }
 
-// Create creates a new certificate uploaded certificate.
+// Create creates a new uploaded certificate.
 //
 // Create returns an error for certificates of any other type. Use
 // CreateCertificate to create such certificates.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -461,7 +445,8 @@ type ListOpts struct {
 	LabelSelector string // Label selector for filtering by labels
 }
 
-func (l ListOpts) values() url.Values {
+// Values returns the ListOpts as URL values.
+func (l ListOpts) Values() url.Values {
 	vals := url.Values{}
 	if l.Page > 0 {
 		vals.Add("page", strconv.Itoa(l.Page))

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/deprecation.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/deprecation.go
@@ -1,0 +1,59 @@
+package hcloud
+
+import "time"
+
+// Deprecatable is a shared interface implemented by all Resources that have a defined deprecation workflow.
+type Deprecatable interface {
+	// IsDeprecated returns true if the resource is marked as deprecated.
+	IsDeprecated() bool
+
+	// UnavailableAfter returns the time that the deprecated resource will be removed from the API.
+	// This only returns a valid value if [Deprecatable.IsDeprecated] returned true.
+	UnavailableAfter() time.Time
+
+	// DeprecationAnnounced returns the time that the deprecation of this resource was announced.
+	// This only returns a valid value if [Deprecatable.IsDeprecated] returned true.
+	DeprecationAnnounced() time.Time
+}
+
+// DeprecationInfo contains the information published when a resource is actually deprecated.
+type DeprecationInfo struct {
+	Announced        time.Time
+	UnavailableAfter time.Time
+}
+
+// DeprecatableResource implements the [Deprecatable] interface and can be embedded in structs for Resources that can be
+// deprecated.
+type DeprecatableResource struct {
+	Deprecation *DeprecationInfo
+}
+
+// IsDeprecated returns true if the resource is marked as deprecated.
+func (d DeprecatableResource) IsDeprecated() bool {
+	return d.Deprecation != nil
+}
+
+// UnavailableAfter returns the time that the deprecated resource will be removed from the API.
+// This only returns a valid value if [Deprecatable.IsDeprecated] returned true.
+func (d DeprecatableResource) UnavailableAfter() time.Time {
+	if !d.IsDeprecated() {
+		// Return "null" time if resource is not deprecated
+		return time.Unix(0, 0)
+	}
+
+	return d.Deprecation.UnavailableAfter
+}
+
+// DeprecationAnnounced returns the time that the deprecation of this resource was announced.
+// This only returns a valid value if [Deprecatable.IsDeprecated] returned true.
+func (d DeprecatableResource) DeprecationAnnounced() time.Time {
+	if !d.IsDeprecated() {
+		// Return "null" time if resource is not deprecated
+		return time.Unix(0, 0)
+	}
+
+	return d.Deprecation.Announced
+}
+
+// Make sure that all expected Resources actually implement the interface.
+var _ Deprecatable = ServerType{}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -32,7 +16,7 @@ import (
 
 // FloatingIP represents a Floating IP in the Hetzner Cloud.
 type FloatingIP struct {
-	ID           int
+	ID           int64
 	Description  string
 	Created      time.Time
 	IP           net.IP
@@ -58,7 +42,7 @@ type FloatingIPProtection struct {
 	Delete bool
 }
 
-// FloatingIPType represents the type of a Floating IP.
+// FloatingIPType represents the type of Floating IP.
 type FloatingIPType string
 
 // Floating IP types.
@@ -67,7 +51,7 @@ const (
 	FloatingIPTypeIPv6 FloatingIPType = "ipv6"
 )
 
-// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// changeDNSPtr changes or resets the reverse DNS pointer for an IP address.
 // Pass a nil ptr to reset the reverse DNS pointer to its default value.
 func (f *FloatingIP) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
 	reqBody := schema.FloatingIPActionChangeDNSPtrRequest{
@@ -111,7 +95,7 @@ type FloatingIPClient struct {
 
 // GetByID retrieves a Floating IP by its ID. If the Floating IP does not exist,
 // nil is returned.
-func (c *FloatingIPClient) GetByID(ctx context.Context, id int) (*FloatingIP, *Response, error) {
+func (c *FloatingIPClient) GetByID(ctx context.Context, id int64) (*FloatingIP, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/floating_ips/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -143,8 +127,8 @@ func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*Floatin
 // Get retrieves a Floating IP by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) Get(ctx context.Context, idOrName string) (*FloatingIP, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -157,7 +141,7 @@ type FloatingIPListOpts struct {
 }
 
 func (l FloatingIPListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -197,7 +181,7 @@ func (c *FloatingIPClient) All(ctx context.Context) ([]*FloatingIP, error) {
 
 // AllWithOpts returns all Floating IPs for the given options.
 func (c *FloatingIPClient) AllWithOpts(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, error) {
-	allFloatingIPs := []*FloatingIP{}
+	var allFloatingIPs []*FloatingIP
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
@@ -1,21 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 // Package hcloud is a library for the Hetzner Cloud API.
 package hcloud
 
 // Version is the library's version following Semantic Versioning.
-const Version = "1.42.0" // x-release-please-version
+const Version = "2.0.0" // x-release-please-version

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/helper.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/helper.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import "time"

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/image.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/image.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -30,7 +14,7 @@ import (
 
 // Image represents an Image in the Hetzner Cloud.
 type Image struct {
-	ID          int
+	ID          int64
 	Name        string
 	Type        ImageType
 	Status      ImageStatus
@@ -97,7 +81,7 @@ type ImageClient struct {
 }
 
 // GetByID retrieves an image by its ID. If the image does not exist, nil is returned.
-func (c *ImageClient) GetByID(ctx context.Context, id int) (*Image, *Response, error) {
+func (c *ImageClient) GetByID(ctx context.Context, id int64) (*Image, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/images/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -148,7 +132,7 @@ func (c *ImageClient) GetByNameAndArchitecture(ctx context.Context, name string,
 //
 // Deprecated: Use [ImageClient.GetForArchitecture] instead.
 func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
 		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
@@ -160,7 +144,7 @@ func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Respon
 // In contrast to [ImageClient.Get], this method also returns deprecated images. Depending on your needs you should
 // check for this in your calling method.
 func (c *ImageClient) GetForArchitecture(ctx context.Context, idOrName string, architecture Architecture) (*Image, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
 		return c.GetByID(ctx, id)
 	}
 	return c.GetByNameAndArchitecture(ctx, idOrName, architecture)
@@ -179,12 +163,12 @@ type ImageListOpts struct {
 }
 
 func (l ImageListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	for _, typ := range l.Type {
 		vals.Add("type", string(typ))
 	}
 	if l.BoundTo != nil {
-		vals.Add("bound_to", strconv.Itoa(l.BoundTo.ID))
+		vals.Add("bound_to", strconv.FormatInt(l.BoundTo.ID, 10))
 	}
 	if l.Name != "" {
 		vals.Add("name", l.Name)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/internal/instrumentation/metrics.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/internal/instrumentation/metrics.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package instrumentation
 
 import (

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -28,7 +12,7 @@ import (
 
 // ISO represents an ISO image in the Hetzner Cloud.
 type ISO struct {
-	ID           int
+	ID           int64
 	Name         string
 	Description  string
 	Type         ISOType
@@ -58,7 +42,7 @@ type ISOClient struct {
 }
 
 // GetByID retrieves an ISO by its ID.
-func (c *ISOClient) GetByID(ctx context.Context, id int) (*ISO, *Response, error) {
+func (c *ISOClient) GetByID(ctx context.Context, id int64) (*ISO, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/isos/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -89,8 +73,8 @@ func (c *ISOClient) GetByName(ctx context.Context, name string) (*ISO, *Response
 
 // Get retrieves an ISO by its ID if the input can be parsed as an integer, otherwise it retrieves an ISO by its name.
 func (c *ISOClient) Get(ctx context.Context, idOrName string) (*ISO, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -105,11 +89,15 @@ type ISOListOpts struct {
 	Architecture []Architecture
 	// IncludeWildcardArchitecture must be set to also return custom ISOs that have no architecture set, if you are
 	// also setting the Architecture field.
+	// Deprecated: Use [ISOListOpts.IncludeArchitectureWildcard] instead.
 	IncludeWildcardArchitecture bool
+	// IncludeWildcardArchitecture must be set to also return custom ISOs that have no architecture set, if you are
+	// also setting the Architecture field.
+	IncludeArchitectureWildcard bool
 }
 
 func (l ISOListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -119,7 +107,7 @@ func (l ISOListOpts) values() url.Values {
 	for _, arch := range l.Architecture {
 		vals.Add("architecture", string(arch))
 	}
-	if l.IncludeWildcardArchitecture {
+	if l.IncludeArchitectureWildcard || l.IncludeWildcardArchitecture {
 		vals.Add("include_architecture_wildcard", "true")
 	}
 	return vals
@@ -150,10 +138,12 @@ func (c *ISOClient) List(ctx context.Context, opts ISOListOpts) ([]*ISO, *Respon
 
 // All returns all ISOs.
 func (c *ISOClient) All(ctx context.Context) ([]*ISO, error) {
-	allISOs := []*ISO{}
+	return c.AllWithOpts(ctx, ISOListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
 
-	opts := ISOListOpts{}
-	opts.PerPage = 50
+// AllWithOpts returns all ISOs for the given options.
+func (c *ISOClient) AllWithOpts(ctx context.Context, opts ISOListOpts) ([]*ISO, error) {
+	allISOs := make([]*ISO, 0)
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/labels.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/labels.go
@@ -6,8 +6,8 @@ import (
 )
 
 var keyRegexp = regexp.MustCompile(
-	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,62}[a-z0-9A-Z])?$`)
-var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$|$)`)
+	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,61}[a-z0-9A-Z])?$`)
+var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,61})?[a-z0-9A-Z]$|$)`)
 
 func ValidateResourceLabels(labels map[string]interface{}) (bool, error) {
 	for k, v := range labels {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -32,7 +16,7 @@ import (
 
 // LoadBalancer represents a Load Balancer in the Hetzner Cloud.
 type LoadBalancer struct {
-	ID               int
+	ID               int64
 	Name             string
 	PublicNet        LoadBalancerPublicNet
 	PrivateNet       []LoadBalancerPrivateNet
@@ -119,7 +103,7 @@ type LoadBalancerAlgorithmType string
 
 const (
 	// LoadBalancerAlgorithmTypeRoundRobin is an algorithm which distributes
-	// requests to targets in a round robin fashion.
+	// requests to targets in a round-robin fashion.
 	LoadBalancerAlgorithmTypeRoundRobin LoadBalancerAlgorithmType = "round_robin"
 	// LoadBalancerAlgorithmTypeLeastConnections is an algorithm which distributes
 	// requests to targets with the least number of connections.
@@ -132,7 +116,7 @@ type LoadBalancerAlgorithm struct {
 	Type LoadBalancerAlgorithmType
 }
 
-// LoadBalancerTargetType specifies the type of a Load Balancer target.
+// LoadBalancerTargetType specifies the type of Load Balancer target.
 type LoadBalancerTargetType string
 
 const (
@@ -213,7 +197,7 @@ type LoadBalancerProtection struct {
 	Delete bool
 }
 
-// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// changeDNSPtr changes or resets the reverse DNS pointer for an IP address.
 // Pass a nil ptr to reset the reverse DNS pointer to its default value.
 func (lb *LoadBalancer) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
 	reqBody := schema.LoadBalancerActionChangeDNSPtrRequest{
@@ -257,7 +241,7 @@ type LoadBalancerClient struct {
 }
 
 // GetByID retrieves a Load Balancer by its ID. If the Load Balancer does not exist, nil is returned.
-func (c *LoadBalancerClient) GetByID(ctx context.Context, id int) (*LoadBalancer, *Response, error) {
+func (c *LoadBalancerClient) GetByID(ctx context.Context, id int64) (*LoadBalancer, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/load_balancers/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -289,8 +273,8 @@ func (c *LoadBalancerClient) GetByName(ctx context.Context, name string) (*LoadB
 // Get retrieves a Load Balancer by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Load Balancer by its name. If the Load Balancer does not exist, nil is returned.
 func (c *LoadBalancerClient) Get(ctx context.Context, idOrName string) (*LoadBalancer, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -303,7 +287,7 @@ type LoadBalancerListOpts struct {
 }
 
 func (l LoadBalancerListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -338,25 +322,7 @@ func (c *LoadBalancerClient) List(ctx context.Context, opts LoadBalancerListOpts
 
 // All returns all Load Balancers.
 func (c *LoadBalancerClient) All(ctx context.Context) ([]*LoadBalancer, error) {
-	allLoadBalancer := []*LoadBalancer{}
-
-	opts := LoadBalancerListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		LoadBalancer, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allLoadBalancer = append(allLoadBalancer, LoadBalancer...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allLoadBalancer, nil
+	return c.AllWithOpts(ctx, LoadBalancerListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all Load Balancers for the given options.
@@ -681,7 +647,7 @@ type LoadBalancerAddServiceOptsHTTP struct {
 	StickySessions *bool
 }
 
-// LoadBalancerAddServiceOptsHealthCheck holds options for specifying an health check
+// LoadBalancerAddServiceOptsHealthCheck holds options for specifying a health check
 // when adding a service to a Load Balancer.
 type LoadBalancerAddServiceOptsHealthCheck struct {
 	Protocol LoadBalancerServiceProtocol

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer_type.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -27,7 +11,7 @@ import (
 
 // LoadBalancerType represents a LoadBalancer type in the Hetzner Cloud.
 type LoadBalancerType struct {
-	ID                      int
+	ID                      int64
 	Name                    string
 	Description             string
 	MaxConnections          int
@@ -43,7 +27,7 @@ type LoadBalancerTypeClient struct {
 }
 
 // GetByID retrieves a Load Balancer type by its ID. If the Load Balancer type does not exist, nil is returned.
-func (c *LoadBalancerTypeClient) GetByID(ctx context.Context, id int) (*LoadBalancerType, *Response, error) {
+func (c *LoadBalancerTypeClient) GetByID(ctx context.Context, id int64) (*LoadBalancerType, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/load_balancer_types/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -75,8 +59,8 @@ func (c *LoadBalancerTypeClient) GetByName(ctx context.Context, name string) (*L
 // Get retrieves a Load Balancer type by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Load Balancer type by its name. If the Load Balancer type does not exist, nil is returned.
 func (c *LoadBalancerTypeClient) Get(ctx context.Context, idOrName string) (*LoadBalancerType, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -89,7 +73,7 @@ type LoadBalancerTypeListOpts struct {
 }
 
 func (l LoadBalancerTypeListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -124,10 +108,12 @@ func (c *LoadBalancerTypeClient) List(ctx context.Context, opts LoadBalancerType
 
 // All returns all Load Balancer types.
 func (c *LoadBalancerTypeClient) All(ctx context.Context) ([]*LoadBalancerType, error) {
-	allLoadBalancerTypes := []*LoadBalancerType{}
+	return c.AllWithOpts(ctx, LoadBalancerTypeListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
 
-	opts := LoadBalancerTypeListOpts{}
-	opts.PerPage = 50
+// AllWithOpts returns all Load Balancer types for the given options.
+func (c *LoadBalancerTypeClient) AllWithOpts(ctx context.Context, opts LoadBalancerTypeListOpts) ([]*LoadBalancerType, error) {
+	var allLoadBalancerTypes []*LoadBalancerType
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/location.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/location.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -27,7 +11,7 @@ import (
 
 // Location represents a location in the Hetzner Cloud.
 type Location struct {
-	ID          int
+	ID          int64
 	Name        string
 	Description string
 	Country     string
@@ -43,7 +27,7 @@ type LocationClient struct {
 }
 
 // GetByID retrieves a location by its ID. If the location does not exist, nil is returned.
-func (c *LocationClient) GetByID(ctx context.Context, id int) (*Location, *Response, error) {
+func (c *LocationClient) GetByID(ctx context.Context, id int64) (*Location, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/locations/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -75,8 +59,8 @@ func (c *LocationClient) GetByName(ctx context.Context, name string) (*Location,
 // Get retrieves a location by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a location by its name. If the location does not exist, nil is returned.
 func (c *LocationClient) Get(ctx context.Context, idOrName string) (*Location, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -89,7 +73,7 @@ type LocationListOpts struct {
 }
 
 func (l LocationListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -124,10 +108,12 @@ func (c *LocationClient) List(ctx context.Context, opts LocationListOpts) ([]*Lo
 
 // All returns all locations.
 func (c *LocationClient) All(ctx context.Context) ([]*Location, error) {
-	allLocations := []*Location{}
+	return c.AllWithOpts(ctx, LocationListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
 
-	opts := LocationListOpts{}
-	opts.PerPage = 50
+// AllWithOpts returns all locations for the given options.
+func (c *LocationClient) AllWithOpts(ctx context.Context, opts LocationListOpts) ([]*Location, error) {
+	var allLocations []*Location
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/metadata/client.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/metadata/client.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package metadata
 
 import (
@@ -120,12 +104,12 @@ func (c *Client) Hostname() (string, error) {
 }
 
 // InstanceID returns the ID of the server that did the request to the Metadata server.
-func (c *Client) InstanceID() (int, error) {
+func (c *Client) InstanceID() (int64, error) {
 	resp, err := c.get("/instance-id")
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(resp)
+	return strconv.ParseInt(resp, 10, 64)
 }
 
 // PublicIPv4 returns the Public IPv4 of the server that did the request to the Metadata server.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/network.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/network.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -52,7 +36,7 @@ const (
 
 // Network represents a network in the Hetzner Cloud.
 type Network struct {
-	ID         int
+	ID         int64
 	Name       string
 	Created    time.Time
 	IPRange    *net.IPNet
@@ -61,6 +45,9 @@ type Network struct {
 	Servers    []*Server
 	Protection NetworkProtection
 	Labels     map[string]string
+
+	// ExposeRoutesToVSwitch indicates if the routes from this network should be exposed to the vSwitch connection.
+	ExposeRoutesToVSwitch bool
 }
 
 // NetworkSubnet represents a subnet of a network in the Hetzner Cloud.
@@ -69,7 +56,7 @@ type NetworkSubnet struct {
 	IPRange     *net.IPNet
 	NetworkZone NetworkZone
 	Gateway     net.IP
-	VSwitchID   int
+	VSwitchID   int64
 }
 
 // NetworkRoute represents a route of a network.
@@ -89,7 +76,7 @@ type NetworkClient struct {
 }
 
 // GetByID retrieves a network by its ID. If the network does not exist, nil is returned.
-func (c *NetworkClient) GetByID(ctx context.Context, id int) (*Network, *Response, error) {
+func (c *NetworkClient) GetByID(ctx context.Context, id int64) (*Network, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/networks/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -121,8 +108,8 @@ func (c *NetworkClient) GetByName(ctx context.Context, name string) (*Network, *
 // Get retrieves a network by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a network by its name. If the network does not exist, nil is returned.
 func (c *NetworkClient) Get(ctx context.Context, idOrName string) (*Network, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -135,7 +122,7 @@ type NetworkListOpts struct {
 }
 
 func (l NetworkListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -206,6 +193,9 @@ func (c *NetworkClient) Delete(ctx context.Context, network *Network) (*Response
 type NetworkUpdateOpts struct {
 	Name   string
 	Labels map[string]string
+	// ExposeRoutesToVSwitch indicates if the routes from this network should be exposed to the vSwitch connection.
+	// The exposing only takes effect if a vSwitch connection is active.
+	ExposeRoutesToVSwitch *bool
 }
 
 // Update updates a network.
@@ -216,6 +206,10 @@ func (c *NetworkClient) Update(ctx context.Context, network *Network, opts Netwo
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels
 	}
+	if opts.ExposeRoutesToVSwitch != nil {
+		reqBody.ExposeRoutesToVSwitch = opts.ExposeRoutesToVSwitch
+	}
+
 	reqBodyData, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, nil, err
@@ -242,6 +236,9 @@ type NetworkCreateOpts struct {
 	Subnets []NetworkSubnet
 	Routes  []NetworkRoute
 	Labels  map[string]string
+	// ExposeRoutesToVSwitch indicates if the routes from this network should be exposed to the vSwitch connection.
+	// The exposing only takes effect if a vSwitch connection is active.
+	ExposeRoutesToVSwitch bool
 }
 
 // Validate checks if options are valid.
@@ -261,8 +258,9 @@ func (c *NetworkClient) Create(ctx context.Context, opts NetworkCreateOpts) (*Ne
 		return nil, nil, err
 	}
 	reqBody := schema.NetworkCreateRequest{
-		Name:    opts.Name,
-		IPRange: opts.IPRange.String(),
+		Name:                  opts.Name,
+		IPRange:               opts.IPRange.String(),
+		ExposeRoutesToVSwitch: opts.ExposeRoutesToVSwitch,
 	}
 	for _, subnet := range opts.Subnets {
 		s := schema.NetworkSubnet{

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/placement_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/placement_group.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -31,11 +15,11 @@ import (
 
 // PlacementGroup represents a Placement Group in the Hetzner Cloud.
 type PlacementGroup struct {
-	ID      int
+	ID      int64
 	Name    string
 	Labels  map[string]string
 	Created time.Time
-	Servers []int
+	Servers []int64
 	Type    PlacementGroupType
 }
 
@@ -53,7 +37,7 @@ type PlacementGroupClient struct {
 }
 
 // GetByID retrieves a PlacementGroup by its ID. If the PlacementGroup does not exist, nil is returned.
-func (c *PlacementGroupClient) GetByID(ctx context.Context, id int) (*PlacementGroup, *Response, error) {
+func (c *PlacementGroupClient) GetByID(ctx context.Context, id int64) (*PlacementGroup, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/placement_groups/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -85,8 +69,8 @@ func (c *PlacementGroupClient) GetByName(ctx context.Context, name string) (*Pla
 // Get retrieves a PlacementGroup by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a PlacementGroup by its name. If the PlacementGroup does not exist, nil is returned.
 func (c *PlacementGroupClient) Get(ctx context.Context, idOrName string) (*PlacementGroup, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -100,7 +84,7 @@ type PlacementGroupListOpts struct {
 }
 
 func (l PlacementGroupListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/primary_ip.go
@@ -15,7 +15,7 @@ import (
 
 // PrimaryIP defines a Primary IP.
 type PrimaryIP struct {
-	ID           int
+	ID           int64
 	IP           net.IP
 	Network      *net.IPNet
 	Labels       map[string]string
@@ -23,7 +23,7 @@ type PrimaryIP struct {
 	Type         PrimaryIPType
 	Protection   PrimaryIPProtection
 	DNSPtr       map[string]string
-	AssigneeID   int
+	AssigneeID   int64
 	AssigneeType string
 	AutoDelete   bool
 	Blocked      bool
@@ -41,6 +41,32 @@ type PrimaryIPProtection struct {
 type PrimaryIPDNSPTR struct {
 	DNSPtr string
 	IP     string
+}
+
+// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// Pass a nil ptr to reset the reverse DNS pointer to its default value.
+func (p *PrimaryIP) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
+	reqBody := schema.PrimaryIPActionChangeDNSPtrRequest{
+		IP:     ip.String(),
+		DNSPtr: ptr,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/primary_ips/%d/actions/change_dns_ptr", p.ID)
+	req, err := client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var respBody PrimaryIPChangeDNSPtrResult
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
 }
 
 // GetDNSPtrForIP searches for the dns assigned to the given IP address.
@@ -66,7 +92,7 @@ const (
 // PrimaryIPCreateOpts defines the request to
 // create a Primary IP.
 type PrimaryIPCreateOpts struct {
-	AssigneeID   *int              `json:"assignee_id,omitempty"`
+	AssigneeID   *int64            `json:"assignee_id,omitempty"`
 	AssigneeType string            `json:"assignee_type"`
 	AutoDelete   *bool             `json:"auto_delete,omitempty"`
 	Datacenter   string            `json:"datacenter,omitempty"`
@@ -93,8 +119,8 @@ type PrimaryIPUpdateOpts struct {
 // PrimaryIPAssignOpts defines the request to
 // assign a Primary IP to an assignee (usually a server).
 type PrimaryIPAssignOpts struct {
-	ID           int
-	AssigneeID   int    `json:"assignee_id"`
+	ID           int64
+	AssigneeID   int64  `json:"assignee_id"`
 	AssigneeType string `json:"assignee_type"`
 }
 
@@ -107,7 +133,7 @@ type PrimaryIPAssignResult struct {
 // PrimaryIPChangeDNSPtrOpts defines the request to
 // change a DNS PTR entry from a Primary IP.
 type PrimaryIPChangeDNSPtrOpts struct {
-	ID     int
+	ID     int64
 	DNSPtr string `json:"dns_ptr"`
 	IP     string `json:"ip"`
 }
@@ -121,7 +147,7 @@ type PrimaryIPChangeDNSPtrResult struct {
 // PrimaryIPChangeProtectionOpts defines the request to
 // change protection configuration of a Primary IP.
 type PrimaryIPChangeProtectionOpts struct {
-	ID     int
+	ID     int64
 	Delete bool `json:"delete"`
 }
 
@@ -137,7 +163,7 @@ type PrimaryIPClient struct {
 }
 
 // GetByID retrieves a Primary IP by its ID. If the Primary IP does not exist, nil is returned.
-func (c *PrimaryIPClient) GetByID(ctx context.Context, id int) (*PrimaryIP, *Response, error) {
+func (c *PrimaryIPClient) GetByID(ctx context.Context, id int64) (*PrimaryIP, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/primary_ips/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -181,8 +207,8 @@ func (c *PrimaryIPClient) GetByName(ctx context.Context, name string) (*PrimaryI
 // Get retrieves a Primary IP by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Primary IP by its name. If the Primary IP does not exist, nil is returned.
 func (c *PrimaryIPClient) Get(ctx context.Context, idOrName string) (*PrimaryIP, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -196,7 +222,7 @@ type PrimaryIPListOpts struct {
 }
 
 func (l PrimaryIPListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -337,7 +363,7 @@ func (c *PrimaryIPClient) Assign(ctx context.Context, opts PrimaryIPAssignOpts) 
 }
 
 // Unassign a Primary IP from a resource.
-func (c *PrimaryIPClient) Unassign(ctx context.Context, id int) (*Action, *Response, error) {
+func (c *PrimaryIPClient) Unassign(ctx context.Context, id int64) (*Action, *Response, error) {
 	path := fmt.Sprintf("/primary_ips/%d/actions/unassign", id)
 	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader([]byte{}))
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/rdns.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/rdns.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -23,7 +7,7 @@ import (
 )
 
 // RDNSSupporter defines functions to change and lookup reverse dns entries.
-// currently implemented by Server, FloatingIP and LoadBalancer.
+// currently implemented by Server, FloatingIP, PrimaryIP and LoadBalancer.
 type RDNSSupporter interface {
 	// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
 	// Pass a nil ptr to reset the reverse DNS pointer to its default value.
@@ -33,7 +17,7 @@ type RDNSSupporter interface {
 	GetDNSPtrForIP(ip net.IP) (string, error)
 }
 
-// RDNSClient simplifys the handling objects which support reverse dns entries.
+// RDNSClient simplifies the handling objects which support reverse dns entries.
 type RDNSClient struct {
 	client *Client
 }
@@ -60,3 +44,9 @@ func RDNSLookup(i interface{}, ip net.IP) (string, error) {
 
 	return rdns.GetDNSPtrForIP(ip)
 }
+
+// Make sure that all expected Resources actually implement the interface.
+var _ RDNSSupporter = &FloatingIP{}
+var _ RDNSSupporter = &PrimaryIP{}
+var _ RDNSSupporter = &Server{}
+var _ RDNSSupporter = &LoadBalancer{}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/resource.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/resource.go
@@ -1,23 +1,7 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 // Resource defines the schema of a resource.
 type Resource struct {
-	ID   int
+	ID   int64
 	Type string
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/action.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/action.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Action defines the schema of an action.
 type Action struct {
-	ID        int                       `json:"id"`
+	ID        int64                     `json:"id"`
 	Status    string                    `json:"status"`
 	Command   string                    `json:"command"`
 	Progress  int                       `json:"progress"`
@@ -32,7 +16,7 @@ type Action struct {
 
 // ActionResourceReference defines the schema of an action resource reference.
 type ActionResourceReference struct {
-	ID   int    `json:"id"`
+	ID   int64  `json:"id"`
 	Type string `json:"type"`
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/certificate.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/certificate.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // CertificateUsedByRef defines the schema of a resource using a certificate.
 type CertificateUsedByRef struct {
-	ID   int    `json:"id"`
+	ID   int64  `json:"id"`
 	Type string `json:"type"`
 }
 
@@ -32,7 +16,7 @@ type CertificateStatusRef struct {
 
 // Certificate defines the schema of an certificate.
 type Certificate struct {
-	ID             int                    `json:"id"`
+	ID             int64                  `json:"id"`
 	Name           string                 `json:"name"`
 	Labels         map[string]string      `json:"labels"`
 	Type           string                 `json:"type"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/datacenter.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/datacenter.go
@@ -1,30 +1,14 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // Datacenter defines the schema of a datacenter.
 type Datacenter struct {
-	ID          int      `json:"id"`
+	ID          int64    `json:"id"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Location    Location `json:"location"`
 	ServerTypes struct {
-		Supported []int `json:"supported"`
-		Available []int `json:"available"`
+		Supported []int64 `json:"supported"`
+		Available []int64 `json:"available"`
 	} `json:"server_types"`
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/deprecation.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/deprecation.go
@@ -1,0 +1,12 @@
+package schema
+
+import "time"
+
+type DeprecationInfo struct {
+	Announced        time.Time `json:"announced"`
+	UnavailableAfter time.Time `json:"unavailable_after"`
+}
+
+type DeprecatableResource struct {
+	Deprecation *DeprecationInfo `json:"deprecation"`
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/error.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/error.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "encoding/json"

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/firewall.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/firewall.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Firewall defines the schema of a Firewall.
 type Firewall struct {
-	ID        int                `json:"id"`
+	ID        int64              `json:"id"`
 	Name      string             `json:"name"`
 	Labels    map[string]string  `json:"labels"`
 	Created   time.Time          `json:"created"`
@@ -70,7 +54,7 @@ type FirewallResourceLabelSelector struct {
 
 // FirewallResourceServer defines the schema of a Server to apply a Firewall on.
 type FirewallResourceServer struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }
 
 // FirewallCreateResponse defines the schema of the response when creating a Firewall.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/floating_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/floating_ip.go
@@ -1,31 +1,15 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // FloatingIP defines the schema of a Floating IP.
 type FloatingIP struct {
-	ID           int                  `json:"id"`
+	ID           int64                `json:"id"`
 	Description  *string              `json:"description"`
 	Created      time.Time            `json:"created"`
 	IP           string               `json:"ip"`
 	Type         string               `json:"type"`
-	Server       *int                 `json:"server"`
+	Server       *int64               `json:"server"`
 	DNSPtr       []FloatingIPDNSPtr   `json:"dns_ptr"`
 	HomeLocation Location             `json:"home_location"`
 	Blocked      bool                 `json:"blocked"`
@@ -75,7 +59,7 @@ type FloatingIPListResponse struct {
 type FloatingIPCreateRequest struct {
 	Type         string             `json:"type"`
 	HomeLocation *string            `json:"home_location,omitempty"`
-	Server       *int               `json:"server,omitempty"`
+	Server       *int64             `json:"server,omitempty"`
 	Description  *string            `json:"description,omitempty"`
 	Labels       *map[string]string `json:"labels,omitempty"`
 	Name         *string            `json:"name,omitempty"`
@@ -91,7 +75,7 @@ type FloatingIPCreateResponse struct {
 // FloatingIPActionAssignRequest defines the schema of the request to
 // create an assign Floating IP action.
 type FloatingIPActionAssignRequest struct {
-	Server int `json:"server"`
+	Server int64 `json:"server"`
 }
 
 // FloatingIPActionAssignResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/image.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/image.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Image defines the schema of an image.
 type Image struct {
-	ID           int               `json:"id"`
+	ID           int64             `json:"id"`
 	Status       string            `json:"status"`
 	Type         string            `json:"type"`
 	Name         *string           `json:"name"`
@@ -29,7 +13,7 @@ type Image struct {
 	DiskSize     float32           `json:"disk_size"`
 	Created      time.Time         `json:"created"`
 	CreatedFrom  *ImageCreatedFrom `json:"created_from"`
-	BoundTo      *int              `json:"bound_to"`
+	BoundTo      *int64            `json:"bound_to"`
 	OSFlavor     string            `json:"os_flavor"`
 	OSVersion    *string           `json:"os_version"`
 	Architecture string            `json:"architecture"`
@@ -47,7 +31,7 @@ type ImageProtection struct {
 
 // ImageCreatedFrom defines the schema of the images created from reference.
 type ImageCreatedFrom struct {
-	ID   int    `json:"id"`
+	ID   int64  `json:"id"`
 	Name string `json:"name"`
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/iso.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/iso.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // ISO defines the schema of an ISO image.
 type ISO struct {
-	ID           int       `json:"id"`
+	ID           int64     `json:"id"`
 	Name         string    `json:"name"`
 	Description  string    `json:"description"`
 	Type         string    `json:"type"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
@@ -1,25 +1,9 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 type LoadBalancer struct {
-	ID               int                      `json:"id"`
+	ID               int64                    `json:"id"`
 	Name             string                   `json:"name"`
 	PublicNet        LoadBalancerPublicNet    `json:"public_net"`
 	PrivateNet       []LoadBalancerPrivateNet `json:"private_net"`
@@ -53,7 +37,7 @@ type LoadBalancerPublicNetIPv6 struct {
 }
 
 type LoadBalancerPrivateNet struct {
-	Network int    `json:"network"`
+	Network int64  `json:"network"`
 	IP      string `json:"ip"`
 }
 
@@ -75,11 +59,11 @@ type LoadBalancerService struct {
 }
 
 type LoadBalancerServiceHTTP struct {
-	CookieName     string `json:"cookie_name"`
-	CookieLifetime int    `json:"cookie_lifetime"`
-	Certificates   []int  `json:"certificates"`
-	RedirectHTTP   bool   `json:"redirect_http"`
-	StickySessions bool   `json:"sticky_sessions"`
+	CookieName     string  `json:"cookie_name"`
+	CookieLifetime int     `json:"cookie_lifetime"`
+	Certificates   []int64 `json:"certificates"`
+	RedirectHTTP   bool    `json:"redirect_http"`
+	StickySessions bool    `json:"sticky_sessions"`
 }
 
 type LoadBalancerServiceHealthCheck struct {
@@ -115,7 +99,7 @@ type LoadBalancerTargetHealthStatus struct {
 }
 
 type LoadBalancerTargetServer struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }
 
 type LoadBalancerTargetLabelSelector struct {
@@ -143,7 +127,7 @@ type LoadBalancerActionAddTargetRequest struct {
 }
 
 type LoadBalancerActionAddTargetRequestServer struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }
 
 type LoadBalancerActionAddTargetRequestLabelSelector struct {
@@ -166,7 +150,7 @@ type LoadBalancerActionRemoveTargetRequest struct {
 }
 
 type LoadBalancerActionRemoveTargetRequestServer struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }
 
 type LoadBalancerActionRemoveTargetRequestLabelSelector struct {
@@ -191,11 +175,11 @@ type LoadBalancerActionAddServiceRequest struct {
 }
 
 type LoadBalancerActionAddServiceRequestHTTP struct {
-	CookieName     *string `json:"cookie_name,omitempty"`
-	CookieLifetime *int    `json:"cookie_lifetime,omitempty"`
-	Certificates   *[]int  `json:"certificates,omitempty"`
-	RedirectHTTP   *bool   `json:"redirect_http,omitempty"`
-	StickySessions *bool   `json:"sticky_sessions,omitempty"`
+	CookieName     *string  `json:"cookie_name,omitempty"`
+	CookieLifetime *int     `json:"cookie_lifetime,omitempty"`
+	Certificates   *[]int64 `json:"certificates,omitempty"`
+	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
+	StickySessions *bool    `json:"sticky_sessions,omitempty"`
 }
 
 type LoadBalancerActionAddServiceRequestHealthCheck struct {
@@ -229,11 +213,11 @@ type LoadBalancerActionUpdateServiceRequest struct {
 }
 
 type LoadBalancerActionUpdateServiceRequestHTTP struct {
-	CookieName     *string `json:"cookie_name,omitempty"`
-	CookieLifetime *int    `json:"cookie_lifetime,omitempty"`
-	Certificates   *[]int  `json:"certificates,omitempty"`
-	RedirectHTTP   *bool   `json:"redirect_http,omitempty"`
-	StickySessions *bool   `json:"sticky_sessions,omitempty"`
+	CookieName     *string  `json:"cookie_name,omitempty"`
+	CookieLifetime *int     `json:"cookie_lifetime,omitempty"`
+	Certificates   *[]int64 `json:"certificates,omitempty"`
+	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
+	StickySessions *bool    `json:"sticky_sessions,omitempty"`
 }
 
 type LoadBalancerActionUpdateServiceRequestHealthCheck struct {
@@ -275,7 +259,7 @@ type LoadBalancerCreateRequest struct {
 	Targets          []LoadBalancerCreateRequestTarget   `json:"targets,omitempty"`
 	Services         []LoadBalancerCreateRequestService  `json:"services,omitempty"`
 	PublicInterface  *bool                               `json:"public_interface,omitempty"`
-	Network          *int                                `json:"network,omitempty"`
+	Network          *int64                              `json:"network,omitempty"`
 }
 
 type LoadBalancerCreateRequestAlgorithm struct {
@@ -291,7 +275,7 @@ type LoadBalancerCreateRequestTarget struct {
 }
 
 type LoadBalancerCreateRequestTargetServer struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }
 
 type LoadBalancerCreateRequestTargetLabelSelector struct {
@@ -312,11 +296,11 @@ type LoadBalancerCreateRequestService struct {
 }
 
 type LoadBalancerCreateRequestServiceHTTP struct {
-	CookieName     *string `json:"cookie_name,omitempty"`
-	CookieLifetime *int    `json:"cookie_lifetime,omitempty"`
-	Certificates   *[]int  `json:"certificates,omitempty"`
-	RedirectHTTP   *bool   `json:"redirect_http,omitempty"`
-	StickySessions *bool   `json:"sticky_sessions,omitempty"`
+	CookieName     *string  `json:"cookie_name,omitempty"`
+	CookieLifetime *int     `json:"cookie_lifetime,omitempty"`
+	Certificates   *[]int64 `json:"certificates,omitempty"`
+	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
+	StickySessions *bool    `json:"sticky_sessions,omitempty"`
 }
 
 type LoadBalancerCreateRequestServiceHealthCheck struct {
@@ -367,7 +351,7 @@ type LoadBalancerActionChangeAlgorithmResponse struct {
 }
 
 type LoadBalancerActionAttachToNetworkRequest struct {
-	Network int     `json:"network"`
+	Network int64   `json:"network"`
 	IP      *string `json:"ip,omitempty"`
 }
 
@@ -376,7 +360,7 @@ type LoadBalancerActionAttachToNetworkResponse struct {
 }
 
 type LoadBalancerActionDetachFromNetworkRequest struct {
-	Network int `json:"network"`
+	Network int64 `json:"network"`
 }
 
 type LoadBalancerActionDetachFromNetworkResponse struct {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer_type.go
@@ -1,24 +1,8 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // LoadBalancerType defines the schema of a LoadBalancer type.
 type LoadBalancerType struct {
-	ID                      int                            `json:"id"`
+	ID                      int64                          `json:"id"`
 	Name                    string                         `json:"name"`
 	Description             string                         `json:"description"`
 	MaxConnections          int                            `json:"max_connections"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/location.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/location.go
@@ -1,24 +1,8 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // Location defines the schema of a location.
 type Location struct {
-	ID          int     `json:"id"`
+	ID          int64   `json:"id"`
 	Name        string  `json:"name"`
 	Description string  `json:"description"`
 	Country     string  `json:"country"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/meta.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/meta.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // Meta defines the schema of meta information which may be included

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/network.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/network.go
@@ -1,34 +1,19 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Network defines the schema of a network.
 type Network struct {
-	ID         int               `json:"id"`
-	Name       string            `json:"name"`
-	Created    time.Time         `json:"created"`
-	IPRange    string            `json:"ip_range"`
-	Subnets    []NetworkSubnet   `json:"subnets"`
-	Routes     []NetworkRoute    `json:"routes"`
-	Servers    []int             `json:"servers"`
-	Protection NetworkProtection `json:"protection"`
-	Labels     map[string]string `json:"labels"`
+	ID                    int64             `json:"id"`
+	Name                  string            `json:"name"`
+	Created               time.Time         `json:"created"`
+	IPRange               string            `json:"ip_range"`
+	Subnets               []NetworkSubnet   `json:"subnets"`
+	Routes                []NetworkRoute    `json:"routes"`
+	Servers               []int64           `json:"servers"`
+	Protection            NetworkProtection `json:"protection"`
+	Labels                map[string]string `json:"labels"`
+	ExposeRoutesToVSwitch bool              `json:"expose_routes_to_vswitch"`
 }
 
 // NetworkSubnet represents a subnet of a network.
@@ -37,7 +22,7 @@ type NetworkSubnet struct {
 	IPRange     string `json:"ip_range"`
 	NetworkZone string `json:"network_zone"`
 	Gateway     string `json:"gateway,omitempty"`
-	VSwitchID   int    `json:"vswitch_id,omitempty"`
+	VSwitchID   int64  `json:"vswitch_id,omitempty"`
 }
 
 // NetworkRoute represents a route of a network.
@@ -53,8 +38,9 @@ type NetworkProtection struct {
 
 // NetworkUpdateRequest defines the schema of the request to update a network.
 type NetworkUpdateRequest struct {
-	Name   string             `json:"name,omitempty"`
-	Labels *map[string]string `json:"labels,omitempty"`
+	Name                  string             `json:"name,omitempty"`
+	Labels                *map[string]string `json:"labels,omitempty"`
+	ExposeRoutesToVSwitch *bool              `json:"expose_routes_to_vswitch,omitempty"`
 }
 
 // NetworkUpdateResponse defines the schema of the response when updating a network.
@@ -76,11 +62,12 @@ type NetworkGetResponse struct {
 
 // NetworkCreateRequest defines the schema of the request to create a network.
 type NetworkCreateRequest struct {
-	Name    string             `json:"name"`
-	IPRange string             `json:"ip_range"`
-	Subnets []NetworkSubnet    `json:"subnets,omitempty"`
-	Routes  []NetworkRoute     `json:"routes,omitempty"`
-	Labels  *map[string]string `json:"labels,omitempty"`
+	Name                  string             `json:"name"`
+	IPRange               string             `json:"ip_range"`
+	Subnets               []NetworkSubnet    `json:"subnets,omitempty"`
+	Routes                []NetworkRoute     `json:"routes,omitempty"`
+	Labels                *map[string]string `json:"labels,omitempty"`
+	ExposeRoutesToVSwitch bool               `json:"expose_routes_to_vswitch"`
 }
 
 // NetworkCreateResponse defines the schema of the response when
@@ -108,7 +95,7 @@ type NetworkActionAddSubnetRequest struct {
 	IPRange     string `json:"ip_range,omitempty"`
 	NetworkZone string `json:"network_zone"`
 	Gateway     string `json:"gateway"`
-	VSwitchID   int    `json:"vswitch_id,omitempty"`
+	VSwitchID   int64  `json:"vswitch_id,omitempty"`
 }
 
 // NetworkActionAddSubnetResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/placement_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/placement_group.go
@@ -1,29 +1,13 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 type PlacementGroup struct {
-	ID      int               `json:"id"`
+	ID      int64             `json:"id"`
 	Name    string            `json:"name"`
 	Labels  map[string]string `json:"labels"`
 	Created time.Time         `json:"created"`
-	Servers []int             `json:"servers"`
+	Servers []int64           `json:"servers"`
 	Type    string            `json:"type"`
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // Pricing defines the schema for pricing information.
@@ -77,7 +61,7 @@ type PricingServerBackup struct {
 
 // PricingServerType defines the schema of pricing information for a server type.
 type PricingServerType struct {
-	ID     int                      `json:"id"`
+	ID     int64                    `json:"id"`
 	Name   string                   `json:"name"`
 	Prices []PricingServerTypePrice `json:"prices"`
 }
@@ -92,7 +76,7 @@ type PricingServerTypePrice struct {
 
 // PricingLoadBalancerType defines the schema of pricing information for a Load Balancer type.
 type PricingLoadBalancerType struct {
-	ID     int                            `json:"id"`
+	ID     int64                          `json:"id"`
 	Name   string                         `json:"name"`
 	Prices []PricingLoadBalancerTypePrice `json:"prices"`
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
@@ -4,14 +4,14 @@ import "time"
 
 // PrimaryIP defines a Primary IP.
 type PrimaryIP struct {
-	ID           int                 `json:"id"`
+	ID           int64               `json:"id"`
 	IP           string              `json:"ip"`
 	Labels       map[string]string   `json:"labels"`
 	Name         string              `json:"name"`
 	Type         string              `json:"type"`
 	Protection   PrimaryIPProtection `json:"protection"`
 	DNSPtr       []PrimaryIPDNSPTR   `json:"dns_ptr"`
-	AssigneeID   int                 `json:"assignee_id"`
+	AssigneeID   int64               `json:"assignee_id"`
 	AssigneeType string              `json:"assignee_type"`
 	AutoDelete   bool                `json:"auto_delete"`
 	Blocked      bool                `json:"blocked"`
@@ -52,4 +52,11 @@ type PrimaryIPListResult struct {
 // when updating a Primary IP.
 type PrimaryIPUpdateResult struct {
 	PrimaryIP PrimaryIP `json:"primary_ip"`
+}
+
+// PrimaryIPActionChangeDNSPtrRequest defines the schema for the request to
+// change a Primary IP's reverse DNS pointer.
+type PrimaryIPActionChangeDNSPtrRequest struct {
+	IP     string  `json:"ip"`
+	DNSPtr *string `json:"dns_ptr"`
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Server defines the schema of a server.
 type Server struct {
-	ID              int                `json:"id"`
+	ID              int64              `json:"id"`
 	Name            string             `json:"name"`
 	Status          string             `json:"status"`
 	Created         time.Time          `json:"created"`
@@ -38,7 +22,7 @@ type Server struct {
 	Image           *Image             `json:"image"`
 	Protection      ServerProtection   `json:"protection"`
 	Labels          map[string]string  `json:"labels"`
-	Volumes         []int              `json:"volumes"`
+	Volumes         []int64            `json:"volumes"`
 	PrimaryDiskSize int                `json:"primary_disk_size"`
 	PlacementGroup  *PlacementGroup    `json:"placement_group"`
 }
@@ -54,14 +38,14 @@ type ServerProtection struct {
 type ServerPublicNet struct {
 	IPv4        ServerPublicNetIPv4 `json:"ipv4"`
 	IPv6        ServerPublicNetIPv6 `json:"ipv6"`
-	FloatingIPs []int               `json:"floating_ips"`
+	FloatingIPs []int64             `json:"floating_ips"`
 	Firewalls   []ServerFirewall    `json:"firewalls"`
 }
 
 // ServerPublicNetIPv4 defines the schema of a server's public
 // network information for an IPv4.
 type ServerPublicNetIPv4 struct {
-	ID      int    `json:"id"`
+	ID      int64  `json:"id"`
 	IP      string `json:"ip"`
 	Blocked bool   `json:"blocked"`
 	DNSPtr  string `json:"dns_ptr"`
@@ -70,7 +54,7 @@ type ServerPublicNetIPv4 struct {
 // ServerPublicNetIPv6 defines the schema of a server's public
 // network information for an IPv6.
 type ServerPublicNetIPv6 struct {
-	ID      int                         `json:"id"`
+	ID      int64                       `json:"id"`
 	IP      string                      `json:"ip"`
 	Blocked bool                        `json:"blocked"`
 	DNSPtr  []ServerPublicNetIPv6DNSPtr `json:"dns_ptr"`
@@ -86,13 +70,13 @@ type ServerPublicNetIPv6DNSPtr struct {
 // ServerFirewall defines the schema of a Server's Firewalls on
 // a certain network interface.
 type ServerFirewall struct {
-	ID     int    `json:"id"`
+	ID     int64  `json:"id"`
 	Status string `json:"status"`
 }
 
 // ServerPrivateNet defines the schema of a server's private network information.
 type ServerPrivateNet struct {
-	Network    int      `json:"network"`
+	Network    int64    `json:"network"`
 	IP         string   `json:"ip"`
 	AliasIPs   []string `json:"alias_ips"`
 	MACAddress string   `json:"mac_address"`
@@ -116,31 +100,31 @@ type ServerCreateRequest struct {
 	Name             string                  `json:"name"`
 	ServerType       interface{}             `json:"server_type"` // int or string
 	Image            interface{}             `json:"image"`       // int or string
-	SSHKeys          []int                   `json:"ssh_keys,omitempty"`
+	SSHKeys          []int64                 `json:"ssh_keys,omitempty"`
 	Location         string                  `json:"location,omitempty"`
 	Datacenter       string                  `json:"datacenter,omitempty"`
 	UserData         string                  `json:"user_data,omitempty"`
 	StartAfterCreate *bool                   `json:"start_after_create,omitempty"`
 	Labels           *map[string]string      `json:"labels,omitempty"`
 	Automount        *bool                   `json:"automount,omitempty"`
-	Volumes          []int                   `json:"volumes,omitempty"`
-	Networks         []int                   `json:"networks,omitempty"`
+	Volumes          []int64                 `json:"volumes,omitempty"`
+	Networks         []int64                 `json:"networks,omitempty"`
 	Firewalls        []ServerCreateFirewalls `json:"firewalls,omitempty"`
-	PlacementGroup   int                     `json:"placement_group,omitempty"`
+	PlacementGroup   int64                   `json:"placement_group,omitempty"`
 	PublicNet        *ServerCreatePublicNet  `json:"public_net,omitempty"`
 }
 
 // ServerCreatePublicNet defines the public network configuration of a server.
 type ServerCreatePublicNet struct {
-	EnableIPv4 bool `json:"enable_ipv4"`
-	EnableIPv6 bool `json:"enable_ipv6"`
-	IPv4ID     int  `json:"ipv4,omitempty"`
-	IPv6ID     int  `json:"ipv6,omitempty"`
+	EnableIPv4 bool  `json:"enable_ipv4"`
+	EnableIPv6 bool  `json:"enable_ipv6"`
+	IPv4ID     int64 `json:"ipv4,omitempty"`
+	IPv6ID     int64 `json:"ipv6,omitempty"`
 }
 
 // ServerCreateFirewalls defines which Firewalls to apply when creating a Server.
 type ServerCreateFirewalls struct {
-	Firewall int `json:"firewall"`
+	Firewall int64 `json:"firewall"`
 }
 
 // ServerCreateResponse defines the schema of the response when
@@ -249,7 +233,7 @@ type ServerActionCreateImageResponse struct {
 // create a enable_rescue server action.
 type ServerActionEnableRescueRequest struct {
 	Type    *string `json:"type,omitempty"`
-	SSHKeys []int   `json:"ssh_keys,omitempty"`
+	SSHKeys []int64 `json:"ssh_keys,omitempty"`
 }
 
 // ServerActionEnableRescueResponse defines the schema of the response when
@@ -380,7 +364,7 @@ type ServerActionRequestConsoleResponse struct {
 // ServerActionAttachToNetworkRequest defines the schema for the request to
 // attach a network to a server.
 type ServerActionAttachToNetworkRequest struct {
-	Network  int       `json:"network"`
+	Network  int64     `json:"network"`
 	IP       *string   `json:"ip,omitempty"`
 	AliasIPs []*string `json:"alias_ips,omitempty"`
 }
@@ -394,7 +378,7 @@ type ServerActionAttachToNetworkResponse struct {
 // ServerActionDetachFromNetworkRequest defines the schema for the request to
 // detach a network from a server.
 type ServerActionDetachFromNetworkRequest struct {
-	Network int `json:"network"`
+	Network int64 `json:"network"`
 }
 
 // ServerActionDetachFromNetworkResponse defines the schema of the response when
@@ -406,7 +390,7 @@ type ServerActionDetachFromNetworkResponse struct {
 // ServerActionChangeAliasIPsRequest defines the schema for the request to
 // change a server's alias IPs in a network.
 type ServerActionChangeAliasIPsRequest struct {
-	Network  int      `json:"network"`
+	Network  int64    `json:"network"`
 	AliasIPs []string `json:"alias_ips"`
 }
 
@@ -435,7 +419,7 @@ type ServerTimeSeriesVals struct {
 // ServerActionAddToPlacementGroupRequest defines the schema for the request to
 // add a server to a placement group.
 type ServerActionAddToPlacementGroupRequest struct {
-	PlacementGroup int `json:"placement_group"`
+	PlacementGroup int64 `json:"placement_group"`
 }
 
 // ServerActionAddToPlacementGroupResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
@@ -1,33 +1,19 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 // ServerType defines the schema of a server type.
 type ServerType struct {
-	ID           int                      `json:"id"`
-	Name         string                   `json:"name"`
-	Description  string                   `json:"description"`
-	Cores        int                      `json:"cores"`
-	Memory       float32                  `json:"memory"`
-	Disk         int                      `json:"disk"`
-	StorageType  string                   `json:"storage_type"`
-	CPUType      string                   `json:"cpu_type"`
-	Architecture string                   `json:"architecture"`
-	Prices       []PricingServerTypePrice `json:"prices"`
+	ID              int64                    `json:"id"`
+	Name            string                   `json:"name"`
+	Description     string                   `json:"description"`
+	Cores           int                      `json:"cores"`
+	Memory          float32                  `json:"memory"`
+	Disk            int                      `json:"disk"`
+	StorageType     string                   `json:"storage_type"`
+	CPUType         string                   `json:"cpu_type"`
+	Architecture    string                   `json:"architecture"`
+	IncludedTraffic int64                    `json:"included_traffic"`
+	Prices          []PricingServerTypePrice `json:"prices"`
+	DeprecatableResource
 }
 
 // ServerTypeListResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/ssh_key.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/ssh_key.go
@@ -1,26 +1,10 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // SSHKey defines the schema of a SSH key.
 type SSHKey struct {
-	ID          int               `json:"id"`
+	ID          int64             `json:"id"`
 	Name        string            `json:"name"`
 	Fingerprint string            `json:"fingerprint"`
 	PublicKey   string            `json:"public_key"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/volume.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/volume.go
@@ -1,28 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package schema
 
 import "time"
 
 // Volume defines the schema of a volume.
 type Volume struct {
-	ID          int               `json:"id"`
+	ID          int64             `json:"id"`
 	Name        string            `json:"name"`
-	Server      *int              `json:"server"`
+	Server      *int64            `json:"server"`
 	Status      string            `json:"status"`
 	Location    Location          `json:"location"`
 	Size        int               `json:"size"`
@@ -37,7 +21,7 @@ type Volume struct {
 type VolumeCreateRequest struct {
 	Name      string             `json:"name"`
 	Size      int                `json:"size"`
-	Server    *int               `json:"server,omitempty"`
+	Server    *int64             `json:"server,omitempty"`
 	Location  interface{}        `json:"location,omitempty"` // int, string, or nil
 	Labels    *map[string]string `json:"labels,omitempty"`
 	Automount *bool              `json:"automount,omitempty"`
@@ -95,7 +79,7 @@ type VolumeActionChangeProtectionResponse struct {
 // VolumeActionAttachVolumeRequest defines the schema of the request to
 // attach a volume to a server.
 type VolumeActionAttachVolumeRequest struct {
-	Server    int   `json:"server"`
+	Server    int64 `json:"server"`
 	Automount *bool `json:"automount,omitempty"`
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -33,7 +17,7 @@ import (
 
 // Server represents a server in the Hetzner Cloud.
 type Server struct {
-	ID              int
+	ID              int64
 	Name            string
 	Status          ServerStatus
 	Created         time.Time
@@ -114,7 +98,7 @@ type ServerPublicNet struct {
 
 // ServerPublicNetIPv4 represents a server's public IPv4 address.
 type ServerPublicNetIPv4 struct {
-	ID      int
+	ID      int64
 	IP      net.IP
 	Blocked bool
 	DNSPtr  string
@@ -126,7 +110,7 @@ func (n *ServerPublicNetIPv4) IsUnspecified() bool {
 
 // ServerPublicNetIPv6 represents a Server's public IPv6 network and address.
 type ServerPublicNetIPv6 struct {
-	ID      int
+	ID      int64
 	IP      net.IP
 	Network *net.IPNet
 	Blocked bool
@@ -210,7 +194,7 @@ type ServerClient struct {
 }
 
 // GetByID retrieves a server by its ID. If the server does not exist, nil is returned.
-func (c *ServerClient) GetByID(ctx context.Context, id int) (*Server, *Response, error) {
+func (c *ServerClient) GetByID(ctx context.Context, id int64) (*Server, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/servers/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -242,8 +226,8 @@ func (c *ServerClient) GetByName(ctx context.Context, name string) (*Server, *Re
 // Get retrieves a server by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) Get(ctx context.Context, idOrName string) (*Server, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -257,7 +241,7 @@ type ServerListOpts struct {
 }
 
 func (l ServerListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -433,14 +417,14 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 	}
 	if opts.Location != nil {
 		if opts.Location.ID != 0 {
-			reqBody.Location = strconv.Itoa(opts.Location.ID)
+			reqBody.Location = strconv.FormatInt(opts.Location.ID, 10)
 		} else {
 			reqBody.Location = opts.Location.Name
 		}
 	}
 	if opts.Datacenter != nil {
 		if opts.Datacenter.ID != 0 {
-			reqBody.Datacenter = strconv.Itoa(opts.Datacenter.ID)
+			reqBody.Datacenter = strconv.FormatInt(opts.Datacenter.ID, 10)
 		} else {
 			reqBody.Datacenter = opts.Datacenter.Name
 		}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -27,7 +11,7 @@ import (
 
 // ServerType represents a server type in the Hetzner Cloud.
 type ServerType struct {
-	ID           int
+	ID           int64
 	Name         string
 	Description  string
 	Cores        int
@@ -36,7 +20,10 @@ type ServerType struct {
 	StorageType  StorageType
 	CPUType      CPUType
 	Architecture Architecture
-	Pricings     []ServerTypeLocationPricing
+	// IncludedTraffic is the free traffic per month in bytes
+	IncludedTraffic int64
+	Pricings        []ServerTypeLocationPricing
+	DeprecatableResource
 }
 
 // StorageType specifies the type of storage.
@@ -67,7 +54,7 @@ type ServerTypeClient struct {
 }
 
 // GetByID retrieves a server type by its ID. If the server type does not exist, nil is returned.
-func (c *ServerTypeClient) GetByID(ctx context.Context, id int) (*ServerType, *Response, error) {
+func (c *ServerTypeClient) GetByID(ctx context.Context, id int64) (*ServerType, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/server_types/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -99,8 +86,8 @@ func (c *ServerTypeClient) GetByName(ctx context.Context, name string) (*ServerT
 // Get retrieves a server type by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a server type by its name. If the server type does not exist, nil is returned.
 func (c *ServerTypeClient) Get(ctx context.Context, idOrName string) (*ServerType, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -113,7 +100,7 @@ type ServerTypeListOpts struct {
 }
 
 func (l ServerTypeListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}
@@ -148,10 +135,12 @@ func (c *ServerTypeClient) List(ctx context.Context, opts ServerTypeListOpts) ([
 
 // All returns all server types.
 func (c *ServerTypeClient) All(ctx context.Context) ([]*ServerType, error) {
-	allServerTypes := []*ServerType{}
+	return c.AllWithOpts(ctx, ServerTypeListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
 
-	opts := ServerTypeListOpts{}
-	opts.PerPage = 50
+// AllWithOpts returns all server types for the given options.
+func (c *ServerTypeClient) AllWithOpts(ctx context.Context, opts ServerTypeListOpts) ([]*ServerType, error) {
+	var allServerTypes []*ServerType
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/ssh_key.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/ssh_key.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -31,7 +15,7 @@ import (
 
 // SSHKey represents a SSH key in the Hetzner Cloud.
 type SSHKey struct {
-	ID          int
+	ID          int64
 	Name        string
 	Fingerprint string
 	PublicKey   string
@@ -45,7 +29,7 @@ type SSHKeyClient struct {
 }
 
 // GetByID retrieves a SSH key by its ID. If the SSH key does not exist, nil is returned.
-func (c *SSHKeyClient) GetByID(ctx context.Context, id int) (*SSHKey, *Response, error) {
+func (c *SSHKeyClient) GetByID(ctx context.Context, id int64) (*SSHKey, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/ssh_keys/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -86,8 +70,8 @@ func (c *SSHKeyClient) GetByFingerprint(ctx context.Context, fingerprint string)
 // Get retrieves a SSH key by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) Get(ctx context.Context, idOrName string) (*SSHKey, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -101,7 +85,7 @@ type SSHKeyListOpts struct {
 }
 
 func (l SSHKeyListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/testing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/testing.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -21,14 +5,12 @@ import (
 	"time"
 )
 
-const apiTimestampFormat = "2006-01-02T15:04:05-07:00"
-
-func mustParseTime(t *testing.T, layout, value string) time.Time {
+func mustParseTime(t *testing.T, value string) time.Time {
 	t.Helper()
 
-	ts, err := time.Parse(layout, value)
+	ts, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		t.Fatalf("parse time: layout %v: value %v: %v", layout, value, err)
+		t.Fatalf("parse time: value %v: %v", value, err)
 	}
 	return ts
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/volume.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/volume.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package hcloud
 
 import (
@@ -31,7 +15,7 @@ import (
 
 // Volume represents a volume in the Hetzner Cloud.
 type Volume struct {
-	ID          int
+	ID          int64
 	Name        string
 	Status      VolumeStatus
 	Server      *Server
@@ -65,7 +49,7 @@ const (
 )
 
 // GetByID retrieves a volume by its ID. If the volume does not exist, nil is returned.
-func (c *VolumeClient) GetByID(ctx context.Context, id int) (*Volume, *Response, error) {
+func (c *VolumeClient) GetByID(ctx context.Context, id int64) (*Volume, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/volumes/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -97,8 +81,8 @@ func (c *VolumeClient) GetByName(ctx context.Context, name string) (*Volume, *Re
 // Get retrieves a volume by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a volume by its name. If the volume does not exist, nil is returned.
 func (c *VolumeClient) Get(ctx context.Context, idOrName string) (*Volume, *Response, error) {
-	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -112,7 +96,7 @@ type VolumeListOpts struct {
 }
 
 func (l VolumeListOpts) values() url.Values {
-	vals := l.ListOpts.values()
+	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -285,7 +285,7 @@ func toInstance(vm *hcloud.Server) cloudprovider.Instance {
 	}
 }
 
-func toProviderID(nodeID int) string {
+func toProviderID(nodeID int64) string {
 	return fmt.Sprintf("%s%d", providerIDPrefix, nodeID)
 }
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache.go
@@ -131,7 +131,7 @@ func (m *serversCache) getServer(nodeIdOrName string) (*hcloud.Server, error) {
 	}
 
 	for _, server := range servers {
-		if server.Name == nodeIdOrName || strconv.Itoa(server.ID) == nodeIdOrName {
+		if server.Name == nodeIdOrName || strconv.FormatInt(server.ID, 10) == nodeIdOrName {
 			return server, nil
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update the vendored copy of `github.com/hetznercloud/hcloud-go` to 2.0.0. This includes a breaking change where we changed the type of all `id` fields from `int` to `int64`. Read more about this in our [docs](https://docs.hetzner.cloud/#52-bit-ids). 

As updating the vendored code is annoying, I wrote a script that automatically updates the vendor. This has removed the License headers (Apache) which were added when the code was originally vendored. Instead I kept around the "LICENSE" (MIT) file from the hcloud-go repo.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
