### PR TITLE
feat: add metrics to show target size of every node group

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -319,6 +319,7 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 	if err != nil {
 		return err
 	}
+	metrics.UpdateNodeGroupTargetSize(targetSizes)
 
 	cloudProviderNodeInstances, err := csr.getCloudProviderNodeInstances()
 	if err != nil {

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -200,6 +200,14 @@ var (
 		}, []string{"node_group"},
 	)
 
+	nodesGroupTargetSize = k8smetrics.NewGaugeVec(
+		&k8smetrics.GaugeOpts{
+			Namespace: caNamespace,
+			Name:      "node_group_target_count",
+			Help:      "Target number of nodes in the node group by CA.",
+		}, []string{"node_group"},
+	)
+
 	/**** Metrics related to autoscaler execution ****/
 	lastActivity = k8smetrics.NewGaugeVec(
 		&k8smetrics.GaugeOpts{
@@ -422,6 +430,7 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	if emitPerNodeGroupMetrics {
 		legacyregistry.MustRegister(nodesGroupMinNodes)
 		legacyregistry.MustRegister(nodesGroupMaxNodes)
+		legacyregistry.MustRegister(nodesGroupTargetSize)
 	}
 }
 
@@ -518,6 +527,13 @@ func UpdateNodeGroupMin(nodeGroup string, minNodes int) {
 // UpdateNodeGroupMax records the node group maximum allowed number of nodes
 func UpdateNodeGroupMax(nodeGroup string, maxNodes int) {
 	nodesGroupMaxNodes.WithLabelValues(nodeGroup).Set(float64(maxNodes))
+}
+
+// UpdateNodeGroupTargetSize records the node group target size
+func UpdateNodeGroupTargetSize(targetSizes map[string]int) {
+	for nodeGroup, targetSize := range targetSizes {
+		nodesGroupTargetSize.WithLabelValues(nodeGroup).Set(float64(targetSize))
+	}
 }
 
 // RegisterError records any errors preventing Cluster Autoscaler from working.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR aims to add a new metric that displays the target size of all node groups.This metric is essential for obtaining a clear understanding of the target size of each node group while using the cluster autoscaler.

for example, we can on comparing this metric with the number of Kubernetes nodes to determine if the environment behaves as expected.This is crucial in detecting issues promptly, especially in the production environment.

The periodic update of this value has already been implemented in the UpdateNodes function of ClusterStateRegistry.We just need to add the reporting metrics functionality.This method does not increase the number of calls to the cloud provider nor does it affect other logic.

We kindly request your review of this PR and your thoughts on the proposed implementation. 

Thank you for your time and consideration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
NONE
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
