### PR TITLE
Update VPA client-go version from v0.26.1 to v0.27.5

### DIFF
--- a/vertical-pod-autoscaler/go.mod
+++ b/vertical-pod-autoscaler/go.mod
@@ -12,12 +12,14 @@ require (
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
-	k8s.io/client-go v0.26.1
+	k8s.io/client-go v0.27.5
 	k8s.io/component-base v0.25.0
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/metrics v0.25.0
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 )
+
+require github.com/prometheus/client_model v0.3.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -46,7 +48,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -132,7 +132,7 @@ func findSpec(name string, containers []apiv1.Container) *apiv1.Container {
 }
 
 // OnAdd is Noop
-func (*observer) OnAdd(obj interface{}) {}
+func (*observer) OnAdd(obj interface{}, isInInitialList bool) {}
 
 // OnUpdate inspects if the update contains oom information and
 // passess it to the ObservedOomsChannel

--- a/vertical-pod-autoscaler/vendor/modules.txt
+++ b/vertical-pod-autoscaler/vendor/modules.txt
@@ -312,7 +312,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/client-go v0.26.1 => k8s.io/client-go v0.26.1
+# k8s.io/client-go v0.27.5 => k8s.io/client-go v0.26.1
 ## explicit; go 1.19
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1
@@ -664,6 +664,7 @@ k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake
+k8s.io/metrics/pkg/client/external_metrics
 # k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 ## explicit; go 1.18
 k8s.io/utils/buffer


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup