### PR TITLE
Adds support for startup taints and extends support for status taints

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
@@ -24,5 +24,5 @@ const (
 
 	// ToBeDeletedByClusterAutoscaler is the taint used to ensure that after a node has been called to be deleted
 	// no more pods will schedule onto it
-	ToBeDeletedByClusterAutoscaler = "startup-taint.cluster-autoscaler.kubernetes.io/oke-impending-node-termination"
+	ToBeDeletedByClusterAutoscaler = "ignore-taint.cluster-autoscaler.kubernetes.io/oke-impending-node-termination"
 )

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
@@ -24,5 +24,5 @@ const (
 
 	// ToBeDeletedByClusterAutoscaler is the taint used to ensure that after a node has been called to be deleted
 	// no more pods will schedule onto it
-	ToBeDeletedByClusterAutoscaler = "ignore-taint.cluster-autoscaler.kubernetes.io/oke-impending-node-termination"
+	ToBeDeletedByClusterAutoscaler = "startup-taint.cluster-autoscaler.kubernetes.io/oke-impending-node-termination"
 )

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -203,10 +203,10 @@ type AutoscalingOptions struct {
 	MaxBulkSoftTaintTime time.Duration
 	// MaxPodEvictionTime sets the maximum time CA tries to evict a pod before giving up.
 	MaxPodEvictionTime time.Duration
-	// IgnoredTaints is a list of taints CA considers to reflect transient node
+	// StartupTaints is a list of taints CA considers to reflect transient node
 	// status that should be removed when creating a node template for scheduling.
-	// The ignored taints are expected to appear during node startup.
-	IgnoredTaints []string
+	// startup taints are expected to appear during node startup.
+	StartupTaints []string
 	// StatusTaints is a list of taints CA considers to reflect transient node
 	// status that should be removed when creating a node template for scheduling.
 	// The status taints are expected to appear during node lifetime, after startup.

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -1260,8 +1260,8 @@ func TestStartDeletion(t *testing.T) {
 						break taintsLoop
 					}
 				}
