### PR TITLE
Add INVALID_RESERVATION error code to GCE Client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -181,6 +181,12 @@ func TestErrors(t *testing.T) {
 			expectedErrorCode:  "OTHER",
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
+		{
+			errorCodes:         []string{"OTHER"},
+			errorMessage:       "Instance 'myinst' creation failed: Could not find the given reservation with the following name: myres",
+			expectedErrorCode:  "INVALID_RESERVATION",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
 	}
 	for _, tc := range testCases {
 		for _, errorCode := range tc.errorCodes {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
This change improves visibility of GCE errors. Issues caused by invalid reservation specified for a node pool will have a dedicated error code.

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add INVALID_RESERVATION error code for GCE errors related to invalid reservations.
```