### PR TITLE
[1.26] Update version.go

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.26.5"
+const ClusterAutoscalerVersion = "1.26.6"


### PR DESCRIPTION
Cutting new version for 1.26 branch.