### PR TITLE
Extend BinpackingLimiter interface

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -164,6 +164,9 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		}
 	}
 
+	// Finalize binpacking limiter.
+	o.processors.BinpackingLimiter.FinalizeBinpacking(o.autoscalingContext, options)
+
 	if len(options) == 0 {
 		klog.V(1).Info("No expansion options")
 		return &status.ScaleUpStatus{

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -357,14 +357,17 @@ func (p *MockBinpackingLimiter) InitBinpacking(context *context.AutoscalingConte
 	p.requiredExpansionOptions = 1
 }
 
+// MarkProcessed is here to satisfy the interface.
+func (p *MockBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
+}
+
 // StopBinpacking stops the binpacking early, if we already have requiredExpansionOptions i.e. 1.
 func (p *MockBinpackingLimiter) StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	return len(evaluatedOptions) == p.requiredExpansionOptions
 }
 
-// MarkProcessed is here to satisfy the interface.
-func (p *MockBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
-
+// FinalizeBinpacking is here to satisfy the interface.
+func (p *MockBinpackingLimiter) FinalizeBinpacking(context *context.AutoscalingContext, finalOptions []expander.Option) {
 }
 
 // NewBackoff creates a new backoff object

--- a/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
@@ -25,8 +25,9 @@ import (
 // BinpackingLimiter processes expansion options to stop binpacking early.
 type BinpackingLimiter interface {
 	InitBinpacking(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup)
-	StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option) bool
 	MarkProcessed(context *context.AutoscalingContext, nodegroupId string)
+	StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option) bool
+	FinalizeBinpacking(context *context.AutoscalingContext, finalOptions []expander.Option)
 }
 
 // NoOpBinpackingLimiter returns true without processing expansion options.
@@ -42,11 +43,15 @@ func NewDefaultBinpackingLimiter() BinpackingLimiter {
 func (p *NoOpBinpackingLimiter) InitBinpacking(context *context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup) {
 }
 
+// MarkProcessed marks the nodegroup as processed.
+func (p *NoOpBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
+}
+
 // StopBinpacking is used to make decsions on the evaluated expansion options.
 func (p *NoOpBinpackingLimiter) StopBinpacking(context *context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	return false
 }
 
-// MarkProcessed marks the nodegroup as processed.
-func (p *NoOpBinpackingLimiter) MarkProcessed(context *context.AutoscalingContext, nodegroupId string) {
+// FinalizeBinpacking is called to finalize the BinpackingLimiter.
+func (p *NoOpBinpackingLimiter) FinalizeBinpacking(context *context.AutoscalingContext, finalOptions []expander.Option) {
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extends the BinpackingLimiter interface with a method called after binpacking finishes. This can be used to analyse the final binpacking state as well as cleanup the internal binpacking state.
