### PR TITLE
check the scalability of one kind prior to get its scale subresource from apiserver

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -81,6 +81,7 @@ type ControllerFetcher interface {
 type controllerFetcher struct {
 	scaleNamespacer              scale.ScalesGetter
 	mapper                       apimeta.RESTMapper
+	cachedDiscoveryClient        discovery.DiscoveryInterface
 	informersMap                 map[wellKnownController]cache.SharedIndexInformer
 	scaleSubresourceCacheStorage controllerCacheStorage
 }
@@ -146,6 +147,7 @@ func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface,
 	return &controllerFetcher{
 		scaleNamespacer:              scaleNamespacer,
 		mapper:                       mapper,
+		cachedDiscoveryClient:        cachedDiscoveryClient,
 		informersMap:                 informersMap,
 		scaleSubresourceCacheStorage: newControllerCacheStorage(betweenRefreshes, lifeTime, jitterFactor),
 	}
@@ -206,6 +208,12 @@ func (f *controllerFetcher) getParentOfController(ctx context.Context, controlle
 		return getParentOfWellKnownController(informer, controllerKey)
 	}
 
+	// check if it's scalable
+	scalable := f.isScalable(controllerKey.ApiVersion, controllerKey.Kind)
+	if !scalable {
+		return nil, nil
+	}
+
 	groupKind, err := controllerKey.groupKind()
 	if err != nil {
 		return nil, err
@@ -258,27 +266,33 @@ func (f *controllerFetcher) isWellKnownOrScalable(ctx context.Context, key *Cont
 		return true
 	}
 
-	//if not well known check if it supports scaling
-	groupKind, err := key.groupKind()
+	return f.isScalable(key.ApiVersion, key.Kind)
+}
+
+// isScalable returns true if the given controller is scalable.
+// isScalable checks if the controller is scalable by checking if the resource "<key>/scale" exists in the cached discovery client.
+func (f *controllerFetcher) isScalable(apiVersion string, kind string) bool {
+	resourceList, err := f.cachedDiscoveryClient.ServerResourcesForGroupVersion(apiVersion)
 	if err != nil {
-		klog.ErrorS(err, "Could not find groupKind", "object", klog.KRef(key.Namespace, key.Name))
+		klog.ErrorS(err, "Could not find groupKind", "kind", kind)
 		return false
 	}
-
-	if wellKnownController(groupKind.Kind) == node {
+	var plural string
+	for _, r := range resourceList.APIResources {
+		// Ref https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+		// the kind is the singular name of the resource
+		if r.Kind == kind {
+			plural = r.Name
+			break
+		}
+	}
+	if plural == "" {
+		klog.ErrorS(fmt.Errorf("could not find plural name"), "Could not find plural name", "kind", kind)
 		return false
 	}
-
-	mappings, err := f.mapper.RESTMappings(groupKind)
-	if err != nil {
-		klog.ErrorS(err, "Could not find mappings", "groupKind", groupKind, "object", klog.KRef(key.Namespace, key.Name))
-		return false
-	}
-
-	for _, mapping := range mappings {
-		groupResource := mapping.Resource.GroupResource()
-		scale, err := f.getScaleForResource(ctx, key.Namespace, groupResource, key.Name)
-		if err == nil && scale != nil {
+	expectedScaleResource := fmt.Sprintf("%s/%s", plural, "scale")
+	for _, r := range resourceList.APIResources {
+		if r.Name == expectedScaleResource {
 			return true
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In the VPA recommender, the controller fetcher gets the top most well known or scalable controller using the function `FindTopMostWellKnownOrScalable`. It works ok in most of the time, but it will lead to client-go limitation when the top most controller isn't well known and isn't scalable, of course, the vpa number is large, like 3k+. Since it tried to get the top most controller's scale subresource for every top most object. This PR checks the top most controller's scale subresource by finding the resource name `<pluralObject>/scale` in the cached discovery client. Of course, if the top most controller has no scale subresource, it fails, and return nil directly. All the process is handled in memory, no need to query kube-apiserver

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No user-facing change.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
check the top most controller's scale subresource by finding the resource name `<pluralObject>/scale` in the cached discovery client.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
