### PR TITLE
Update image builder to use Go 1.21.3

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.4
+FROM golang:1.21.3
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/


### PR DESCRIPTION
Some of Cluster Autoscaler code is now using features only available in Go 1.21.