### PR TITLE
Shorten the names of the Provisioning Class names.

### DIFF
--- a/cluster-autoscaler/proposals/provisioning-request.md
+++ b/cluster-autoscaler/proposals/provisioning-request.md
@@ -88,9 +88,9 @@ type ProvisioningRequestSpec struct {
 
 	// ProvisioningClass describes the different modes of provisioning the resources.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.k8s.io - check if current cluster state can fullfil this request,
 	//   do not reserve the capacity.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner
+	// * atomic-scale-up.k8s.io - provision the resources in an atomic manner
     // * ... - potential other classes that are specific to the cloud providers
 	//
 	// +kubebuilder:validation:Required
@@ -152,18 +152,18 @@ type ProvisioningRequestStatus struct {
 
 ### Provisioning Classes
 
-#### check-capacity.kubernetes.io class
+#### check-capacity.k8s.io class
 
-The `check-capacity.kubernetes.io` is one-off check to verify that the in the cluster
+The `check-capacity.k8s.io` is one-off check to verify that the in the cluster
 there is enough capacity to provision given set of pods.
 
 Note: If two of such objects are created around the same time, CA will consider
 them independently and place no guards for the capacity.
 Also the capacity is not reserved in any manner so it may be scaled-down.
 
-#### atomic-scale-up.kubernetes.io class
+#### atomic-scale-up.k8s.io class
 
-The `atomic-scale-up.kubernetes.io` aims to provision the resources required for the
+The `atomic-scale-up.k8s.io` aims to provision the resources required for the
 specified pods in an atomic way. The proposed logic is to:
 1. Try to provision required VMs in one loop.
 2. If it failed, remove the partially provisioned VMs and back-off.
@@ -188,7 +188,7 @@ annotations:
     "cluster-autoscaler.kubernetes.io/consume-provisioning-request": "provreq-name"
 ```
 
-If those are provided for the pods that consume the ProvReq with `check-capacity.kubernetes.io` class,
+If those are provided for the pods that consume the ProvReq with `check-capacity.k8s.io` class,
 the CA will not provision the capacity, even if it was needed (as some other pods might have been
 scheduled on it) and will result in visibility events passed to the ProvReq and pods.
 If those are not passed the CA will behave normally and just provision the capacity if it needed.
@@ -278,9 +278,9 @@ loop. This will require changes in multiple parts of CA:
 The following e2e test scenarios will be created to check whether ProvReq
 handling works as expected:
 
-1.  A new ProvReq with `check-capacity.kubernetes.io` provisioning class is created, CA
+1.  A new ProvReq with `check-capacity.k8s.io` provisioning class is created, CA
     checks if there is enough capacity in cluster to provision specified pods.
-2.  A new ProvReq with `atomic-scale-up.kubernetes.io` provisioning class is created, CA
+2.  A new ProvReq with `atomic-scale-up.k8s.io` provisioning class is created, CA
     picks an appropriate node group scales it up atomically.
 3.  A new atomic ProvReq is created for which a NAP needs to provision a new
     node group. NAP creates it CA scales it atomically.
@@ -308,7 +308,7 @@ which follows the same approach as
 [StorageClass object](https://kubernetes.io/docs/concepts/storage/storage-classes/).
 Such approach would allow administrators of the cluster to introduce a list of allowed
 ProvisioningClasses. Such CRD can also contain a pre set configuration, i.e.
-administrators may set that `atomic-scale-up.kubernetes.io` would retry up to `2h`.
+administrators may set that `atomic-scale-up.k8s.io` would retry up to `2h`.
 
 Possible CRD definition:
 ```go


### PR DESCRIPTION
This PR changes the paths from kubernetes.io to k8s.io for the proposed Provisioning Class names.

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
