### PR TITLE
Fix scalingMode

### DIFF
--- a/addon-resizer/nanny/nanny_lib.go
+++ b/addon-resizer/nanny/nanny_lib.go
@@ -131,9 +131,9 @@ func updateResources(k8s KubernetesClient, est ResourceEstimator, now, lastChang
 	var num uint64
 	var err error
 	if scalingMode == ContainerProportional {
-		num, err = k8s.CountNodes()
-	} else {
 		num, err = k8s.CountContainers()
+	} else {
+		num, err = k8s.CountNodes()
 	}
 
 	if err != nil {

--- a/addon-resizer/nanny/nanny_lib_test.go
+++ b/addon-resizer/nanny/nanny_lib_test.go
@@ -350,9 +350,19 @@ func TestNodeVsContainerProportional(t *testing.T) {
 			t.Errorf("updateResources got %d, want %d for test case %d.", gotScaling, tc.wantScaling, i)
 		}
 		if gotScaling == overwrite {
-			wantCPU := "400m"  // 300m + 10 * 10m
-			if gotCPU := k8s.newResources.Requests.Cpu().String(); gotCPU != wantCPU {
-				t.Errorf("updateResources got %q, want %q for test case %d.", gotCPU, wantCPU, i)
+			wantCPU := cpuBase
+			n := 0
+			if tc.scalingMode == ContainerProportional {
+				n = int(tc.containers)
+			} else {
+				n = int(tc.nodes)
+			}
+			for i := 0; i < n; i++ {
+				wantCPU.Add(cpuExtra)
+			}
+
+			if gotCPU := k8s.newResources.Requests.Cpu().String(); gotCPU != wantCPU.String() {
+				t.Errorf("updateResources got %q, want %q for test case %d.", gotCPU, wantCPU.String(), i)
 			}
 		}
 	}

--- a/addon-resizer/nanny/nanny_lib_test.go
+++ b/addon-resizer/nanny/nanny_lib_test.go
@@ -286,6 +286,78 @@ func TestUpdateResources(t *testing.T) {
 	}
 }
 
+func TestNodeVsContainerProportional(t *testing.T) {
+	// i.e. NodeProportional triggers, but ContainerProportional does not (and vice versa)
+
+	now := time.Now()
+	oneMinuteAgo := now.Add(-time.Minute)
+	testCases := []struct {
+		nodes       uint64
+		containers  uint64
+		scalingMode string
+		wantScaling updateResult
+	}{
+		{
+			nodes: 10,
+			containers: 1,
+			scalingMode: NodeProportional,
+			wantScaling: overwrite,
+		}, {
+			nodes: 10,
+			containers: 1,
+			scalingMode: ContainerProportional,
+			wantScaling: noChange,
+		},
+		{
+			nodes: 1,
+			containers: 10,
+			scalingMode: NodeProportional,
+			wantScaling: noChange,
+		},
+		{
+			nodes: 1,
+			containers: 10,
+			scalingMode: ContainerProportional,
+			wantScaling: overwrite,
+		},
+	}
+
+	threshold := 10
+	cpuBase := resource.MustParse("300m")
+	cpuExtra := resource.MustParse("10m")
+
+	for i, tc := range testCases {
+		resRequests := corev1.ResourceList{
+			"cpu": cpuBase,
+		}
+		resLimits := corev1.ResourceList{
+			"cpu": cpuBase,
+		}
+
+		k8s := newFakeKubernetesClient(tc.nodes, tc.containers, resLimits, resRequests)
+		est := LinearEstimator{
+			Resources: []Resource{
+				{
+					Base:             cpuBase,
+					ExtraPerResource: cpuExtra,
+					Name:             "cpu",
+				},
+			},
+		}
+
+		gotScaling := updateResources(k8s, est, now, oneMinuteAgo, noDelay, oneMinuteDelay, uint64(threshold), noChange, tc.scalingMode)
+		if tc.wantScaling != gotScaling {
+			t.Errorf("updateResources got %d, want %d for test case %d.", gotScaling, tc.wantScaling, i)
+		}
+		if gotScaling == overwrite {
+			wantCPU := "400m"  // 300m + 10 * 10m
+			if gotCPU := k8s.newResources.Requests.Cpu().String(); gotCPU != wantCPU {
+				t.Errorf("updateResources got %q, want %q for test case %d.", gotCPU, wantCPU, i)
+			}
+		}
+	}
+}
+
 type fakeKubernetesClient struct {
 	nodes        uint64
 	containers   uint64


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/pull/5993 added a 'scalingMode' but reversed it's sense (so if you specified 'containers' it would scale on nodes, and vice versa).

/kind bug

```release-note
NONE
```