### PR TITLE
Add error code for invalid reservations to GCE client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -59,6 +59,15 @@ const (
 	// is facing errors caused by vmExternalIpAccess policy constraint misconfiguration.
 	ErrorCodeVmExternalIpAccessPolicyConstraint = "VM_EXTERNAL_IP_ACCESS_POLICY_CONSTRAINT"
 
+	// ErrorInvalidReservation is an error code for InstanceErrorInfo if the node group couldn't
+	// be scaled up because no reservation was found, or the reservation associated with the MIG
+	// was invalid.
+	ErrorInvalidReservation = "INVALID_RESERVATION"
+
+	// ErrorReservationNotReady is an error code for InstanceErrorInfo if the node group couldn't
+	// be scaled up because the associated reservation was not ready.
+	ErrorReservationNotReady = "RESERVATION_NOT_READY"
+
 	// ErrorCodeOther is an error code used in InstanceErrorInfo if other error occurs.
 	ErrorCodeOther = "OTHER"
 )
@@ -372,6 +381,16 @@ func GetErrorInfo(errorCode, errorMessage, instanceStatus string, previousErrorI
 			ErrorClass: cloudprovider.OtherErrorClass,
 			ErrorCode:  ErrorCodeVmExternalIpAccessPolicyConstraint,
 		}
+	} else if isReservationNotReady(errorCode, errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorReservationNotReady,
+		}
+	} else if isInvalidReservationError(errorCode, errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorInvalidReservation,
+		}
 	} else if isInstanceStatusNotRunningYet(instanceStatus) {
 		if previousErrorInfo != nil {
 			// keep the current error
@@ -426,6 +445,26 @@ func isVmExternalIpAccessPolicyConstraintError(errorCode, errorMessage string) b
 
 func isInstanceStatusNotRunningYet(instanceStatus string) bool {
 	return instanceStatus == "" || instanceStatus == "PROVISIONING" || instanceStatus == "STAGING"
+}
+
+func isReservationNotReady(errorCode, errorMessage string) bool {
+	return strings.Contains(errorMessage, "it requires reservation to be in READY state")
+}
+
+func isInvalidReservationError(errorCode, errorMessage string) bool {
+	reservationErrors := []string{
+		"Incompatible AggregateReservation VMFamily",
+		"Could not find the given reservation with the following name",
+		"must use ReservationAffinity of",
+		"The reservation must exist in the same project as the instance",
+		"only compatible with Aggregate Reservations",
+	}
+	for _, rErr := range reservationErrors {
+		if strings.Contains(errorMessage, rErr) {
+			return true
+		}
+	}
+	return false
 }
 
 func generateInstanceName(baseName string, existingNames map[string]bool) string {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -177,6 +177,18 @@ func TestErrors(t *testing.T) {
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
 		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Instance 'myinst' creation failed: The reservation must exist in the same project as the instance.",
+			expectedErrorCode:  "INVALID_RESERVATION",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Cannot insert instance to a reservation with status: CREATING, as it requires reservation to be in READY state.",
+			expectedErrorCode:  "RESERVATION_NOT_READY",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
 			errorCodes:         []string{"xyz", "abc"},
 			expectedErrorCode:  "OTHER",
 			expectedErrorClass: cloudprovider.OtherErrorClass,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds more visibility to the GCE errors. Issues caused by invalid reservations will have a dedicated error code.
(Credit to @kawych for the code)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```