### PR TITLE
Backport #5285 & #5596 [CA] AWS - add nodegroup name to default labels & Add support for tags on AWS managed nodegroups to indicate resources into CA 1.24

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -446,6 +446,18 @@ func (m *AwsManager) buildNodeFromTemplate(asg *asg, template *asgTemplate) (*ap
 			node.Spec.Taints = append(node.Spec.Taints, mngTaints...)
 			klog.V(5).Infof("node.Spec.Taints : %+v\n", node.Spec.Taints)
 		}
+
+		mngTags, err := m.managedNodegroupCache.getManagedNodegroupTags(nodegroupName, clusterName)
+		if err != nil {
+			klog.Errorf("Failed to get tags from EKS DescribeNodegroup API for nodegroup %s in cluster %s because %s.", nodegroupName, clusterName, err)
+		} else if mngTags != nil && len(mngTags) > 0 {
+			resourcesFromMngTags := extractAllocatableResourcesFromTags(mngTags)
+			klog.V(5).Infof("Extracted resources from EKS nodegroup tags %v", resourcesFromTags)
+			// ManagedNodeGroup resource-indicating tags override conflicting tags on the ASG if they exist
+			for resourceName, val := range resourcesFromMngTags {
+				node.Status.Capacity[apiv1.ResourceName(resourceName)] = *val
+			}
+		}
 	}
 
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
@@ -587,6 +599,27 @@ func extractAllocatableResourcesFromAsg(tags []*autoscaling.TagDescription) map[
 			if label != "" {
 				quantity, err := resource.ParseQuantity(v)
 				if err != nil {
+					continue
+				}
+				result[label] = &quantity
+			}
+		}
+	}
+
+	return result
+}
+
+func extractAllocatableResourcesFromTags(tags map[string]string) map[string]*resource.Quantity {
+	result := make(map[string]*resource.Quantity)
+
+	for k, v := range tags {
+		splits := strings.Split(k, "k8s.io/cluster-autoscaler/node-template/resources/")
+		if len(splits) > 1 {
+			label := splits[1]
+			if label != "" {
+				quantity, err := resource.ParseQuantity(v)
+				if err != nil {
+					klog.Warningf("Failed to parse resource quanitity '%s' for resource '%s'", v, label)
 					continue
 				}
 				result[label] = &quantity

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -142,6 +142,27 @@ func TestExtractAllocatableResourcesFromAsg(t *testing.T) {
 	assert.Equal(t, resource.NewQuantity(5, resource.DecimalSI).String(), labels["custom-resource"].String())
 }
 
+func TestExtractAllocatableResourcesFromTags(t *testing.T) {
+	tags := map[string]string{
+		"k8s.io/cluster-autoscaler/node-template/resources/cpu":               "100m",
+		"k8s.io/cluster-autoscaler/node-template/resources/memory":            "100M",
+		"k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage": "20G",
+		"k8s.io/cluster-autoscaler/node-template/resources/custom-resource":   "5",
+		"k8s.io/cluster-autoscaler/node-template/resources/error-resource":    "GG",
+	}
+
+	labels := extractAllocatableResourcesFromTags(tags)
+
+	assert.Equal(t, 4, len(labels))
+	assert.NotContains(t, labels, "error-resource")
+	assert.Equal(t, resource.NewMilliQuantity(100, resource.DecimalSI).String(), labels["cpu"].String())
+	expectedMemory := resource.MustParse("100M")
+	assert.Equal(t, (&expectedMemory).String(), labels["memory"].String())
+	expectedEphemeralStorage := resource.MustParse("20G")
+	assert.Equal(t, (&expectedEphemeralStorage).String(), labels["ephemeral-storage"].String())
+	assert.Equal(t, resource.NewQuantity(5, resource.DecimalSI).String(), labels["custom-resource"].String())
+}
+
 func TestGetAsgOptions(t *testing.T) {
 	defaultOptions := config.NodeGroupAutoscalingOptions{
 		ScaleDownUtilizationThreshold:    0.1,
@@ -251,11 +272,17 @@ func TestBuildNodeFromTemplateWithManagedNodegroup(t *testing.T) {
 		Value:  taintValue2,
 	}
 
+	ephemeralStorageKey := "ephemeral-storage"
+	diskSizeGb := 80
+	tagKey1 := fmt.Sprintf("k8s.io/cluster-autoscaler/node-template/resources/%s", ephemeralStorageKey)
+	tagValue1 := fmt.Sprintf("%dGi", diskSizeGb)
+
 	err := mngCache.Add(managedNodegroupCachedObject{
 		name:        ngNameLabelValue,
 		clusterName: clusterNameLabelValue,
 		taints:      []apiv1.Taint{taint1, taint2},
 		labels:      map[string]string{labelKey1: labelValue1, labelKey2: labelValue2},
+		tags:        map[string]string{tagKey1: tagValue1},
 	})
 	require.NoError(t, err)
 
@@ -278,6 +305,9 @@ func TestBuildNodeFromTemplateWithManagedNodegroup(t *testing.T) {
 		},
 	})
 	assert.NoError(t, observedErr)
+	esValue, esExist := observedNode.Status.Capacity[apiv1.ResourceName(ephemeralStorageKey)]
+	assert.True(t, esExist)
+	assert.Equal(t, int64(diskSizeGb*1024*1024*1024), esValue.Value())
 	assert.GreaterOrEqual(t, len(observedNode.Labels), 4)
 	ngNameValue, ngLabelExist := observedNode.Labels["nodegroup-name"]
 	assert.True(t, ngLabelExist)

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -57,7 +57,7 @@ type awsWrapper struct {
 	eksI
 }
 
-func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName string) ([]apiv1.Taint, map[string]string, error) {
+func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName string) ([]apiv1.Taint, map[string]string, map[string]string, error) {
 	params := &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -66,13 +66,14 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 	r, err := m.DescribeNodegroup(params)
 	observeAWSRequest("DescribeNodegroup", err, start)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	klog.V(6).Infof("DescribeNodegroup output : %+v\n", r)
 
 	taints := make([]apiv1.Taint, 0)
 	labels := make(map[string]string)
+	tags := make(map[string]string)
 
 	// Labels will include diskSize, amiType, capacityType, version
 	if r.Nodegroup.DiskSize != nil {
@@ -104,6 +105,15 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		}
 	}
 
+	if r.Nodegroup.Tags != nil && len(r.Nodegroup.Tags) > 0 {
+		tagsMap := r.Nodegroup.Tags
+		for k, v := range tagsMap {
+			if v != nil {
+				tags[k] = *v
+			}
+		}
+	}
+
 	if r.Nodegroup.Taints != nil && len(r.Nodegroup.Taints) > 0 {
 		taintList := r.Nodegroup.Taints
 		for _, taint := range taintList {
@@ -117,7 +127,7 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		}
 	}
 
-	return taints, labels, nil
+	return taints, labels, tags, nil
 }
 
 func (m *awsWrapper) getInstanceTypeByLaunchConfigNames(launchConfigToQuery []*string) (map[string]string, error) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -91,6 +91,10 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		labels["k8sVersion"] = *r.Nodegroup.Version
 	}
 
+	if r.Nodegroup.NodegroupName != nil && len(*r.Nodegroup.NodegroupName) > 0 {
+		labels["eks.amazonaws.com/nodegroup"] = *r.Nodegroup.NodegroupName
+	}
+
 	if r.Nodegroup.Labels != nil && len(r.Nodegroup.Labels) > 0 {
 		labelsMap := r.Nodegroup.Labels
 		for k, v := range labelsMap {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -138,6 +138,11 @@ func TestGetManagedNodegroup(t *testing.T) {
 	capacityType := "testCapacityType"
 	k8sVersion := "1.19"
 
+	tagKey1 := "tag 1"
+	tagValue1 := "value 1"
+	tagKey2 := "tag 2"
+	tagValue2 := "value 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -148,6 +153,7 @@ func TestGetManagedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -155,7 +161,7 @@ func TestGetManagedNodegroup(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 2)
 	assert.Equal(t, taintList[0].Effect, apiv1.TaintEffect(taintEffect1))
@@ -172,6 +178,9 @@ func TestGetManagedNodegroup(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 2)
+	assert.Equal(t, tagMap[tagKey1], tagValue1)
+	assert.Equal(t, tagMap[tagKey2], tagValue2)
 }
 
 func TestGetManagedNodegroupWithNilValues(t *testing.T) {
@@ -199,6 +208,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -206,7 +216,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
 	assert.Equal(t, len(labelMap), 4)
@@ -214,6 +224,7 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 0)
 }
 
 func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
@@ -241,6 +252,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        make([]*eks.Taint, 0),
+		Tags:          make(map[string]*string),
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -248,7 +260,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
 
-	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
+	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
 	assert.Equal(t, len(labelMap), 4)
@@ -256,6 +268,7 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
 	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(tagMap), 0)
 }
 
 func TestMoreThen100Groups(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -164,13 +164,14 @@ func TestGetManagedNodegroup(t *testing.T) {
 	assert.Equal(t, taintList[1].Effect, apiv1.TaintEffect(taintEffect2))
 	assert.Equal(t, taintList[1].Key, taintKey2)
 	assert.Equal(t, taintList[1].Value, taintValue2)
-	assert.Equal(t, len(labelMap), 6)
+	assert.Equal(t, len(labelMap), 7)
 	assert.Equal(t, labelMap[labelKey1], labelValue1)
 	assert.Equal(t, labelMap[labelKey2], labelValue2)
 	assert.Equal(t, labelMap["diskSize"], strconv.FormatInt(diskSize, 10))
 	assert.Equal(t, labelMap["amiType"], amiType)
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
+	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
 }
 
 func TestGetManagedNodegroupWithNilValues(t *testing.T) {
@@ -208,10 +209,11 @@ func TestGetManagedNodegroupWithNilValues(t *testing.T) {
 	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
-	assert.Equal(t, len(labelMap), 3)
+	assert.Equal(t, len(labelMap), 4)
 	assert.Equal(t, labelMap["amiType"], amiType)
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
+	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
 }
 
 func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
@@ -249,10 +251,11 @@ func TestGetManagedNodegroupWithEmptyValues(t *testing.T) {
 	taintList, labelMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 0)
-	assert.Equal(t, len(labelMap), 3)
+	assert.Equal(t, len(labelMap), 4)
 	assert.Equal(t, labelMap["amiType"], amiType)
 	assert.Equal(t, labelMap["capacityType"], capacityType)
 	assert.Equal(t, labelMap["k8sVersion"], k8sVersion)
+	assert.Equal(t, labelMap["eks.amazonaws.com/nodegroup"], nodegroupName)
 }
 
 func TestMoreThen100Groups(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -125,10 +125,11 @@ func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.name, nodegroupName)
 	assert.Equal(t, cacheObj.clusterName, clusterName)
 	assert.Equal(t, len(cacheObj.taints), 0)
-	assert.Equal(t, len(cacheObj.labels), 3)
+	assert.Equal(t, len(cacheObj.labels), 4)
 	assert.Equal(t, cacheObj.labels["amiType"], amiType)
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
 }
 
 func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
