### PR TITLE
[1.27] Update version.go

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.27.4"
+const ClusterAutoscalerVersion = "1.27.5"


### PR DESCRIPTION
Cutting new version for 1.27 branch.