### PR TITLE
fix log initialization

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -569,11 +569,10 @@ func main() {
 	featureGate.AddFlag(pflag.CommandLine)
 	kube_flag.InitFlags()
 
+	logs.InitLogs()
 	if err := logsapi.ValidateAndApply(loggingConfig, featureGate); err != nil {
 		klog.Fatalf("Failed to validate and apply logging configuration: %v", err)
 	}
-
-	logs.InitLogs()
 
 	healthCheck := metrics.NewHealthCheck(*maxInactivityTimeFlag, *maxFailingTimeFlag)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

InitLogs unconditionally disables contextual logging, while ValidateAndApply checks the feature gate for that. InitLogs must come first, otherwise

    --feature-gates=ContextualLogging=true

doesn't work.

#### Does this PR introduce a user-facing change?
```release-note
Fixed support for --feature-gates=ContextualLogging=true.
```
