### PR TITLE
Fixing clutter-autoscaler docs to point to correct tutorial for auto-discovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/CA_with_AWS_IAM_OIDC.md
+++ b/cluster-autoscaler/cloudprovider/aws/CA_with_AWS_IAM_OIDC.md
@@ -42,7 +42,7 @@ Edit the OIDC provider suffix and change it from :aud to :sub.
 Replace sts.amazonaws.com to your service account ID.
 - Update trust policy to finish. 
 
-D) Set up [Cluster Autoscaler Auto-Discovery] using the [tutorial] . 
+D) Set up [Cluster Autoscaler Auto-Discovery] using the [tutorial](README.md#auto-discovery-setup) . 
 - Open the Amazon EC2 console, and then choose EKS worker node Auto Scaling Groups from the navigation pane.
 - In the "Add/Edit Auto Scaling Group Tags" window, please make sure you enter the following tags by replacing 'awsExampleClusterName' with the name of your EKS cluster. Then, choose "Save".
 
@@ -174,7 +174,6 @@ I1025 13:48:42.975037       1 scale_up.go:529] Final scale-up plan: [{eksctl-xxx
    [IAM OIDC]: <https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html> 
    [IAM policy]: <https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html>
    [documentation]: <https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html> 
-   [tutorial]: <https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-autoscaler-setup/>
 
    
    


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
Fixes the documentation to point to the correct documentation for auto-discovery for cluster-autoscaler

#### Which issue(s) this PR fixes:
Fixes #6171

#### Special notes for your reviewer:
The AWS documentation referenced in the current doc does not exist anymore and the official AWS docs were updated to point to this repo a while ago.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
