### PR TITLE
Pass Burst and QPS client params to capi k8s clients 1.28

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -158,7 +158,7 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	if err != nil {
 		klog.Fatalf("cannot build management cluster config: %v", err)
 	}
-	managementConfig.QPS = opts.KubeClientQPS
+	managementConfig.QPS = float32(opts.KubeClientQPS)
 	managementConfig.Burst = opts.KubeClientBurst
 
 	workloadKubeconfig := opts.KubeConfigPath
@@ -167,7 +167,7 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	if err != nil {
 		klog.Fatalf("cannot build workload cluster config: %v", err)
 	}
-	workloadConfig.QPS = opts.KubeClientQPS
+	workloadConfig.QPS = float32(opts.KubeClientQPS)
 	workloadConfig.Burst = opts.KubeClientBurst
 
 	// Grab a dynamic interface that we can create informers from

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -158,6 +158,8 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	if err != nil {
 		klog.Fatalf("cannot build management cluster config: %v", err)
 	}
+	managementConfig.QPS = opts.KubeClientQPS
+	managementConfig.Burst = opts.KubeClientBurst
 
 	workloadKubeconfig := opts.KubeConfigPath
 
@@ -165,6 +167,8 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	if err != nil {
 		klog.Fatalf("cannot build workload cluster config: %v", err)
 	}
+	workloadConfig.QPS = opts.KubeClientQPS
+	workloadConfig.Burst = opts.KubeClientBurst
 
 	// Grab a dynamic interface that we can create informers from
 	managementClient, err := dynamic.NewForConfig(managementConfig)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Passes the kubeClientBurst and kubeClientQPS flags to the clusterapi provider k8s clients to allow tuning of client and avoid excessive client-side throttling. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/6333

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeClientBurst and kubeClientQPS flags are now passed to the clusterapi provider k8s clients
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Cherry pick of https://github.com/kubernetes/autoscaler/pull/6416