### PR TITLE
Bump addon-resizer version 1.8.20 to release #5993

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -27,7 +27,7 @@ REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.19
+TAG = 1.8.20
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Bumps addon-resizer release tag from 1.8.19 to 1.8.20 to release #5993

#### Does this PR introduce a user-facing change?

```release-note
NONE
```