### PR TITLE
use vpaObject instead of vpaModel to reduce deps of post-processors

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/capping_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/capping_post_processor.go
@@ -17,10 +17,10 @@ limitations under the License.
 package routines
 
 import (
-	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	vpa_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 	"k8s.io/klog/v2"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 // CappingPostProcessor ensure that the policy is applied to recommendation
@@ -30,11 +30,11 @@ type CappingPostProcessor struct{}
 var _ RecommendationPostProcessor = &CappingPostProcessor{}
 
 // Process apply the capping post-processing to the recommendation. (use to be function getCappedRecommendation)
-func (c CappingPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+func (c CappingPostProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
 	// TODO: maybe rename the vpa_utils.ApplyVPAPolicy to something that mention that it is doing capping only
-	cappedRecommendation, err := vpa_utils.ApplyVPAPolicy(recommendation, policy)
+	cappedRecommendation, err := vpa_utils.ApplyVPAPolicy(recommendation, vpa.Spec.ResourcePolicy)
 	if err != nil {
-		klog.Errorf("Failed to apply policy for VPA %v/%v: %v", vpa.ID.Namespace, vpa.ID.VpaName, err)
+		klog.Errorf("Failed to apply policy for VPA %v/%v: %v", vpa.GetNamespace(), vpa.GetName(), err)
 		return recommendation
 	}
 	return cappedRecommendation

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
@@ -17,11 +17,12 @@ limitations under the License.
 package routines
 
 import (
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	"strings"
 )
 
 // IntegerCPUPostProcessor ensures that the recommendation delivers an integer value for CPU
@@ -40,7 +41,7 @@ var _ RecommendationPostProcessor = &IntegerCPUPostProcessor{}
 
 // Process apply the capping post-processing to the recommendation.
 // For this post processor the CPU value is rounded up to an integer
-func (p *IntegerCPUPostProcessor) Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources, policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources {
+func (p *IntegerCPUPostProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
 
 	amendedRecommendation := recommendation.DeepCopy()
 

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommendation_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommendation_post_processor.go
@@ -18,11 +18,9 @@ package routines
 
 import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
 
 // RecommendationPostProcessor can amend the recommendation according to the defined policies
 type RecommendationPostProcessor interface {
-	Process(vpa *model.Vpa, recommendation *vpa_types.RecommendedPodResources,
-		policy *vpa_types.PodResourcePolicy) *vpa_types.RecommendedPodResources
+	Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources
 }

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -97,7 +97,7 @@ func (r *recommender) UpdateVPAs() {
 		listOfResourceRecommendation := logic.MapToListOfRecommendedContainerResources(resources)
 
 		for _, postProcessor := range r.recommendationPostProcessor {
-			listOfResourceRecommendation = postProcessor.Process(vpa, listOfResourceRecommendation, observedVpa.Spec.ResourcePolicy)
+			listOfResourceRecommendation = postProcessor.Process(observedVpa, listOfResourceRecommendation)
 		}
 
 		vpa.UpdateRecommendation(listOfResourceRecommendation)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

The post-processor interface is taking a model.Vpa when a simple vpa object is enough.
Using a vpa object reduces dependencies of the post-processing layer on the rest of the code base. This is better for user that creates external recommender and that want to include the post-processor.

Not done in this PR to reduce the size of the diff: move the post-processors in a dedicated package. This move should be done in a follow-up PR. This will isolate the post-processors from the rest of the recommender routine and make it easy to import/maintain/understand.

#### What this PR does / why we need it:

This can be considered as a code cleanup. Thanks to this reusing the post-processing layer in external-recommender will be easier since it will come with less dependencies on the rest of the codebase.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
