### PR TITLE
Introduce GceInstance that extends cloudprovider.Instance with NumericId

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -237,13 +237,14 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 		name             string
 		lmiResponse      gce_api.InstanceGroupManagersListManagedInstancesResponse
 		lmiPageResponses map[string]gce_api.InstanceGroupManagersListManagedInstancesResponse
-		wantInstances    []cloudprovider.Instance
+		wantInstances    []GceInstance
 	}{
 		{
 			name: "all instances good",
 			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
 				ManagedInstances: []*gce_api.ManagedInstance{
 					{
+						Id:            2,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 2),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -251,6 +252,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 						},
 					},
 					{
+						Id:            42,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -259,14 +261,20 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 					},
 				},
 			},
-			wantInstances: []cloudprovider.Instance{
+			wantInstances: []GceInstance{
 				{
-					Id:     "gce://myprojid/myzone/myinst_2",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_2",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 2,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_42",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_42",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 42,
 				},
 			},
 		},
@@ -275,6 +283,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
 				ManagedInstances: []*gce_api.ManagedInstance{
 					{
+						Id:            2,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 2),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -282,6 +291,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 						},
 					},
 					{
+						Id:            42,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -295,6 +305,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 				"foo": {
 					ManagedInstances: []*gce_api.ManagedInstance{
 						{
+							Id:            123,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 123),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -302,6 +313,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 							},
 						},
 						{
+							Id:            456,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 456),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -311,22 +323,34 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 					},
 				},
 			},
-			wantInstances: []cloudprovider.Instance{
+			wantInstances: []GceInstance{
 				{
-					Id:     "gce://myprojid/myzone/myinst_2",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_2",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 2,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_42",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_42",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 42,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_123",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_123",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 123,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_456",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_456",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 456,
 				},
 			},
 		},
@@ -335,6 +359,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
 				ManagedInstances: []*gce_api.ManagedInstance{
 					{
+						Id:            2,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 2),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -342,6 +367,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 						},
 					},
 					{
+						Id:            42,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -355,6 +381,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 				"foo": {
 					ManagedInstances: []*gce_api.ManagedInstance{
 						{
+							Id:            123,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 123),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -362,6 +389,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 							},
 						},
 						{
+							Id:            456,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 456),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -374,6 +402,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 				"bar": {
 					ManagedInstances: []*gce_api.ManagedInstance{
 						{
+							Id:            789,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 789),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -381,6 +410,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 							},
 						},
 						{
+							Id:            666,
 							Instance:      fmt.Sprintf(goodInstanceUrlTempl, 666),
 							CurrentAction: "CREATING",
 							LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -390,30 +420,48 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 					},
 				},
 			},
-			wantInstances: []cloudprovider.Instance{
+			wantInstances: []GceInstance{
 				{
-					Id:     "gce://myprojid/myzone/myinst_2",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_2",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 2,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_42",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_42",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 42,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_123",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_123",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 123,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_456",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_456",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 456,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_789",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_789",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 789,
 				},
 				{
-					Id:     "gce://myprojid/myzone/myinst_666",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_666",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 666,
 				},
 			},
 		},
@@ -422,6 +470,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 			lmiResponse: gce_api.InstanceGroupManagersListManagedInstancesResponse{
 				ManagedInstances: []*gce_api.ManagedInstance{
 					{
+						Id:            99999,
 						Instance:      badInstanceUrl,
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -429,6 +478,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 						},
 					},
 					{
+						Id:            42,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -437,10 +487,13 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 					},
 				},
 			},
-			wantInstances: []cloudprovider.Instance{
+			wantInstances: []GceInstance{
 				{
-					Id:     "gce://myprojid/myzone/myinst_42",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_42",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 42,
 				},
 			},
 		},
@@ -456,6 +509,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 						},
 					},
 					{
+						Id:            42,
 						Instance:      fmt.Sprintf(goodInstanceUrlTempl, 42),
 						CurrentAction: "CREATING",
 						LastAttempt: &gce_api.ManagedInstanceLastAttempt{
@@ -464,10 +518,13 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 					},
 				},
 			},
-			wantInstances: []cloudprovider.Instance{
+			wantInstances: []GceInstance{
 				{
-					Id:     "gce://myprojid/myzone/myinst_42",
-					Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					Instance: cloudprovider.Instance{
+						Id:     "gce://myprojid/myzone/myinst_42",
+						Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating},
+					},
+					NumericId: 42,
 				},
 			},
 		},

