### PR TITLE
Make backoff.Status.ErrorInfo non-pointer.

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -928,7 +928,7 @@ func TestScaleUpBackoff(t *testing.T) {
 		Healthy:     true,
 		BackoffStatus: backoff.Status{
 			IsBackedOff: true,
-			ErrorInfo: &cloudprovider.InstanceErrorInfo{
+			ErrorInfo: cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    "timeout",
 				ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
@@ -937,7 +937,7 @@ func TestScaleUpBackoff(t *testing.T) {
 	}, clusterstate.IsNodeGroupSafeToScaleUp(ng1, now))
 	assert.Equal(t, backoff.Status{
 		IsBackedOff: true,
-		ErrorInfo: &cloudprovider.InstanceErrorInfo{
+		ErrorInfo: cloudprovider.InstanceErrorInfo{
 			ErrorClass:   cloudprovider.OtherErrorClass,
 			ErrorCode:    "timeout",
 			ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
@@ -961,7 +961,7 @@ func TestScaleUpBackoff(t *testing.T) {
 		Healthy:     true,
 		BackoffStatus: backoff.Status{
 			IsBackedOff: true,
-			ErrorInfo: &cloudprovider.InstanceErrorInfo{
+			ErrorInfo: cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    "timeout",
 				ErrorMessage: "Scale-up timed out for node group ng1 after 2m1s",
@@ -975,7 +975,7 @@ func TestScaleUpBackoff(t *testing.T) {
 		Healthy:     true,
 		BackoffStatus: backoff.Status{
 			IsBackedOff: true,
-			ErrorInfo: &cloudprovider.InstanceErrorInfo{
+			ErrorInfo: cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    "timeout",
 				ErrorMessage: "Scale-up timed out for node group ng1 after 2m1s",

--- a/cluster-autoscaler/utils/backoff/backoff.go
+++ b/cluster-autoscaler/utils/backoff/backoff.go
@@ -26,7 +26,7 @@ import (
 // Status contains information about back off status.
 type Status struct {
 	IsBackedOff bool
-	ErrorInfo   *cloudprovider.InstanceErrorInfo
+	ErrorInfo   cloudprovider.InstanceErrorInfo
 }
 
 // Backoff allows time-based backing off of node groups considered in scale up algorithm

--- a/cluster-autoscaler/utils/backoff/exponential_backoff.go
+++ b/cluster-autoscaler/utils/backoff/exponential_backoff.go
@@ -101,7 +101,7 @@ func (b *exponentialBackoff) BackoffStatus(nodeGroup cloudprovider.NodeGroup, no
 	}
 	return Status{
 		IsBackedOff: true,
-		ErrorInfo:   &backoffInfo.errorInfo,
+		ErrorInfo:   backoffInfo.errorInfo,
 	}
 }
 

--- a/cluster-autoscaler/utils/backoff/exponential_backoff_test.go
+++ b/cluster-autoscaler/utils/backoff/exponential_backoff_test.go
@@ -41,11 +41,11 @@ var ipSpaceExhaustedError = cloudprovider.InstanceErrorInfo{ErrorClass: cloudpro
 var noBackOff = Status{IsBackedOff: false}
 var backoffWithQuotaError = Status{
 	IsBackedOff: true,
-	ErrorInfo:   &quotaError,
+	ErrorInfo:   quotaError,
 }
 var backoffWithIpSpaceExhaustedError = Status{
 	IsBackedOff: true,
-	ErrorInfo:   &ipSpaceExhaustedError,
+	ErrorInfo:   ipSpaceExhaustedError,
 }
 
 func TestBackoffTwoKeys(t *testing.T) {


### PR DESCRIPTION
Change-Id: I1f812d4d6f42db97670ef7304fc0e895c837a13b

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In Backoff() method in backoff interface, we already accept ErrorInfo as non-pointer, so no need to make it pointer to make the code simpler.

#### Which issue(s) this PR fixes:

#6318

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
