### PR TITLE
Fix:Adding missing RBAC + Update Deployment tolerations

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,6 +165,7 @@ rules:
     - machinedeployments/scale
     - machines
     - machinesets
+    - machinepools
     verbs:
     - get
     - list


### PR DESCRIPTION
#### What type of PR is this?

Deprecation and fix

#### What this PR does / why we need it:

1. Adding RBAC permissions to watch, list and get `MachinePools`
```
E1227 10:17:59.322411       1 reflector.go:147] k8s.io/client-go/dynamic/dynamicinformer/informer.go:108: Failed to watch cluster.x-k8s.io/v1beta1, Resource=machinepools: failed to list cluster.x-k8s.io/v1beta1, Resource=machinepools: machinepools.cluster.x-k8s.io is forbidden: User "system:serviceaccount:test-cluster:cluster-autoscaler" cannot list resource "machinepools" in API group "cluster.x-k8s.io" at the cluster scope
```
2. As of Kubernetes version 1.24, the control plane (formerly master) nodes no longer have the deprecated node-role.kubernetes.io/master label.