### PR TITLE
Implement TemplateNodeInfo for civo cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/civo/README.md
+++ b/cluster-autoscaler/cloudprovider/civo/README.md
@@ -2,8 +2,9 @@
 
 The cluster autoscaler for Civo Cloud scales worker nodes within any specified Civo Cloud Kubernetes cluster.
 
-# Configuration
-As there is no concept of a node group within Civo Cloud's Kubernetes offering, the configuration required is quite 
+## Configuration
+
+As there is no concept of a node group within Civo Cloud's Kubernetes offering, the configuration required is quite
 simple. You need to set:
 
 - Your Civo Cloud API Key
@@ -11,14 +12,13 @@ simple. You need to set:
 - The region of the cluster
 - The minimum and maximum number of **worker** nodes you want (the master is excluded)
 
-See the [cluster-autoscaler-standard.yaml](examples/cluster-autoscaler-standard.yaml) example configuration, but to 
-summarise you should set a `nodes` startup parameter for cluster autoscaler to specify a node group called `workers` 
+See the [cluster-autoscaler-standard.yaml](examples/cluster-autoscaler-standard.yaml) example configuration, but to
+summarise you should set a `nodes` startup parameter for cluster autoscaler to specify a node group called `workers`
 e.g. `--nodes=1:10:workers`.
 
 The remaining parameters can be set via environment variables (`CIVO_API_KEY`, `CIVO_CLUSTER_ID` and `CIVO_REGION`) as in the
 example YAML.
- 
-It is also possible to get these parameters through a YAML file mounted into the container
-(for example via a Kubernetes Secret). The path configured with a startup parameter e.g. 
-`--cloud-config=/etc/kubernetes/cloud.config`. In this case the YAML keys are `api_url`, `api_key`, `cluster_id` and `region`.
 
+It is also possible to get these parameters through a YAML file mounted into the container
+(for example via a Kubernetes Secret). The path configured with a startup parameter e.g.
+`--cloud-config=/etc/kubernetes/cloud.config`. In this case the YAML keys are `api_url`, `api_key`, `cluster_id` and `region`.

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -19,10 +19,13 @@ package civo
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	civocloud "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/civo/civo-cloud-sdk-go"
 
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	autoscaler "k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/klog/v2"
@@ -33,13 +36,22 @@ import (
 // configuration info and functions to control a set of nodes that have the
 // same capacity and set of labels.
 type NodeGroup struct {
-	id         string
-	clusterID  string
-	client     nodeGroupClient
-	nodePool   *civocloud.KubernetesPool
-	minSize    int
-	maxSize    int
-	getOptions *autoscaler.NodeGroupAutoscalingOptions
+	id           string
+	clusterID    string
+	client       nodeGroupClient
+	nodePool     *civocloud.KubernetesPool
+	minSize      int
+	maxSize      int
+	getOptions   *autoscaler.NodeGroupAutoscalingOptions
+	nodeTemplate *CivoNodeTemplate
+}
+
+type CivoNodeTemplate struct {
+	CPUCores      int    `json:"cpu_cores,omitempty"`
+	RAMMegabytes  int    `json:"ram_mb,omitempty"`
+	DiskGigabytes int    `json:"disk_gb,omitempty"`
+	GpuCount      int    `json:"gpu_count,omitempty"`
+	Region        string `json:"region,omitempty"`
 }
 
 // MaxSize returns maximum size of the node group.
@@ -90,9 +102,9 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 		return err
 	}
 
-	if updatedNodePool.Count != targetSize {
-		return fmt.Errorf("couldn't increase size to %d (delta: %d). Current size is: %d",
-			targetSize, delta, updatedNodePool.Count)
+	if targetSize > n.MaxSize() {
+		return fmt.Errorf("size increase too large. current: %d, desired: %d, max: %d",
+			updatedNodePool.Count, targetSize, n.MaxSize())
 	}
 
 	// update internal cache
@@ -186,7 +198,15 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
 func (n *NodeGroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	node, err := n.buildNodeFromTemplate(n.Id(), n.nodeTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build node from template")
+	}
+
+	nodeInfo := schedulerframework.NewNodeInfo(cloudprovider.BuildKubeProxy(n.Id()))
+	nodeInfo.SetNode(node)
+
+	return nodeInfo, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
@@ -258,4 +278,29 @@ func toInstanceStatus(nodeState string) *cloudprovider.InstanceStatus {
 	}
 
 	return st
+}
+
+func (n *NodeGroup) buildNodeFromTemplate(name string, template *CivoNodeTemplate) (*apiv1.Node, error) {
+	node := &apiv1.Node{}
+	nodeName := fmt.Sprintf("%s-nodegroup-%d", name, rand.Int63())
+
+	node.ObjectMeta = metav1.ObjectMeta{
+		Name:     nodeName,
+		SelfLink: fmt.Sprintf("/api/v1/nodes/%s", nodeName),
+		Labels:   map[string]string{},
+	}
+
+	node.Status = apiv1.NodeStatus{
+		Capacity: apiv1.ResourceList{},
+	}
+	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(int64(template.CPUCores*1000), resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(int64(template.RAMMegabytes*1024*1024*1024), resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(template.DiskGigabytes*1024*1024*1024), resource.DecimalSI)
+
+	node.Status.Allocatable = node.Status.Capacity
+
+	node.Status.Conditions = cloudprovider.BuildReadyConditions()
+
+	return node, nil
 }

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -46,6 +46,7 @@ type NodeGroup struct {
 	nodeTemplate *CivoNodeTemplate
 }
 
+// CivoNodeTemplate reference to implements TemplateNodeInfo
 type CivoNodeTemplate struct {
 	CPUCores      int    `json:"cpu_cores,omitempty"`
 	RAMMegabytes  int    `json:"ram_mb,omitempty"`
@@ -280,6 +281,7 @@ func toInstanceStatus(nodeState string) *cloudprovider.InstanceStatus {
 	return st
 }
 
+// buildNodeFromTemplate returns a Node object from the given template
 func (n *NodeGroup) buildNodeFromTemplate(name string, template *CivoNodeTemplate) (*apiv1.Node, error) {
 	node := &apiv1.Node{}
 	nodeName := fmt.Sprintf("%s-nodegroup-%d", name, rand.Int63())

--- a/cluster-autoscaler/cloudprovider/civo/examples/cluster-autoscaler-node-pool.yaml
+++ b/cluster-autoscaler/cloudprovider/civo/examples/cluster-autoscaler-node-pool.yaml
@@ -139,7 +139,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0 # or your custom image
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.0 # or your custom image
           name: cluster-autoscaler
           imagePullPolicy: Always
           resources:
@@ -154,8 +154,8 @@ spec:
             - --v=4
             - --stderrthreshold=info
             - --cloud-provider=civo
-            - --nodes=1:5:<POOL_ID>
-            - --nodes=5:10:<POOL_ID>
+            - --nodes=1:5:<POOL_ID/NAME>
+            - --nodes=5:10:<POOL_ID/NAME>
             - --skip-nodes-with-local-storage=false
             - --skip-nodes-with-system-pods=false
           env:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Implement `TemplateNodeInfo()` method for civo cloudprovider

#### Special notes for your reviewer:

Observe that civo cloudprovider doesn't support scale node group zero because `TemplateNodeInfo()` was not implemented

#### Does this PR introduce a user-facing change?

NONE

```release-note
Scale up node group from zero to max
```