### PR TITLE
Remove gce-expander-ephemeral-storage-support flag

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -374,7 +374,7 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		klog.Fatalf("Failed to create GCE Manager: %v", err)
 	}
 
-	pricingModel := NewGcePriceModel(NewGcePriceInfo(), opts.GCEOptions.ExpanderEphemeralStorageSupport)
+	pricingModel := NewGcePriceModel(NewGcePriceInfo())
 	provider, err := BuildGceCloudProvider(manager, rl, pricingModel)
 	if err != nil {
 		klog.Fatalf("Failed to create GCE cloud provider: %v", err)

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -30,15 +30,13 @@ import (
 
 // GcePriceModel implements PriceModel interface for GCE.
 type GcePriceModel struct {
-	PriceInfo               PriceInfo
-	EphemeralStorageSupport bool
+	PriceInfo PriceInfo
 }
 
 // NewGcePriceModel gets a new instance of GcePriceModel
-func NewGcePriceModel(info PriceInfo, ephemeralStorageSupport bool) *GcePriceModel {
+func NewGcePriceModel(info PriceInfo) *GcePriceModel {
 	return &GcePriceModel{
-		PriceInfo:               info,
-		EphemeralStorageSupport: ephemeralStorageSupport,
+		PriceInfo: info,
 	}
 }
 
@@ -81,35 +79,33 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 	}
 
 	// Ephemeral Storage
-	if model.EphemeralStorageSupport {
-		// Local SSD price
-		if node.Labels[ephemeralStorageLocalSsdLabel] == "true" || node.Annotations[EphemeralStorageLocalSsdAnnotation] == "true" {
-			localSsdCount, _ := strconv.ParseFloat(node.Annotations[LocalSsdCountAnnotation], 64)
-			localSsdPrice := model.PriceInfo.LocalSsdPricePerHour()
-			if hasPreemptiblePricing(node) {
-				localSsdPrice = model.PriceInfo.SpotLocalSsdPricePerHour()
-			}
-			price += localSsdCount * float64(LocalSSDDiskSizeInGiB) * localSsdPrice * getHours(startTime, endTime)
+	// Local SSD price
+	if node.Labels[ephemeralStorageLocalSsdLabel] == "true" || node.Annotations[EphemeralStorageLocalSsdAnnotation] == "true" {
+		localSsdCount, _ := strconv.ParseFloat(node.Annotations[LocalSsdCountAnnotation], 64)
+		localSsdPrice := model.PriceInfo.LocalSsdPricePerHour()
+		if hasPreemptiblePricing(node) {
+			localSsdPrice = model.PriceInfo.SpotLocalSsdPricePerHour()
 		}
-
-		// Boot disk price
-		bootDiskSize, _ := strconv.ParseInt(node.Annotations[BootDiskSizeAnnotation], 10, 64)
-		if bootDiskSize == 0 {
-			klog.Errorf("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSizeGB)
-			bootDiskSize = DefaultBootDiskSizeGB
-		}
-		bootDiskType := node.Annotations[BootDiskTypeAnnotation]
-		if val, ok := node.Labels[bootDiskTypeLabel]; ok {
-			bootDiskType = val
-		}
-		if bootDiskType == "" {
-			klog.Errorf("Boot disk type is not found for node %s, using default type %s", node.Name, DefaultBootDiskType)
-			bootDiskType = DefaultBootDiskType
-		}
-		bootDiskPrice := model.PriceInfo.BootDiskPricePerHour()[bootDiskType]
-
-		price += bootDiskPrice * float64(bootDiskSize) * getHours(startTime, endTime)
+		price += localSsdCount * float64(LocalSSDDiskSizeInGiB) * localSsdPrice * getHours(startTime, endTime)
 	}
+
+	// Boot disk price
+	bootDiskSize, _ := strconv.ParseInt(node.Annotations[BootDiskSizeAnnotation], 10, 64)
+	if bootDiskSize == 0 {
+		klog.Errorf("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSizeGB)
+		bootDiskSize = DefaultBootDiskSizeGB
+	}
+	bootDiskType := node.Annotations[BootDiskTypeAnnotation]
+	if val, ok := node.Labels[bootDiskTypeLabel]; ok {
+		bootDiskType = val
+	}
+	if bootDiskType == "" {
+		klog.Errorf("Boot disk type is not found for node %s, using default type %s", node.Name, DefaultBootDiskType)
+		bootDiskType = DefaultBootDiskType
+	}
+	bootDiskPrice := model.PriceInfo.BootDiskPricePerHour()[bootDiskType]
+
+	price += bootDiskPrice * float64(bootDiskSize) * getHours(startTime, endTime)
 
 	// GPUs
 	if gpuRequest, found := node.Status.Capacity[gpu.ResourceNvidiaGPU]; found {
@@ -196,12 +192,10 @@ func (model *GcePriceModel) getBasePrice(resources apiv1.ResourceList, instanceT
 	}
 	price += float64(mem.Value()) / float64(units.GiB) * memPrice * hours
 
-	if model.EphemeralStorageSupport {
-		ephemeralStorage := resources[apiv1.ResourceEphemeralStorage]
-		// For simplification using a fixed price for default boot disk.
-		ephemeralStoragePrice := model.PriceInfo.BootDiskPricePerHour()[DefaultBootDiskType]
-		price += float64(ephemeralStorage.Value()) / float64(units.GiB) * ephemeralStoragePrice * hours
-	}
+	ephemeralStorage := resources[apiv1.ResourceEphemeralStorage]
+	// For simplification using a fixed price for default boot disk.
+	ephemeralStoragePrice := model.PriceInfo.BootDiskPricePerHour()[DefaultBootDiskType]
+	price += float64(ephemeralStorage.Value()) / float64(units.GiB) * ephemeralStoragePrice * hours
 
 	return price
 }

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -60,8 +60,6 @@ type GCEOptions struct {
 	ConcurrentRefreshes int
 	// MigInstancesMinRefreshWaitTime is the minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.
 	MigInstancesMinRefreshWaitTime time.Duration
-	// ExpanderEphemeralStorageSupport is whether scale-up takes ephemeral storage resources into account.
-	ExpanderEphemeralStorageSupport bool
 }
 
 const (

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -206,9 +206,9 @@ var (
 	awsUseStaticInstanceList  = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
 
 	// GCE specific flags
-	concurrentGceRefreshes             = flag.Int("gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
-	gceMigInstancesMinRefreshWaitTime  = flag.Duration("gce-mig-instances-min-refresh-wait-time", 5*time.Second, "The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.")
-	gceExpanderEphemeralStorageSupport = flag.Bool("gce-expander-ephemeral-storage-support", false, "Whether scale-up takes ephemeral storage resources into account for GCE cloud provider")
+	concurrentGceRefreshes            = flag.Int("gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
+	gceMigInstancesMinRefreshWaitTime = flag.Duration("gce-mig-instances-min-refresh-wait-time", 5*time.Second, "The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.")
+	_                                 = flag.Bool("gce-expander-ephemeral-storage-support", true, "Whether scale-up takes ephemeral storage resources into account for GCE cloud provider (Deprecated, to be removed in 1.30+)")
 
 	enableProfiling                    = flag.Bool("profiling", false, "Is debug/pprof endpoint enabled")
 	clusterAPICloudConfigAuthoritative = flag.Bool("clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
@@ -357,9 +357,8 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		NodeDeletionDelayTimeout:         *nodeDeletionDelayTimeout,
 		AWSUseStaticInstanceList:         *awsUseStaticInstanceList,
 		GCEOptions: config.GCEOptions{
-			ConcurrentRefreshes:             *concurrentGceRefreshes,
-			MigInstancesMinRefreshWaitTime:  *gceMigInstancesMinRefreshWaitTime,
-			ExpanderEphemeralStorageSupport: *gceExpanderEphemeralStorageSupport,
+			ConcurrentRefreshes:            *concurrentGceRefreshes,
+			MigInstancesMinRefreshWaitTime: *gceMigInstancesMinRefreshWaitTime,
 		},
 		ClusterAPICloudConfigAuthoritative: *clusterAPICloudConfigAuthoritative,
 		CordonNodeBeforeTerminate:          *cordonNodeBeforeTerminate,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Always enable the ephemeral-storage feature

#### Does this PR introduce a user-facing change?

```release-note
Flag --gce-expander-ephemeral-storage-support is now Deprecated. The ephemeral-storage support is always enabled and the flag itself would be ignored.
```

/assign @x13n 