### PR TITLE
Fix duplicate -addext when generating certificates with admission-controller/gencerts.sh

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
+++ b/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
@@ -51,7 +51,7 @@ set -o errexit
 # Create a server certificate
 openssl genrsa -out ${TMP_DIR}/serverKey.pem 2048
 # Note the CN is the DNS name of the service of the webhook.
-openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN=vpa-webhook.kube-system.svc" -config ${TMP_DIR}/server.conf -addext "subjectAltName = DNS:vpa-webhook.kube-system.svc"
+openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN=vpa-webhook.kube-system.svc" -config ${TMP_DIR}/server.conf
 openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/caCert.pem -CAkey ${TMP_DIR}/caKey.pem -CAcreateserial -out ${TMP_DIR}/serverCert.pem -days 100000 -extensions SAN -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
 echo "Uploading certs to the cluster."


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The autoscaler/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh script fails with the following error:

```
Generating certs for the VPA Admission Controller in /tmp/vpa-certs.
req: Skipping unknown subject name attribute "/CN"
Error adding extensions defined via -addext
40C7A2C93F7F0000:error:0580008C:x509 certificate routines:X509at_add1_attr:duplicate attribute:../crypto/x509/x509_att.c:86:
```

This is because https://github.com/kubernetes/autoscaler/blob/cf8c507d2421e7ed8b8d6f9ae44e9a624e221c43/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh#L54 adds a `-addext` argument that duplicates what is already added in https://github.com/kubernetes/autoscaler/blob/cf8c507d2421e7ed8b8d6f9ae44e9a624e221c43/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh#L38.

Perhaps this used to work because openSSL ignored duplicate entries? However, in the latest version of OpenSSL I'm using (3.0.10) this causes an error and prevents the script from finishing.

#### Which issue(s) this PR fixes:

Part of #6113, this fix was needed to unblock release testing.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