-				ignoreTaintValue := cmpopts.IgnoreFields(apiv1.Taint{}, "Value")
-				if diff := cmp.Diff(tc.wantTaintUpdates, gotTaintUpdates, ignoreTaintValue, cmpopts.EquateEmpty()); diff != "" {
+				startupTaintValue := cmpopts.IgnoreFields(apiv1.Taint{}, "Value")
+				if diff := cmp.Diff(tc.wantTaintUpdates, gotTaintUpdates, startupTaintValue, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("taintUpdates diff (-want +got):\n%s", diff)
 				}
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -959,7 +959,7 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
-	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.taintConfig.IgnoredTaints, allNodes, readyNodes)
+	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.taintConfig.StartupTaints, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -959,7 +959,7 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
-	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.taintConfig, allNodes, readyNodes)
+	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(a.taintConfig, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -959,7 +959,7 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
-	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.taintConfig.StartupTaints, allNodes, readyNodes)
+	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.taintConfig, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -197,7 +197,7 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
-	ignoreTaintsFlag          = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	ignoreTaintsFlag          = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
 	startupTaintFlag          = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
 	statusTaintsFlag          = multiStringFlag("status-taint", "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
 	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -198,7 +198,7 @@ var (
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
 	ignoreTaintsFlag          = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
-	startupTaintFlag          = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
+	startupTaintsFlag         = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
 	statusTaintsFlag          = multiStringFlag("status-taint", "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
 	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag       = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
@@ -348,7 +348,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
-		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintFlag...),
+		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintsFlag...),
 		StatusTaints:                     *statusTaintsFlag,
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -199,6 +199,7 @@ var (
 
 	ignoreTaintsFlag          = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
 	startupTaintFlag          = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
+	statusTaintsFlag          = multiStringFlag("status-taint", "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
 	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag       = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
 	awsUseStaticInstanceList  = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
@@ -348,6 +349,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
 		IgnoredTaints:                    append(*ignoreTaintsFlag, *startupTaintFlag...),
+		StatusTaints:                     *statusTaintsFlag,
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,
 		KubeConfigPath:                   *kubeConfigFile,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -348,7 +348,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
-		IgnoredTaints:                    append(*ignoreTaintsFlag, *startupTaintFlag...),
+		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintFlag...),
 		StatusTaints:                     *statusTaintsFlag,
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -198,6 +198,7 @@ var (
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
 	ignoreTaintsFlag          = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	startupTaintFlag          = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
 	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag       = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
 	awsUseStaticInstanceList  = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
@@ -346,7 +347,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
-		IgnoredTaints:                    *ignoreTaintsFlag,
+		IgnoredTaints:                    append(*ignoreTaintsFlag, *startupTaintFlag...),
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,
 		KubeConfigPath:                   *kubeConfigFile,

--- a/cluster-autoscaler/utils/kubernetes/ready.go
+++ b/cluster-autoscaler/utils/kubernetes/ready.go
@@ -35,10 +35,10 @@ const (
 	// still upcoming due to a missing resource (e.g. GPU).
 	ResourceUnready NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/resource-not-ready"
 
-	// IgnoreTaint is a fake identifier used internally by Cluster Autoscaler
+	// StartupNodes is a fake identifier used internally by Cluster Autoscaler
 	// to indicate nodes that appear Ready in the API, but are treated as
-	// still upcoming due to applied ignore taint.
-	IgnoreTaint NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/ignore-taint"
+	// still upcoming due to applied startup taint.
+	StartupNodes NodeNotReadyReason = "cluster-autoscaler.kubernetes.io/startup-taint"
 )
 
 // IsNodeReadyAndSchedulable returns true if the node is ready and schedulable.

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -47,7 +47,7 @@ const (
 	// StartupTaintPrefix (Same as IgnoreTaintPrefix) any taint starting with it will be filtered out from autoscaler template node.
 	StartupTaintPrefix = "startup-taint.cluster-autoscaler.kubernetes.io/"
 
-	// StartupTaintPrefix (Same as IgnoreTaintPrefix) any taint starting with it will be filtered out from autoscaler template node.
+	// DefaultStatusTaintPrefix any taint starting with it will be filtered out from autoscaler template node but unlike IgnoreTaintPrefix & StartTaintPrefix it should not be trated as unready.
 	DefaultStatusTaintPrefix = "status-taint.cluster-autoscaler.kubernetes.io/"
 
 	gkeNodeTerminationHandlerTaint = "cloud.google.com/impending-node-termination"

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -61,8 +61,8 @@ type TaintKeySet map[string]bool
 
 // TaintConfig is a config of taints that require special handling
 type TaintConfig struct {
-	IgnoredTaints     TaintKeySet
-	StatusTaints      TaintKeySet
+	IgnoredTaints TaintKeySet
+	StatusTaints  TaintKeySet
 }
 
 // NewTaintConfig returns the taint config extracted from options
@@ -80,8 +80,8 @@ func NewTaintConfig(opts config.AutoscalingOptions) TaintConfig {
 	}
 
 	return TaintConfig{
-		IgnoredTaints:     ignoredTaints,
-		StatusTaints:      statusTaints,
+		IgnoredTaints: ignoredTaints,
+		StatusTaints:  statusTaints,
 	}
 }
 

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -63,7 +63,6 @@ type TaintKeySet map[string]bool
 type TaintConfig struct {
 	IgnoredTaints     TaintKeySet
 	StatusTaints      TaintKeySet
-	StatusTaintPrefix string
 }
 
 // NewTaintConfig returns the taint config extracted from options
@@ -83,7 +82,6 @@ func NewTaintConfig(opts config.AutoscalingOptions) TaintConfig {
 	return TaintConfig{
 		IgnoredTaints:     ignoredTaints,
 		StatusTaints:      statusTaints,
-		StatusTaintPrefix: DefaultStatusTaintPrefix,
 	}
 }
 

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -307,7 +307,7 @@ func buildFakeClientWithConflicts(t *testing.T, nodes ...*apiv1.Node) *fake.Clie
 	return fakeClient
 }
 
-func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
+func TestFilterOutNodesWithStartupTaints(t *testing.T) {
 	isReady := func(t *testing.T, node *apiv1.Node) bool {
 		for _, condition := range node.Status.Conditions {
 			if condition.Type == apiv1.NodeReady {
@@ -331,13 +331,13 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		startupTaintsPrefixes []string
 		node                  *apiv1.Node
 	}{
-		"empty ignored taints, no node": {
+		"empty startup taints, no node": {
 			readyNodes:    0,
 			allNodes:      0,
 			startupTaints: map[string]bool{},
 			node:          nil,
 		},
-		"one ignored taint, no node": {
+		"one startup taint, no node": {
 			readyNodes: 0,
 			allNodes:   0,
 			startupTaints: map[string]bool{
@@ -345,7 +345,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 			},
 			node: nil,
 		},
-		"one ignored taint, one ready untainted node": {
+		"one startup taint, one ready untainted node": {
 			readyNodes: 1,
 			allNodes:   1,
 			startupTaints: map[string]bool{
@@ -364,7 +364,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				},
 			},
 		},
-		"one ignored taint, one unready tainted node": {
+		"one startup taint, one unready tainted node": {
 			readyNodes: 0,
 			allNodes:   1,
 			startupTaints: map[string]bool{
@@ -389,7 +389,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				},
 			},
 		},
-		"no ignored taint, one node unready prefixed with startup taint prefix": {
+		"no startup taint, one node unready prefixed with startup taint prefix (Compatability)": {
 			readyNodes:            0,
 			allNodes:              1,
 			startupTaints:         map[string]bool{},
@@ -413,7 +413,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				},
 			},
 		},
-		"no ignored taint, one node unready prefixed with startup taint": {
+		"no startup taint, one node unready prefixed with startup taint prefix": {
 			readyNodes:            0,
 			allNodes:              1,
 			startupTaints:         map[string]bool{},
@@ -437,7 +437,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				},
 			},
 		},
-		"no ignored taint, two taints": {
+		"no startup taint, two taints": {
 			readyNodes:    1,
 			allNodes:      1,
 			startupTaints: map[string]bool{},
@@ -475,7 +475,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 				StartupTaints:        tc.startupTaints,
 				StartupTaintPrefixes: tc.startupTaintsPrefixes,
 			}
-			allNodes, readyNodes := FilterOutNodesWithIgnoredTaints(taintConfig, nodes, nodes)
+			allNodes, readyNodes := FilterOutNodesWithStartupTaints(taintConfig, nodes, nodes)
 			assert.Equal(t, tc.allNodes, len(allNodes))
 			assert.Equal(t, tc.readyNodes, len(readyNodes))
 

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -389,7 +389,7 @@ func TestFilterOutNodesWithStartupTaints(t *testing.T) {
 				},
 			},
 		},
-		"no startup taint, one node unready prefixed with startup taint prefix (Compatability)": {
+		"no startup taint, one node unready prefixed with startup taint prefix (Compatibility)": {
 			readyNodes:            0,
 			allNodes:              1,
 			startupTaints:         map[string]bool{},

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -557,7 +557,6 @@ func TestSanitizeTaints(t *testing.T) {
 	taintConfig := TaintConfig{
 		IgnoredTaints:     map[string]bool{"ignore-me": true},
 		StatusTaints:      map[string]bool{"status-me": true},
-		StatusTaintPrefix: DefaultStatusTaintPrefix,
 	}
 
 	newTaints := SanitizeTaints(node.Spec.Taints, taintConfig)

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -555,8 +555,8 @@ func TestSanitizeTaints(t *testing.T) {
 		},
 	}
 	taintConfig := TaintConfig{
-		IgnoredTaints:     map[string]bool{"ignore-me": true},
-		StatusTaints:      map[string]bool{"status-me": true},
+		IgnoredTaints: map[string]bool{"ignore-me": true},
+		StatusTaints:  map[string]bool{"status-me": true},
 	}
 
 	newTaints := SanitizeTaints(node.Spec.Taints, taintConfig)

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -327,19 +327,19 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 	for name, tc := range map[string]struct {
 		readyNodes    int
 		allNodes      int
-		ignoredTaints TaintKeySet
+		startupTaints TaintKeySet
 		node          *apiv1.Node
 	}{
 		"empty ignored taints, no node": {
 			readyNodes:    0,
 			allNodes:      0,
-			ignoredTaints: map[string]bool{},
+			startupTaints: map[string]bool{},
 			node:          nil,
 		},
 		"one ignored taint, no node": {
 			readyNodes: 0,
 			allNodes:   0,
-			ignoredTaints: map[string]bool{
+			startupTaints: map[string]bool{
 				"my-taint": true,
 			},
 			node: nil,
@@ -347,7 +347,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		"one ignored taint, one ready untainted node": {
 			readyNodes: 1,
 			allNodes:   1,
-			ignoredTaints: map[string]bool{
+			startupTaints: map[string]bool{
 				"my-taint": true,
 			},
 			node: &apiv1.Node{
@@ -366,7 +366,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		"one ignored taint, one unready tainted node": {
 			readyNodes: 0,
 			allNodes:   1,
-			ignoredTaints: map[string]bool{
+			startupTaints: map[string]bool{
 				"my-taint": true,
 			},
 			node: &apiv1.Node{
@@ -391,7 +391,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		"no ignored taint, one node unready prefixed with ignore taint": {
 			readyNodes:    0,
 			allNodes:      1,
-			ignoredTaints: map[string]bool{},
+			startupTaints: map[string]bool{},
 			node: &apiv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "notReadyTainted",
@@ -414,7 +414,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		"no ignored taint, one node unready prefixed with startup taint": {
 			readyNodes:    0,
 			allNodes:      1,
-			ignoredTaints: map[string]bool{},
+			startupTaints: map[string]bool{},
 			node: &apiv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "notReadyTainted",
@@ -437,7 +437,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 		"no ignored taint, two taints": {
 			readyNodes:    1,
 			allNodes:      1,
-			ignoredTaints: map[string]bool{},
+			startupTaints: map[string]bool{},
 			node: &apiv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "ReadyTainted",
@@ -468,7 +468,7 @@ func TestFilterOutNodesWithIgnoredTaints(t *testing.T) {
 			if tc.node != nil {
 				nodes = append(nodes, tc.node)
 			}
-			allNodes, readyNodes := FilterOutNodesWithIgnoredTaints(tc.ignoredTaints, nodes, nodes)
+			allNodes, readyNodes := FilterOutNodesWithIgnoredTaints(tc.startupTaints, nodes, nodes)
 			assert.Equal(t, tc.allNodes, len(allNodes))
 			assert.Equal(t, tc.readyNodes, len(readyNodes))
 
@@ -509,7 +509,7 @@ func TestSanitizeTaints(t *testing.T) {
 					Effect: apiv1.TaintEffectNoSchedule,
 				},
 				{
-					Key:    DefaultStatusTaintPrefix + "some-taint",
+					Key:    StatusTaintPrefix + "some-taint",
 					Value:  "myValue",
 					Effect: apiv1.TaintEffectNoSchedule,
 				},
@@ -555,7 +555,7 @@ func TestSanitizeTaints(t *testing.T) {
 		},
 	}
 	taintConfig := TaintConfig{
-		IgnoredTaints: map[string]bool{"ignore-me": true},
+		StartupTaints: map[string]bool{"ignore-me": true},
 		StatusTaints:  map[string]bool{"status-me": true},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Following up on PR #5659,
- `startup-taint` flag is added and combined with `ignore-taint` flag so both will have the same effect
- Prefix `startup-taint.cluster-autoscaler.kubernetes.io/` is added to be similar to `ignore-taint.cluster-autoscaler.kubernetes.io/` and behaves the same
- `status-taint` flag is added and passed to autoscaling options
- Prefix `status-taint.cluster-autoscaler.kubernetes.io/` is added to ignore nodes with taints starting with it when scaling up.
- Updates `TaintConfig` to have prefixes list instead of relying on constant hardcoded values

> Updates `ToBeDeletedByClusterAutoscaler` & `NodeNotReadyReason.IgnoreTaint` might have side effects which affect third party providers which rely on these taints

#### Which issue(s) this PR fixes:

Allows status-taints to be specified by the users in addition to supporting taints with prefix `status-taint.cluster-autoscaler.kubernetes.io/` 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
2 new flags have been added
- `startup-taint` flag which is identical to `ignore-taint`
- `status-taint` flag which allows users to specify taints of nodes which should be ignored when scaling up (similar to `ignore-taint` behaviour but without treating such nodes as unready
In addition to these flags, 2 new prefixes are also supported which are
- Taints starting with `startup-taint.cluster-autoscaler.kubernetes.io/` will be treated as `status-taint` (identical to `ignore-taint.cluster-autoscaler.kubernetes.io/`)
- Taints starting with `status-taint.cluster-autoscaler.kubernetes.io/` will be treated as `startup-taint`
```



