### PR TITLE
Backport #5373 [CA] AWS - Update Docs all actions IAM policy into CA1.25

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -47,6 +47,7 @@ should be updated to restrict the resources/add conditionals:
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeLaunchTemplateVersions"
@@ -411,7 +412,7 @@ To refresh static list, please run `go run ec2_instance_types/gen.go` under
 
 ## Using the AWS SDK vendored in the AWS cloudprovider
 
-If you want to use a newer version of the AWS SDK than the version currently vendored as a direct dependency by Cluster Autoscaler, then you can use the version vendored under this AWS cloudprovider. 
+If you want to use a newer version of the AWS SDK than the version currently vendored as a direct dependency by Cluster Autoscaler, then you can use the version vendored under this AWS cloudprovider.
 
 The current version vendored is `v1.44.24`.
 
@@ -432,12 +433,12 @@ If you want to use custom AWS cloud config e.g. endpoint urls
 2. Add the following in your `values.yaml`:
     ```yaml
     cloudConfigPath: config/cloud.conf
-    
+
     extraVolumes:
       - name: cloud-config
         configMap:
           name: cloud-config
-    
+
     extraVolumeMounts:
       - name: cloud-config
         mountPath: config
@@ -450,7 +451,7 @@ Please note: it is also possible to mount the cloud config file from host:
       - name: cloud-config
         hostPath:
           path: /path/to/file/on/host
-    
+
     extraVolumeMounts:
       - name: cloud-config
         mountPath: config/cloud.conf


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR is cherry-picked, which backports #5373 into CA1.25

#### Which issue(s) this PR fixes:

Part of #6138

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
