### PR TITLE
fix(clusterstate): invalidate instance cache when scaling down

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -1,5 +1,5 @@
-//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud
-// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud
+//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok
+// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok
 
 /*
 Copyright 2018 The Kubernetes Authors.

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_provider.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_provider.go
@@ -73,7 +73,20 @@ func (kwok *KwokCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
 // Since there is no underlying cloud provider instance, return true
 func (kwok *KwokCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
-	return true, nil
+	for _, nodeGroup := range kwok.nodeGroups {
+		nodeList, err := nodeGroup.lister.List()
+		if err != nil {
+			return false, err
+		}
+
+		for _, no := range nodeList {
+			if no.GetName() == node.GetName() {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -477,7 +477,7 @@ func TestRegisterScaleDown(t *testing.T) {
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}))
 	now := time.Now()
-	clusterstate.RegisterScaleDown(provider.GetNodeGroup("ng1"), "ng1-1", now.Add(time.Minute), now)
+	clusterstate.RegisterScaleDown(provider.GetNodeGroup("ng1"), ng1_1, now.Add(time.Minute), now)
 	assert.Equal(t, 1, len(clusterstate.scaleDownRequests))
 	clusterstate.updateScaleRequests(now.Add(5 * time.Minute))
 	assert.Equal(t, 0, len(clusterstate.scaleDownRequests))

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -200,7 +200,7 @@ func RegisterAndRecordSuccessfulScaleDownEvent(ctx *context.AutoscalingContext, 
 	ctx.Recorder.Eventf(node, apiv1.EventTypeNormal, "ScaleDown", "nodes removed by cluster autoscaler")
 	currentTime := time.Now()
 	expectedDeleteTime := time.Now().Add(MaxCloudProviderNodeDeletionTime)
-	scaleStateNotifier.RegisterScaleDown(nodeGroup, node.Name, currentTime, expectedDeleteTime)
+	scaleStateNotifier.RegisterScaleDown(nodeGroup, node, currentTime, expectedDeleteTime)
 	gpuConfig := ctx.CloudProvider.GetNodeGpuConfig(node)
 	metricResourceName, metricGpuType := gpu.GetGpuInfoForMetrics(gpuConfig, ctx.CloudProvider.GetAvailableGPUTypes(), node, nodeGroup)
 	metrics.RegisterScaleDown(1, metricResourceName, metricGpuType, nodeScaleDownReason(node, drain))

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -489,6 +489,8 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 	SetNodeReadyState(n1, true, time.Now())
 	n2 := BuildTestNode("n2", 1000, 1000)
 	SetNodeReadyState(n2, true, time.Now())
+	n3 := BuildTestNode("n3", 1000, 1000)
+	SetNodeReadyState(n3, true, time.Now())
 
 	tn := BuildTestNode("tn", 1000, 1000)
 	tni := schedulerframework.NewNodeInfo()
@@ -618,7 +620,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 			description: "ng2 scaled down recently - both ng1 and ng2 have under-utilized nodes",
 			beforeTest: func(processors *ca_processors.AutoscalingProcessors) {
 				// make CA think ng2 scaled down recently
-				processors.ScaleStateNotifier.RegisterScaleDown(ng2, "n3", time.Now().Add(-3*time.Minute), time.Now())
+				processors.ScaleStateNotifier.RegisterScaleDown(ng2, n3, time.Now().Add(-3*time.Minute), time.Now())
 			},
 			expectedScaleDownNG:   "ng1",
 			expectedScaleDownNode: "n1",
@@ -626,8 +628,8 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 				// reset scale down in ng1 and ng2 so that it doesn't block scale down in the next test
 				// scale down is always recorded relative to time.Now(), no matter
 				// what currentTime time is passed to RunOnce()
-				processors.ScaleStateNotifier.RegisterScaleDown(ng2, "n3", time.Time{}, time.Time{})
-				processors.ScaleStateNotifier.RegisterScaleDown(ng1, "n1", time.Time{}, time.Time{})
+				processors.ScaleStateNotifier.RegisterScaleDown(ng2, n3, time.Time{}, time.Time{})
+				processors.ScaleStateNotifier.RegisterScaleDown(ng1, n1, time.Time{}, time.Time{})
 			},
 		},
 

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
@@ -32,7 +34,7 @@ type NodeGroupChangeObserver interface {
 	// RegisterScaleUp records scale up for a nodegroup.
 	RegisterScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time)
 	// RegisterScaleDowns records scale down for a nodegroup.
-	RegisterScaleDown(nodeGroup cloudprovider.NodeGroup, nodeName string, currentTime time.Time, expectedDeleteTime time.Time)
+	RegisterScaleDown(nodeGroup cloudprovider.NodeGroup, node *apiv1.Node, currentTime time.Time, expectedDeleteTime time.Time)
 	// RegisterFailedScaleUp records failed scale-up for a nodegroup.
 	// reason denotes optional reason for failed scale-up
 	// errMsg denotes the actual error message
@@ -66,11 +68,11 @@ func (l *NodeGroupChangeObserversList) RegisterScaleUp(nodeGroup cloudprovider.N
 
 // RegisterScaleDown calls RegisterScaleDown for each observer.
 func (l *NodeGroupChangeObserversList) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
-	nodeName string, currentTime time.Time, expectedDeleteTime time.Time) {
+	node *apiv1.Node, currentTime time.Time, expectedDeleteTime time.Time) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	for _, observer := range l.observers {
-		observer.RegisterScaleDown(nodeGroup, nodeName, currentTime, expectedDeleteTime)
+		observer.RegisterScaleDown(nodeGroup, node, currentTime, expectedDeleteTime)
 	}
 }
 

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -99,7 +99,7 @@ func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(nodeGroup cloudprovi
 
 // RegisterScaleDown records when the last scale down happened for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
-	nodeName string, currentTime time.Time, _ time.Time) {
+	node *apiv1.Node, currentTime time.Time, _ time.Time) {
 	p.scaleDowns[nodeGroup.Id()] = currentTime
 }
 

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
@@ -80,9 +80,9 @@ func TestGetScaleDownCandidates(t *testing.T) {
 				ng2 := test.NewTestNodeGroup("ng-2", 0, 0, 0, false, false, "", nil, nil)
 				ng3 := test.NewTestNodeGroup("ng-3", 0, 0, 0, false, false, "", nil, nil)
 				// in cool down
-				p.RegisterScaleDown(ng2, "n2", time.Now().Add(-time.Minute*5), time.Time{})
+				p.RegisterScaleDown(ng2, n2, time.Now().Add(-time.Minute*5), time.Time{})
 				// not in cool down anymore
-				p.RegisterScaleDown(ng3, "n3", time.Now().Add(-time.Minute*11), time.Time{})
+				p.RegisterScaleDown(ng3, n3, time.Now().Add(-time.Minute*11), time.Time{})
 
 				return p
 			},


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

After CA finishes scaling down, the instance cache still exists in the ClusterStateRegistry, causing CA to mistakenly believe that there are some unregistered nodes until the cache is refreshed (`CloudProviderNodeInstancesCacheRefreshInterval = 2 * time.Minute`).

This PR invalidates the cache once the scale down is completed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
