### PR TITLE
doc: cluster-autoscaler: Oracle provider: Add small security note

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -32,7 +32,9 @@ The following policy provides the privileges necessary for Cluster Autoscaler to
 All {instance.compartment.id = 'ocid1.compartment.oc1..aaaaaaaa7ey4sg3a6b5wnv5hlkjlkjadslkfjalskfjalsadfadsf'}
 ```
 
-or even better
+Note: the matching rule in the dynamic group above includes all instances
+in the specified compartment. If this is too broad for your requirements,
+you can add more conditions for example
 
 ```
 All {instance.compartment.id = '...', tag.MyTagNamespace.MyNodeRole = 'MyTagValue'}

--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -24,13 +24,29 @@ We recommend setting up and configuring the Cluster Autoscaler to use
 [Instance Principals](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
 to authenticate to the OCI APIs.
 
-The following policy provides the minimum privileges necessary for Cluster Autoscaler to run:
+The following policy provides the privileges necessary for Cluster Autoscaler to run:
 
 1: Create a compartment-level dynamic group containing the nodes (compute instances) in the cluster:
 
 ```
 All {instance.compartment.id = 'ocid1.compartment.oc1..aaaaaaaa7ey4sg3a6b5wnv5hlkjlkjadslkfjalskfjalsadfadsf'}
 ```
+
+**WARNING:** The above dynamic group with its tenancy-level policy in
+the next step will allow all machines in the specified compartment
+to handle all important computing resources. This may lead to some serious
+security problems on your system. It's highly recommended to limit the
+scope of this setting by for example
+
+  1. Using a proper `nodeSelector` for the `cluster-autoscaler`'s pods and
+  2. Setting up `Defined-Tag` for all selected nodes (via node pools' setting):
+    `MyTagNamespace.MyNodeRole=ClusterAutoscaler`
+  3. Refining the dynamic group with those defined tags, for example,
+
+      ```
+      All {instance.compartment.id = 'ocid1.compartment.oc1.....',
+       tag.MyTagNamespace.MyNodeRole = 'ClusterAutoscaler'}
+      ```
 
 2: Create a *tenancy-level* policy to allow nodes to manage node-pools and/or instance-pools:
 
@@ -51,7 +67,7 @@ Allow dynamic-group acme-oci-cluster-autoscaler-dyn-grp to inspect compartments 
 
 ### If using Workload Identity
 
-Note: This is available to use with OKE Node Pools or OCI Managed Instance Pools with OKE Enhanced Clusters only. 
+Note: This is available to use with OKE Node Pools or OCI Managed Instance Pools with OKE Enhanced Clusters only.
 
 See the [documentation](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contenggrantingworkloadaccesstoresources.htm) for more details
 
@@ -235,7 +251,7 @@ OCI config file based authentication deployment:
 kubectl apply -f ./cloudprovider/oci/examples/oci-ip-cluster-autoscaler-w-config.yaml
 ```
 
-OCI with node pool yamls: 
+OCI with node pool yamls:
 
 ```
 # First substitute any values mentioned in the file and then apply

--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -42,8 +42,10 @@ All {instance.compartment.id = '...', tag.MyTagNamespace.MyNodeRole = 'MyTagValu
 
 here `MyTagValue` is the defined-tag assigned to all nodes where `cluster-autoscaler` pods will be scheduled
 (for example, with `nodeSeletor`).
-See also [node-pool](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengtaggingclusterresources_tagging-oke-resources_node-tags.htm)
+See [node-pool](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengtaggingclusterresources_tagging-oke-resources_node-tags.htm)
 or [instance-pool](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/creatinginstanceconfig.htm)
+and also [managing dynamic groups](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingdynamicgroups.htm).
+
 
 2: Create a *tenancy-level* policy to allow nodes to manage node-pools and/or instance-pools:
 

--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -32,21 +32,16 @@ The following policy provides the privileges necessary for Cluster Autoscaler to
 All {instance.compartment.id = 'ocid1.compartment.oc1..aaaaaaaa7ey4sg3a6b5wnv5hlkjlkjadslkfjalskfjalsadfadsf'}
 ```
 
-**WARNING:** The above dynamic group with its tenancy-level policy in
-the next step will allow all machines in the specified compartment
-to handle all important computing resources. This may lead to some serious
-security problems on your system. It's highly recommended to limit the
-scope of this setting by for example
+or even better
 
-  1. Using a proper `nodeSelector` for the `cluster-autoscaler`'s pods and
-  2. Setting up `Defined-Tag` for all selected nodes (via node pools' setting):
-    `MyTagNamespace.MyNodeRole=ClusterAutoscaler`
-  3. Refining the dynamic group with those defined tags, for example,
+```
+All {instance.compartment.id = '...', tag.MyTagNamespace.MyNodeRole = 'MyTagValue'}
+```
 
-      ```
-      All {instance.compartment.id = 'ocid1.compartment.oc1.....',
-       tag.MyTagNamespace.MyNodeRole = 'ClusterAutoscaler'}
-      ```
+here `MyTagValue` is the defined-tag assigned to all nodes where `cluster-autoscaler` pods will be scheduled
+(for example, with `nodeSeletor`).
+See also [node-pool](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengtaggingclusterresources_tagging-oke-resources_node-tags.htm)
+or [instance-pool](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/creatinginstanceconfig.htm)
 
 2: Create a *tenancy-level* policy to allow nodes to manage node-pools and/or instance-pools:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Update the doc on setting up cluster-autoscaler on Oracle platform with a security in mind.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
 

#### Special notes for your reviewer:

The current documentation gives a wrong security sense by using the word `minimal`. I also remove that in my patch.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
