### PR TITLE
Fix index out of range when fail to get instance types

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -334,10 +334,13 @@ func (m *awsWrapper) getInstanceTypeFromInstanceRequirements(imageId string, req
 		return !isLastPage
 	})
 	observeAWSRequest("GetInstanceTypesFromInstanceRequirements", err, start)
-	if err != nil || len(instanceTypes) == 0 {
-		return "", fmt.Errorf("unable to get instance types from requirements")
+	if err != nil {
+		return "", fmt.Errorf("unable to get instance types from requirements: %w", err)
 	}
 
+	if len(instanceTypes) == 0 {
+		return "", fmt.Errorf("no instance types found for requirements")
+	}
 	return instanceTypes[0], nil
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -326,7 +326,7 @@ func (m *awsWrapper) getInstanceTypeFromInstanceRequirements(imageId string, req
 	}
 
 	start = time.Now()
-	instanceTypes := []string{}
+	var instanceTypes []string
 	err = m.GetInstanceTypesFromInstanceRequirementsPages(requirementsInput, func(page *ec2.GetInstanceTypesFromInstanceRequirementsOutput, isLastPage bool) bool {
 		for _, instanceType := range page.InstanceTypes {
 			instanceTypes = append(instanceTypes, *instanceType.InstanceType)
@@ -334,7 +334,7 @@ func (m *awsWrapper) getInstanceTypeFromInstanceRequirements(imageId string, req
 		return !isLastPage
 	})
 	observeAWSRequest("GetInstanceTypesFromInstanceRequirements", err, start)
-	if err != nil {
+	if err != nil || len(instanceTypes) == 0 {
 		return "", fmt.Errorf("unable to get instance types from requirements")
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -731,6 +731,7 @@ func TestGetInstanceTypesFromInstanceRequirementsWithEmptyList(t *testing.T) {
 
 	result, err := awsWrapper.getInstanceTypeFromInstanceRequirements("123", requirements)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unable to get instance types from requirements")
+	exp := fmt.Errorf("no instance types found for requirements")
+	assert.EqualError(t, err, exp.Error())
 	assert.Equal(t, "", result)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -695,3 +695,42 @@ func TestBuildLaunchTemplateFromSpec(t *testing.T) {
 		assert.Equal(unit.exp, got)
 	}
 }
+
+func TestGetInstanceTypesFromInstanceRequirementsWithEmptyList(t *testing.T) {
+	e := &ec2Mock{}
+	awsWrapper := &awsWrapper{
+		autoScalingI: nil,
+		ec2I:         e,
+		eksI:         nil,
+	}
+	requirements := &ec2.InstanceRequirementsRequest{}
+
+	e.On("DescribeImages", &ec2.DescribeImagesInput{
+		ImageIds: []*string{aws.String("123")},
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{
+			{
+				Architecture:       aws.String("x86_64"),
+				VirtualizationType: aws.String("xen"),
+			},
+		},
+	})
+	e.On("GetInstanceTypesFromInstanceRequirementsPages",
+		&ec2.GetInstanceTypesFromInstanceRequirementsInput{
+			ArchitectureTypes:    []*string{aws.String("x86_64")},
+			InstanceRequirements: requirements,
+			VirtualizationTypes:  []*string{aws.String("xen")},
+		},
+		mock.AnythingOfType("func(*ec2.GetInstanceTypesFromInstanceRequirementsOutput, bool) bool"),
+	).Run(func(args mock.Arguments) {
+		fn := args.Get(1).(func(*ec2.GetInstanceTypesFromInstanceRequirementsOutput, bool) bool)
+		fn(&ec2.GetInstanceTypesFromInstanceRequirementsOutput{
+			InstanceTypes: []*ec2.InstanceTypeInfoFromInstanceRequirements{},
+		}, false)
+	}).Return(nil)
+
+	result, err := awsWrapper.getInstanceTypeFromInstanceRequirements("123", requirements)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to get instance types from requirements")
+	assert.Equal(t, "", result)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6025 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
