### PR TITLE
chore: adding telemetry to monitor run once loop

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -283,17 +283,17 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	a.clusterStateRegistry.PeriodicCleanup()
 	a.DebuggingSnapshotter.StartDataCollection()
 	defer a.DebuggingSnapshotter.Flush()
-			
+
 	podLister := a.AllPodLister()
 	autoscalingContext := a.AutoscalingContext
 
 	stateUpdateStart := time.Now()
 	klog.V(3).Infof("Starting main loop at %v", currentTime)
 	defer func() {
-		endOfLoop := time.Now() 
-		runOnceLoopDuration := endOfLoop.Sub(currentTime) 
+		endOfLoop := time.Now()
+		runOnceLoopDuration := endOfLoop.Sub(currentTime)
 		metrics.RunOnceLoopDurationInSeconds.Set(runOnceLoopDuration.Seconds())
-		klog.V(3).Infof("Finished main loop at %v", endOfLoop) 
+		klog.V(3).Infof("Finished main loop at %v", endOfLoop)
 	}()
 
 	// Get nodes and pods currently living on cluster

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -283,13 +283,18 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	a.clusterStateRegistry.PeriodicCleanup()
 	a.DebuggingSnapshotter.StartDataCollection()
 	defer a.DebuggingSnapshotter.Flush()
-
+			
 	podLister := a.AllPodLister()
 	autoscalingContext := a.AutoscalingContext
 
-	klog.V(4).Info("Starting main loop")
-
 	stateUpdateStart := time.Now()
+	klog.V(3).Infof("Starting main loop at %v", currentTime)
+	defer func() {
+		endOfLoop := time.Now() 
+		runOnceLoopDuration := endOfLoop.Sub(currentTime) 
+		metrics.RunOnceLoopDurationInSeconds.Set(runOnceLoopDuration.Seconds())
+		klog.V(3).Infof("Finished main loop at %v", endOfLoop) 
+	}()
 
 	// Get nodes and pods currently living on cluster
 	allNodes, readyNodes, typedErr := a.obtainNodeLists(a.CloudProvider)

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -398,6 +398,14 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	RunOnceLoopDurationInSeconds = k8smetrics.NewGauge(
+		&k8smetrics.GaugeOpts{
+			Namespace: caNamespace,
+			Name:      "runonce_duration_seconds",
+			Help:      "Duration of the run once loop in seconds.",
+		},
+	)
 )
 
 // RegisterAll registers all metrics.
@@ -433,6 +441,7 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	legacyregistry.MustRegister(nodeGroupDeletionCount)
 	legacyregistry.MustRegister(pendingNodeDeletions)
 	legacyregistry.MustRegister(nodeTaintsCount)
+	legacyregistry.MustRegister(RunOnceLoopDurationInSeconds)
 
 	if emitPerNodeGroupMetrics {
 		legacyregistry.MustRegister(nodesGroupMinNodes)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature 


#### What this PR does / why we need it:
We would like to be able to alert and monitor if a given cluster is exceeding its run once loop scan interval. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding Metric cluster_autoscaler_runonce_duration_seconds to monitor the length of the run once loop
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
