### PR TITLE
fix: update node annotation used to limit log spam with valid key

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -143,7 +143,7 @@ func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	//   Nodes that belong to an asg that is not autoscaled will not be found in the asgCache below,
 	//   so do not trigger warning spam by returning an error from being unable to find them.
 	//   Annotation is not automated, but users that see the warning can add the annotation to avoid it.
-	if node.Annotations != nil && node.Annotations["k8s.io/cluster-autoscaler/enabled"] == "false" {
+	if node.Annotations != nil && node.Annotations["k8s.io/cluster-autoscaler-enabled"] == "false" {
 		return false, nil
 	}
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -728,7 +728,7 @@ func TestHasInstance(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-2",
 			Annotations: map[string]string{
-				"k8s.io/cluster-autoscaler/enabled": "false",
+				"k8s.io/cluster-autoscaler-enabled": "false",
 			},
 		},
 		Spec: apiv1.NodeSpec{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/kubernetes/autoscaler/pull/6265 introduced the ability for users to apply an annotation to cluster Nodes that are not managed by the autoscaler, reducing the amount of "spam" messages logged by the controller.

However, the chosen annotation key `k8s.io/cluster-autoscaler/enabled` is not a valid identifier - https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set - which expects only a _single_ DNS prefix.

Attempting to manually add this annotation to an existing node will fail -

```
# nodes "ip-XXX-XXX-XXX-XXX.ec2.internal" was not valid:
# * metadata.annotations: Invalid value: "k8s.io/cluster-autoscaler/enabled": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```

Note that the use of the `k8s.io/cluster-autoscaler/enabled` _tag_ is valid within AWS.

This PR uses a valid identifier `k8s.io/cluster-autoscaler-enabled`


#### Which issue(s) this PR fixes: 6300
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
