### PR TITLE
Add kwiesmueller to OWNERS

### DIFF
--- a/addon-resizer/OWNERS
+++ b/addon-resizer/OWNERS
@@ -1,6 +1,8 @@
 approvers:
+- kwiesmueller
 - jbartosik
 reviewers:
+- kwiesmueller
 - jbartosik
 emeritus_approvers:
 - bskiba # 2022-09-30

--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -1,8 +1,10 @@
 approvers:
+- kwiesmueller
 - kgolab
 - jbartosik
 - krzysied
 reviewers:
+- kwiesmueller
 - kgolab
 - jbartosik
 - krzysied


### PR DESCRIPTION
jbartosik et al are transitioning off of workload autoscalers (incl vpa and addon-resizer). kwiesmueller is on the new team and has agreed to take on reviewer/approver responsibilities.

/kind cleanup

```release-note
NONE
```