### PR TITLE
Allow setting a separate timeout for instance registration.

### DIFF
--- a/cluster-autoscaler/clusterstate/providers/max_node_provision_time_provider.go
+++ b/cluster-autoscaler/clusterstate/providers/max_node_provision_time_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package providers
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -25,16 +26,35 @@ import (
 )
 
 // NewDefaultMaxNodeProvisionTimeProvider returns the default maxNodeProvisionTimeProvider which uses the NodeGroupConfigProcessor.
-func NewDefaultMaxNodeProvisionTimeProvider(context *context.AutoscalingContext, nodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor) *defultMaxNodeProvisionTimeProvider {
-	return &defultMaxNodeProvisionTimeProvider{context: context, nodeGroupConfigProcessor: nodeGroupConfigProcessor}
+func NewDefaultMaxNodeProvisionTimeProvider() *defultMaxNodeProvisionTimeProvider {
+	return &defultMaxNodeProvisionTimeProvider{}
 }
 
 type defultMaxNodeProvisionTimeProvider struct {
+	initialized              bool
 	context                  *context.AutoscalingContext
 	nodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor
 }
 
-// GetMaxNodeProvisionTime returns MaxNodeProvisionTime value that should be used for the given NodeGroup.
+// Initialize initializes defultMaxNodeProvisionTimeProvider
+func (p *defultMaxNodeProvisionTimeProvider) Initialize(context *context.AutoscalingContext, nodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor) {
+	p.context = context
+	p.nodeGroupConfigProcessor = nodeGroupConfigProcessor
+	p.initialized = true
+}
+
+// GetMaxNodeProvisionTime is a time a node has to register since its creation started
 func (p *defultMaxNodeProvisionTimeProvider) GetMaxNodeProvisionTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
+	if !p.initialized {
+		return 0, fmt.Errorf("defultMaxNodeProvisionTimeProvider uninitialized")
+	}
+	return p.nodeGroupConfigProcessor.GetMaxNodeProvisionTime(p.context, nodeGroup)
+}
+
+// GetMaxNodeRegisterTime is a time a node has to register, starting from when its creation finished
+func (p *defultMaxNodeProvisionTimeProvider) GetMaxNodeRegisterTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
+	if !p.initialized {
+		return 0, fmt.Errorf("defultMaxNodeProvisionTimeProvider uninitialized")
+	}
 	return p.nodeGroupConfigProcessor.GetMaxNodeProvisionTime(p.context, nodeGroup)
 }

--- a/cluster-autoscaler/core/providers/providers.go
+++ b/cluster-autoscaler/core/providers/providers.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
+)
+
+// MaxNodeProvisionTimeProvider provides maximum time for stages of node provisioning:
+// - end to end
+// - node registration only
+type MaxNodeProvisionTimeProvider interface {
+	// Initialize performs initialization of MaxNodeProvisionTimeProvider
+	Initialize(context *context.AutoscalingContext, nodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor)
+	// GetMaxNodeProvisionTime is a time a node has to register since its creation started
+	GetMaxNodeProvisionTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error)
+	// GetMaxNodeRegisterTime is a time a node has to register, starting from when its creation finished
+	GetMaxNodeRegisterTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error)
+}

--- a/cluster-autoscaler/core/providers/testutils.go
+++ b/cluster-autoscaler/core/providers/testutils.go
@@ -14,22 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clusterstate
+package providers
 
 import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 )
 
 // NewMockMaxNodeProvisionTimeProvider returns static maxNodeProvisionTimeProvider which returns constant MaxNodeProvisionTime for every NodeGroup.
