### PR TITLE
Add support to filter out pods being deleted.

### DIFF
--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -201,7 +201,9 @@ func (lister *scheduledAndUnschedulablePodLister) List() (scheduledPods []*apiv1
 		}
 		_, condition := podv1.GetPodCondition(&pod.Status, apiv1.PodScheduled)
 		if condition != nil && condition.Status == apiv1.ConditionFalse && condition.Reason == apiv1.PodReasonUnschedulable {
-			unschedulablePods = append(unschedulablePods, pod)
+			if pod.GetDeletionTimestamp() == nil {
+				unschedulablePods = append(unschedulablePods, pod)
+			}
 		}
 	}
 	return scheduledPods, unschedulablePods, nil


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Pods in process of being deleted should be filtered out from being considered for scale up. This should be done before filter out schedulable, as the pod can "virtually" consume capacity of the cluster.

This being in line with schedule code (https://github.com/kubernetes/kubernetes/blob/cb56c4c627fc627b2eb1ba69a435cc3f205f7363/pkg/scheduler/schedule_one.go#L350-L354), which will no schedule pods that have a deletionTimestamp set.

This has further implications on scale down also, the pod can stay alive for their gracePeriod, however, they will stay pending and consume "virtual" capacity on the cluster, having impact on scale down decisions.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
