### PR TITLE
[VPA] feat: add prometheus basic auth in the VPA recommender

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -19,6 +19,7 @@ package history
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -32,6 +33,18 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
+// PrometheusBasicAuthTransport contains the username and password of prometheus server
+type PrometheusBasicAuthTransport struct {
+	Username string
+	Password string
+}
+
+// RoundTrip function injects the username and password in the request's basic auth header
+func (t *PrometheusBasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.Username, t.Password)
+	return http.DefaultTransport.RoundTrip(req)
+}
+
 // PrometheusHistoryProviderConfig allow to select which metrics
 // should be queried to get real resource utilization.
 type PrometheusHistoryProviderConfig struct {
@@ -43,6 +56,7 @@ type PrometheusHistoryProviderConfig struct {
 	CtrNamespaceLabel, CtrPodNameLabel, CtrNameLabel string
 	CadvisorMetricsJobName                           string
 	Namespace                                        string
+	PrometheusBasicAuthTransport
 }
 
 // PodHistory represents history of usage and labels for a given pod.
@@ -76,9 +90,19 @@ type prometheusHistoryProvider struct {
 
 // NewPrometheusHistoryProvider constructs a history provider that gets data from Prometheus.
 func NewPrometheusHistoryProvider(config PrometheusHistoryProviderConfig) (HistoryProvider, error) {
-	promClient, err := promapi.NewClient(promapi.Config{
+	promConfig := promapi.Config{
 		Address: config.Address,
-	})
+	}
+
+	if config.Username != "" && config.Password != "" {
+		transport := &PrometheusBasicAuthTransport{
+			Username: config.Username,
+			Password: config.Password,
+		}
+		promConfig.RoundTripper = transport
+	}
+
+	promClient, err := promapi.NewClient(promConfig)
 	if err != nil {
 		return &prometheusHistoryProvider{}, err
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -68,6 +68,8 @@ var (
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container pod names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 	vpaObjectNamespace  = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects and pod stats. Empty means all namespaces will be used.")
+	username            = flag.String("username", "", "The username used in the prometheus server basic auth")
+	password            = flag.String("password", "", "The password used in the prometheus server basic auth")
 	memorySaver         = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
 )
 
@@ -174,6 +176,10 @@ func main() {
 			CtrNameLabel:           *ctrNameLabel,
 			CadvisorMetricsJobName: *prometheusJobName,
 			Namespace:              *vpaObjectNamespace,
+			PrometheusBasicAuthTransport: history.PrometheusBasicAuthTransport{
+				Username: *username,
+				Password: *password,
+			},
 		}
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds the basic auth for Prometheus provider in the VPA recommender, e.g adds the `username` and `password` options.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5534.

#### Special notes for your reviewer:
I didn't find any document to update or any kind of tests to add. If you have any suggestions please feel free to ask.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
adds the `--username` and `--password` flags to ensure secure communication with Prometheus in the VPA recommender.
```
