### PR TITLE
Addon-resizer-release-1.8 branch: Add repo root OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- mwielgus
+- maciekpytel
+- gjtempleton
+reviewers:
+- mwielgus
+- maciekpytel
+- gjtempleton
+emeritus_approvers:
+- bskiba # 2022-09-30


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

We don't currently have the same repo root OWNERS file as the default branch of the repo, meaning that approval is required from the addon-resizer OWNERS file, even for trivial changes such as #6400 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a new repo root level OWNERS file with the same contents as [currently in the repo's default branch](https://github.com/kubernetes/autoscaler/blob/master/OWNERS). I haven't touched/updated the OWNERS file for the addon-resizer though we should also update that in the near future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
