### PR TITLE
Fixed the hyperlink for Node group auto discovery.

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/README.md
+++ b/cluster-autoscaler/cloudprovider/magnum/README.md
@@ -48,7 +48,7 @@ to match your cluster.
 | --cluster-name              | The name of your Kubernetes cluster. If there are multiple clusters sharing the same name then the cluster IDs should be used instead.           |
 | --cloud-provider            | Can be omitted if the autoscaler is built with `BUILD_TAGS=magnum`, otherwise use `--cloud-provider=magnum`.                                     |
 | --nodes                     | Used to select a specific node group to autoscale and constrain its node count. Of the form `min:max:NodeGroupName`. Can be used multiple times. |
-| --node-group-auto-discovery | See below(#node-group-auto-discovery).                                                                                                                                       |
+| --node-group-auto-discovery | [See below](#node-group-auto-discovery).                                                                                                                                       |
 
 #### Deployment with helm
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This PR fixed the hyperlink for `Node group auto discovery` in [README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/magnum/README.md#autoscaler-deployment) under the Magnum Cloud Provider.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
