### PR TITLE
Removed node drainer, kept node termination handler

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -496,11 +496,8 @@ Please note: it is also possible to mount the cloud config file from host:
   enabled, which means it will actively work to balance the number of instances
   between AZs, and possibly terminate instances. If your applications could be
   impacted from sudden termination, you can either suspend the AZRebalance
-  feature, or use a tool for automatic draining upon ASG scale-in such as the
-  [k8s-node-drainer](https://github.com/aws-samples/amazon-k8s-node-drainer). The
-  [AWS Node Termination
-  Handler](https://github.com/aws/aws-node-termination-handler/issues/95) will
-  also support this use-case in the future.
+  feature, or use a tool for automatic draining upon ASG scale-in such as the [AWS Node Termination
+  Handler](https://github.com/aws/aws-node-termination-handler/issues/95).
 - By default, cluster autoscaler will not terminate nodes running pods in the
   kube-system namespace. You can override this default behaviour by passing in
   the `--skip-nodes-with-system-pods=false` flag.

--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -497,7 +497,7 @@ Please note: it is also possible to mount the cloud config file from host:
   between AZs, and possibly terminate instances. If your applications could be
   impacted from sudden termination, you can either suspend the AZRebalance
   feature, or use a tool for automatic draining upon ASG scale-in such as the [AWS Node Termination
-  Handler](https://github.com/aws/aws-node-termination-handler/issues/95).
+  Handler](https://github.com/aws/aws-node-termination-handler/).
 - By default, cluster autoscaler will not terminate nodes running pods in the
   kube-system namespace. You can override this default behaviour by passing in
   the `--skip-nodes-with-system-pods=false` flag.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) is the recommended solution and it supports capacity AZ rebalance events since October 2020. Hence I removed the previous wording and kept node termination handler.  That is the only change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
