### PR TITLE
fix(cluster-autoscaler-chart): if secretKeyRefNameOverride is true, d…

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.27.2
+appVersion: 1.27.3
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler

--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.27.3
+appVersion: 1.27.2
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.29.3
+version: 9.29.4

--- a/charts/cluster-autoscaler/templates/secret.yaml
+++ b/charts/cluster-autoscaler/templates/secret.yaml
@@ -1,11 +1,16 @@
-{{- if or (eq .Values.cloudProvider "azure") (and (eq .Values.cloudProvider "aws") (not (has "" (list .Values.awsAccessKeyID .Values.awsSecretAccessKey)))) }}
+{{- if not .Values.secretKeyRefNameOverride }}
+{{- $isAzure := eq .Values.cloudProvider "azure" }}
+{{- $isAws := eq .Values.cloudProvider "aws" }}
+{{- $awsCredentialsProvided := and .Values.awsAccessKeyID .Values.awsSecretAccessKey }}
+
+{{- if or $isAzure (and $isAws $awsCredentialsProvided) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "cluster-autoscaler.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
-{{- if eq .Values.cloudProvider "azure" }}
+{{- if $isAzure }}
   ClientID: "{{ .Values.azureClientID | b64enc }}"
   ClientSecret: "{{ .Values.azureClientSecret | b64enc }}"
   ResourceGroup: "{{ .Values.azureResourceGroup | b64enc }}"
@@ -14,8 +19,9 @@ data:
   VMType: "{{ .Values.azureVMType | b64enc }}"
   ClusterName: "{{ .Values.azureClusterName | b64enc }}"
   NodeResourceGroup: "{{ .Values.azureNodeResourceGroup | b64enc }}"
-{{- else if eq .Values.cloudProvider "aws" }}
+{{- else if $isAws }}
   AwsAccessKeyId: "{{ .Values.awsAccessKeyID | b64enc }}"
   AwsSecretAccessKey: "{{ .Values.awsSecretAccessKey | b64enc }}"
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
…on't create secret

Don't create secret if `secretKeyRefNameOverride` is used

/kind bug 

#### What this PR does / why we need it:

Don't create secret if `secretKeyRefNameOverride` is used in the helm chart for cluster autoscaler.

Fixes #

#### Special notes for your reviewer:

Clean up so no extra secret is created unnecessarily.

#### Does this PR introduce a user-facing change?
```None

```

