### PR TITLE
Set Go versions to the same settings kubernetes/kubernetes uses

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.3
+FROM golang:1.21.4
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/cluster-autoscaler
 
-go 1.21.3
+go 1.21
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Looks like specifying the Go patch version in go.mod might've been a mistake: https://github.com/kubernetes/kubernetes/pull/121808.
