### PR TITLE
[1.28] Update version.go

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.28.1"
+const ClusterAutoscalerVersion = "1.28.2"


### PR DESCRIPTION
Cutting new version for 1.28 branch.