### PR TITLE
Support ZeroOrMaxNodeScaling node groups when cleaning up unregistered nodes

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -1010,7 +1010,7 @@ func getNotRegisteredNodes(allNodes []*apiv1.Node, cloudProviderNodeInstances ma
 		for _, instance := range instances {
 			if !registered.Has(instance.Id) && expectedToRegister(instance) {
 				notRegistered = append(notRegistered, UnregisteredNode{
-					Node:              fakeNode(instance, cloudprovider.FakeNodeUnregistered),
+					Node:              FakeNode(instance, cloudprovider.FakeNodeUnregistered),
 					UnregisteredSince: time,
 				})
 			}
@@ -1191,7 +1191,7 @@ func (csr *ClusterStateRegistry) GetCreatedNodesWithErrors() []*apiv1.Node {
 		_, _, instancesByErrorCode := csr.buildInstanceToErrorCodeMappings(nodeGroupInstances)
 		for _, instances := range instancesByErrorCode {
 			for _, instance := range instances {
-				nodesWithCreateErrors = append(nodesWithCreateErrors, fakeNode(instance, cloudprovider.FakeNodeCreateError))
+				nodesWithCreateErrors = append(nodesWithCreateErrors, FakeNode(instance, cloudprovider.FakeNodeCreateError))
 			}
 		}
 	}
@@ -1208,7 +1208,8 @@ func (csr *ClusterStateRegistry) InvalidateNodeInstancesCacheEntry(nodeGroup clo
 	csr.cloudProviderNodeInstancesCache.InvalidateCacheEntry(nodeGroup)
 }
 
-func fakeNode(instance cloudprovider.Instance, reason string) *apiv1.Node {
+// FakeNode creates a fake node with Name field populated and FakeNodeReasonAnnotation added
+func FakeNode(instance cloudprovider.Instance, reason string) *apiv1.Node {
 	return &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: instance.Id,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -405,7 +405,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	unregisteredNodes := a.clusterStateRegistry.GetUnregisteredNodes()
 	if len(unregisteredNodes) > 0 {
 		klog.V(1).Infof("%d unregistered nodes present", len(unregisteredNodes))
-		removedAny, err := removeOldUnregisteredNodes(unregisteredNodes, autoscalingContext,
+		removedAny, err := a.removeOldUnregisteredNodes(unregisteredNodes, autoscalingContext,
 			a.clusterStateRegistry, currentTime, autoscalingContext.LogRecorder)
 		// There was a problem with removing unregistered nodes. Retry in the next loop.
 		if err != nil {
@@ -723,14 +723,16 @@ func fixNodeGroupSize(context *context.AutoscalingContext, clusterStateRegistry 
 }
 
 // Removes unregistered nodes if needed. Returns true if anything was removed and error if such occurred.
-func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNode, context *context.AutoscalingContext,
+func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clusterstate.UnregisteredNode, context *context.AutoscalingContext,
 	csr *clusterstate.ClusterStateRegistry, currentTime time.Time, logRecorder *utils.LogEventRecorder) (bool, error) {
-	removedAny := false
-	for _, unregisteredNode := range unregisteredNodes {
-		nodeGroup, err := context.CloudProvider.NodeGroupForNode(unregisteredNode.Node)
+
+	nodeGroups := a.nodeGroupsById()
+	nodesToBeDeletedByNodeGroupId := make(map[string][]clusterstate.UnregisteredNode)
+	for _, unregisteredNode := range allUnregisteredNodes {
+		nodeGroup, err := a.CloudProvider.NodeGroupForNode(unregisteredNode.Node)
 		if err != nil {
 			klog.Warningf("Failed to get node group for %s: %v", unregisteredNode.Node.Name, err)
-			return removedAny, err
+			continue
 		}
 		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
 			klog.Warningf("No node group for node %s, skipping", unregisteredNode.Node.Name)
@@ -739,35 +741,78 @@ func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNod
 
 		maxNodeProvisionTime, err := csr.MaxNodeProvisionTime(nodeGroup)
 		if err != nil {
-			return removedAny, fmt.Errorf("failed to retrieve maxNodeProvisionTime for node %s in nodeGroup %s", unregisteredNode.Node.Name, nodeGroup.Id())
+			return false, fmt.Errorf("failed to retrieve maxNodeProvisionTime for node %s in nodeGroup %s", unregisteredNode.Node.Name, nodeGroup.Id())
 		}
 
 		if unregisteredNode.UnregisteredSince.Add(maxNodeProvisionTime).Before(currentTime) {
-			klog.V(0).Infof("Removing unregistered node %v", unregisteredNode.Node.Name)
-			size, err := nodeGroup.TargetSize()
-			if err != nil {
-				klog.Warningf("Failed to get node group size; unregisteredNode=%v; nodeGroup=%v; err=%v", unregisteredNode.Node.Name, nodeGroup.Id(), err)
-				continue
-			}
-			if nodeGroup.MinSize() >= size {
-				klog.Warningf("Failed to remove node %s: node group min size reached, skipping unregistered node removal", unregisteredNode.Node.Name)
-				continue
-			}
-			err = nodeGroup.DeleteNodes([]*apiv1.Node{unregisteredNode.Node})
-			csr.InvalidateNodeInstancesCacheEntry(nodeGroup)
-			if err != nil {
-				klog.Warningf("Failed to remove node %s: %v", unregisteredNode.Node.Name, err)
-				logRecorder.Eventf(apiv1.EventTypeWarning, "DeleteUnregisteredFailed",
-					"Failed to remove node %s: %v", unregisteredNode.Node.Name, err)
-				return removedAny, err
-			}
-			logRecorder.Eventf(apiv1.EventTypeNormal, "DeleteUnregistered",
-				"Removed unregistered node %v", unregisteredNode.Node.Name)
-			metrics.RegisterOldUnregisteredNodesRemoved(1)
-			removedAny = true
+			klog.V(0).Infof("Marking unregistered node %v for removal", unregisteredNode.Node.Name)
+			nodesToBeDeletedByNodeGroupId[nodeGroup.Id()] = append(nodesToBeDeletedByNodeGroupId[nodeGroup.Id()], unregisteredNode)
 		}
 	}
+
+	removedAny := false
+	for nodeGroupId, unregisteredNodesToDelete := range nodesToBeDeletedByNodeGroupId {
+		nodeGroup := nodeGroups[nodeGroupId]
+
+		klog.V(0).Infof("Removing %v unregistered nodes for node group %v", len(unregisteredNodesToDelete), nodeGroupId)
+		size, err := nodeGroup.TargetSize()
+		if err != nil {
+			klog.Warningf("Failed to get node group size; nodeGroup=%v; err=%v", nodeGroup.Id(), err)
+			continue
+		}
+		possibleToDelete := size - nodeGroup.MinSize()
+		if possibleToDelete <= 0 {
+			klog.Warningf("Node group %s min size reached, skipping removal of %v unregistered nodes", nodeGroupId, len(unregisteredNodesToDelete))
+			continue
+		}
+		if len(unregisteredNodesToDelete) > possibleToDelete {
+			klog.Warningf("Capping node group %s unregistered node removal to %d nodes, removing all %d would exceed min size constaint", nodeGroupId, possibleToDelete, len(unregisteredNodesToDelete))
+			unregisteredNodesToDelete = unregisteredNodesToDelete[:possibleToDelete]
+		}
+		nodesToDelete := toNodes(unregisteredNodesToDelete)
+
+		opts, err := nodeGroup.GetOptions(a.NodeGroupDefaults)
+		if err != nil {
+			klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
+			continue
+		}
+		// If a scale-up of "ZeroOrMaxNodeScaling" node group failed, the cleanup
+		// should stick to the all-or-nothing principle. Deleting all nodes.
+		if opts != nil && opts.ZeroOrMaxNodeScaling {
+			instances, err := nodeGroup.Nodes()
+			if err != nil {
+				klog.Warningf("Failed to fill in unregistered nodes from group %s based on ZeroOrMaxNodeScaling option: %s", nodeGroupId, err)
+				continue
+			}
+			nodesToDelete = instancesToFakeNodes(instances)
+		}
+
+		err = nodeGroup.DeleteNodes(nodesToDelete)
+		csr.InvalidateNodeInstancesCacheEntry(nodeGroup)
+		if err != nil {
+			klog.Warningf("Failed to remove %v unregistered nodes from node group %s: %v", len(nodesToDelete), nodeGroupId, err)
+			for _, node := range nodesToDelete {
+				logRecorder.Eventf(apiv1.EventTypeWarning, "DeleteUnregisteredFailed",
+					"Failed to remove node %s: %v", node.Name, err)
+			}
+			return removedAny, err
+		}
+		for _, node := range nodesToDelete {
+			logRecorder.Eventf(apiv1.EventTypeNormal, "DeleteUnregistered",
+				"Removed unregistered node %v", node.Name)
+		}
+		metrics.RegisterOldUnregisteredNodesRemoved(len(nodesToDelete))
+		removedAny = true
+	}
 	return removedAny, nil
+}
+
+func toNodes(unregisteredNodes []clusterstate.UnregisteredNode) []*apiv1.Node {
+	nodes := []*apiv1.Node{}
+	for _, n := range unregisteredNodes {
+		nodes = append(nodes, n.Node)
+	}
+	return nodes
 }
 
 func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
@@ -805,6 +850,21 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
 		} else {
+			opts, err := nodeGroup.GetOptions(a.NodeGroupDefaults)
+			if err != nil {
+				klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
+				continue
+			}
+			// If a scale-up of "ZeroOrMaxNodeScaling" node group failed, the cleanup
+			// should stick to the all-or-nothing principle. Deleting all nodes.
+			if opts != nil && opts.ZeroOrMaxNodeScaling {
+				instances, err := nodeGroup.Nodes()
+				if err != nil {
+					klog.Warningf("Failed to fill in failed nodes from group %s based on ZeroOrMaxNodeScaling option: %s", nodeGroupId, err)
+					continue
+				}
+				nodesToBeDeleted = instancesToFakeNodes(instances)
+			}
 			err = nodeGroup.DeleteNodes(nodesToBeDeleted)
 		}
 
@@ -817,6 +877,16 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 	}
 
 	return deletedAny, nil
+}
+
+// instancesToNodes returns a list of fake nodes with just names populated,
+// so that they can be passed as nodes to delete
+func instancesToFakeNodes(instances []cloudprovider.Instance) []*apiv1.Node {
+	nodes := []*apiv1.Node{}
+	for _, i := range instances {
+		nodes = append(nodes, clusterstate.FakeNode(i, ""))
+	}
+	return nodes
 }
 
 func (a *StaticAutoscaler) nodeGroupsById() map[string]cloudprovider.NodeGroup {


### PR DESCRIPTION
<!--
/kind bug
-->

#### What this PR does / why we need it:
Fixes a bug, where a regular scale-down for "ZeroOrMaxNodeScaling" node groups was performed as intended, but error cases were handled like all other node groups.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bugfix: ZeroOrMaxNodeScaling option is supported also for error scenarios (node creation timeout or errors).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
-->
```docs

```