-func NewMockMaxNodeProvisionTimeProvider(maxProvisioningTime, maxRegistrationTime time.Duration) *staticMockMaxNodeProvisionTimeProvider {
-	return &staticMockMaxNodeProvisionTimeProvider{maxProvisioningTime, maxRegistrationTime}
+func NewMockMaxNodeProvisionTimeProvider(maxNodeProvisionTime time.Duration) *staticMockMaxNodeProvisionTimeProvider {
+	return &staticMockMaxNodeProvisionTimeProvider{maxNodeProvisionTime}
 }
 
 type staticMockMaxNodeProvisionTimeProvider struct {
 	staticMaxNodeProvisionTime time.Duration
-	staticMaxNodeRegisterTime  time.Duration
+}
+
+func (p *staticMockMaxNodeProvisionTimeProvider) Initialize(context *context.AutoscalingContext, nodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor) {
 }
 
 // GetMaxNodeProvisionTime returns constant MaxNodeProvisionTime value that should be used for every NodeGroup.
@@ -39,5 +43,5 @@ func (p *staticMockMaxNodeProvisionTimeProvider) GetMaxNodeProvisionTime(cloudpr
 
 // GetMaxNodeRegisterTime is a time a node has to register, starting from when its creation finished
 func (p *staticMockMaxNodeProvisionTimeProvider) GetMaxNodeRegisterTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
-	return p.staticMaxNodeRegisterTime, nil
+	return p.staticMaxNodeProvisionTime, nil
 }

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -39,6 +39,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/core/providers"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/budgets"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
@@ -948,8 +949,8 @@ func TestStartDeletion(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Couldn't set up autoscaling context: %v", err)
 				}
-				csr := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, ctx.LogRecorder, NewBackoff())
-				csr.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+				nptProv := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+				csr := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, ctx.LogRecorder, NewBackoff(), nptProv)
 				for _, bucket := range tc.emptyNodes {
 					for _, node := range bucket.Nodes {
 						err := ctx.ClusterSnapshot.AddNodeWithPods(node, tc.pods[node.Name])
@@ -1207,8 +1208,8 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Couldn't set up autoscaling context: %v", err)
 			}
-			csr := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, ctx.LogRecorder, NewBackoff())
-			csr.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+			nptProv := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+			csr := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, ctx.LogRecorder, NewBackoff(), nptProv)
 			ndt := deletiontracker.NewNodeDeletionTracker(0)
 			ndb := NewNodeDeletionBatcher(&ctx, csr, ndt, deleteInterval)
 			evictor := Evictor{EvictionRetryTime: 0, DsEvictionRetryTime: 0, DsEvictionEmptyNodeTimeout: 0, PodEvictionHeadroom: DefaultPodEvictionHeadroom}

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	clusterstate_utils "k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/core/providers"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -162,8 +163,8 @@ func TestRemove(t *testing.T) {
 				})
 
 			ctx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, fakeClient, nil, provider, nil, nil)
-			clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder, NewBackoff())
-			clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+			nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+			clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, fakeLogRecorder, NewBackoff(), nptProvider)
 			if err != nil {
 				t.Fatalf("Couldn't set up autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/providers"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
@@ -146,8 +147,8 @@ func TestFindUnneededNodes(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 	allNodes := []*apiv1.Node{n1, n2, n3, n4, n5, n7, n8, n9}
@@ -278,8 +279,8 @@ func TestFindUnneededGPUNodes(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 	allNodes := []*apiv1.Node{n1, n2, n3}
@@ -394,8 +395,8 @@ func TestFindUnneededWithPerNodeGroupThresholds(t *testing.T) {
 
 			context, err := NewScaleTestAutoscalingContext(globalOptions, &fake.Clientset{}, registry, provider, nil, nil)
 			assert.NoError(t, err)
-			clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-			clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+			nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+			clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 			wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 			sd := wrapper.sd
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, allNodes, allPods)
@@ -478,8 +479,8 @@ func TestPodsWithPreemptionsFindUnneededNodes(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 
@@ -543,8 +544,8 @@ func TestFindUnneededMaxCandidates(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 
@@ -628,8 +629,8 @@ func TestFindUnneededEmptyNodes(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 
@@ -686,8 +687,8 @@ func TestFindUnneededNodePool(t *testing.T) {
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	sd := wrapper.sd
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, pods)
@@ -778,8 +779,8 @@ func TestScaleDown(t *testing.T) {
 	assert.NoError(t, err)
 	nodes := []*apiv1.Node{n1, n2}
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
@@ -1036,8 +1037,8 @@ func simpleScaleDownEmpty(t *testing.T, config *ScaleTestConfig) {
 	context, err := NewScaleTestAutoscalingContext(config.Options, fakeClient, registry, provider, nil, nil)
 	assert.NoError(t, err)
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, config.NodeDeletionTracker)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
@@ -1131,9 +1132,9 @@ func TestNoScaleDownUnready(t *testing.T) {
 
 	nodes := []*apiv1.Node{n1, n2}
 
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
 	// N1 is unready so it requires a bigger unneeded time.
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))
@@ -1247,8 +1248,8 @@ func TestScaleDownNoMove(t *testing.T) {
 
 	nodes := []*apiv1.Node{n1, n2}
 
-	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff())
-	clusterStateRegistry.RegisterProviders(clusterstate.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute))
+	nptProvider := providers.NewMockMaxNodeProvisionTimeProvider(15 * time.Minute)
+	clusterStateRegistry := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nptProvider)
 	wrapper := newWrapperForTesting(&context, clusterStateRegistry, nil)
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, []*apiv1.Pod{p1, p2})
 	autoscalererr = wrapper.UpdateClusterState(nodes, nodes, nil, time.Now().Add(-5*time.Minute))


### PR DESCRIPTION
MaxNodeProvisionTimeProvider may be now passed via AutoscalerOptions, by default the same timeout is applied for end-to-end node provisioning and node registration after the instance is created. If needed, MaxNodeProvisionTimeProvider might be extended with other timeouts with custom logic (e.g. instance provisioning excluding registration as a node).

#### What type of PR is this?

<!--
/kind feature
-->

#### What this PR does / why we need it:
This PR allows setting max node provisioning time on higher granularity.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Directly this PR doesn't have any effect, but it adds support to override MaxNodeProvisionTimeProvider.

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
