### PR TITLE
feat: each node pool can now have different init configs

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -10,6 +10,38 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 
 `HCLOUD_IMAGE` Defaults to `ubuntu-20.04`, @see https://docs.hetzner.cloud/#images. You can also use an image ID here (e.g. `15512617`), or a label selector associated with a custom snapshot (e.g. `customized_ubuntu=true`). The most recent snapshot will be used in the latter case.
 
+`HCLOUD_CLUSTER_CONFIG` This is the new format replacing 
+ * `HCLOUD_CLOUD_INIT` 
+ * `HCLOUD_IMAGE` 
+ 
+ Base64 encoded JSON according to the following structure
+
+```json
+{
+    "imagesForArch": { // These should be the same format as HCLOUD_IMAGE
+        "arm64": "", 
+        "amd64": ""
+    },
+    "nodeConfigs": {
+        "pool1": { // This equals the pool name. Required for each pool that you have
+            "cloudInit": "", // HCLOUD_CLOUD_INIT make sure it isn't base64 encoded twice ;]
+            "labels": {
+                "node.kubernetes.io/role": "autoscaler-node"
+            },
+            "taints": 
+            [
+                {
+                    "key": "node.kubernetes.io/role",
+                    "value": "autoscaler-node",
+                    "effect": "NoExecute",
+                }
+            ]
+        }
+    }
+}
+```
+
+
 `HCLOUD_NETWORK` Default empty , The name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
 
 `HCLOUD_FIREWALL` Default empty , The name of the firewall that is used in the cluster , @see https://docs.hetzner.cloud/#firewalls


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently the Hetzner provider is very lacking and the autoscaler does not know beforehand which custom taints/labels the provided node pools have.
This PR adds support for a each nodepool to have their own initconfig (currently breaking change, but will see if I have the time to make it backwards compatible). It also supports multi arch node pools. I have been running this a month or so~ build my own image

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Currently this PR introduces a breaking change. However if required I can refactor it so it is backwards compatible
```

