### PR TITLE
Allow overriding domain suffix in GCE cloud provider.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -115,6 +115,7 @@ type autoscalingGceClientV1 struct {
 	gceService *gce.Service
 
 	projectId string
+	domainUrl string
 
 	// These can be overridden, e.g. for testing.
 	operationWaitTimeout          time.Duration
@@ -141,7 +142,7 @@ func NewAutoscalingGceClientV1(client *http.Client, projectId string, userAgent 
 
 // NewCustomAutoscalingGceClientV1 creates a new client using custom server url and timeouts
 // for communicating with GCE v1 API.
-func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, userAgent string,
+func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, userAgent, domainUrl string,
 	waitTimeout, pollInterval time.Duration, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
 	gceService, err := gce.New(client)
 	if err != nil {
@@ -153,6 +154,7 @@ func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, 
 	return &autoscalingGceClientV1{
 		projectId:                     projectId,
 		gceService:                    gceService,
+		domainUrl:                     domainUrl,
 		operationWaitTimeout:          waitTimeout,
 		operationPollInterval:         pollInterval,
 		operationDeletionPollInterval: deletionPollInterval,
@@ -295,7 +297,7 @@ func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances [
 		SkipInstancesOnValidationError: true,
 	}
 	for _, i := range instances {
-		req.Instances = append(req.Instances, GenerateInstanceUrl(i))
+		req.Instances = append(req.Instances, GenerateInstanceUrl(client.domainUrl, i))
 	}
 	op, err := client.gceService.InstanceGroupManagers.DeleteInstances(migRef.Project, migRef.Zone, migRef.Name, &req).Do()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -228,7 +228,7 @@ func TestErrors(t *testing.T) {
 
 func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 	const goodInstanceUrlTempl = "https://content.googleapis.com/compute/v1/projects/myprojid/zones/myzone/instances/myinst_%d"
-	const badInstanceUrl = "https://badurl.com/compute/v1/projects/myprojid/zones/myzone/instances/myinst"
+	const badInstanceUrl = "https://badurl.com/compute/v1/projects3/myprojid/zones/myzone/instances/myinst"
 	server := test_util.NewHttpServerMock()
 	defer server.Close()
 	g := newTestAutoscalingGceClient(t, "project1", server.URL, "")

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -197,6 +197,7 @@ type gceMig struct {
 	gceManager GceManager
 	minSize    int
 	maxSize    int
+	domainUrl  string
 }
 
 // GceRef returns Mig's GceRef
@@ -307,7 +308,7 @@ func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
 
 // Id returns mig url.
 func (mig *gceMig) Id() string {
-	return GenerateMigUrl(mig.gceRef)
+	return GenerateMigUrl(mig.domainUrl, mig.gceRef)
 }
 
 // Debug returns a debug string for the Mig.
@@ -369,7 +370,7 @@ func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 		defer config.Close()
 	}
 
-	manager, err := CreateGceManager(config, do, opts.Regional, opts.GCEOptions.ConcurrentRefreshes, opts.UserAgent, opts.GCEOptions.MigInstancesMinRefreshWaitTime)
+	manager, err := CreateGceManager(config, do, opts.Regional, opts.GCEOptions.ConcurrentRefreshes, opts.UserAgent, opts.GCEOptions.DomainUrl, opts.GCEOptions.MigInstancesMinRefreshWaitTime)
 	if err != nil {
 		klog.Fatalf("Failed to create GCE Manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -114,6 +114,7 @@ type gceManagerImpl struct {
 
 	location              string
 	projectId             string
+	domainUrl             string
 	templates             *GceTemplateBuilder
 	interrupt             chan struct{}
 	regional              bool
@@ -123,7 +124,7 @@ type gceManagerImpl struct {
 }
 
 // CreateGceManager constructs GceManager object.
-func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, regional bool, concurrentGceRefreshes int, userAgent string, migInstancesMinRefreshWaitTime time.Duration) (GceManager, error) {
+func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, regional bool, concurrentGceRefreshes int, userAgent, domainUrl string, migInstancesMinRefreshWaitTime time.Duration) (GceManager, error) {
 	// Create Google Compute Engine token.
 	var err error
 	tokenSource := google.ComputeTokenSource("")
@@ -192,6 +193,7 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 		explicitlyConfigured:   make(map[GceRef]bool),
 		concurrentGceRefreshes: concurrentGceRefreshes,
 		reserved:               &GceReserved{},
+		domainUrl:              domainUrl,
 	}
 
 	if err := manager.fetchExplicitMigs(discoveryOpts.NodeGroupSpecs); err != nil {
@@ -416,6 +418,7 @@ func (m *gceManagerImpl) buildMigFromSpec(s *dynamic.NodeGroupSpec) (Mig, error)
 		gceManager: m,
 		minSize:    s.MinSize,
 		maxSize:    s.MaxSize,
+		domainUrl:  m.domainUrl,
 	}
 	return mig, nil
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
@@ -17,29 +17,249 @@ limitations under the License.
 package gce
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseUrl(t *testing.T) {
-	proj, zone, name, err := parseGceUrl("https://www.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
-	assert.Nil(t, err)
-	assert.Equal(t, "mwielgus-proj", proj)
-	assert.Equal(t, "us-central1-b", zone)
-	assert.Equal(t, "kubernetes-minion-group", name)
+func TestGenerateInstanceUrl(t *testing.T) {
+	tests := []struct {
+		name      string
+		domainUrl string
+		ref       GceRef
+		want      string
+	}{
+		{
+			name: "empty domain url",
+			ref: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+			want: "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instances/name1",
+		},
+		{
+			name: "custom url",
+			ref: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+			domainUrl: "https://www.googleapis.com/compute-custom/v2",
+			want:      "https://www.googleapis.com/compute-custom/v2/projects/proj1/zones/us-central1-a/instances/name1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, GenerateInstanceUrl(tt.domainUrl, tt.ref), "GenerateInstanceUrl(%v, %v)", tt.domainUrl, tt.ref)
+		})
+	}
+}
 
-	// Cluster Autoscaler previously used this format for MIG id (with "content" instead of "www"). Make sure it's still accepted
-	// just to be safe.
-	proj, zone, name, err = parseGceUrl("https://content.googleapis.com/compute/v1/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
-	assert.Nil(t, err)
-	assert.Equal(t, "mwielgus-proj", proj)
-	assert.Equal(t, "us-central1-b", zone)
-	assert.Equal(t, "kubernetes-minion-group", name)
+func TestGenerateMigUrl(t *testing.T) {
+	tests := []struct {
+		name      string
+		domainUrl string
+		ref       GceRef
+		want      string
+	}{
+		{
+			name: "no custom url",
+			ref: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+			want: "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instanceGroups/name1",
+		},
+		{
+			name:      "custom url",
+			domainUrl: "https://www.googleapis.com/compute-custom/v2",
+			ref: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+			want: "https://www.googleapis.com/compute-custom/v2/projects/proj1/zones/us-central1-a/instanceGroups/name1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, GenerateMigUrl(tt.domainUrl, tt.ref), "GenerateMigUrl(%v, %v)", tt.domainUrl, tt.ref)
+		})
+	}
+}
 
-	_, _, _, err = parseGceUrl("www.onet.pl", "instanceGroups")
-	assert.NotNil(t, err)
+func TestParseIgmUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantProject string
+		wantZone    string
+		wantName    string
+		wantErr     error
+	}{
+		{
+			name:        "default domain",
+			url:         "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instanceGroupManagers/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:        "custom domain",
+			url:         "https://www.googleapis.com/compute_test/v1/projects/proj1/zones/us-central1-a/instanceGroupManagers/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:    "incorrect domain",
+			url:     "https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instanceGroupManagers2/name1",
+			wantErr: fmt.Errorf("wrong url: expected format <url>/projects/<project-id>/zones/<zone>/instanceGroupManagers/<name>, got https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instanceGroupManagers2/name1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProject, gotZone, gotName, err := ParseIgmUrl(tt.url)
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				return
+			}
+			assert.Equalf(t, tt.wantProject, gotProject, "ParseIgmUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantZone, gotZone, "ParseIgmUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantName, gotName, "ParseIgmUrl(%v)", tt.url)
+		})
+	}
+}
 
-	_, _, _, err = parseGceUrl("https://www.googleapis.com/compute/vabc/projects/mwielgus-proj/zones/us-central1-b/instanceGroups/kubernetes-minion-group", "instanceGroups")
-	assert.NotNil(t, err)
+func TestParseInstanceUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantProject string
+		wantZone    string
+		wantName    string
+		wantErr     error
+	}{
+		{
+			name:        "default domain",
+			url:         "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instances/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:        "custom domain",
+			url:         "https://www.googleapis.com/compute_test/v1/projects/proj1/zones/us-central1-a/instances/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:    "incorrect domain",
+			url:     "https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instances2/name1",
+			wantErr: fmt.Errorf("wrong url: expected format <url>/projects/<project-id>/zones/<zone>/instances/<name>, got https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instances2/name1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProject, gotZone, gotName, err := ParseInstanceUrl(tt.url)
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				return
+			}
+			assert.Equalf(t, tt.wantProject, gotProject, "ParseInstanceUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantZone, gotZone, "ParseInstanceUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantName, gotName, "ParseInstanceUrl(%v)", tt.url)
+		})
+	}
+}
+
+func TestParseInstanceUrlRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    GceRef
+		wantErr error
+	}{
+		{
+			name: "default domain",
+			url:  "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instances/name1",
+			want: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+		},
+		{
+			name: "custom domain",
+			url:  "https://www.googleapis.com/compute_test/v1/projects/proj1/zones/us-central1-a/instances/name1",
+			want: GceRef{
+				Project: "proj1",
+				Name:    "name1",
+				Zone:    "us-central1-a",
+			},
+		},
+		{
+			name:    "incorrect domain",
+			url:     "https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instances2/name1",
+			wantErr: fmt.Errorf("wrong url: expected format <url>/projects/<project-id>/zones/<zone>/instances/<name>, got https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instances2/name1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseInstanceUrlRef(tt.url)
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "ParseInstanceUrlRef(%v)", tt.url)
+		})
+	}
+}
+
+func TestParseMigUrl(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		url         string
+		wantProject string
+		wantZone    string
+		wantName    string
+		wantErr     error
+	}{
+		{
+			name:        "default domain",
+			url:         "https://www.googleapis.com/compute/v1/projects/proj1/zones/us-central1-a/instanceGroups/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:        "custom domain",
+			url:         "https://www.googleapis.com/compute_test/v1/projects/proj1/zones/us-central1-a/instanceGroups/name1",
+			wantProject: "proj1",
+			wantName:    "name1",
+			wantZone:    "us-central1-a",
+		},
+		{
+			name:    "incorrect domain",
+			url:     "https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instanceGroups/name1",
+			wantErr: fmt.Errorf("wrong url: expected format <url>/projects/<project-id>/zones/<zone>/instanceGroups/<name>, got https://www.googleapis.com/compute_test/v1/projects2/proj1/zones/us-central1-a/instanceGroups/name1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProject, gotZone, gotName, err := ParseMigUrl(tt.url)
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				return
+			}
+			assert.Equalf(t, tt.wantProject, gotProject, "ParseMigUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantZone, gotZone, "ParseMigUrl(%v)", tt.url)
+			assert.Equalf(t, tt.wantName, gotName, "ParseMigUrl(%v)", tt.url)
+		})
+	}
 }

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -60,6 +60,8 @@ type GCEOptions struct {
 	ConcurrentRefreshes int
 	// MigInstancesMinRefreshWaitTime is the minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.
 	MigInstancesMinRefreshWaitTime time.Duration
+	// DomainUrl is the GCE url used to make calls to GCE API.
+	DomainUrl string
 }
 
 const (


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR allows overriding Domain Suffix in calls made to GCE cloud provider. If it's not specified the default domain suffix is used.


