### PR TITLE
fix: scale down broken for providers not implementing NodeGroup.GetOptions()

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
@@ -78,7 +78,7 @@ func (ds *GroupDeletionScheduler) ReportMetrics() {
 // other nodes are passed over to NodeDeletionBatcher immediately.
 func (ds *GroupDeletionScheduler) ScheduleDeletion(nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
 	opts, err := nodeGroup.GetOptions(ds.ctx.NodeGroupDefaults)
-	if err != nil {
+	if err != nil && err != cloudprovider.ErrNotImplemented {
 		nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerError(errors.InternalError, "GetOptions returned error %v", err)}
 		ds.AbortNodeDeletion(nodeInfo.Node(), nodeGroup.Id(), drain, "failed to get autoscaling options for a node group", nodeDeleteResult)
 		return

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -198,7 +198,7 @@ func (bp *ScaleDownBudgetProcessor) group(nodes []*apiv1.Node) []*NodeGroupView 
 func (bp *ScaleDownBudgetProcessor) categorize(groups []*NodeGroupView) (individual, atomic []*NodeGroupView) {
 	for _, view := range groups {
 		autoscalingOptions, err := view.Group.GetOptions(bp.ctx.NodeGroupDefaults)
-		if err != nil {
+		if err != nil && err != cloudprovider.ErrNotImplemented {
 			klog.Errorf("Failed to get autoscaling options for node group %s: %v", view.Group.Id(), err)
 			continue
 		}

--- a/cluster-autoscaler/processors/nodes/post_filtering_processor.go
+++ b/cluster-autoscaler/processors/nodes/post_filtering_processor.go
@@ -55,7 +55,7 @@ func (p *PostFilteringScaleDownNodeProcessor) filterOutIncompleteAtomicNodeGroup
 			continue
 		}
 		autoscalingOptions, err := nodeGroup.GetOptions(ctx.NodeGroupDefaults)
-		if err != nil {
+		if err != nil && err != cloudprovider.ErrNotImplemented {
 			klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:

Properly handle calls to `NodeGroup.GetOptions()` that return `cloudprovider.ErrNotImplemented` in the scale down path.

Previously scale down was broken for providers not implementing this method. I assume this was introduced in #5695 but did not do a bisect to figure out if this was actually the PR that broke it.

#### Which issue(s) this PR fixes:

Fixes #6037


#### Special notes for your reviewer:

There were a few more calls to `NodeGroup.GetOptions()` that do not handle `cloudprovider.ErrNotImplemented` in `cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go` & `cluster-autoscaler/core/static_autoscaler.go`. I was not sure If these also need fixes, because the issue I was experiencing was related to scale down and went away with the changes in this PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
