### PR TITLE
Add HasNodeGroupStartedScaleUp to cluster state registry.

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -501,6 +501,17 @@ func (csr *ClusterStateRegistry) IsNodeGroupScalingUp(nodeGroupName string) bool
 	return found
 }
 
+// HasNodeGroupStartedScaleUp returns true if the node group has started scale up regardless
+// of whether there are any upcoming nodes. This is useful in the case when the node group's
+// size reverts back to its previous size before the next UpdatesCall and we want to know
+// if a scale up for node group has started.
+func (csr *ClusterStateRegistry) HasNodeGroupStartedScaleUp(nodeGroupName string) bool {
+	csr.Lock()
+	defer csr.Unlock()
+	_, found := csr.scaleUpRequests[nodeGroupName]
+	return found
+}
+
 // AcceptableRange contains information about acceptable size of a node group.
 type AcceptableRange struct {
 	// MinNodes is the minimum number of nodes in the group.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a new function to `ClusterStateRegistry` called `HasNodeGroupStartedScaleUp()` which returns whether the node group has a scale up request without checking if there are any upcoming nodes in the node group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
