### PR TITLE
Add requirement for Custom Resources to VPA FAQ

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -3,6 +3,7 @@
 ## Contents
 
 - [VPA restarts my pods but does not modify CPU or memory settings. Why?](#vpa-restarts-my-pods-but-does-not-modify-CPU-or-memory-settings)
+- [How can I apply VPA to my Custom Resource?](#how-can-i-apply-vpa-to-my-custom-resource)
 - [How can I use Prometheus as a history provider for the VPA recommender?](#how-can-i-use-prometheus-as-a-history-provider-for-the-vpa-recommender)
 - [I get recommendations for my single pod replicaSet, but they are not applied. Why?](#i-get-recommendations-for-my-single-pod-replicaset-but-they-are-not-applied)
 - [What are the parameters to VPA recommender?](#what-are-the-parameters-to-vpa-recommender)
@@ -106,6 +107,17 @@ You can also curl the service's endpoint from within the cluster to make sure it
 is serving.
 
 Note: the commands will differ if you deploy VPA in a different namespace.
+
+### How can I apply VPA to my Custom Resource?
+
+The VPA cannot only scale the built-in resources like Deployment or StatefulSet, but also Custom Resources which manage
+Pods. Just like the Horizontal Pod Autoscaler, the [VPA requires that the Custom Resource implements the `/scale`
+subresource with the optional field `labelSelector`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource),
+which corresponds to `.scale.status.selector`. VPA doesn't use the `/scale` subresource for the actual scaling, but uses
+this label selector to identify the Pods managed by a Custom Resource. As VPA relies on Pod eviction to apply new
+resource recommendations, this ensures that all Pods with a matching VPA object are managed by a controller that will
+recreate them after eviction. Furthermore, it avoids misconfigurations that happened in the past when label selectors
+were specified manually.
 
 ### How can I use Prometheus as a history provider for the VPA recommender
 

--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -111,8 +111,9 @@ Note: the commands will differ if you deploy VPA in a different namespace.
 ### How can I apply VPA to my Custom Resource?
 
 The VPA can scale not only the built-in resources like Deployment or StatefulSet, but also Custom Resources which manage
-Pods. Just like the Horizontal Pod Autoscaler, the [VPA requires that the Custom Resource implements the `/scale`
-subresource with the optional field `labelSelector`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource),
+Pods. Just like the Horizontal Pod Autoscaler, the VPA requires that the Custom Resource implements the
+[`/scale` subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource)
+with the optional field `labelSelector`,
 which corresponds to `.scale.status.selector`. VPA doesn't use the `/scale` subresource for the actual scaling, but uses
 this label selector to identify the Pods managed by a Custom Resource. As VPA relies on Pod eviction to apply new
 resource recommendations, this ensures that all Pods with a matching VPA object are managed by a controller that will

--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -110,7 +110,7 @@ Note: the commands will differ if you deploy VPA in a different namespace.
 
 ### How can I apply VPA to my Custom Resource?
 
-The VPA cannot only scale the built-in resources like Deployment or StatefulSet, but also Custom Resources which manage
+The VPA can scale not only the built-in resources like Deployment or StatefulSet, but also Custom Resources which manage
 Pods. Just like the Horizontal Pod Autoscaler, the [VPA requires that the Custom Resource implements the `/scale`
 subresource with the optional field `labelSelector`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource),
 which corresponds to `.scale.status.selector`. VPA doesn't use the `/scale` subresource for the actual scaling, but uses


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

#### What this PR does / why we need it:
As discussed in today's SIG meeting: Let's add the contract for VPA's support for Custom Resources more explicitly to the FAQ, as this question [keeps](https://github.com/kubernetes/autoscaler/issues/5836) [coming](https://github.com/kubernetes/autoscaler/issues/5925) [back](https://github.com/kubernetes/autoscaler/issues/3766).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
