### PR TITLE
Clarify simulation for removal log statement

### DIFF
--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -156,7 +156,7 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	if err != nil {
 		klog.Errorf("Can't retrieve node %s from snapshot, err: %v", nodeName, err)
 	}
-	klog.V(2).Infof("%s for removal", nodeName)
+	klog.V(2).Infof("Simulating node %s for removal", nodeName)
 
 	if _, found := destinationMap[nodeName]; !found {
 		klog.V(2).Infof("nodeInfo for %s not found", nodeName)

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -156,7 +156,7 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	if err != nil {
 		klog.Errorf("Can't retrieve node %s from snapshot, err: %v", nodeName, err)
 	}
-	klog.V(2).Infof("Simulating node %s for removal", nodeName)
+	klog.V(2).Infof("Simulating node %s removal", nodeName)
 
 	if _, found := destinationMap[nodeName]; !found {
 		klog.V(2).Infof("nodeInfo for %s not found", nodeName)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR helps improve supportability by improving the clarity of an informational logging statement that adds context for the log's reader.  The message will go from:
```
I1003 18:48:06.916732       1 cluster.go:155] ip-10-0-41-141.ec2.internal for removal
```
to:
```
I1003 18:48:06.916732       1 cluster.go:155] Simulating node ip-10-0-41-141.ec2.internal for removal
```

Previously, it was difficult to determine the _for removal_ action.  Also, prefixing the node's name with `node` is consistent with other node-named log statements.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6170

