### PR TITLE
Updated the owners of externalgrpc cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/externalgrpc/OWNERS
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/OWNERS
@@ -1,7 +1,7 @@
 approvers:
-#- dbonfigli
+- dbonfigli
 reviewers:
-#- dbonfigli
+- dbonfigli
 
 labels:
 - area/provider/externalgrpc


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind cleanup
/kind documentation

#### What this PR does / why we need it:

This PR adds owners for externalgrpc cloud provider

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

According to https://github.com/kubernetes/autoscaler/pull/5198 Adding owners for externalgrpc cloud provider

#### Does this PR introduce a user-facing change?
```
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
```