### PR TITLE
[WIP] feat: Rename comments, logs, structs, and vars from packet to equinix metal

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_packet.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_packet.go
@@ -28,7 +28,7 @@ import (
 // AvailableCloudProviders supported by the cloud provider builder.
 var AvailableCloudProviders = []string{
 	packet.ProviderName,
-	cloudprovider.EquinixMetalProviderName,
+	packet.EquinixMetalProviderName,
 }
 
 // DefaultCloudProvider for Packet-only build is Packet.
@@ -37,6 +37,8 @@ const DefaultCloudProvider = cloudprovider.EquinixMetalProviderName
 func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case packet.ProviderName, cloudprovider.EquinixMetalProviderName:
+		return packet.BuildCloudProvider(opts, do, rl)
+	case cloudprovider.EquinixMetalProviderName:
 		return packet.BuildCloudProvider(opts, do, rl)
 	}
 

--- a/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_cloud_provider.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	// ProviderName is the cloud provider name for Packet cloud provider, now named as equinixmetal
+	// ProviderName is the cloud provider name for Equinix Metal
 	ProviderName = "packet"
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation
/kind deprecation

#### What this PR does / why we need it:
Changing all the struct, variable names, comments and logs, referring from packet -> equinix metal. This PR will be a part of overall effort to completely migrate packet cloud autoscaler to equinix-metal autoscaler.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/4286

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
