### PR TITLE
Add min/max/current asg size to log

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -139,8 +139,6 @@ func (m *asgCache) register(asg *asg) *asg {
 			return existing
 		}
 
-		klog.V(4).Infof("Updating ASG %s", asg.AwsRef.Name)
-
 		// Explicit registered groups should always use the manually provided min/max
 		// values and the not the ones returned by the API
 		if !m.explicitlyConfigured[asg.AwsRef] {
@@ -157,6 +155,8 @@ func (m *asgCache) register(asg *asg) *asg {
 		existing.LaunchTemplate = asg.LaunchTemplate
 		existing.MixedInstancesPolicy = asg.MixedInstancesPolicy
 		existing.Tags = asg.Tags
+
+		klog.V(4).Infof("Updated ASG %s. min/max/current is %d/%d/%d", asg.AwsRef.Name, existing.minSize, existing.maxSize, existing.curSize)
 
 		return existing
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We're experiencing an odd scaling behaviour when using cluster-autoscaler as a library from a custom autoscaler expander. Our custom autoscaler-expander is invoking `NodeGroupIncreaseSize` with a delta of `1` but somehow that makes it want to scale the node group from 7 to 71. See https://github.com/kubernetes/autoscaler/issues/6281 for details.

The only explanation I can see is that AWS somehow returned `70` as the current taget size. We don't see any evidence in CloudTrail this though. In CloudTrail we only have SetDesiredCapacity of 7 and then 71.

This PR logs out the minimum, maximum, and current size of the auto scaling group when reading the values from AWS. This information would have helped us understand where the jump from 7 to 70+1 is coming from.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of https://github.com/kubernetes/autoscaler/issues/6281

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds additional log output when updating the ASG information form AWS
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
