### PR TITLE
[gha] Build and push vpa-recommender to mindbox registry. Test only vpa

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         env:
           GO111MODULE: auto
 
-      - name: Test
+      - name: Test Vertical pod autoscaler
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler
         run: hack/for-go-proj.sh test
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,30 +4,27 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: write  # for helm/chart-releaser-action to push chart release and create a release
+      contents: write
+    name: Build and push images
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Docker login
+        uses: docker/login-action@v2.1.0
         with:
-          fetch-depth: 0
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure Git
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Build and push VPA recommender
+        uses: docker/build-push-action@v4.0.0
         with:
-          version: v3.4.0
-
-      - env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CR_RELEASE_NAME_TEMPLATE: "cluster-autoscaler-chart-{{ .Version }}"
-        name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
-name: Release Charts
+          context: ./vertical-pod-autoscaler
+          tags: "vpa-recommender:1.0.${{ github.run_number }}"
+          push: true
+name: Release
 on:
   push:
     branches:

--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -19,7 +19,7 @@ set -o pipefail
 set -o nounset
 
 CONTRIB_ROOT="$(dirname ${BASH_SOURCE})/.."
-PROJECT_NAMES=(addon-resizer cluster-autoscaler vertical-pod-autoscaler)
+PROJECT_NAMES=(vertical-pod-autoscaler)
 
 if [[ $# -ne 1 ]]; then
   echo "missing subcommand: [build|install|test]"

--- a/vertical-pod-autoscaler/Dockerfile
+++ b/vertical-pod-autoscaler/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.21.0 as builder
+
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$PATH
+
+ARG GOARCH
+ARG LDFLAGS
+
+RUN go version
+RUN go install github.com/tools/godep@latest
+RUN godep version
+
+WORKDIR /src
+COPY . .
+RUN go mod download
+WORKDIR /src/pkg/recommender
+RUN GOOS=linux CGO_ENABLED=0 go build -o /out
+
+FROM gcr.io/distroless/static:latest
+COPY --from=builder /out /recommender
+ENTRYPOINT ["/recommender"]


### PR DESCRIPTION
https://github.com/mindbox-cloud/issues-platform/issues/1647

- Добавил упрощенный автоматический билд образа `vpa-recommender`
- Выключил все тесты, кроме vpa, чтобы снизить время чеков. В официальном репо длятся полчаса.