### PR TITLE
Validate APIVersion when checking for DaemonSet pods

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -124,7 +124,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 			for i, dsName := range scenario.dsPods {
 				ds := BuildTestPod(dsName, 100, 0)
 				ds.Spec.NodeName = "n1"
-				ds.OwnerReferences = GenerateOwnerReferences("", "DaemonSet", "", "")
+				ds.OwnerReferences = GenerateOwnerReferences("", "DaemonSet", "apps/v1", "")
 				if v, ok := scenario.extraAnnotationValue[dsName]; ok {
 					ds.Annotations[daemonset.EnableDsEvictionKey] = v
 				}

--- a/cluster-autoscaler/simulator/nodes_test.go
+++ b/cluster-autoscaler/simulator/nodes_test.go
@@ -227,7 +227,7 @@ func buildDSPod(ds *appsv1.DaemonSet, nodeName string) *apiv1.Pod {
 	pod.Name = ds.Name
 	ptrVal := true
 	pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-		{Kind: "DaemonSet", UID: ds.UID, Controller: &ptrVal},
+		{APIVersion: "apps/v1", Kind: "DaemonSet", UID: ds.UID, Controller: &ptrVal},
 	}
 	return pod
 }

--- a/cluster-autoscaler/utils/pod/pod.go
+++ b/cluster-autoscaler/utils/pod/pod.go
@@ -31,7 +31,7 @@ const (
 // IsDaemonSetPod returns true if the Pod should be considered as Pod managed by a DaemonSet
 func IsDaemonSetPod(pod *apiv1.Pod) bool {
 	controllerRef := metav1.GetControllerOf(pod)
-	if controllerRef != nil && controllerRef.Kind == "DaemonSet" {
+	if controllerRef != nil && controllerRef.APIVersion == "apps/v1" && controllerRef.Kind == "DaemonSet" {
 		return true
 	}
 

--- a/cluster-autoscaler/utils/pod/pod.go
+++ b/cluster-autoscaler/utils/pod/pod.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -31,8 +32,11 @@ const (
 // IsDaemonSetPod returns true if the Pod should be considered as Pod managed by a DaemonSet
 func IsDaemonSetPod(pod *apiv1.Pod) bool {
 	controllerRef := metav1.GetControllerOf(pod)
-	if controllerRef != nil && controllerRef.APIVersion == "apps/v1" && controllerRef.Kind == "DaemonSet" {
-		return true
+	if controllerRef != nil {
+		groupVersionKind := schema.FromAPIVersionAndKind(controllerRef.APIVersion, controllerRef.Kind)
+		if groupVersionKind.Group == "apps" && groupVersionKind.Kind == "DaemonSet" {
+			return true
+		}
 	}
 
 	return pod.Annotations[DaemonSetPodAnnotationKey] == "true"

--- a/cluster-autoscaler/utils/pod/pod_test.go
+++ b/cluster-autoscaler/utils/pod/pod_test.go
@@ -43,7 +43,7 @@ func TestIsDaemonSetPod(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Pod with empty OwnerRef.Kind == DaemonSet",
+			name: "Pod with OwnerRef.Kind == DaemonSet",
 			pod: &apiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -51,12 +51,30 @@ func TestIsDaemonSetPod(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Controller: newBool(true),
+							APIVersion: "apps/v1",
 							Kind:       "DaemonSet",
 						},
 					},
 				},
 			},
 			want: true,
+		},
+		{
+			name: "Pod with OwnerRef.Kind == DaemonSet and OwnerRef.APIVersion != apps/v1",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Controller: newBool(true),
+							APIVersion: "apps.tomain.tld/v1alpha1",
+							Kind:       "DaemonSet",
+						},
+					},
+				},
+			},
+			want: false,
 		},
 		{
 			name: "Pod with annotation but not with `DaemonSetPodAnnotationKey`",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The issue is described in #5977

#### Which issue(s) this PR fixes:

Fixes #5977

#### Special notes for your reviewer:

In the change I added a validation for `APIVersion`, and adjusted all relevant tests to support that. If `APIVersion` shouldn't be required when validating the DaemonSet's owner referense, I can ensure that the `APIVersion` validation happens only if it's not empty. Let me know...

#### Does this PR introduce a user-facing change?

NONE
