### PR TITLE
Backport #6090 [CA] Add aws csi zone label to node template into CA1.26

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -50,6 +50,7 @@ const (
 	autoDiscovererTypeASG   = "asg"
 	asgAutoDiscovererKeyTag = "tag"
 	optionsTagsPrefix       = "k8s.io/cluster-autoscaler/node-template/autoscaling-options/"
+	labelAwsCSITopologyZone = "topology.ebs.csi.aws.com/zone"
 )
 
 // AwsManager is handles aws communication and data caching.
@@ -395,6 +396,7 @@ func buildGenericLabels(template *asgTemplate, nodeName string) map[string]strin
 
 	result[apiv1.LabelTopologyRegion] = template.Region
 	result[apiv1.LabelTopologyZone] = template.Zone
+	result[labelAwsCSITopologyZone] = template.Zone
 	result[apiv1.LabelHostname] = nodeName
 	return result
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -65,8 +65,11 @@ func TestBuildGenericLabels(t *testing.T) {
 			Architecture: cloudprovider.DefaultArch,
 		},
 		Region: "us-east-1",
+		Zone:   "us-east-1c",
 	}, "sillyname")
-	assert.Equal(t, "us-east-1", labels[apiv1.LabelZoneRegionStable])
+	assert.Equal(t, "us-east-1", labels[apiv1.LabelTopologyRegion])
+	assert.Equal(t, "us-east-1c", labels[apiv1.LabelTopologyZone])
+	assert.Equal(t, "us-east-1c", labels[labelAwsCSITopologyZone])
 	assert.Equal(t, "sillyname", labels[apiv1.LabelHostname])
 	assert.Equal(t, "c4.large", labels[apiv1.LabelInstanceTypeStable])
 	assert.Equal(t, cloudprovider.DefaultArch, labels[apiv1.LabelArchStable])


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is cherry-picked, which backports #6090 into CA1.26

#### Which issue(s) this PR fixes:

Part of #6136

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
