### PR TITLE
Cherry pick #6151 to VPA release 1.0 branch

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -40,17 +40,16 @@ if [ $# -gt 2 ]; then
 fi
 
 ACTION=$1
-COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment recommender-externalmetrics-deployment"
-TEST_COMPONENTS=(recommender-externalmetrics-deployment)
+COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
 
 function script_path {
   # Regular components have deployment yaml files under /deploy/.  But some components only have
-  # test deployment yaml files that are under hack/e2e.  If $1 is one of ${TEST_COMPONENTS}, use
-  # the hack/e2e subdir instead of deploy.
-  if printf '%s\0' "${TEST_COMPONENTS[@]}" | grep -Fqxz -- $1; then
-    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
-  else
+  # test deployment yaml files that are under hack/e2e. Check the main deploy directory before
+  # using the e2e subdirectory.
+  if test -f "${SCRIPT_ROOT}/deploy/${1}.yaml"; then
     echo "${SCRIPT_ROOT}/deploy/${1}.yaml"
+  else
+    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
   fi
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR is cherry-picked, which backports #6151 into the VPA 1.0 release branch. See the [comment](https://github.com/kubernetes/autoscaler/issues/6113#issuecomment-1738562106) for the information.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
