### PR TITLE
fix: add aws csi zone label to node template

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -50,6 +50,7 @@ const (
 	autoDiscovererTypeASG   = "asg"
 	asgAutoDiscovererKeyTag = "tag"
 	optionsTagsPrefix       = "k8s.io/cluster-autoscaler/node-template/autoscaling-options/"
+	labelAwsCSITopologyZone = "topology.ebs.csi.aws.com/zone"
 )
 
 // AwsManager is handles aws communication and data caching.
@@ -416,6 +417,7 @@ func buildGenericLabels(template *asgTemplate, nodeName string) map[string]strin
 
 	result[apiv1.LabelTopologyRegion] = template.Region
 	result[apiv1.LabelTopologyZone] = template.Zone
+	result[labelAwsCSITopologyZone] = template.Zone
 	result[apiv1.LabelHostname] = nodeName
 	return result
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -65,8 +65,11 @@ func TestBuildGenericLabels(t *testing.T) {
 			Architecture: cloudprovider.DefaultArch,
 		},
 		Region: "us-east-1",
+		Zone:   "us-east-1c",
 	}, "sillyname")
-	assert.Equal(t, "us-east-1", labels[apiv1.LabelZoneRegionStable])
+	assert.Equal(t, "us-east-1", labels[apiv1.LabelTopologyRegion])
+	assert.Equal(t, "us-east-1c", labels[apiv1.LabelTopologyZone])
+	assert.Equal(t, "us-east-1c", labels[labelAwsCSITopologyZone])
 	assert.Equal(t, "sillyname", labels[apiv1.LabelHostname])
 	assert.Equal(t, "c4.large", labels[apiv1.LabelInstanceTypeStable])
 	assert.Equal(t, cloudprovider.DefaultArch, labels[apiv1.LabelArchStable])


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #3845

#### Special notes for your reviewer:

While touching the code I also removed the use of the deprecated constant `apiv1.LabelZoneRegionStable` in a test

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scale up from 0 now working with existing AWS EBS CSI PersistentVolume without having to add tag to ASG
```