@@ -194,13 +195,14 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.taints[1].Effect, apiv1.TaintEffect(taintEffect2))
 	assert.Equal(t, cacheObj.taints[1].Key, taintKey2)
 	assert.Equal(t, cacheObj.taints[1].Value, taintValue2)
-	assert.Equal(t, len(cacheObj.labels), 6)
+	assert.Equal(t, len(cacheObj.labels), 7)
 	assert.Equal(t, cacheObj.labels[labelKey1], labelValue1)
 	assert.Equal(t, cacheObj.labels[labelKey2], labelValue2)
 	assert.Equal(t, cacheObj.labels["diskSize"], strconv.FormatInt(diskSize, 10))
 	assert.Equal(t, cacheObj.labels["amiType"], amiType)
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
 }
 
 func TestGetManagedNodegroupInfoObjectWithError(t *testing.T) {
@@ -294,13 +296,14 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 
 	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
 	require.NoError(t, err)
-	assert.Equal(t, len(mngInfoObject.labels), 6)
+	assert.Equal(t, len(mngInfoObject.labels), 7)
 	assert.Equal(t, mngInfoObject.labels[labelKey1], labelValue1)
 	assert.Equal(t, mngInfoObject.labels[labelKey2], labelValue2)
 	assert.Equal(t, mngInfoObject.labels["diskSize"], strconv.FormatInt(diskSize, 10))
 	assert.Equal(t, mngInfoObject.labels["amiType"], amiType)
 	assert.Equal(t, mngInfoObject.labels["capacityType"], capacityType)
 	assert.Equal(t, mngInfoObject.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, mngInfoObject.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -377,13 +380,14 @@ func TestGetManagedNodegroupLabelsNoCachedNodegroup(t *testing.T) {
 
 	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
 	require.NoError(t, err)
-	assert.Equal(t, len(labelsMap), 6)
+	assert.Equal(t, len(labelsMap), 7)
 	assert.Equal(t, labelsMap[labelKey1], labelValue1)
 	assert.Equal(t, labelsMap[labelKey2], labelValue2)
 	assert.Equal(t, labelsMap["diskSize"], strconv.FormatInt(diskSize, 10))
 	assert.Equal(t, labelsMap["amiType"], amiType)
 	assert.Equal(t, labelsMap["capacityType"], capacityType)
 	assert.Equal(t, labelsMap["k8sVersion"], k8sVersion)
+	assert.Equal(t, labelsMap["eks.amazonaws.com/nodegroup"], nodegroupName)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -471,13 +475,14 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroupThatExpires(t *testing.T) {
 	// Query for nodegroup entry after it expires - should have the new labels added
 	newLabelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
 	require.NoError(t, err)
-	assert.Equal(t, len(newLabelsMap), 6)
+	assert.Equal(t, len(newLabelsMap), 7)
 	assert.Equal(t, newLabelsMap[labelKey1], labelValue1)
 	assert.Equal(t, newLabelsMap[labelKey2], labelValue2)
 	assert.Equal(t, newLabelsMap["diskSize"], strconv.FormatInt(diskSize, 10))
 	assert.Equal(t, newLabelsMap["amiType"], amiType)
 	assert.Equal(t, newLabelsMap["capacityType"], capacityType)
 	assert.Equal(t, newLabelsMap["k8sVersion"], k8sVersion)
+	assert.Equal(t, newLabelsMap["eks.amazonaws.com/nodegroup"], nodegroupName)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -38,6 +38,8 @@ func TestManagedNodegroupCache(t *testing.T) {
 	taintEffect := "effect 1"
 	taintKey := "key 1"
 	taintValue := "value 1"
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 	taint := apiv1.Taint{
 		Effect: apiv1.TaintEffect(taintEffect),
 		Key:    taintKey,
@@ -50,6 +52,7 @@ func TestManagedNodegroupCache(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 	require.NoError(t, err)
 	obj, ok, err := c.GetByKey(nodegroupName)
@@ -63,6 +66,8 @@ func TestManagedNodegroupCache(t *testing.T) {
 	assert.Equal(t, apiv1.TaintEffect(taintEffect), obj.(managedNodegroupCachedObject).taints[0].Effect)
 	assert.Equal(t, taintKey, obj.(managedNodegroupCachedObject).taints[0].Key)
 	assert.Equal(t, taintValue, obj.(managedNodegroupCachedObject).taints[0].Value)
+	assert.Equal(t, len(obj.(managedNodegroupCachedObject).tags), 1)
+	assert.Equal(t, tagValue, obj.(managedNodegroupCachedObject).tags[tagKey])
 }
 
 func TestGetManagedNodegroupWithError(t *testing.T) {
@@ -111,6 +116,7 @@ func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -130,6 +136,7 @@ func TestGetManagedNodegroupNoTaintsOrLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(cacheObj.tags), 0)
 }
 
 func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
@@ -165,6 +172,11 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 		Value:  &taintValue2,
 	}
 
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -175,6 +187,7 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -203,6 +216,9 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.labels["capacityType"], capacityType)
 	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(cacheObj.tags), 2)
+	assert.Equal(t, cacheObj.tags[tagKey1], tagValue1)
+	assert.Equal(t, cacheObj.tags[tagKey2], tagValue2)
 }
 
 func TestGetManagedNodegroupInfoObjectWithError(t *testing.T) {
@@ -241,6 +257,8 @@ func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
 		Key:    taintKey,
 		Value:  taintValue,
 	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 
 	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
 	err := c.Add(managedNodegroupCachedObject{
@@ -248,6 +266,7 @@ func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 
 	mngInfoObject, err := c.getManagedNodegroupInfoObject(nodegroupName, clusterName)
@@ -275,6 +294,11 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 	labelValue1 := "testValue 1"
 	labelValue2 := "testValue 2"
 
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
 	// Create test nodegroup
 	testNodegroup := eks.Nodegroup{
 		AmiType:       &amiType,
@@ -285,6 +309,7 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -304,6 +329,9 @@ func TestGetManagedNodegroupInfoObjectNoCachedNodegroup(t *testing.T) {
 	assert.Equal(t, mngInfoObject.labels["capacityType"], capacityType)
 	assert.Equal(t, mngInfoObject.labels["k8sVersion"], k8sVersion)
 	assert.Equal(t, mngInfoObject.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, len(mngInfoObject.tags), 2)
+	assert.Equal(t, mngInfoObject.tags[tagKey1], tagValue1)
+	assert.Equal(t, mngInfoObject.tags[tagKey2], tagValue2)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,
@@ -325,6 +353,8 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
 		Key:    taintKey,
 		Value:  taintValue,
 	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
 
 	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
 	err := c.Add(managedNodegroupCachedObject{
@@ -332,6 +362,7 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
 		clusterName: clusterName,
 		taints:      []apiv1.Taint{taint},
 		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
 	})
 
 	labelsMap, err := c.getManagedNodegroupLabels(nodegroupName, clusterName)
@@ -369,6 +400,7 @@ func TestGetManagedNodegroupLabelsNoCachedNodegroup(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -419,6 +451,7 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroupThatExpires(t *testing.T) {
 		CapacityType:  &capacityType,
 		Version:       &k8sVersion,
 		Taints:        nil,
+		Tags:          nil,
 	}
 
 	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -581,6 +614,107 @@ func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
 	assert.Equal(t, taintsList[1].Effect, apiv1.TaintEffect(taintEffect2))
 	assert.Equal(t, taintsList[1].Key, taintKey2)
 	assert.Equal(t, taintsList[1].Value, taintValue2)
+	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTagsWithCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "nodegroupName"
+	clusterName := "clusterName"
+	labelKey := "label key 1"
+	labelValue := "label value 1"
+	taintEffect := "effect 1"
+	taintKey := "key 1"
+	taintValue := "value 1"
+	taint := apiv1.Taint{
+		Effect: apiv1.TaintEffect(taintEffect),
+		Key:    taintKey,
+		Value:  taintValue,
+	}
+	tagKey := "tag key 1"
+	tagValue := "tag value 1"
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+	err := c.Add(managedNodegroupCachedObject{
+		name:        nodegroupName,
+		clusterName: clusterName,
+		taints:      []apiv1.Taint{taint},
+		labels:      map[string]string{labelKey: labelValue},
+		tags:        map[string]string{tagKey: tagValue},
+	})
+
+	tagsMap, err := c.getManagedNodegroupTags(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(tagsMap), 1)
+	assert.Equal(t, tagsMap[tagKey], tagValue)
+	k.AssertNotCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	})
+}
+
+func TestGetManagedNodegroupTagsNoCachedNodegroup(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+	diskSize := int64(100)
+
+	taintEffect1 := "effect 1"
+	taintKey1 := "key 1"
+	taintValue1 := "value 1"
+	taint1 := eks.Taint{
+		Effect: &taintEffect1,
+		Key:    &taintKey1,
+		Value:  &taintValue1,
+	}
+
+	taintEffect2 := "effect 2"
+	taintKey2 := "key 2"
+	taintValue2 := "value 2"
+	taint2 := eks.Taint{
+		Effect: &taintEffect2,
+		Key:    &taintKey2,
+		Value:  &taintValue2,
+	}
+
+	tagKey1 := "tagKey 1"
+	tagKey2 := "tagKey 2"
+	tagValue1 := "tagValue 1"
+	tagValue2 := "tagValue 2"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      &diskSize,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        []*eks.Taint{&taint1, &taint2},
+		Tags:          map[string]*string{tagKey1: &tagValue1, tagKey2: &tagValue2},
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	tagsMap, err := c.getManagedNodegroupTags(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, len(tagsMap), 2)
+	assert.Equal(t, tagsMap[tagKey1], tagValue1)
+	assert.Equal(t, tagsMap[tagKey2], tagValue2)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
 		NodegroupName: &nodegroupName,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is cherry-picked, which backports https://github.com/kubernetes/autoscaler/pull/5285 & https://github.com/kubernetes/autoscaler/pull/5596 into CA 1.24

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Originally just intended to backport https://github.com/kubernetes/autoscaler/pull/5596, but the cherry-pick runs into a test file merge conflict for CA 1.25 and CA 1.24 due to https://github.com/kubernetes/autoscaler/pull/5285. That change is fairly small/contained and the merge conflict occurs only in tests so I figured it was easier and cleaner to backport both of the features.

Put them in the one PR, but happy to split into 2 PRs if that's preferred and will get them reviewed/merged sequentially.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
[#5285]
YES. After this PR, when scaling an AWS ASG from 0, the ASG name could be used without any additional work as the NodeSelector.

      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: eks.amazonaws.com/nodegroup
                    operator: In
                    values:
                      - XXXXXXX

[#5596]
Allow k8s.io/cluster-autoscaler/resources/<resource>:<quantity> tags on AWS managed nodegroups (in addition to ASGs) to indicate availability of custom resources or ephemeral storage in a scale-from-zero scenario
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
