### PR TITLE
Fix VPA e2e test failures

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -238,6 +238,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 		containerName := GetHamsterContainerNameByIndex(0)
 		vpaCRD := test.VerticalPodAutoscaler().
 			WithName("hamster-vpa").
+			WithRecommender("non-recognized").
 			WithNamespace(f.Namespace.Name).
 			WithTargetRef(targetRef).
 			WithContainer(containerName).

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -126,7 +126,7 @@ type EvictionRequirement struct {
 	// Resources is a list of one or more resources that the condition applies
 	// to. If more than one resource is given, the EvictionRequirement is fulfilled
 	// if at least one resource meets `changeRequirement`.
-	Resources         []v1.ResourceName         `json:"resource" protobuf:"bytes,1,name=resources"`
+	Resources         []v1.ResourceName         `json:"resources" protobuf:"bytes,1,name=resources"`
 	ChangeRequirement EvictionChangeRequirement `json:"changeRequirement" protobuf:"bytes,2,name=changeRequirement"`
 }
 

--- a/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/e2e/vendor/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -248,7 +248,12 @@ func (b *verticalPodAutoscalerBuilder) Get() *vpa_types.VerticalPodAutoscaler {
 			Mode:             b.scalingMode[containerName],
 		})
 	}
-	recommendation = b.recommendation.WithContainer(b.containerNames[0]).Get()
+	// VPAs with a single container may still use the old/implicit way of adding recommendations
+	r := b.recommendation.WithContainer(b.containerNames[0]).Get()
+	if r.ContainerRecommendations[0].Target != nil {
+		recommendation = r
+	}
+
 	recommendation.ContainerRecommendations = append(recommendation.ContainerRecommendations, b.appendedRecommendations...)
 
 	return &vpa_types.VerticalPodAutoscaler{

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -248,7 +248,12 @@ func (b *verticalPodAutoscalerBuilder) Get() *vpa_types.VerticalPodAutoscaler {
 			Mode:             b.scalingMode[containerName],
 		})
 	}
-	recommendation = b.recommendation.WithContainer(b.containerNames[0]).Get()
+	// VPAs with a single container may still use the old/implicit way of adding recommendations
+	r := b.recommendation.WithContainer(b.containerNames[0]).Get()
+	if r.ContainerRecommendations[0].Target != nil {
+		recommendation = r
+	}
+
 	recommendation.ContainerRecommendations = append(recommendation.ContainerRecommendations, b.appendedRecommendations...)
 
 	return &vpa_types.VerticalPodAutoscaler{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fixes failing e2e tests for VPA. After the refactorings done in #5599, the tests started failing – but nobody realized this until now: #6389

This PR fixes the tests by doing two things:
* The way the new builder pattern for VPA test objects was introduced in the e2e tests had a problem with how recommendations are created. For the first container, a recommendation is created implicitly when you call `Build()` on the VPA object. This interferes with the pattern of `AppendRecommendation()`, which lead to a second entry in the `containerRecommendations` section, where one of those entries was empty.
* During the refactorings mentioned above, the test for the named recommender were broken and we didn't realize it. This PR brings back the recommender name for the VPA object created in the test, such that it can succeed again.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6389

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

