### PR TITLE
Backport #6298 fix: handle error when listing machines into 1.27

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -344,9 +344,12 @@ func (ng *nodeGroup) listMachines() ([]unstructured.Unstructured, error) {
 			LabelSelector: fmt.Sprintf("%s=%s-%s", machineDeploymentNameLabelKey, ng.provider.config.ClusterName, ng.name),
 		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("could not list machines: %w", err)
+	}
 
 	ng.machines = machinesList.Items
-	return machinesList.Items, err
+	return machinesList.Items, nil
 }
 
 func (ng *nodeGroup) machineByName(name string) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Cherry pick https://github.com/kubernetes/autoscaler/commit/4c53c2063c82859170396fecb5d3ce5451d87ffb

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
