### PR TITLE
Fix '.spec.updatePolicy.evictionRequirements.resources' to be plural in yaml

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -283,9 +283,11 @@ spec:
               resourcePolicy:
                 description: Controls how the autoscaler computes recommended resources.
                   The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
+                  for individual containers. If any individual containers need to
+                  be excluded from getting the VPA recommendations, then it must be
+                  disabled explicitly by setting mode to "Off" under containerPolicies.
+                  If not specified, the autoscaler computes recommended resources
+                  for all containers in the pod, without additional constraints.
                 properties:
                   containerPolicies:
                     description: Per-container resource policies.
@@ -397,7 +399,7 @@ spec:
                           - TargetHigherThanRequests
                           - TargetLowerThanRequests
                           type: string
-                        resource:
+                        resources:
                           description: Resources is a list of one or more resources
                             that the condition applies to. If more than one resource
                             is given, the EvictionRequirement is fulfilled if at least
@@ -409,7 +411,7 @@ spec:
                           type: array
                       required:
                       - changeRequirement
-                      - resource
+                      - resources
                       type: object
                     type: array
                   minReplicas:

--- a/vertical-pod-autoscaler/enhancements/4831-control-eviction-behavior/README.md
+++ b/vertical-pod-autoscaler/enhancements/4831-control-eviction-behavior/README.md
@@ -27,7 +27,7 @@ A single `EvictionRequirement` specifies `Resources` and a `ChangeRequirement` c
 
 Add validation to prevent users from adding `EvictionRequirements` which can never evaluate to `true`:
 * Reject if more than one `EvictionRequirement` for a single resource is found
-* Reject if `Resource: [CPU, Memory]` is specified on one `EvictionRequirement` together with `Resource: [CPU]` or `Resource: [Memory]` on another `EvictionRequirement`
+* Reject if `Resources: [CPU, Memory]` is specified on one `EvictionRequirement` together with `Resources: [CPU]` or `Resources: [Memory]` on another `EvictionRequirement`
 
 ## Design Details
 ### Test Plan

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -126,7 +126,7 @@ type EvictionRequirement struct {
 	// Resources is a list of one or more resources that the condition applies
 	// to. If more than one resource is given, the EvictionRequirement is fulfilled
 	// if at least one resource meets `changeRequirement`.
-	Resources         []v1.ResourceName         `json:"resource" protobuf:"bytes,1,name=resources"`
+	Resources         []v1.ResourceName         `json:"resources" protobuf:"bytes,1,name=resources"`
 	ChangeRequirement EvictionChangeRequirement `json:"changeRequirement" protobuf:"bytes,2,name=changeRequirement"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fix '.spec.updatePolicy.evictionRequirements.resources' to be plural in yaml. Seems like this slipped through the cracks in #5599. We didn't release the CRD yet, so changing it shouldn't be an issue?


