### PR TITLE
David.benque/prevent empty resource propagation upstream 2

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 
 	core "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-	"k8s.io/klog/v2"
 )
 
 // Provider gets current recommendation, annotations and vpaName for the given pod.
@@ -109,5 +110,13 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 		resourcePolicy = vpa.Spec.ResourcePolicy
 	}
 	containerResources := GetContainersResources(pod, resourcePolicy, *recommendedPodResources, containerLimitRange, false, annotations)
+
+	// Ensure that we are not propagating empty resource key if any.
+	for _, resource := range containerResources {
+		if resource.RemoveEmptyResourceKeyIfAny() {
+			klog.Error("An empty resource key was found and purged for pod=%s/%s with vpa=", pod.Namespace, pod.Name, vpa.Name)
+		}
+	}
+
 	return containerResources, annotations, nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -114,7 +114,7 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 	// Ensure that we are not propagating empty resource key if any.
 	for _, resource := range containerResources {
 		if resource.RemoveEmptyResourceKeyIfAny() {
-			klog.Error("An empty resource key was found and purged for pod=%s/%s with vpa=", pod.Namespace, pod.Name, vpa.Name)
+			klog.Infof("An empty resource key was found and purged for pod=%s/%s with vpa=", pod.Namespace, pod.Name, vpa.Name)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
@@ -60,7 +61,8 @@ func TestUpdateResourceRequests(t *testing.T) {
 		WithContainer(containerName).
 		WithTarget("2", "200Mi").
 		WithMinAllowed("1", "100Mi").
-		WithMaxAllowed("3", "1Gi")
+		WithMaxAllowed("3", "1Gi").
+		WithResourceInTarget("", "666") // Testing that this weird/empty resource will be purged
 	vpa := vpaBuilder.Get()
 
 	uninitialized := test.Pod().WithName("test_uninitialized").
@@ -308,6 +310,9 @@ func TestUpdateResourceRequests(t *testing.T) {
 				if !assert.Equal(t, len(resources), 1) {
 					return
 				}
+
+				_, foundEmpty := resources[0].Requests[""]
+				assert.Equal(t, foundEmpty, false, "empty resourceKey have not been purged")
 
 				cpuRequest := resources[0].Requests[apiv1.ResourceCPU]
 				assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -311,7 +311,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 					return
 				}
 
-				assert.Contains(t, resources, "", "expected empty resource to be removed")
+				assert.NotContains(t, resources, "", "expected empty resource to be removed")
 
 				cpuRequest := resources[0].Requests[apiv1.ResourceCPU]
 				assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -62,7 +62,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 		WithTarget("2", "200Mi").
 		WithMinAllowed("1", "100Mi").
 		WithMaxAllowed("3", "1Gi").
-		WithResourceInTarget("", "666") // Testing that this weird/empty resource will be purged
+		WithTargetResource("", "666") // Testing that this weird/empty resource will be purged
 	vpa := vpaBuilder.Get()
 
 	uninitialized := test.Pod().WithName("test_uninitialized").

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -311,8 +311,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 					return
 				}
 
-				_, foundEmpty := resources[0].Requests[""]
-				assert.Equal(t, foundEmpty, false, "empty resourceKey have not been purged")
+				assert.Contains(t, resources, "", "expected empty resource to be removed")
 
 				cpuRequest := resources[0].Requests[apiv1.ResourceCPU]
 				assert.Equal(t, tc.expectedCPU.Value(), cpuRequest.Value(), "cpu request doesn't match")

--- a/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	apiv1 "k8s.io/api/core/v1"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
@@ -25,6 +26,7 @@ import (
 type RecommendationBuilder interface {
 	WithContainer(containerName string) RecommendationBuilder
 	WithTarget(cpu, memory string) RecommendationBuilder
+	WithResource(resource apiv1.ResourceName, value string) RecommendationBuilder
 	WithLowerBound(cpu, memory string) RecommendationBuilder
 	WithUpperBound(cpu, memory string) RecommendationBuilder
 	Get() *vpa_types.RecommendedPodResources
@@ -52,6 +54,15 @@ func (b *recommendationBuilder) WithContainer(containerName string) Recommendati
 func (b *recommendationBuilder) WithTarget(cpu, memory string) RecommendationBuilder {
 	c := *b
 	c.target = Resources(cpu, memory)
+	return &c
+}
+
+func (b *recommendationBuilder) WithResource(resource apiv1.ResourceName, value string) RecommendationBuilder {
+	c := *b
+	if c.target == nil {
+		c.target = apiv1.ResourceList{}
+	}
+	AddResource(c.target, resource, value)
 	return &c
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_recommendation.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
@@ -26,12 +27,14 @@ import (
 type RecommendationBuilder interface {
 	WithContainer(containerName string) RecommendationBuilder
 	WithTarget(cpu, memory string) RecommendationBuilder
-	WithResource(resource apiv1.ResourceName, value string) RecommendationBuilder
+	WithTargetResource(resource apiv1.ResourceName, value string) RecommendationBuilder
 	WithLowerBound(cpu, memory string) RecommendationBuilder
 	WithUpperBound(cpu, memory string) RecommendationBuilder
 	Get() *vpa_types.RecommendedPodResources
 	GetContainerResources() vpa_types.RecommendedContainerResources
 }
+
+// TODO part of this interface is repeated in VerticalPodAutoscalerBuilder, we can probably factorize some code
 
 // Recommendation returns a new RecommendationBuilder.
 func Recommendation() RecommendationBuilder {
@@ -57,12 +60,12 @@ func (b *recommendationBuilder) WithTarget(cpu, memory string) RecommendationBui
 	return &c
 }
 
-func (b *recommendationBuilder) WithResource(resource apiv1.ResourceName, value string) RecommendationBuilder {
+func (b *recommendationBuilder) WithTargetResource(resource apiv1.ResourceName, value string) RecommendationBuilder {
 	c := *b
 	if c.target == nil {
 		c.target = apiv1.ResourceList{}
 	}
-	AddResource(c.target, resource, value)
+	addResource(c.target, resource, value)
 	return &c
 }
 
@@ -102,4 +105,14 @@ func (b *recommendationBuilder) GetContainerResources() vpa_types.RecommendedCon
 		LowerBound:     b.lowerBound,
 		UpperBound:     b.upperBound,
 	}
+}
+
+// addResource add a resource to the given resource list
+func addResource(rl apiv1.ResourceList, resourceName apiv1.ResourceName, value string) apiv1.ResourceList {
+	val, _ := resource.ParseQuantity(value)
+	if rl == nil {
+		rl = apiv1.ResourceList{}
+	}
+	rl[resourceName] = val
+	return rl
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -74,16 +74,6 @@ func Resources(cpu, mem string) apiv1.ResourceList {
 	return result
 }
 
-// AddResource add a resource to the given resource list
-func AddResource(rl apiv1.ResourceList, resourceName apiv1.ResourceName, value string) apiv1.ResourceList {
-	val, _ := resource.ParseQuantity(value)
-	if rl == nil {
-		rl = apiv1.ResourceList{}
-	}
-	rl[resourceName] = val
-	return rl
-}
-
 // RecommenderAPIMock is a mock of RecommenderAPI
 type RecommenderAPIMock struct {
 	mock.Mock

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -26,12 +26,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_types_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	vpa_lister_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
-	v1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/record"
 )
 
 var (
@@ -71,6 +72,16 @@ func Resources(cpu, mem string) apiv1.ResourceList {
 		result[apiv1.ResourceMemory] = memVal
 	}
 	return result
+}
+
+// AddResource add a resource to the given resource list
+func AddResource(rl apiv1.ResourceList, resourceName apiv1.ResourceName, value string) apiv1.ResourceList {
+	val, _ := resource.ParseQuantity(value)
+	if rl == nil {
+		rl = apiv1.ResourceList{}
+	}
+	rl[resourceName] = val
+	return rl
 }
 
 // RecommenderAPIMock is a mock of RecommenderAPI

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -22,6 +22,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
@@ -36,6 +37,7 @@ type VerticalPodAutoscalerBuilder interface {
 	WithMaxAllowed(cpu, memory string) VerticalPodAutoscalerBuilder
 	WithControlledValues(mode vpa_types.ContainerControlledValues) VerticalPodAutoscalerBuilder
 	WithTarget(cpu, memory string) VerticalPodAutoscalerBuilder
+	WithResourceInTarget(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder
 	WithLowerBound(cpu, memory string) VerticalPodAutoscalerBuilder
 	WithTargetRef(targetRef *autoscaling.CrossVersionObjectReference) VerticalPodAutoscalerBuilder
 	WithUpperBound(cpu, memory string) VerticalPodAutoscalerBuilder
@@ -131,6 +133,12 @@ func (b *verticalPodAutoscalerBuilder) WithControlledValues(mode vpa_types.Conta
 func (b *verticalPodAutoscalerBuilder) WithTarget(cpu, memory string) VerticalPodAutoscalerBuilder {
 	c := *b
 	c.recommendation = c.recommendation.WithTarget(cpu, memory)
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) WithResourceInTarget(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder {
+	c := *b
+	c.recommendation = c.recommendation.WithResource(resource, value)
 	return &c
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -37,7 +37,7 @@ type VerticalPodAutoscalerBuilder interface {
 	WithMaxAllowed(cpu, memory string) VerticalPodAutoscalerBuilder
 	WithControlledValues(mode vpa_types.ContainerControlledValues) VerticalPodAutoscalerBuilder
 	WithTarget(cpu, memory string) VerticalPodAutoscalerBuilder
-	WithResourceInTarget(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder
+	WithTargetResource(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder
 	WithLowerBound(cpu, memory string) VerticalPodAutoscalerBuilder
 	WithTargetRef(targetRef *autoscaling.CrossVersionObjectReference) VerticalPodAutoscalerBuilder
 	WithUpperBound(cpu, memory string) VerticalPodAutoscalerBuilder
@@ -49,6 +49,8 @@ type VerticalPodAutoscalerBuilder interface {
 	AppendRecommendation(vpa_types.RecommendedContainerResources) VerticalPodAutoscalerBuilder
 	Get() *vpa_types.VerticalPodAutoscaler
 }
+
+// TODO part of this interface is a repetition of RecommendationBuilder, we can probably factorize some code
 
 // VerticalPodAutoscaler returns a new VerticalPodAutoscalerBuilder.
 func VerticalPodAutoscaler() VerticalPodAutoscalerBuilder {
@@ -136,9 +138,9 @@ func (b *verticalPodAutoscalerBuilder) WithTarget(cpu, memory string) VerticalPo
 	return &c
 }
 
-func (b *verticalPodAutoscalerBuilder) WithResourceInTarget(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder {
+func (b *verticalPodAutoscalerBuilder) WithTargetResource(resource core.ResourceName, value string) VerticalPodAutoscalerBuilder {
 	c := *b
-	c.recommendation = c.recommendation.WithResource(resource, value)
+	c.recommendation = c.recommendation.WithTargetResource(resource, value)
 	return &c
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
@@ -172,3 +172,17 @@ func scaleQuantityProportionallyMem(scaledQuantity, scaleBase, scaleResult *reso
 	}
 	return resource.NewQuantity(math.MaxInt64, scaledQuantity.Format), true
 }
+
+// RemoveEmptyResourceKeyIfAny ensure that we are not pushing a resource with an empty key. Return true if an empty key was eliminated
+func (cr *ContainerResources) RemoveEmptyResourceKeyIfAny() bool {
+	var found bool
+	if _, foundEmptyKey := cr.Limits[""]; foundEmptyKey {
+		delete(cr.Limits, "")
+		found = true
+	}
+	if _, foundEmptyKey := cr.Requests[""]; foundEmptyKey {
+		delete(cr.Requests, "")
+		found = true
+	}
+	return found
+}


### PR DESCRIPTION

#### Which component this PR applies to?

vertical-pod-autoscaler/admission-controller

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Using external recommender that was coming with a bug, we ended up with a VPA object that was presenting a recommendation for a resource that has an empty name:

```
 resources:
          limits:
            cpu: "1"
            memory: 3Gi
          requests:
            "": "0"              <== empty key
            cpu: "1"
            ephemeral-storage: 10Gi
            memory: 3Gi
```

In this PR we are proposing to sanitise the recommendation by removing any resource key that would be empty so that the admission is not pushing "garbage" to the pods.

Possible extension: instead of purging empty key, we could have a list of allowed resourceName given as input parameter of the admission. This would also allow us to purge unknown resource or the one coming with typo.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

If a recommendation comes with a resource key that is empty, this resource will be ignored in the admission-controller.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
