### PR TITLE
Set batch size to target size for atomically scaled groups

### DIFF
--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -110,7 +110,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(as scaledown.ActuationStatus, empt
 		if _, found := emptyAtomicMap[bucket.Group.Id()]; found {
 			// This atomically-scaled node group should have been already processed
 			// in the previous loop.
-			break
+			continue
 		}
 		if drainBudget < len(bucket.Nodes) {
 			// One pod slice can sneak in even if it would exceed parallelism budget.


### PR DESCRIPTION
For atomically scaled groups with both empty and drainable nodes, we need to wait for both sets of nodes before proceeding with deletion. Before this change, batch size was set separately for empty and drainable node sets.

1st commit: test case exposing error with batch size
2nd commit: fix for the error with batch size
3rd commit: some extra validation and fix for tests (test cases leak state)
4th commit: test case exposing error with atomic groups interfering with each other's scale down (fails with `-race`)
5th commit: fix for the error with atomic groups interfering with each other's scale down

Sent for review together because changes depend on the previous ones, happy to sqush/split based on review comments.

/kind bug

```release-note
Fixes issue where scale down of atomically scaled node group may fail post-drain.
```
