### PR TITLE
refactor(*): move getKubeClient to utils/kubernetes

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -221,8 +221,12 @@ type AutoscalingOptions struct {
 	AWSUseStaticInstanceList bool
 	// GCEOptions contain autoscaling options specific to GCE cloud provider.
 	GCEOptions GCEOptions
+	// Kubernetes master location.
+	Kubernetes string
 	// Path to kube configuration if available
 	KubeConfigPath string
+	// Content type of requests sent to APIServer.
+	KubeAPIContentType string
 	// Burst setting for kubernetes client
 	KubeClientBurst int
 	// QPS setting for kubernetes client

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -63,7 +62,6 @@ import (
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	kube_flag "k8s.io/component-base/cli/flag"
@@ -353,7 +351,9 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		StatusTaints:                     *statusTaintsFlag,
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,
+		Kubernetes:                       *kubernetes,
 		KubeConfigPath:                   *kubeConfigFile,
+		KubeAPIContentType:               *kubeAPIContentType,
 		KubeClientBurst:                  *kubeClientBurst,
 		KubeClientQPS:                    *kubeClientQPS,
 		NodeDeletionDelayTimeout:         *nodeDeletionDelayTimeout,
@@ -393,31 +393,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 	}
 }
 
-func getKubeConfig() *rest.Config {
-	if *kubeConfigFile != "" {
-		klog.V(1).Infof("Using kubeconfig file: %s", *kubeConfigFile)
-		// use the current context in kubeconfig
-		config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
-		if err != nil {
-			klog.Fatalf("Failed to build config: %v", err)
-		}
-		return config
-	}
-	url, err := url.Parse(*kubernetes)
-	if err != nil {
-		klog.Fatalf("Failed to parse Kubernetes url: %v", err)
-	}
-
-	kubeConfig, err := config.GetKubeClientConfig(url)
-	if err != nil {
-		klog.Fatalf("Failed to build Kubernetes client configuration: %v", err)
-	}
-
-	kubeConfig.ContentType = *kubeAPIContentType
-
-	return kubeConfig
-}
-
 func createKubeClient(kubeConfig *rest.Config) kube_client.Interface {
 	return kube_client.NewForConfigOrDie(kubeConfig)
 }
@@ -441,7 +416,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	// Create basic config from flags.
 	autoscalingOptions := createAutoscalingOptions()
 
-	kubeClientConfig := getKubeConfig()
+	kubeClientConfig := kube_util.GetKubeConfig(autoscalingOptions)
 	kubeClientConfig.Burst = autoscalingOptions.KubeClientBurst
 	kubeClientConfig.QPS = float32(autoscalingOptions.KubeClientQPS)
 	kubeClient := createKubeClient(kubeClientConfig)
@@ -455,7 +430,7 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	}
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0, informers.WithTransform(trim))
 
-	eventsKubeClient := createKubeClient(getKubeConfig())
+	eventsKubeClient := createKubeClient(kube_util.GetKubeConfig(autoscalingOptions))
 
 	predicateChecker, err := predicatechecker.NewSchedulerBasedPredicateChecker(informerFactory, autoscalingOptions.SchedulerConfig)
 	if err != nil {
@@ -624,7 +599,7 @@ func main() {
 			klog.Fatalf("Unable to get hostname: %v", err)
 		}
 
-		kubeClient := createKubeClient(getKubeConfig())
+		kubeClient := createKubeClient(kube_util.GetKubeConfig(createAutoscalingOptions()))
 
 		// Validate that the client is ok.
 		_, err = kubeClient.CoreV1().Nodes().List(ctx.TODO(), metav1.ListOptions{})

--- a/cluster-autoscaler/utils/kubernetes/client.go
+++ b/cluster-autoscaler/utils/kubernetes/client.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"net/url"
+
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+// GetKubeConfig returns the rest config from AutoscalingOptions.
+func GetKubeConfig(opts config.AutoscalingOptions) *rest.Config {
+	var kubeConfig *rest.Config
+	var err error
+
+	if opts.KubeConfigPath != "" {
+		klog.V(1).Infof("Using kubeconfig file: %s", opts.KubeConfigPath)
+		// use the current context in kubeconfig
+		kubeConfig, err = clientcmd.BuildConfigFromFlags("", opts.KubeConfigPath)
+		if err != nil {
+			klog.Fatalf("Failed to build config: %v", err)
+		}
+	} else {
+		url, err := url.Parse(opts.Kubernetes)
+		if err != nil {
+			klog.Fatalf("Failed to parse Kubernetes url: %v", err)
+		}
+
+		kubeConfig, err = config.GetKubeClientConfig(url)
+		if err != nil {
+			klog.Fatalf("Failed to build Kubernetes client configuration: %v", err)
+		}
+	}
+
+	kubeConfig.ContentType = opts.KubeAPIContentType
+
+	return kubeConfig
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

move getKubeClient to `utils/kubernetes` and make this function public.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
