### PR TITLE
feat: deprecating max-scale-down-parallelism in place of existing flag

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -244,8 +244,6 @@ type AutoscalingOptions struct {
 	MaxNodeGroupBackoffDuration time.Duration
 	// NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.
 	NodeGroupBackoffResetTimeout time.Duration
-	// MaxScaleDownParallelism is the maximum number of nodes (both empty and needing drain) that can be deleted in parallel.
-	MaxScaleDownParallelism int
 	// MaxDrainParallelism is the maximum number of nodes needing drain, that can be drained and deleted in parallel.
 	MaxDrainParallelism int
 	// RecordDuplicatedEvents controls whether events should be duplicated within a 5 minute window.

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -924,7 +924,7 @@ func TestStartDeletion(t *testing.T) {
 
 				// Set up other needed structures and options.
 				opts := config.AutoscalingOptions{
-					MaxScaleDownParallelism:        10,
+					MaxEmptyBulkDelete:             10,
 					MaxDrainParallelism:            5,
 					MaxPodEvictionTime:             0,
 					DaemonSetEvictionForEmptyNodes: true,
@@ -1194,7 +1194,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 				}
 			}
 			opts := config.AutoscalingOptions{
-				MaxScaleDownParallelism:        10,
+				MaxEmptyBulkDelete:             10,
 				MaxDrainParallelism:            5,
 				MaxPodEvictionTime:             0,
 				DaemonSetEvictionForEmptyNodes: true,

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -1,4 +1,4 @@
-/*
+MaxEmptyBulkDelete/*
 Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(as scaledown.ActuationStatus, empt
 	drainAtomicMap := groupBuckets(drainAtomic)
 
 	emptyInProgress, drainInProgress := as.DeletionsInProgress()
-	parallelismBudget := bp.ctx.MaxScaleDownParallelism - len(emptyInProgress) - len(drainInProgress)
+	parallelismBudget := bp.ctx.MaxEmptyBulkDelete - len(emptyInProgress) - len(drainInProgress)
 	drainBudget := bp.ctx.MaxDrainParallelism - len(drainInProgress)
 
 	canOverflow := true

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -1,4 +1,4 @@
-MaxEmptyBulkDelete/*
+/*
 Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -313,7 +313,7 @@ func TestCropNodesToBudgets(t *testing.T) {
 
 			ctx := &context.AutoscalingContext{
 				AutoscalingOptions: config.AutoscalingOptions{
-					MaxScaleDownParallelism:     10,
+					MaxEmptyBulkDelete:          10,
 					MaxDrainParallelism:         5,
 					NodeDeletionBatcherInterval: 0 * time.Second,
 					NodeDeleteDelayAfterTaint:   1 * time.Second,

--- a/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
+++ b/cluster-autoscaler/core/scaledown/legacy/legacy_test.go
@@ -1291,7 +1291,7 @@ func generateReplicaSets() []*appsv1.ReplicaSet {
 
 func newWrapperForTesting(ctx *context.AutoscalingContext, clusterStateRegistry *clusterstate.ClusterStateRegistry, ndt *deletiontracker.NodeDeletionTracker) *ScaleDownWrapper {
 	ctx.MaxDrainParallelism = 1
-	ctx.MaxScaleDownParallelism = 10
+	ctx.MaxEmptyBulkDelete = 10
 	ctx.NodeDeletionBatcherInterval = 0 * time.Second
 	ctx.NodeDeleteDelayAfterTaint = 0 * time.Second
 	if ndt == nil {

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -301,9 +301,9 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 // unneeded nodes is a waste of time. The reasoning behind it is essentially as
 // follows.
 // If the nodes are being removed instantly, then during each iteration we're
-// going to delete up to MaxScaleDownParallelism nodes. Therefore, it doesn't
+// going to delete up to MaxEmptyBulkDelete nodes. Therefore, it doesn't
 // really make sense to add more unneeded nodes than that.
-// Let N = MaxScaleDownParallelism. When there are no unneeded nodes, we only
+// Let N = MaxEmptyBulkDelete. When there are no unneeded nodes, we only
 // need to find N of them in the first iteration. Once the unneeded time
 // accumulates for them, only up to N will get deleted in a single iteration.
 // When there are >0 unneeded nodes, we only need to add N more: once the first
@@ -323,7 +323,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 // of unneeded nodes shouldn't really exceed N*U/I - scale down will not be
 // able to keep up with removing them anyway.
 func (p *Planner) unneededNodesLimit() int {
-	n := p.context.AutoscalingOptions.MaxScaleDownParallelism
+	n := p.context.AutoscalingOptions.MaxEmptyBulkDelete
 	extraBuffer := n
 	limit := len(p.unneededNodes.AsList()) + n + extraBuffer
 	// TODO(x13n): Use moving average instead of min.

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -488,7 +488,7 @@ func TestUpdateClusterState(t *testing.T) {
 					ScaleDownUnneededTime: 10 * time.Minute,
 				},
 				ScaleDownSimulationTimeout: 1 * time.Second,
-				MaxScaleDownParallelism:    10,
+				MaxEmptyBulkDelete:         10,
 			}, &fake.Clientset{}, registry, provider, nil, nil)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, tc.nodes, tc.pods)
@@ -520,7 +520,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 		name               string
 		previouslyUnneeded int
 		nodes              int
-		maxParallelism     int
+		maxEmptyBulkDelete int
 		maxUnneededTime    time.Duration
 		updateInterval     time.Duration
 		wantUnneeded       int
@@ -529,7 +529,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "no unneeded, default settings",
 			previouslyUnneeded: 0,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     10 * time.Second,
 			wantUnneeded:       20,
@@ -538,7 +538,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "some unneeded, default settings",
 			previouslyUnneeded: 3,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     10 * time.Second,
 			wantUnneeded:       23,
@@ -547,7 +547,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "max unneeded, default settings",
 			previouslyUnneeded: 70,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     10 * time.Second,
 			wantUnneeded:       70,
@@ -556,7 +556,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "too many unneeded, default settings",
 			previouslyUnneeded: 77,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     10 * time.Second,
 			wantUnneeded:       70,
@@ -565,7 +565,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "instant kill nodes",
 			previouslyUnneeded: 0,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    0 * time.Minute,
 			updateInterval:     10 * time.Second,
 			wantUnneeded:       20,
@@ -574,7 +574,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "quick loops",
 			previouslyUnneeded: 13,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     1 * time.Second,
 			wantUnneeded:       33,
@@ -583,7 +583,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			name:               "slow loops",
 			previouslyUnneeded: 13,
 			nodes:              100,
-			maxParallelism:     10,
+			maxEmptyBulkDelete: 10,
 			maxUnneededTime:    1 * time.Minute,
 			updateInterval:     30 * time.Second,
 			wantUnneeded:       30,
@@ -607,7 +607,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 					ScaleDownUnneededTime: tc.maxUnneededTime,
 				},
 				ScaleDownSimulationTimeout: 1 * time.Hour,
-				MaxScaleDownParallelism:    tc.maxParallelism,
+				MaxEmptyBulkDelete:         tc.maxEmptyBulkDelete,
 			}, &fake.Clientset{}, nil, provider, nil, nil)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, nil)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1888,7 +1888,7 @@ func waitForDeleteToFinish(t *testing.T, deleteFinished <-chan bool) {
 }
 
 func newScaleDownPlannerAndActuator(t *testing.T, ctx *context.AutoscalingContext, p *ca_processors.AutoscalingProcessors, cs *clusterstate.ClusterStateRegistry) (scaledown.Planner, scaledown.Actuator) {
-	ctx.MaxScaleDownParallelism = 10
+	ctx.MaxEmptyBulkDelete = 10
 	ctx.MaxDrainParallelism = 1
 	ctx.NodeDeletionBatcherInterval = 0 * time.Second
 	ctx.NodeDeleteDelayAfterTaint = 1 * time.Second

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -218,7 +218,7 @@ var (
 		"maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start.")
 	nodeGroupBackoffResetTimeout = flag.Duration("node-group-backoff-reset-timeout", 3*time.Hour,
 		"nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.")
-	maxScaleDownParallelismFlag       = flag.Int("max-scale-down-parallelism", 10, "Maximum number of nodes (both empty and needing drain) that can be deleted in parallel.")
+	maxScaleDownParallelismFlag       = flag.Int("max-scale-down-parallelism", 10, "Maximum number of nodes (both empty and needing drain) that can be deleted in parallel.WARNING BEING DEPRECATED IN 1.29")
 	maxDrainParallelismFlag           = flag.Int("max-drain-parallelism", 1, "Maximum number of nodes needing drain, that can be drained and deleted in parallel.")
 	recordDuplicatedEvents            = flag.Bool("record-duplicated-events", false, "enable duplication of similar events within a 5 minute window.")
 	maxNodesPerScaleUp                = flag.Int("max-nodes-per-scaleup", 1000, "Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput.")
@@ -269,12 +269,9 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 
 	// in order to avoid inconsistent deletion thresholds for the legacy planner and the new actuator, the max-empty-bulk-delete,
 	// and max-scale-down-parallelism flags must be set to the same value.
-	if isFlagPassed("max-empty-bulk-delete") && !isFlagPassed("max-scale-down-parallelism") {
-		*maxScaleDownParallelismFlag = *maxEmptyBulkDeleteFlag
-		klog.Warning("The max-empty-bulk-delete flag will be deprecated in k8s version 1.29. Please use max-scale-down-parallelism instead.")
-		klog.Infof("Setting max-scale-down-parallelism to %d, based on the max-empty-bulk-delete value %d", *maxScaleDownParallelismFlag, *maxEmptyBulkDeleteFlag)
-	} else if !isFlagPassed("max-empty-bulk-delete") && isFlagPassed("max-scale-down-parallelism") {
+	if isFlagPassed("max-scale-down-parallelism") {
 		*maxEmptyBulkDeleteFlag = *maxScaleDownParallelismFlag
+		klog.Warning("The max-scale-down-parallelism flag will be deprecated in k8s version 1.29. Please use max-empty-bulk-delete instead.")
 	}
 
 	var parsedSchedConfig *scheduler_config.KubeSchedulerConfiguration
@@ -361,7 +358,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		InitialNodeGroupBackoffDuration:    *initialNodeGroupBackoffDuration,
 		MaxNodeGroupBackoffDuration:        *maxNodeGroupBackoffDuration,
 		NodeGroupBackoffResetTimeout:       *nodeGroupBackoffResetTimeout,
-		MaxScaleDownParallelism:            *maxScaleDownParallelismFlag,
 		MaxDrainParallelism:                *maxDrainParallelismFlag,
 		RecordDuplicatedEvents:             *recordDuplicatedEvents,
 		MaxNodesPerScaleUp:                 *maxNodesPerScaleUp,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug 
/kind deprecation 
#### What this PR does / why we need it:
There are two flags that control the deletion thresholds. FOr now to mitigate, we just set them to the same value, but long term, we should only have one flag that controls the number of deletion candidates. 

It might be easier to deprecate the parallelism flag rather than maxEmptyBulk delete since it has been around for ages. So this pr is the implementation of that approach. I have an alternative PR that If the discussion dictates, we can use instead https://github.com/kubernetes/autoscaler/pull/5949

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecation Notice added for max-scale-down-parallelism
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
