### PR TITLE
test(core): add test case for filterOutSchedulableByPacking

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -151,6 +151,64 @@ func TestFilterOutSchedulable(t *testing.T) {
 			},
 			nodeMatches: matchesAllNodes,
 		},
+		"different schedule order 1: 12c 12c 6c 6c": {
+			nodesWithPods: map[*apiv1.Node][]*apiv1.Pod{
+				BuildTestNode("node16c_1", 15600, 200000): {},
+				BuildTestNode("node16c_2", 15600, 200000): {},
+				BuildTestNode("node16c_3", 15600, 200000): {},
+			},
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod12c_1", 12000, 10),
+				BuildTestPod("pod12c_2", 12000, 10),
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+			},
+			expectedScheduledPods: []*apiv1.Pod{
+				BuildTestPod("pod12c_1", 12000, 10),
+				BuildTestPod("pod12c_2", 12000, 10),
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+			},
+			expectedUnscheduledPods: []*apiv1.Pod{},
+			nodeMatches:             matchesAllNodes,
+		},
+		"different schedule order 2: 12c 6c 6c": {
+			nodesWithPods: map[*apiv1.Node][]*apiv1.Pod{
+				BuildTestNode("node16c_1", 15600, 200000): {},
+				BuildTestNode("node16c_2", 15600, 200000): {},
+			},
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod12c_1", 12000, 10),
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+			},
+			expectedScheduledPods: []*apiv1.Pod{
+				BuildTestPod("pod12c_1", 12000, 10),
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+			},
+			expectedUnscheduledPods: []*apiv1.Pod{},
+			nodeMatches:             matchesAllNodes,
+		},
+		"different schedule order 3: 6c 6c 12c": {
+			nodesWithPods: map[*apiv1.Node][]*apiv1.Pod{
+				BuildTestNode("node16c_1", 15600, 200000): {},
+				BuildTestNode("node16c_2", 15600, 200000): {},
+			},
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+				BuildTestPod("pod12c_1", 12000, 10),
+			},
+			expectedScheduledPods: []*apiv1.Pod{
+				BuildTestPod("pod6c_1", 6000, 10),
+				BuildTestPod("pod6c_2", 6000, 10),
+			},
+			expectedUnscheduledPods: []*apiv1.Pod{
+				BuildTestPod("pod12c_1", 12000, 10),
+			},
+			nodeMatches: matchesAllNodes,
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR only introduces additional unit test cases for the `filterOutSchedulableByPacking` function. 

I notice that the order of unschedulable pods affects the result of filterOutSchedulableByPacking, which may lead to the following unexpected scenario:

Assuming there are 2 pending pods using 12c cpu and 2 pending pods using 6c cpu. The node group has 16c allocatable cpu.

loop 1: CA finds the 4 pending pod and estimates 3 nodes: node1 (6c pod + 6c pod), node2 (12c pod), and node3 (12c pod). Node group is triggered to scale up for 3 nodes.

loop 2: CA finds the same pending pod, and 3 new fake nodes. The expected result of `filterOutSchedulableByPacking` is that all 4 pending pods can be scheduled to these 3 fake nodes: node1 (6c, 6c), node2 (12c), and node3 (12c). However, it is possible that one of the 12c pods fails to be scheduled, the nodes maybe like this: node1 (6c), node2 (6c), node3 (12c), and then this unschedulable pod triggers the node group to scale up for 1 more node.

The root cause of this issue is that `filterOutSchedulableByPacking` and `estimator` have a different schedule order. `filterOutSchedulableByPacking` schedule pods by spec.priority first, if pods have same priority, it depends on the list order from `lister`. `estimator` schedules pods by score, pods with higher utilization will be scheduled with higher priority.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
