### PR TITLE
docs: precise AWS IAM policy example

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -49,8 +49,11 @@ should be updated to restrict the resources/add conditionals:
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
+        "ec2:DescribeImages",
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeLaunchTemplateVersions"
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:GetInstanceTypesFromInstanceRequirements",
+        "eks:DescribeNodegroup"
       ],
       "Resource": ["*"]
     },
@@ -58,10 +61,7 @@ should be updated to restrict the resources/add conditionals:
       "Effect": "Allow",
       "Action": [
         "autoscaling:SetDesiredCapacity",
-        "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "ec2:DescribeImages",
-        "ec2:GetInstanceTypesFromInstanceRequirements",
-        "eks:DescribeNodegroup"
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
       ],
       "Resource": ["*"]
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

On the same page where I made my changes for this PR is the following instruction written:
_"In this example, only the second block of actions should be updated to restrict the resources/add conditionals:"_

If you then add a common condition like its often mentioned here in the issues or also recommended in the [EKS Best Practices Guides](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/#employ-least-privileged-access-to-the-iam-role) which looks like: 
```json
            "Condition": {
                "StringEquals": {
                    "aws:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
                    "aws:ResourceTag/k8s.io/cluster-autoscaler/<my-cluster>": "owned"
                }
            }
```
It's important to note that applying such conditions togehter with the example IAM policy often lead to an issue where the Cluster Autoscaler does not have the necessary access on the EKS API. If for example all is deployed with [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/2cb1fac31b0fc2dd6a236b0c0678df75819c5a3b/node_groups.tf#L197), the EKS does not have out of the box these tags but the Auto Scaling Group already have it. This causes the following exception of the Cluster Autoscaler:
```
E0110 12:34:56.789123 1 managed_nodegroup_cache.go:133] Failed to query the managed nodegroup example-node-group-name for the cluster exmaple-cluster-name while looking for labels/taints: AccessDeniedException: User: arn:aws:sts::account-id:assumed-role/example-role/resource-id is not authorized to perform: eks:DescribeNodegroup on resource: arn:aws:eks:region:account-id:nodegroup/exmaple-cluster-name/example-node-group-name/resource-id
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
