### PR TITLE
ScaleUp is only ever called when there are unscheduled pods

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -91,13 +91,6 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		return scaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "ScaleUpOrchestrator is not initialized"))
 	}
 
-	// From now on we only care about unschedulable pods that were marked after the newest
-	// node became available for the scheduler.
-	if len(unschedulablePods) == 0 {
-		klog.V(1).Info("No unschedulable pods")
-		return &status.ScaleUpStatus{Result: status.ScaleUpNotNeeded}, nil
-	}
-
 	loggingQuota := klogx.PodsLoggingQuota()
 	for _, pod := range unschedulablePods {
 		klogx.V(1).UpTo(loggingQuota).Infof("Pod %s/%s is unschedulable", pod.Namespace, pod.Name)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`func (o *ScaleUpOrchestrator) ScaleUp(` has code to dead with "No unschedulable pods"
but that can never happen because it is only called from static_autoscaler.go after checking that there are pods
`if len(unschedulablePodsToHelp) == 0 { ... else`
so this code is unnecessary and adds confusion and should be removed.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```