### PR TITLE
[GCE] Support paginated instance listing

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -234,9 +234,10 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 	g := newTestAutoscalingGceClient(t, "project1", server.URL, "")
 
 	testCases := []struct {
-		name          string
-		lmiResponse   gce_api.InstanceGroupManagersListManagedInstancesResponse
-		wantInstances []cloudprovider.Instance
+		name             string
+		lmiResponse      gce_api.InstanceGroupManagersListManagedInstancesResponse
+		lmiPageResponses map[string]gce_api.InstanceGroupManagersListManagedInstancesResponse
+		wantInstances    []cloudprovider.Instance
 	}{
 		{
 			name: "all instances good",
@@ -265,6 +266,153 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 				},
 				{
 					Id:     "gce://myprojid/myzone/myinst_42",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+			},
+		},
+		{
+			name: "paginated response",
+			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
+				ManagedInstances: []*gce_api.ManagedInstance{
+					{
+						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 2),
+						CurrentAction: "CREATING",
+						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+							Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+						},
+					},
+					{
+						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
+						CurrentAction: "CREATING",
+						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+							Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+						},
+					},
+				},
+				NextPageToken: "foo",
+			},
+			lmiPageResponses: map[string]gce_api.InstanceGroupManagersListManagedInstancesResponse{
+				"foo": {
+					ManagedInstances: []*gce_api.ManagedInstance{
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 123),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 456),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+					},
+				},
+			},
+			wantInstances: []cloudprovider.Instance{
+				{
+					Id:     "gce://myprojid/myzone/myinst_2",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_42",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_123",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_456",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+			},
+		},
+		{
+			name: "paginated response, more pages",
+			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
+				ManagedInstances: []*gce_api.ManagedInstance{
+					{
+						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 2),
+						CurrentAction: "CREATING",
+						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+							Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+						},
+					},
+					{
+						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
+						CurrentAction: "CREATING",
+						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+							Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+						},
+					},
+				},
+				NextPageToken: "foo",
+			},
+			lmiPageResponses: map[string]gce_api.InstanceGroupManagersListManagedInstancesResponse{
+				"foo": {
+					ManagedInstances: []*gce_api.ManagedInstance{
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 123),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 456),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+					},
+					NextPageToken: "bar",
+				},
+				"bar": {
+					ManagedInstances: []*gce_api.ManagedInstance{
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 789),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+						{
+							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 666),
+							CurrentAction: "CREATING",
+							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
+								Errors: &gce_api.ManagedInstanceLastAttemptErrors{},
+							},
+						},
+					},
+				},
+			},
+			wantInstances: []cloudprovider.Instance{
+				{
+					Id:     "gce://myprojid/myzone/myinst_2",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_42",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_123",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_456",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_789",
+					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+				},
+				{
+					Id:     "gce://myprojid/myzone/myinst_666",
 					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
 				},
 			},
@@ -329,6 +477,11 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 			b, err := json.Marshal(tc.lmiResponse)
 			assert.NoError(t, err)
 			server.On("handle", "/projects/zones/instanceGroupManagers/listManagedInstances").Return(string(b)).Times(1)
+			for token, response := range tc.lmiPageResponses {
+				b, err := json.Marshal(response)
+				assert.NoError(t, err)
+				server.On("handle", "/projects/zones/instanceGroupManagers/listManagedInstances", token).Return(string(b)).Times(1)
+			}
 			gotInstances, err := g.FetchMigInstances(GceRef{})
 			assert.NoError(t, err)
 			if diff := cmp.Diff(tc.wantInstances, gotInstances, cmpopts.EquateErrors()); diff != "" {

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -426,8 +426,14 @@ func NewHttpServerMock(fields ...HttpServerMockField) *HttpServerMock {
 
 func (l *HttpServerMock) handle(req *http.Request, w http.ResponseWriter, serverMock *HttpServerMock) string {
 	url := req.URL.Path
+	query := req.URL.Query()
 	var response string
-	args := l.Called(url)
+	var args mock.Arguments
+	if query.Has("pageToken") {
+		args = l.Called(url, query.Get("pageToken"))
+	} else {
+		args = l.Called(url)
+	}
 	for i, field := range l.fields {
 		switch field {
 		case MockFieldResponse:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This makes Cluster Autoscaler work with MIGs that have pagination enabled. Without this change, a subset of instances may be never listed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[GCE] Support for paginated MIG instance listing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
