### PR TITLE
Template the autoDiscovery.clusterName variable in the Helm chart

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.30.1
+version: 9.31.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -74,6 +74,10 @@ To create a valid configuration, follow instructions for your cloud provider:
 - [OpenStack Magnum](#openstack-magnum)
 - [Cluster API](#cluster-api)
 
+### Templating the autoDiscovery.clusterName
+
+The cluster name can be templated in the `autoDiscovery.clusterName` variable. This is useful when the cluster name is dynamically generated based on other values coming from external systems like Argo CD or Flux. This also allows you to use global Helm values to set the cluster name, e.g., `autoDiscovery.clusterName=\{\{ .Values.global.clusterName }}`, so that you don't need to set it in more than 1 location in the values file.
+
 ### AWS - Using auto-discovery of tagged instance groups
 
 Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG. `cloudProvider=aws` only.

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -74,6 +74,10 @@ To create a valid configuration, follow instructions for your cloud provider:
 - [OpenStack Magnum](#openstack-magnum)
 - [Cluster API](#cluster-api)
 
+### Templating the autoDiscovery.clusterName
+
+The cluster name can be templated in the `autoDiscovery.clusterName` variable. This is useful when the cluster name is dynamically generated based on other values coming from external systems like Argo CD or Flux. This also allows you to use global Helm values to set the cluster name, e.g., `autoDiscovery.clusterName=\{\{ .Values.global.clusterName }}`, so that you don't need to set it in more than 1 location in the values file.
+
 ### AWS - Using auto-discovery of tagged instance groups
 
 Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG. `cloudProvider=aws` only.

--- a/charts/cluster-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-autoscaler/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Return the autodiscoveryparameters for clusterapi.
 */}}
 {{- define "cluster-autoscaler.capiAutodiscoveryConfig" -}}
 {{- if .Values.autoDiscovery.clusterName -}}
-{{- print "clusterName=" -}}{{ .Values.autoDiscovery.clusterName }}
+{{- print "clusterName=" -}}{{ tpl (.Values.autoDiscovery.clusterName) . }}
 {{- end -}}
 {{- if and .Values.autoDiscovery.clusterName .Values.autoDiscovery.labels -}}
 {{- print "," -}}

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -88,10 +88,10 @@ spec:
           {{- end }}
           {{- else if eq .Values.cloudProvider "magnum" }}
             {{- if .Values.autoDiscovery.clusterName }}
-            - --cluster-name={{ .Values.autoDiscovery.clusterName }}
+            - --cluster-name={{ tpl (.Values.autoDiscovery.clusterName) . }}
             - --node-group-auto-discovery=magnum:role={{ tpl (join "," .Values.autoDiscovery.roles) . }}
             {{- else }}
-            - --cluster-name={{ .Values.magnumClusterName }}
+            - --cluster-name={{ tpl (.Values.magnumClusterName) . }}
             {{- end }}
           {{- else if eq .Values.cloudProvider "clusterapi" }}
             {{- if or .Values.autoDiscovery.clusterName .Values.autoDiscovery.labels }}
@@ -110,7 +110,7 @@ spec:
             {{- end }}
           {{- else if eq .Values.cloudProvider "azure" }}
             {{- if .Values.autoDiscovery.clusterName }}
-            - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ .Values.autoDiscovery.clusterName }}
+            - --node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name={{ tpl (.Values.autoDiscovery.clusterName) . }}
             {{- end }}
           {{- end }}
           {{- if eq .Values.cloudProvider "magnum" }}

--- a/charts/cluster-autoscaler/templates/secret.yaml
+++ b/charts/cluster-autoscaler/templates/secret.yaml
@@ -17,7 +17,7 @@ data:
   SubscriptionID: "{{ .Values.azureSubscriptionID | b64enc }}"
   TenantID: "{{ .Values.azureTenantID | b64enc }}"
   VMType: "{{ .Values.azureVMType | b64enc }}"
-  ClusterName: "{{ .Values.azureClusterName | b64enc }}"
+  ClusterName: "{{ tpl (.Values.azureClusterName) . | b64enc }}"
   NodeResourceGroup: "{{ .Values.azureNodeResourceGroup | b64enc }}"
 {{- else if $isAws }}
   AwsAccessKeyId: "{{ .Values.awsAccessKeyID | b64enc }}"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This allows templating of the `autoDiscovery.clusterName` parameter in the Helm chart so that you can do more dynamic processing of the cluster's name.

#### Which issue(s) this PR fixes:
Fixes # n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Template the autoDiscovery.clusterName variable in the Helm chart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
