### PR TITLE
Fix vpa-up.sh script by removing duplicate recommender

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -40,17 +40,16 @@ if [ $# -gt 2 ]; then
 fi
 
 ACTION=$1
-COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment recommender-externalmetrics-deployment"
-TEST_COMPONENTS=(recommender-externalmetrics-deployment)
+COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
 
 function script_path {
   # Regular components have deployment yaml files under /deploy/.  But some components only have
-  # test deployment yaml files that are under hack/e2e.  If $1 is one of ${TEST_COMPONENTS}, use
-  # the hack/e2e subdir instead of deploy.
-  if printf '%s\0' "${TEST_COMPONENTS[@]}" | grep -Fqxz -- $1; then
-    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
-  else
+  # test deployment yaml files that are under hack/e2e. Check the main deploy directory before
+  # using the e2e subdirectory.
+  if test -f "${SCRIPT_ROOT}/deploy/${1}.yaml"; then
     echo "${SCRIPT_ROOT}/deploy/${1}.yaml"
+  else
+    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
   fi
 }
 


### PR DESCRIPTION
Fix vpa-up.sh script by removing duplicate recommender from the vpa-process-yamls.sh. Tweak that script so that it can accept recommender-externalmetrics as an argument if someone wants to run that separately by having the script look in both the `deploy` and `e2e` directories.

Having both recommenders in this list breaks vpa-up.sh, see #6141.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes a small bug when running `vpa-up.sh`, which is a step in the VPA release process.

See #6141 for full details.

#### Which issue(s) this PR fixes:

Fixes #6141 

#### Special notes for your reviewer:

I've taken a look at [the PR](https://github.com/kubernetes/autoscaler/pull/5576) that introduced this change and I *don't think* this should break anything but would love to confirm with @lallydd.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
