### PR TITLE
Add additional test cases to scale down budget tests.

### DIFF
--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -39,6 +39,7 @@ func TestCropNodesToBudgets(t *testing.T) {
 	testNg2 := testprovider.NewTestNodeGroup("test-ng2", 0, 100, 3, true, false, "n1-standard-2", nil, nil)
 	atomic3 := sizedNodeGroup("atomic-3", 3, true)
 	atomic4 := sizedNodeGroup("atomic-4", 4, true)
+	atomic5 := sizedNodeGroup("atomic-5", 5, true)
 	atomic8 := sizedNodeGroup("atomic-8", 8, true)
 	atomic11 := sizedNodeGroup("atomic-11", 11, true)
 	for tn, tc := range map[string]struct {
@@ -222,6 +223,30 @@ func TestCropNodesToBudgets(t *testing.T) {
 			wantEmpty: generateNodeGroupViewList(atomic8, 0, 8),
 			wantDrain: []*NodeGroupView{},
 		},
+		"empty&drain atomic nodes in same group within overall limit, no deletions in progress": {
+			empty:     generateNodeGroupViewList(atomic8, 0, 5),
+			drain:     generateNodeGroupViewList(atomic8, 5, 8),
+			wantEmpty: generateNodeGroupViewList(atomic8, 0, 5),
+			wantDrain: generateNodeGroupViewList(atomic8, 5, 8),
+		},
+		"empty&drain atomic nodes in same group exceeding overall limit, no deletions in progress": {
+			empty:     generateNodeGroupViewList(atomic11, 0, 8),
+			drain:     generateNodeGroupViewList(atomic11, 8, 11),
+			wantEmpty: generateNodeGroupViewList(atomic11, 0, 8),
+			wantDrain: generateNodeGroupViewList(atomic11, 8, 11),
+		},
+		"empty&drain atomic nodes in same group exceeding drain limit, no deletions in progress": {
+			empty:     generateNodeGroupViewList(atomic8, 0, 2),
+			drain:     generateNodeGroupViewList(atomic8, 2, 8),
+			wantEmpty: generateNodeGroupViewList(atomic8, 0, 2),
+			wantDrain: generateNodeGroupViewList(atomic8, 2, 8),
+		},
+		"empty&drain atomic nodes in same group not matching node group size, no deletions in progress": {
+			empty:     generateNodeGroupViewList(atomic8, 0, 2),
+			drain:     generateNodeGroupViewList(atomic8, 2, 4),
+			wantEmpty: []*NodeGroupView{},
+			wantDrain: []*NodeGroupView{},
+		},
 		"empty&drain atomic nodes exceeding drain limit, no deletions in progress": {
 			empty:     generateNodeGroupViewList(atomic4, 0, 4),
 			drain:     generateNodeGroupViewList(atomic8, 0, 8),
@@ -233,6 +258,24 @@ func TestCropNodesToBudgets(t *testing.T) {
 			drain:     generateNodeGroupViewList(atomic8, 0, 8),
 			wantEmpty: append(generateNodeGroupViewList(atomic3, 0, 3), generateNodeGroupViewList(testNg, 0, 5)...),
 			wantDrain: []*NodeGroupView{},
+		},
+		"empty&drain regular and atomic nodes in same group exceeding overall limit, no deletions in progress": {
+			empty:     append(generateNodeGroupViewList(testNg, 0, 5), generateNodeGroupViewList(atomic11, 0, 8)...),
+			drain:     generateNodeGroupViewList(atomic11, 8, 11),
+			wantEmpty: generateNodeGroupViewList(atomic11, 0, 8),
+			wantDrain: generateNodeGroupViewList(atomic11, 8, 11),
+		},
+		"empty&drain regular and multiple atomic nodes in same group exceeding drain limit, no deletions in progress": {
+			empty:     append(append(generateNodeGroupViewList(testNg, 0, 5), generateNodeGroupViewList(atomic8, 0, 5)...), generateNodeGroupViewList(atomic11, 0, 8)...),
+			drain:     append(generateNodeGroupViewList(atomic11, 8, 11), generateNodeGroupViewList(atomic8, 5, 8)...),
+			wantEmpty: append(generateNodeGroupViewList(atomic8, 0, 5), generateNodeGroupViewList(testNg, 0, 2)...),
+			wantDrain: generateNodeGroupViewList(atomic8, 5, 8),
+		},
+		"empty&drain multiple atomic nodes in same group exceeding overall limit, no deletions in progress": {
+			empty:     append(append(generateNodeGroupViewList(atomic3, 0, 3), generateNodeGroupViewList(atomic4, 0, 2)...), generateNodeGroupViewList(atomic11, 0, 11)...),
+			drain:     generateNodeGroupViewList(atomic4, 2, 4),
+			wantEmpty: append(generateNodeGroupViewList(atomic3, 0, 3), generateNodeGroupViewList(atomic4, 0, 2)...),
+			wantDrain: generateNodeGroupViewList(atomic4, 2, 4),
 		},
 		"empty regular and drain atomic nodes exceeding overall limit, no deletions in progress": {
 			drain:     generateNodeGroupViewList(atomic8, 0, 8),
@@ -253,6 +296,20 @@ func TestCropNodesToBudgets(t *testing.T) {
 			wantEmpty:                []*NodeGroupView{},
 			wantDrain:                []*NodeGroupView{},
 		},
+		"empty&drain atomic nodes with deletions in progress, 0 overall budget left": {
+			emptyDeletionsInProgress: 10,
+			empty:                    generateNodeGroupViewList(atomic4, 0, 4),
+			drain:                    generateNodeGroupViewList(atomic3, 0, 3),
+			wantEmpty:                []*NodeGroupView{},
+			wantDrain:                []*NodeGroupView{},
+		},
+		"empty&drain atomic nodes in same group with deletions in progress, 0 overall budget left": {
+			emptyDeletionsInProgress: 10,
+			empty:                    generateNodeGroupViewList(atomic8, 0, 4),
+			drain:                    generateNodeGroupViewList(atomic8, 4, 8),
+			wantEmpty:                []*NodeGroupView{},
+			wantDrain:                []*NodeGroupView{},
+		},
 		"empty&drain nodes with deletions in progress, overall budget exceeded (shouldn't happen, just a sanity check)": {
 			emptyDeletionsInProgress: 50,
 			empty:                    generateNodeGroupViewList(testNg, 0, 5),
@@ -265,6 +322,13 @@ func TestCropNodesToBudgets(t *testing.T) {
 			empty:                    generateNodeGroupViewList(testNg, 0, 5),
 			drain:                    generateNodeGroupViewList(testNg, 0, 5),
 			wantEmpty:                generateNodeGroupViewList(testNg, 0, 5),
+			wantDrain:                []*NodeGroupView{},
+		},
+		"empty&drain atomic nodes with deletions in progress, 0 drain budget left": {
+			drainDeletionsInProgress: 5,
+			empty:                    generateNodeGroupViewList(atomic4, 0, 4),
+			drain:                    generateNodeGroupViewList(atomic3, 0, 3),
+			wantEmpty:                generateNodeGroupViewList(atomic4, 0, 4),
 			wantDrain:                []*NodeGroupView{},
 		},
 		"empty&drain nodes with deletions in progress, drain budget exceeded (shouldn't happen, just a sanity check)": {
@@ -297,6 +361,62 @@ func TestCropNodesToBudgets(t *testing.T) {
 			drain:                    generateNodeGroupViewList(testNg, 0, 5),
 			wantEmpty:                generateNodeGroupViewList(testNg, 0, 4),
 			wantDrain:                generateNodeGroupViewList(testNg, 0, 2),
+		},
+		"empty&drain atomic nodes with deletions in progress, overall budget exceeded, only empty nodes fit": {
+			emptyDeletionsInProgress: 5,
+			drainDeletionsInProgress: 2,
+			empty:                    generateNodeGroupViewList(atomic4, 0, 4),
+			drain:                    generateNodeGroupViewList(atomic3, 0, 3),
+			wantEmpty:                generateNodeGroupViewList(atomic4, 0, 4),
+			wantDrain:                []*NodeGroupView{},
+		},
+		"empty&drain atomic nodes in same group with deletions in progress, both empty&drain nodes fit": {
+			emptyDeletionsInProgress: 5,
+			drainDeletionsInProgress: 2,
+			empty:                    generateNodeGroupViewList(atomic3, 0, 2),
+			drain:                    generateNodeGroupViewList(atomic3, 2, 3),
+			wantEmpty:                generateNodeGroupViewList(atomic3, 0, 2),
+			wantDrain:                generateNodeGroupViewList(atomic3, 2, 3),
+		},
+		"empty&drain atomic nodes in same group with deletions in progress, overall budget exceeded, both empty&drain nodes fit": {
+			emptyDeletionsInProgress: 5,
+			drainDeletionsInProgress: 2,
+			empty:                    generateNodeGroupViewList(atomic8, 0, 6),
+			drain:                    generateNodeGroupViewList(atomic8, 6, 8),
+			wantEmpty:                generateNodeGroupViewList(atomic8, 0, 6),
+			wantDrain:                generateNodeGroupViewList(atomic8, 6, 8),
+		},
+		"empty&drain atomic nodes in same group with deletions in progress, drain budget exceeded, both empty&drain nodes fit": {
+			emptyDeletionsInProgress: 2,
+			drainDeletionsInProgress: 2,
+			empty:                    generateNodeGroupViewList(atomic5, 0, 1),
+			drain:                    generateNodeGroupViewList(atomic5, 1, 5),
+			wantEmpty:                generateNodeGroupViewList(atomic5, 0, 1),
+			wantDrain:                generateNodeGroupViewList(atomic5, 1, 5),
+		},
+		"empty&drain regular and atomic nodes with deletions in progress, overall budget exceeded, only empty atomic is deleted": {
+			emptyDeletionsInProgress: 5,
+			drainDeletionsInProgress: 2,
+			empty:                    append(generateNodeGroupViewList(testNg, 0, 4), generateNodeGroupViewList(atomic4, 0, 4)...),
+			drain:                    append(generateNodeGroupViewList(testNg2, 0, 4), generateNodeGroupViewList(atomic3, 0, 3)...),
+			wantEmpty:                generateNodeGroupViewList(atomic4, 0, 4),
+			wantDrain:                []*NodeGroupView{},
+		},
+		"empty&drain regular and atomic nodes in same group with deletions in progress, overall budget exceeded, both empty&drain atomic nodes fit": {
+			emptyDeletionsInProgress: 5,
+			drainDeletionsInProgress: 2,
+			empty:                    append(generateNodeGroupViewList(testNg, 0, 4), generateNodeGroupViewList(atomic4, 0, 2)...),
+			drain:                    append(generateNodeGroupViewList(testNg2, 0, 4), generateNodeGroupViewList(atomic4, 2, 4)...),
+			wantEmpty:                generateNodeGroupViewList(atomic4, 0, 2),
+			wantDrain:                generateNodeGroupViewList(atomic4, 2, 4),
+		},
+		"empty&drain regular and atomic nodes in same group with deletions in progress, both empty&drain nodes fit": {
+			emptyDeletionsInProgress: 2,
+			drainDeletionsInProgress: 2,
+			empty:                    append(generateNodeGroupViewList(testNg, 0, 4), generateNodeGroupViewList(atomic4, 0, 2)...),
+			drain:                    append(generateNodeGroupViewList(testNg2, 0, 4), generateNodeGroupViewList(atomic4, 2, 4)...),
+			wantEmpty:                append(generateNodeGroupViewList(atomic4, 0, 2), generateNodeGroupViewList(testNg, 0, 2)...),
+			wantDrain:                generateNodeGroupViewList(atomic4, 2, 4),
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Tests were missing cases where the empty and drain nodes are from the same atomic group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
This is a follow-up pr addressing this comment: https://github.com/kubernetes/autoscaler/pull/6034/files#r1291199619

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
