### PR TITLE
Refactor ScaleDownSet processor into a composite processor

### DIFF
--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -178,7 +178,10 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 		NodeGroupListProcessor: &nodegroups.NoOpNodeGroupListProcessor{},
 		BinpackingLimiter:      binpacking.NewDefaultBinpackingLimiter(),
 		NodeGroupSetProcessor:  nodegroupset.NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{}),
-		ScaleDownSetProcessor:  nodes.NewPostFilteringScaleDownNodeProcessor(),
+		ScaleDownSetProcessor: nodes.NewCompositeScaleDownSetProcessor([]nodes.ScaleDownSetProcessor{
+			nodes.NewAtomicResizeFilteringProcessor(),
+			nodes.NewMaxNodesProcessor(),
+		}),
 		// TODO(bskiba): change scale up test so that this can be a NoOpProcessor
 		ScaleUpStatusProcessor:      &status.EventingScaleUpStatusProcessor{},
 		ScaleDownStatusProcessor:    &status.NoOpScaleDownStatusProcessor{},

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -80,9 +80,14 @@ func DefaultProcessors(options config.AutoscalingOptions) *AutoscalingProcessors
 			MaxCapacityMemoryDifferenceRatio: config.DefaultMaxCapacityMemoryDifferenceRatio,
 			MaxFreeDifferenceRatio:           config.DefaultMaxFreeDifferenceRatio,
 		}),
-		ScaleUpStatusProcessor:      status.NewDefaultScaleUpStatusProcessor(),
-		ScaleDownNodeProcessor:      nodes.NewPreFilteringScaleDownNodeProcessor(),
-		ScaleDownSetProcessor:       nodes.NewPostFilteringScaleDownNodeProcessor(),
+		ScaleUpStatusProcessor: status.NewDefaultScaleUpStatusProcessor(),
+		ScaleDownNodeProcessor: nodes.NewPreFilteringScaleDownNodeProcessor(),
+		ScaleDownSetProcessor: nodes.NewCompositeScaleDownSetProcessor(
+			[]nodes.ScaleDownSetProcessor{
+				nodes.NewMaxNodesProcessor(),
+				nodes.NewAtomicResizeFilteringProcessor(),
+			},
+		),
 		ScaleDownStatusProcessor:    status.NewDefaultScaleDownStatusProcessor(),
 		AutoscalingStatusProcessor:  status.NewDefaultAutoscalingStatusProcessor(),
 		NodeGroupManager:            nodegroups.NewDefaultNodeGroupManager(),


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind cleanup
-->

#### What this PR does / why we need it:
Split ScaleDownSet processor into two processors doing their individual tasks. This allows more flexibility when overriding these processors, such as adding another targeted processor to the pipeline, or removing one of the processors if it's not needed.

#### Special notes for your reviewer:
CC @towca 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```