### PR TITLE
Add fetch reservations in specific project

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -87,6 +87,7 @@ type AutoscalingGceClient interface {
 	FetchZones(region string) ([]string, error)
 	FetchAvailableCpuPlatforms() (map[string][]string, error)
 	FetchReservations() ([]*gce.Reservation, error)
+	FetchReservationsInProject(projectId string) ([]*gce.Reservation, error)
 
 	// modifying resources
 	ResizeMig(GceRef, int64) error
@@ -550,8 +551,12 @@ func (client *autoscalingGceClientV1) FetchMigsWithName(zone string, name *regex
 }
 
 func (client *autoscalingGceClientV1) FetchReservations() ([]*gce.Reservation, error) {
+	return client.FetchReservationsInProject(client.projectId)
+}
+
+func (client *autoscalingGceClientV1) FetchReservationsInProject(projectId string) ([]*gce.Reservation, error) {
 	reservations := make([]*gce.Reservation, 0)
-	call := client.gceService.Reservations.AggregatedList(client.projectId)
+	call := client.gceService.Reservations.AggregatedList(projectId)
 	err := call.Pages(context.TODO(), func(ls *gce.ReservationAggregatedList) error {
 		for _, items := range ls.Items {
 			reservations = append(reservations, items.Reservations...)

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -105,6 +105,10 @@ func (client *mockAutoscalingGceClient) FetchReservations() ([]*gce.Reservation,
 	return nil, nil
 }
 
+func (client *mockAutoscalingGceClient) FetchReservationsInProject(_ string) ([]*gce.Reservation, error) {
+	return nil, nil
+}
+
 func (client *mockAutoscalingGceClient) ResizeMig(_ GceRef, _ int64) error {
 	return nil
 }


### PR DESCRIPTION
/kind feature
/kind api-change

#### What this PR does / why we need it:
GCE supports shared reservations where the reservation is in a different project than the project the cluster is in. Add GCE client method to get said reservations so logic can support shared reservations in the future. This change does not change autoscaling logic, just enables the ability to fetch reservations in other projects.

#### Which issue(s) this PR fixes:
N/A

Fixes #

#### Special notes for your reviewer:
Added a new methods instead of changing an the existing one to be backwards compatible. The existing one is currently in use for GKE. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [GCE Shared Reservation Docs]: https://cloud.google.com/compute/docs/instances/reservations-shared
```
