### PR TITLE
fix(chart): cloudProvider name reference for OCI

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.29.2
+version: 9.29.3

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - --node-group-auto-discovery=mig:namePrefix={{ .name }},min={{ .minSize }},max={{ .maxSize }}
             {{- end }}
           {{- end }}
-          {{- if eq .Values.cloudProvider "oci-oke" }}
+          {{- if eq .Values.cloudProvider "oci" }}
             {{- if .Values.cloudConfigPath }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
             - --balance-similar-node-groups

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -6,7 +6,7 @@ affinity: {}
 additionalLabels: {}
 
 autoDiscovery:
-  # cloudProviders `aws`, `gce`, `azure`, `magnum` and `clusterapi` `oci-oke` are supported by auto-discovery at this time
+  # cloudProviders `aws`, `gce`, `azure`, `magnum` and `clusterapi` `oci` are supported by auto-discovery at this time
   # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
 
   # autoDiscovery.clusterName -- Enable autodiscovery for `cloudProvider=aws`, for groups matching `autoDiscovery.tags`.

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -6,7 +6,7 @@ affinity: {}
 additionalLabels: {}
 
 autoDiscovery:
-  # cloudProviders `aws`, `gce`, `azure`, `magnum` and `clusterapi` `oci` are supported by auto-discovery at this time
+  # cloudProviders `aws`, `gce`, `azure`, `magnum`, `clusterapi` and `oci` are supported by auto-discovery at this time
   # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
 
   # autoDiscovery.clusterName -- Enable autodiscovery for `cloudProvider=aws`, for groups matching `autoDiscovery.tags`.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation

#### What this PR does / why we need it:

Fixes the cloudProvider.name reference for OCI, correct is `oci`, not `oci-oke`

This is found both in a comment and in a condition

Autoscaler crashes with `oci-oke`:

```
1 cloud_provider_builder.go:29] Building oci-oke cloud provider.
1 cloud_provider_builder.go:50] Unknown cloud provider: oci-oke
```

The examples are correct ([example 1](https://github.com/kubernetes/autoscaler/blob/574c534e4fe7e3f09466cf8dca9af9a3bb9e9c66/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml#L150), [example 2](https://github.com/kubernetes/autoscaler/blob/574c534e4fe7e3f09466cf8dca9af9a3bb9e9c66/cluster-autoscaler/cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-principals.yaml#L150), [example 3](https://github.com/kubernetes/autoscaler/blob/574c534e4fe7e3f09466cf8dca9af9a3bb9e9c66/cluster-autoscaler/cloudprovider/oci/examples/oci-nodepool-cluster-autoscaler-w-principals.yaml#L154)), but the chart isn't.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

![image](https://github.com/kubernetes/autoscaler/assets/10081640/581f509e-5ca1-4552-9a66-85f0777df8b4)

#### Does this PR introduce a user-facing change?

```release-note
Fixed invalid reference for OCI on autoscaler's Helm chart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
