### PR TITLE
fix: updated readme for hetzner cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -33,7 +33,7 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
                 {
                     "key": "node.kubernetes.io/role",
                     "value": "autoscaler-node",
-                    "effect": "NoExecute",
+                    "effect": "NoExecute"
                 }
             ]
         }
@@ -42,11 +42,11 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 ```
 
 
-`HCLOUD_NETWORK` Default empty , The name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
+`HCLOUD_NETWORK` Default empty , The id or name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
 
-`HCLOUD_FIREWALL` Default empty , The name of the firewall that is used in the cluster , @see https://docs.hetzner.cloud/#firewalls
+`HCLOUD_FIREWALL` Default empty , The id or name of the firewall that is used in the cluster , @see https://docs.hetzner.cloud/#firewalls
 
-`HCLOUD_SSH_KEY` Default empty , This SSH Key will have access to the fresh created server, @see https://docs.hetzner.cloud/#ssh-keys
+`HCLOUD_SSH_KEY` Default empty , The id or name of SSH Key that will have access to the fresh created server, @see https://docs.hetzner.cloud/#ssh-keys
 
 `HCLOUD_PUBLIC_IPV4` Default true , Whether the server is created with a public IPv4 address or not, @see https://docs.hetzner.cloud/#primary-ips
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -157,18 +157,18 @@ func newManager() (*hetznerManager, error) {
 	}
 
 	var sshKey *hcloud.SSHKey
-	sshKeyName := os.Getenv("HCLOUD_SSH_KEY")
-	if sshKeyName != "" {
-		sshKey, _, err = client.SSHKey.Get(ctx, sshKeyName)
+	sshKeyIdOrName := os.Getenv("HCLOUD_SSH_KEY")
+	if sshKeyIdOrName != "" {
+		sshKey, _, err = client.SSHKey.Get(ctx, sshKeyIdOrName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ssh key error: %s", err)
 		}
 	}
 
 	var network *hcloud.Network
-	networkName := os.Getenv("HCLOUD_NETWORK")
-	if networkName != "" {
-		network, _, err = client.Network.Get(ctx, networkName)
+	networkIdOrName := os.Getenv("HCLOUD_NETWORK")
+	if networkIdOrName != "" {
+		network, _, err = client.Network.Get(ctx, networkIdOrName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get network error: %s", err)
 		}
@@ -182,9 +182,9 @@ func newManager() (*hetznerManager, error) {
 	}
 
 	var firewall *hcloud.Firewall
-	firewallName := os.Getenv("HCLOUD_FIREWALL")
-	if firewallName != "" {
-		firewall, _, err = client.Firewall.Get(ctx, firewallName)
+	firewallIdOrName := os.Getenv("HCLOUD_FIREWALL")
+	if firewallIdOrName != "" {
+		firewall, _, err = client.Firewall.Get(ctx, firewallIdOrName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get firewall error: %s", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
This provides a better way of letting someone know that it's also possible to use the id of a network, firewall or ssh key instead of only the name as before mentioned on the readme.