### PR TITLE
add selectorLabels

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.29.3
+version: 9.29.4

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -413,6 +413,7 @@ vpa:
 | resources | object | `{}` | Pod resource requests and limits. |
 | secretKeyRefNameOverride | string | `""` | Overrides the name of the Secret to use when loading the secretKeyRef for AWS and Azure env variables |
 | securityContext | object | `{}` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| selectorLabels | object | `{}` | Selector Match Labels to add to deployment. |
 | service.annotations | object | `{}` | Annotations to add to service |
 | service.create | bool | `true` | If `true`, a Service will be created. |
 | service.externalIPs | list | `[]` | List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/user-guide/services/#external-ips. |

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -14,8 +14,8 @@ spec:
   selector:
     matchLabels:
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}
-    {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 6 }}
+    {{- if .Values.selectorLabels }}
+{{ toYaml .Values.selectorLabels | indent 6 }}
     {{- end }}
 {{- if .Values.updateStrategy }}
   strategy:

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -268,6 +268,9 @@ podDisruptionBudget:
 # podLabels -- Labels to add to each pod.
 podLabels: {}
 
+# selectorLabels -- Selector Match Labels to add to deployment.
+selectorLabels: {}
+
 # priorityClassName -- priorityClassName
 priorityClassName: "system-cluster-critical"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

/kind helm-chart

#### What this PR does / why we need it:

Once deployed, if you change the `podLabels`, the next deployment will not match `selector.matchLabels` and will throw an error. 
So I added `selectorLabels` to create them separately.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
