### PR TITLE
Fix flag name in documentation

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -304,7 +304,7 @@ For example you could have 3 profiles: [frugal](deploy/recommender-deployment-lo
 use different TargetCPUPercentile (50, 90 and 95) to calculate their recommendations.
 
 Please note the usage of the following arguments to override default names and percentiles:
-- --name=performance
+- --recommender-name=performance
 - --target-cpu-percentile=0.95
 
 You can then choose which recommender to use by setting `recommenders` inside the `VerticalPodAutoscaler` spec.

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -29,7 +29,7 @@ spec:
         image: registry.k8s.io/autoscaling/vpa-recommender:0.14.0
         imagePullPolicy: Always
         args:
-          - --name=performance
+          - --recommender-name=performance
           - --target-cpu-percentile=0.95
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -29,7 +29,7 @@ spec:
         image: registry.k8s.io/autoscaling/vpa-recommender:0.14.0
         imagePullPolicy: Always
         args:
-          - --name=frugal
+          - --recommender-name=frugal
           - --target-cpu-percentile=0.50
         resources:
           limits:


### PR DESCRIPTION
It's [`recommender-name`](https://github.com/kubernetes/autoscaler/blob/cd5ed0be530e2313f762e30042cb324b768507f6/vertical-pod-autoscaler/pkg/recommender/main.go#L48C40-L48C56) not `name`. Documentation added in #5231

fixes #5451

/kind documentation
