### PR TITLE
support stateful scheduler plugins

### DIFF
--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -97,8 +98,8 @@ func (e *BinpackingNodeEstimator) Estimate(
 		})
 		if err == nil {
 			found = true
-			if err := e.clusterSnapshot.AddPod(pod, nodeName); err != nil {
-				klog.Errorf("Error adding pod %v.%v to node %v in ClusterSnapshot; %v", pod.Namespace, pod.Name, nodeName, err)
+			if err := e.predicateChecker.BindPod(context.TODO(), e.clusterSnapshot, pod, nodeName); err != nil {
+				klog.Errorf("Error binding pod to node, not scaling up: %v", err)
 				return 0, nil
 			}
 			scheduledPods = append(scheduledPods, pod)
@@ -136,8 +137,8 @@ func (e *BinpackingNodeEstimator) Estimate(
 			if err := e.predicateChecker.CheckPredicates(e.clusterSnapshot, pod, newNodeName); err != nil {
 				continue
 			}
-			if err := e.clusterSnapshot.AddPod(pod, newNodeName); err != nil {
-				klog.Errorf("Error adding pod %v.%v to node %v in ClusterSnapshot; %v", pod.Namespace, pod.Name, newNodeName, err)
+			if err := e.predicateChecker.BindPod(context.TODO(), e.clusterSnapshot, pod, newNodeName); err != nil {
+				klog.Errorf("Error binding pod to node, not scaling up: %v", err)
 				return 0, nil
 			}
 			newNodesWithPods[newNodeName] = true

--- a/cluster-autoscaler/simulator/clustersnapshot/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/basic.go
@@ -32,6 +32,7 @@ type BasicClusterSnapshot struct {
 type internalBasicSnapshotData struct {
 	nodeInfoMap        map[string]*schedulerframework.NodeInfo
 	pvcNamespacePodMap map[string]map[string]bool
+	cycleState         *schedulerframework.CycleState
 }
 
 func (data *internalBasicSnapshotData) listNodeInfos() ([]*schedulerframework.NodeInfo, error) {
@@ -120,6 +121,7 @@ func newInternalBasicSnapshotData() *internalBasicSnapshotData {
 	return &internalBasicSnapshotData{
 		nodeInfoMap:        make(map[string]*schedulerframework.NodeInfo),
 		pvcNamespacePodMap: make(map[string]map[string]bool),
+		cycleState:         schedulerframework.NewCycleState(),
 	}
 }
 
@@ -138,6 +140,7 @@ func (data *internalBasicSnapshotData) clone() *internalBasicSnapshotData {
 	return &internalBasicSnapshotData{
 		nodeInfoMap:        clonedNodeInfoMap,
 		pvcNamespacePodMap: clonedPvcNamespaceNodeMap,
+		cycleState:         data.cycleState.Clone(),
 	}
 }
 
@@ -321,4 +324,9 @@ func (snapshot *basicClusterSnapshotNodeLister) Get(nodeName string) (*scheduler
 // Returns the IsPVCUsedByPods in a given key.
 func (snapshot *basicClusterSnapshotStorageLister) IsPVCUsedByPods(key string) bool {
 	return (*BasicClusterSnapshot)(snapshot).getInternalData().isPVCUsedByPods(key)
+}
+
+// CycleState returns the cycle state of the current snapshot state.
+func (snapshot *BasicClusterSnapshot) CycleState() *schedulerframework.CycleState {
+	return snapshot.getInternalData().cycleState
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -42,6 +42,9 @@ type ClusterSnapshot interface {
 	AddNodeWithPods(node *apiv1.Node, pods []*apiv1.Pod) error
 	// IsPVCUsedByPods returns if the pvc is used by any pod, key = <namespace>/<pvc_name>
 	IsPVCUsedByPods(key string) bool
+	// CycleState returns a scheduler cycle state that was created when the snapshot
+	// was created. Fork will clone that state.
+	CycleState() *schedulerframework.CycleState
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
 	// Use WithForkedSnapshot() helper function instead if possible.

--- a/cluster-autoscaler/simulator/predicatechecker/interface.go
+++ b/cluster-autoscaler/simulator/predicatechecker/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package predicatechecker
 
 import (
+	"context"
+
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -25,7 +27,16 @@ import (
 
 // PredicateChecker checks whether all required predicates pass for given Pod and Node.
 type PredicateChecker interface {
+	// Snapshot gets called at the beginning of a scale up simulation,
+	// before any of the other methods. In contrast to the check methods
+	// it is allowed to modify the snapshot.
+	Snapshot(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot) error
+
 	FitsAnyNode(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod) (string, error)
 	FitsAnyNodeMatching(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeMatches func(*schedulerframework.NodeInfo) bool) (string, error)
 	CheckPredicates(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeName string) *PredicateError
+
+	// BindPod gets called to record in the cluster snapshot that a pod was scheduled
+	// to a node as part of the simulation.
+	BindPod(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, nodeName string) error
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The assumption so far was that plugins which are active during cluster autoscaling can do their work exclusively based on the information maintained by cluster autoscaler about nodes and pods on those nodes. This assumption doesn't hold for plugins which need to observe and potentially modified other cluster state, like the dynamic resource allocation plugin.

Such plugins need a way to do their own snapshotting of the cluster state at the start of a simulation and then update that snapshotting while the cluster autoscaler simulates the placement of pods on nodes.

The new ClusterAutoScalerPlugin interface provides a mechanism for this. It needs to be called in a few places if a plugin implements that interface.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/118612

#### Special notes for your reviewer:

If the dynamic resource allocation plugin is inactive, then no plugin implements the new interface and these code changes become mostly no-ops.

The [corresponding PR in k/k](https://github.com/kubernetes/kubernetes/pull/120936) needs to be merged first.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
