### PR TITLE
[charts/cluster-autoscaler] Revert "update RBAC to only use verbs that exist for the resources"

### DIFF
--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -151,7 +151,9 @@ rules:
     - cluster.x-k8s.io
     resources:
     - machinedeployments
+    - machinedeployments/scale
     - machinepools
+    - machinepools/scale
     - machines
     - machinesets
     verbs:
@@ -159,14 +161,5 @@ rules:
     - list
     - update
     - watch
-  - apiGroups:
-    - cluster.x-k8s.io
-    resources:
-    - machinedeployments/scale
-    - machinepools/scale
-    verbs:
-    - get
-    - patch
-    - update
 {{- end }}
 {{- end -}}

--- a/charts/cluster-autoscaler/templates/role.yaml
+++ b/charts/cluster-autoscaler/templates/role.yaml
@@ -49,7 +49,9 @@ rules:
     - cluster.x-k8s.io
     resources:
     - machinedeployments
+    - machinedeployments/scale
     - machinepools
+    - machinepools/scale
     - machines
     - machinesets
     verbs:
@@ -57,15 +59,6 @@ rules:
     - list
     - update
     - watch
-  - apiGroups:
-    - cluster.x-k8s.io
-    resources:
-    - machinedeployments/scale
-    - machinepools/scale
-    verbs:
-    - get
-    - patch
-    - update
 {{- end }}
 {{- if ( not .Values.rbac.clusterScoped ) }}
   - apiGroups:


### PR DESCRIPTION
Reverts kubernetes/autoscaler#5927
See https://github.com/kubernetes/autoscaler/pull/5927#issuecomment-1695754325 for more details