### PR TITLE
Bump go version from 1.20.5 to 1.20.10 (current)

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -22,7 +22,7 @@ ARCH ?= amd64
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 GOARM=7
-GOLANG_VERSION = 1.20.5
+GOLANG_VERSION = 1.20.10
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)


### PR DESCRIPTION
/kind cleanup