### PR TITLE
Add mechanism to override drainability status

### DIFF
--- a/cluster-autoscaler/simulator/drain_test.go
+++ b/cluster-autoscaler/simulator/drain_test.go
@@ -790,17 +790,29 @@ func TestGetPodsToMove(t *testing.T) {
 
 type alwaysDrain struct{}
 
+func (a alwaysDrain) Name() string {
+	return "AlwaysDrain"
+}
+
 func (a alwaysDrain) Drainable(*drainability.DrainContext, *apiv1.Pod) drainability.Status {
 	return drainability.NewDrainableStatus()
 }
 
 type neverDrain struct{}
 
+func (n neverDrain) Name() string {
+	return "NeverDrain"
+}
+
 func (n neverDrain) Drainable(*drainability.DrainContext, *apiv1.Pod) drainability.Status {
 	return drainability.NewBlockedStatus(drain.UnexpectedError, fmt.Errorf("nope"))
 }
 
 type cantDecide struct{}
+
+func (c cantDecide) Name() string {
+	return "CantDecide"
+}
 
 func (c cantDecide) Drainable(*drainability.DrainContext, *apiv1.Pod) drainability.Status {
 	return drainability.NewUndefinedStatus()

--- a/cluster-autoscaler/simulator/drainability/rules/daemonset/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/daemonset/rule.go
@@ -30,6 +30,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "DaemonSet"
+}
+
 // Drainable decides what to do with daemon set pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if pod_util.IsDaemonSetPod(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/daemonset/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/daemonset/rule_test.go
@@ -19,6 +19,7 @@ package daemonset
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -52,8 +53,8 @@ func TestDrainable(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			got := New().Drainable(nil, tc.pod)
-			if tc.want != got {
-				t.Errorf("Rule.Drainable(%v) = %v, want %v", tc.pod.Name, got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/drainability/rules/localstorage/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/localstorage/rule.go
@@ -32,6 +32,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "LocalStorage"
+}
+
 // Drainable decides what to do with local storage pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drain.HasBlockingLocalStorage(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/longterminating/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/longterminating/rule.go
@@ -30,6 +30,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "LongTerminating"
+}
+
 // Drainable decides what to do with long terminating pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drain.IsPodLongTerminating(pod, drainCtx.Timestamp) {

--- a/cluster-autoscaler/simulator/drainability/rules/longterminating/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/longterminating/rule_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -120,8 +121,8 @@ func TestDrainable(t *testing.T) {
 				Timestamp: testTime,
 			}
 			got := New().Drainable(drainCtx, tc.pod)
-			if tc.want != got {
-				t.Errorf("Rule.Drainable(%v) = %v, want %v", tc.pod.Name, got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/drainability/rules/mirror/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/mirror/rule.go
@@ -30,6 +30,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "Mirror"
+}
+
 // Drainable decides what to do with mirror pods on node drain.
 func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if pod_util.IsMirrorPod(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/mirror/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/mirror/rule_test.go
@@ -19,6 +19,7 @@ package mirror
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -54,8 +55,8 @@ func TestDrainable(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			got := New().Drainable(nil, tc.pod)
-			if tc.want != got {
-				t.Errorf("Rule.Drainable(%v) = %v, want %v", tc.pod.Name, got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/drainability/rules/notsafetoevict/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/notsafetoevict/rule.go
@@ -32,6 +32,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "NotSafeToEvict"
+}
+
 // Drainable decides what to do with not safe to evict pods on node drain.
 func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drain.HasNotSafeToEvictAnnotation(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
@@ -32,6 +32,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "PDB"
+}
+
 // Drainable decides how to handle pods with pdbs on node drain.
 func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule_test.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDrainable(t *testing.T) {
@@ -142,9 +144,8 @@ func TestDrainable(t *testing.T) {
 			}
 
 			got := New().Drainable(drainCtx, tc.pod)
-			if got.Outcome != tc.wantOutcome || got.BlockingReason != tc.wantReason {
-				t.Errorf("Rule.Drainable(%s) = (outcome: %v, reason: %v), want (outcome: %v, reason: %v)", tc.pod.Name, got.Outcome, got.BlockingReason, tc.wantOutcome, tc.wantReason)
-			}
+			assert.Equal(t, tc.wantReason, got.BlockingReason)
+			assert.Equal(t, tc.wantOutcome, got.Outcome)
 		})
 	}
 }

--- a/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
@@ -38,6 +38,11 @@ func New(minReplicaCount int) *Rule {
 	}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "ReplicaCount"
+}
+
 // Drainable decides what to do with replicated pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drainCtx.Listers == nil {

--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
@@ -36,6 +36,11 @@ func New(skipNodesWithCustomControllerPods bool) *Rule {
 	}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "Replicated"
+}
+
 // Drainable decides what to do with replicated pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	controllerRef := drain.ControllerRef(pod)

--- a/cluster-autoscaler/simulator/drainability/rules/rules_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+)
+
+func TestDrainable(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		rules Rules
+		want  drainability.Status
+	}{
+		"no rules": {
+			want: drainability.NewUndefinedStatus(),
+		},
+		"first non-undefined rule returned": {
+			rules: Rules{
+				fakeRule{drainability.NewUndefinedStatus()},
+				fakeRule{drainability.NewDrainableStatus()},
+				fakeRule{drainability.NewSkipStatus()},
+			},
+			want: drainability.NewDrainableStatus(),
+		},
+		"override match": {
+			rules: Rules{
+				fakeRule{drainability.Status{
+					Outcome:   drainability.DrainOk,
+					Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+				}},
+				fakeRule{drainability.NewBlockedStatus(drain.NotEnoughPdb, nil)},
+			},
+			want: drainability.Status{
+				Outcome:   drainability.DrainOk,
+				Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+			},
+		},
+		"override no match": {
+			rules: Rules{
+				fakeRule{drainability.Status{
+					Outcome:   drainability.DrainOk,
+					Overrides: []drainability.OutcomeType{drainability.SkipDrain},
+				}},
+				fakeRule{drainability.NewBlockedStatus(drain.NotEnoughPdb, nil)},
+			},
+			want: drainability.NewBlockedStatus(drain.NotEnoughPdb, nil),
+		},
+		"override unreachable": {
+			rules: Rules{
+				fakeRule{drainability.NewSkipStatus()},
+				fakeRule{drainability.Status{
+					Outcome:   drainability.DrainOk,
+					Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+				}},
+				fakeRule{drainability.NewBlockedStatus(drain.NotEnoughPdb, nil)},
+			},
+			want: drainability.NewSkipStatus(),
+		},
+		"multiple overrides all run": {
+			rules: Rules{
+				fakeRule{drainability.Status{
+					Outcome:   drainability.DrainOk,
+					Overrides: []drainability.OutcomeType{drainability.SkipDrain},
+				}},
+				fakeRule{drainability.Status{
+					Outcome:   drainability.SkipDrain,
+					Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+				}},
+				fakeRule{drainability.NewBlockedStatus(drain.NotEnoughPdb, nil)},
+			},
+			want: drainability.Status{
+				Outcome:   drainability.SkipDrain,
+				Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+			},
+		},
+		"multiple overrides respects order": {
+			rules: Rules{
+				fakeRule{drainability.Status{
+					Outcome:   drainability.SkipDrain,
+					Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+				}},
+				fakeRule{drainability.Status{
+					Outcome:   drainability.DrainOk,
+					Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+				}},
+				fakeRule{drainability.NewBlockedStatus(drain.NotEnoughPdb, nil)},
+			},
+			want: drainability.Status{
+				Outcome:   drainability.SkipDrain,
+				Overrides: []drainability.OutcomeType{drainability.BlockDrain},
+			},
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			got := tc.rules.Drainable(nil, nil)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Drainable(): got status diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeRule struct {
+	status drainability.Status
+}
+
+func (r fakeRule) Drainable(*drainability.DrainContext, *apiv1.Pod) drainability.Status {
+	return r.status
+}

--- a/cluster-autoscaler/simulator/drainability/rules/rules_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules_test.go
@@ -111,7 +111,7 @@ func TestDrainable(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			got := tc.rules.Drainable(nil, nil)
+			got := tc.rules.Drainable(nil, &apiv1.Pod{})
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Drainable(): got status diff (-want +got):\n%s", diff)
 			}
@@ -121,6 +121,10 @@ func TestDrainable(t *testing.T) {
 
 type fakeRule struct {
 	status drainability.Status
+}
+
+func (r fakeRule) Name() string {
+	return "FakeRule"
 }
 
 func (r fakeRule) Drainable(*drainability.DrainContext, *apiv1.Pod) drainability.Status {

--- a/cluster-autoscaler/simulator/drainability/rules/safetoevict/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/safetoevict/rule.go
@@ -30,6 +30,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "SafeToEvict"
+}
+
 // Drainable decides what to do with safe to evict pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drain.HasSafeToEvictAnnotation(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/safetoevict/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/safetoevict/rule_test.go
@@ -19,6 +19,7 @@ package safetoevict
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -54,8 +55,8 @@ func TestDrainable(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			got := New().Drainable(nil, tc.pod)
-			if tc.want != got {
-				t.Errorf("Rule.Drainable(%v) = %v, want %v", tc.pod.Name, got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/drainability/rules/system/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/system/rule.go
@@ -32,6 +32,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "System"
+}
+
 // Drainable decides what to do with system pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if pod.Namespace == "kube-system" && len(drainCtx.RemainingPdbTracker.MatchingPdbs(pod)) == 0 {

--- a/cluster-autoscaler/simulator/drainability/rules/terminal/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/terminal/rule.go
@@ -30,6 +30,11 @@ func New() *Rule {
 	return &Rule{}
 }
 
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "Terminal"
+}
+
 // Drainable decides what to do with terminal pods on node drain.
 func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 	if drain.IsPodTerminal(pod) {

--- a/cluster-autoscaler/simulator/drainability/rules/terminal/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/terminal/rule_test.go
@@ -19,6 +19,7 @@ package terminal
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -71,8 +72,8 @@ func TestDrainable(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			got := New().Drainable(nil, tc.pod)
-			if tc.want != got {
-				t.Errorf("Rule.Drainable(%v) = %v, want %v", tc.pod.Name, got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Rule.Drainable(%v): got status diff (-want +got):\n%s", tc.pod.Name, diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/drainability/status.go
+++ b/cluster-autoscaler/simulator/drainability/status.go
@@ -43,6 +43,12 @@ type Status struct {
 	// Outcome indicates what can happen when it comes to draining a
 	// specific pod.
 	Outcome OutcomeType
+	// Overrides specifies Outcomes that should be trumped by this Status.
+	// If Overrides is empty, this Status is returned immediately.
+	// If Overrides is non-empty, we continue running the remaining Rules. If a
+	// Rule is encountered that matches one of the Outcomes specified by this
+	// field, this Status will will be returned instead.
+	Overrides []OutcomeType
 	// Reason contains the reason why a pod is blocking node drain. It is
 	// set only when Outcome is BlockDrain.
 	BlockingReason drain.BlockingPodReason


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a mechanism for one rule to selectively override other rules. This allows for custom rules that override some outcomes (e.g. BlockDrain -> DrainOk) while not overriding others (e.g. SkipDrain).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