--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -57,7 +57,7 @@ type GceCache struct {
 
 	// Cache content.
 	migs                      map[GceRef]Mig
-	instances                 map[GceRef][]cloudprovider.Instance
+	instances                 map[GceRef][]GceInstance
 	instancesUpdateTime       map[GceRef]time.Time
 	instancesToMig            map[GceRef]GceRef
 	instancesFromUnknownMig   map[GceRef]bool
@@ -74,7 +74,7 @@ type GceCache struct {
 func NewGceCache() *GceCache {
 	return &GceCache{
 		migs:                      map[GceRef]Mig{},
-		instances:                 map[GceRef][]cloudprovider.Instance{},
+		instances:                 map[GceRef][]GceInstance{},
 		instancesUpdateTime:       map[GceRef]time.Time{},
 		instancesToMig:            map[GceRef]GceRef{},
 		instancesFromUnknownMig:   map[GceRef]bool{},
@@ -144,7 +144,7 @@ func (gc *GceCache) GetMigs() []Mig {
 }
 
 // GetMigInstances returns the cached instances for a given MIG GceRef
-func (gc *GceCache) GetMigInstances(migRef GceRef) ([]cloudprovider.Instance, bool) {
+func (gc *GceCache) GetMigInstances(migRef GceRef) ([]GceInstance, bool) {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
@@ -152,7 +152,7 @@ func (gc *GceCache) GetMigInstances(migRef GceRef) ([]cloudprovider.Instance, bo
 	if found {
 		klog.V(5).Infof("Instances cache hit for %s", migRef)
 	}
-	return append([]cloudprovider.Instance{}, instances...), found
+	return append([]GceInstance{}, instances...), found
 }
 
 // GetMigInstancesUpdateTime returns the timestamp when the cached instances
@@ -194,12 +194,12 @@ func (gc *GceCache) IsMigUnknownForInstance(instanceRef GceRef) bool {
 }
 
 // SetMigInstances sets instances for a given Mig ref
-func (gc *GceCache) SetMigInstances(migRef GceRef, instances []cloudprovider.Instance, timeNow time.Time) error {
+func (gc *GceCache) SetMigInstances(migRef GceRef, instances []GceInstance, timeNow time.Time) error {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	gc.removeMigInstances(migRef)
-	gc.instances[migRef] = append([]cloudprovider.Instance{}, instances...)
+	gc.instances[migRef] = append([]GceInstance{}, instances...)
 	gc.instancesUpdateTime[migRef] = timeNow
 	for _, instance := range instances {
 		instanceRef, err := GceRefFromProviderId(instance.Id)
@@ -227,7 +227,7 @@ func (gc *GceCache) InvalidateAllMigInstances() {
 	defer gc.cacheMutex.Unlock()
 
 	klog.V(5).Infof("Mig instances cache invalidated")
-	gc.instances = make(map[GceRef][]cloudprovider.Instance)
+	gc.instances = make(map[GceRef][]GceInstance)
 	gc.instancesUpdateTime = make(map[GceRef]time.Time)
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -318,7 +318,15 @@ func (mig *gceMig) Debug() string {
 
 // Nodes returns a list of all nodes that belong to this node group.
 func (mig *gceMig) Nodes() ([]cloudprovider.Instance, error) {
-	return mig.gceManager.GetMigNodes(mig)
+	gceInstances, err := mig.gceManager.GetMigNodes(mig)
+	if err != nil {
+		return nil, err
+	}
+	instances := make([]cloudprovider.Instance, len(gceInstances), len(gceInstances))
+	for i, inst := range gceInstances {
+		instances[i] = inst.Instance
+	}
+	return instances, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -58,9 +58,9 @@ func (m *gceManagerMock) GetMigForInstance(instance GceRef) (Mig, error) {
 	return args.Get(0).(*gceMig), args.Error(1)
 }
 
-func (m *gceManagerMock) GetMigNodes(mig Mig) ([]cloudprovider.Instance, error) {
+func (m *gceManagerMock) GetMigNodes(mig Mig) ([]GceInstance, error) {
 	args := m.Called(mig)
-	return args.Get(0).([]cloudprovider.Instance), args.Error(1)
+	return args.Get(0).([]GceInstance), args.Error(1)
 }
 
 func (m *gceManagerMock) Refresh() error {
@@ -297,18 +297,24 @@ func TestMig(t *testing.T) {
 	// Test DecreaseTargetSize.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(3), nil).Once()
 	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
-		[]cloudprovider.Instance{
+		[]GceInstance{
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 1,
 			},
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 222,
 			},
 		}, nil).Once()
 	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.gceMig"), int64(2)).Return(nil).Once()
@@ -324,18 +330,24 @@ func TestMig(t *testing.T) {
 	// Test DecreaseTargetSize - fail on deleting existing nodes.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(3), nil).Once()
 	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
-		[]cloudprovider.Instance{
+		[]GceInstance{
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 1111,
 			},
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 333,
 			},
 		}, nil).Once()
 	err = mig1.DecreaseTargetSize(-2)
@@ -395,18 +407,24 @@ func TestMig(t *testing.T) {
 
 	// Test Nodes.
 	gceManagerMock.On("GetMigNodes", mock.AnythingOfType("*gce.gceMig")).Return(
-		[]cloudprovider.Instance{
+		[]GceInstance{
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 1,
 			},
 			{
-				Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceRunning,
+				Instance: cloudprovider.Instance{
+					Id: "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
 				},
+				NumericId: 2,
 			},
 		}, nil).Once()
 	nodes, err := mig1.Nodes()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -82,7 +82,7 @@ type GceManager interface {
 	// GetMigs returns list of registered MIGs.
 	GetMigs() []Mig
 	// GetMigNodes returns mig nodes.
-	GetMigNodes(mig Mig) ([]cloudprovider.Instance, error)
+	GetMigNodes(mig Mig) ([]GceInstance, error)
 	// GetMigForInstance returns MIG to which the given instance belongs.
 	GetMigForInstance(instance GceRef) (Mig, error)
 	// GetMigTemplateNode returns a template node for MIG.
@@ -286,7 +286,7 @@ func (m *gceManagerImpl) GetMigForInstance(instance GceRef) (Mig, error) {
 }
 
 // GetMigNodes returns mig nodes.
-func (m *gceManagerImpl) GetMigNodes(mig Mig) ([]cloudprovider.Instance, error) {
+func (m *gceManagerImpl) GetMigNodes(mig Mig) ([]GceInstance, error) {
 	return m.migInfoProvider.GetMigInstances(mig.GceRef())
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -333,7 +333,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 
 	cache := &GceCache{
 		migs:                    make(map[GceRef]Mig),
-		instances:               make(map[GceRef][]cloudprovider.Instance),
+		instances:               make(map[GceRef][]GceInstance),
 		instancesUpdateTime:     make(map[GceRef]time.Time),
 		instancesToMig:          make(map[GceRef]GceRef),
 		instancesFromUnknownMig: make(map[GceRef]bool),

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	gce "google.golang.org/api/compute/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/client-go/util/workqueue"
 	klog "k8s.io/klog/v2"
 )
@@ -34,7 +33,7 @@ import (
 // MigInfoProvider allows obtaining information about MIGs
 type MigInfoProvider interface {
 	// GetMigInstances returns instances for a given MIG ref
-	GetMigInstances(migRef GceRef) ([]cloudprovider.Instance, error)
+	GetMigInstances(migRef GceRef) ([]GceInstance, error)
 	// GetMigForInstance returns MIG ref for a given instance
 	GetMigForInstance(instanceRef GceRef) (Mig, error)
 	// RegenerateMigInstancesCache regenerates MIGs to instances mapping cache
@@ -89,7 +88,7 @@ func NewCachingMigInfoProvider(cache *GceCache, migLister MigLister, gceClient A
 }
 
 // GetMigInstances returns instances for a given MIG ref
-func (c *cachingMigInfoProvider) GetMigInstances(migRef GceRef) ([]cloudprovider.Instance, error) {
+func (c *cachingMigInfoProvider) GetMigInstances(migRef GceRef) ([]GceInstance, error) {
 	instances, found := c.cache.GetMigInstances(migRef)
 	if found {
 		return instances, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows access to numeric instance id in GCE Cloud Provider implementation.

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
