### PR TITLE
Fix multiple run of informers created in fetcher.go

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
@@ -60,9 +60,7 @@ func NewLimitsRangeCalculator(f informers.SharedInformerFactory) (*limitsChecker
 	go informer.Run(stopCh)
 	ok := cache.WaitForCacheSync(stopCh, informer.HasSynced)
 	if !ok {
-		if !f.Core().V1().LimitRanges().Informer().HasSynced() {
-			return nil, fmt.Errorf("informer did not sync")
-		}
+		return nil, fmt.Errorf("informer did not sync")
 	}
 	return &limitsChecker{limitRangeLister}, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 // LimitRangeCalculator calculates limit range items that has the same effect as all limit range items present in the cluster.
@@ -55,12 +56,12 @@ func NewLimitsRangeCalculator(f informers.SharedInformerFactory) (*limitsChecker
 	}
 	limitRangeLister := f.Core().V1().LimitRanges().Lister()
 	stopCh := make(chan struct{})
-	f.Start(stopCh)
-	for _, ok := range f.WaitForCacheSync(stopCh) {
-		if !ok {
-			if !f.Core().V1().LimitRanges().Informer().HasSynced() {
-				return nil, fmt.Errorf("informer did not sync")
-			}
+	informer := f.Core().V1().LimitRanges().Informer()
+	go informer.Run(stopCh)
+	ok := cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	if !ok {
+		if !f.Core().V1().LimitRanges().Informer().HasSynced() {
+			return nil, fmt.Errorf("informer did not sync")
 		}
 	}
 	return &limitsChecker{limitRangeLister}, nil


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Suppress warn logs `The sharedIndexInformer has started, run more than once is not allowed` appear at every admission-controller startup

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6156

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
