### PR TITLE
allow users to avoid aws instance not found spam

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -139,6 +139,14 @@ func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 		return true, cloudprovider.ErrNotImplemented
 	}
 
+	// avoid log spam for not autoscaled asgs:
+	//   Nodes that belong to an asg that is not autoscaled will not be found in the asgCache below,
+	//   so do not trigger warning spam by returning an error from being unable to find them.
+	//   Annotation is not automated, but users that see the warning can add the annotation to avoid it.
+	if node.Annotations != nil && node.Annotations["k8s.io/cluster-autoscaler/enabled"] == "false" {
+		return false, nil
+	}
+
 	awsRef, err := AwsRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return false, err

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -723,4 +723,19 @@ func TestHasInstance(t *testing.T) {
 	assert.ErrorContains(t, err, nodeNotPresentErr)
 	assert.False(t, present)
 
+	// Case 4: correct node - not autoscaled -> not present in AWS -> no warning
+	node4 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-2",
+			Annotations: map[string]string{
+				"k8s.io/cluster-autoscaler/enabled": "false",
+			},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id-2",
+		},
+	}
+	present, err = provider.HasInstance(node4)
+	assert.NoError(t, err)
+	assert.False(t, present)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

allows users to mark nodes for "do not spam me about missing aws instance"

#### Which issue(s) this PR fixes:

fixes https://github.com/kubernetes/autoscaler/issues/6096

#### Special notes for your reviewer:

not ready to be merged, just for discussion

#### Does this PR introduce a user-facing change?
```release-note
TODO
```