### PR TITLE
Fixed bug with missing taint translation layer between AWS EKS format and Kubernetes format

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -118,10 +118,14 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 		taintList := r.Nodegroup.Taints
 		for _, taint := range taintList {
 			if taint != nil && taint.Effect != nil && taint.Key != nil && taint.Value != nil {
+				formattedEffect, err := taintEksTranslator(taint)
+				if err != nil {
+					return nil, labels, tags, err
+				}
 				taints = append(taints, apiv1.Taint{
 					Key:    *taint.Key,
 					Value:  *taint.Value,
-					Effect: apiv1.TaintEffect(*taint.Effect),
+					Effect: apiv1.TaintEffect(formattedEffect),
 				})
 			}
 		}
@@ -778,5 +782,19 @@ func buildLaunchTemplateFromSpec(ltSpec *autoscaling.LaunchTemplateSpecification
 	return &launchTemplate{
 		name:    aws.StringValue(ltSpec.LaunchTemplateName),
 		version: version,
+	}
+}
+
+func taintEksTranslator(t *eks.Taint) (apiv1.TaintEffect, error) {
+	// Translation between AWS EKS and Kubernetes taints
+	switch effect := *t.Effect; effect {
+	case eks.TaintEffectNoSchedule:
+		return apiv1.TaintEffectNoSchedule, nil
+	case eks.TaintEffectNoExecute:
+		return apiv1.TaintEffectNoExecute, nil
+	case eks.TaintEffectPreferNoSchedule:
+		return apiv1.TaintEffectPreferNoSchedule, nil
+	default:
+		return "", fmt.Errorf("couldn't translate EKS DescribeNodegroup response taint %s into Kubernetes format", effect)
 	}
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -787,6 +787,10 @@ func buildLaunchTemplateFromSpec(ltSpec *autoscaling.LaunchTemplateSpecification
 
 func taintEksTranslator(t *eks.Taint) (apiv1.TaintEffect, error) {
 	// Translation between AWS EKS and Kubernetes taints
+	//
+	// See:
+	//
+	// https://docs.aws.amazon.com/eks/latest/APIReference/API_Taint.html
 	switch effect := *t.Effect; effect {
 	case eks.TaintEffectNoSchedule:
 		return apiv1.TaintEffectNoSchedule, nil

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -120,7 +120,7 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 			if taint != nil && taint.Effect != nil && taint.Key != nil && taint.Value != nil {
 				formattedEffect, err := taintEksTranslator(taint)
 				if err != nil {
-					return nil, labels, tags, err
+					return nil, nil, nil, err
 				}
 				taints = append(taints, apiv1.Taint{
 					Key:    *taint.Key,

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper_test.go
@@ -114,7 +114,8 @@ func TestGetManagedNodegroup(t *testing.T) {
 	nodegroupName := "testNodegroup"
 	clusterName := "testCluster"
 
-	taintEffect1 := "effect 1"
+	taintEffect1 := eks.TaintEffectNoSchedule
+	taintEffectTranslated1 := apiv1.TaintEffectNoSchedule
 	taintKey1 := "key 1"
 	taintValue1 := "value 1"
 	taint1 := eks.Taint{
@@ -123,7 +124,8 @@ func TestGetManagedNodegroup(t *testing.T) {
 		Value:  &taintValue1,
 	}
 
-	taintEffect2 := "effect 2"
+	taintEffect2 := eks.TaintEffectNoExecute
+	taintEffectTranslated2 := apiv1.TaintEffectNoExecute
 	taintKey2 := "key 2"
 	taintValue2 := "value 2"
 	taint2 := eks.Taint{
@@ -163,10 +165,10 @@ func TestGetManagedNodegroup(t *testing.T) {
 	taintList, labelMap, tagMap, err := awsWrapper.getManagedNodegroupInfo(nodegroupName, clusterName)
 	assert.Nil(t, err)
 	assert.Equal(t, len(taintList), 2)
-	assert.Equal(t, taintList[0].Effect, apiv1.TaintEffect(taintEffect1))
+	assert.Equal(t, taintList[0].Effect, taintEffectTranslated1)
 	assert.Equal(t, taintList[0].Key, taintKey1)
 	assert.Equal(t, taintList[0].Value, taintValue1)
-	assert.Equal(t, taintList[1].Effect, apiv1.TaintEffect(taintEffect2))
+	assert.Equal(t, taintList[1].Effect, taintEffectTranslated2)
 	assert.Equal(t, taintList[1].Key, taintKey2)
 	assert.Equal(t, taintList[1].Value, taintValue2)
 	assert.Equal(t, len(labelMap), 7)
@@ -734,4 +736,52 @@ func TestGetInstanceTypesFromInstanceRequirementsWithEmptyList(t *testing.T) {
 	exp := fmt.Errorf("no instance types found for requirements")
 	assert.EqualError(t, err, exp.Error())
 	assert.Equal(t, "", result)
+}
+
+func TestTaintEksTranslator(t *testing.T) {
+	key := "key"
+	value := "value"
+
+	taintEffect1 := eks.TaintEffectNoSchedule
+	taintEffectTranslated1 := apiv1.TaintEffectNoSchedule
+	taint1 := eks.Taint{
+		Effect: &taintEffect1,
+		Key:    &key,
+		Value:  &value,
+	}
+
+	t1, err := taintEksTranslator(&taint1)
+	assert.Nil(t, err)
+	assert.Equal(t, t1, taintEffectTranslated1)
+
+	taintEffect2 := eks.TaintEffectNoSchedule
+	taintEffectTranslated2 := apiv1.TaintEffectNoSchedule
+	taint2 := eks.Taint{
+		Effect: &taintEffect2,
+		Key:    &key,
+		Value:  &value,
+	}
+	t2, err := taintEksTranslator(&taint2)
+	assert.Nil(t, err)
+	assert.Equal(t, t2, taintEffectTranslated2)
+
+	taintEffect3 := eks.TaintEffectNoExecute
+	taintEffectTranslated3 := apiv1.TaintEffectNoExecute
+	taint3 := eks.Taint{
+		Effect: &taintEffect3,
+		Key:    &key,
+		Value:  &value,
+	}
+	t3, err := taintEksTranslator(&taint3)
+	assert.Nil(t, err)
+	assert.Equal(t, t3, taintEffectTranslated3)
+
+	taintEffect4 := "TAINT_NO_EXISTS"
+	taint4 := eks.Taint{
+		Effect: &taintEffect4,
+		Key:    &key,
+		Value:  &value,
+	}
+	_, err = taintEksTranslator(&taint4)
+	assert.Error(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -35,13 +35,13 @@ func TestManagedNodegroupCache(t *testing.T) {
 	clusterName := "clusterName"
 	labelKey := "label key 1"
 	labelValue := "label value 1"
-	taintEffect := "effect 1"
+	taintEffect := apiv1.TaintEffectNoSchedule
 	taintKey := "key 1"
 	taintValue := "value 1"
 	tagKey := "tag key 1"
 	tagValue := "tag value 1"
 	taint := apiv1.Taint{
-		Effect: apiv1.TaintEffect(taintEffect),
+		Effect: taintEffect,
 		Key:    taintKey,
 		Value:  taintValue,
 	}
@@ -154,7 +154,8 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 	labelValue1 := "testValue 1"
 	labelValue2 := "testValue 2"
 
-	taintEffect1 := "effect 1"
+	taintEffect1 := eks.TaintEffectNoSchedule
+	taintEffectTranslated1 := apiv1.TaintEffectNoSchedule
 	taintKey1 := "key 1"
 	taintValue1 := "value 1"
 	taint1 := eks.Taint{
@@ -163,7 +164,8 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 		Value:  &taintValue1,
 	}
 
-	taintEffect2 := "effect 2"
+	taintEffect2 := eks.TaintEffectNoExecute
+	taintEffectTranslated2 := apiv1.TaintEffectNoExecute
 	taintKey2 := "key 2"
 	taintValue2 := "value 2"
 	taint2 := eks.Taint{
@@ -202,10 +204,10 @@ func TestGetManagedNodegroupWithTaintsAndLabels(t *testing.T) {
 	assert.Equal(t, cacheObj.name, nodegroupName)
 	assert.Equal(t, cacheObj.clusterName, clusterName)
 	assert.Equal(t, len(cacheObj.taints), 2)
-	assert.Equal(t, cacheObj.taints[0].Effect, apiv1.TaintEffect(taintEffect1))
+	assert.Equal(t, cacheObj.taints[0].Effect, taintEffectTranslated1)
 	assert.Equal(t, cacheObj.taints[0].Key, taintKey1)
 	assert.Equal(t, cacheObj.taints[0].Value, taintValue1)
-	assert.Equal(t, cacheObj.taints[1].Effect, apiv1.TaintEffect(taintEffect2))
+	assert.Equal(t, cacheObj.taints[1].Effect, taintEffectTranslated2)
 	assert.Equal(t, cacheObj.taints[1].Key, taintKey2)
 	assert.Equal(t, cacheObj.taints[1].Value, taintValue2)
 	assert.Equal(t, len(cacheObj.labels), 7)
@@ -249,11 +251,11 @@ func TestGetManagedNodegroupInfoObjectWithCachedNodegroup(t *testing.T) {
 	clusterName := "clusterName"
 	labelKey := "label key 1"
 	labelValue := "label value 1"
-	taintEffect := "effect 1"
+	taintEffect := apiv1.TaintEffectNoSchedule
 	taintKey := "key 1"
 	taintValue := "value 1"
 	taint := apiv1.Taint{
-		Effect: apiv1.TaintEffect(taintEffect),
+		Effect: taintEffect,
 		Key:    taintKey,
 		Value:  taintValue,
 	}
@@ -345,11 +347,11 @@ func TestGetManagedNodegroupLabelsWithCachedNodegroup(t *testing.T) {
 	clusterName := "clusterName"
 	labelKey := "label key 1"
 	labelValue := "label value 1"
-	taintEffect := "effect 1"
+	taintEffect := apiv1.TaintEffectNoSchedule
 	taintKey := "key 1"
 	taintValue := "value 1"
 	taint := apiv1.Taint{
-		Effect: apiv1.TaintEffect(taintEffect),
+		Effect: taintEffect,
 		Key:    taintKey,
 		Value:  taintValue,
 	}
@@ -568,7 +570,8 @@ func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
 	k8sVersion := "1.19"
 	diskSize := int64(100)
 
-	taintEffect1 := "effect 1"
+	taintEffect1 := eks.TaintEffectNoExecute
+	taintEffectTranslated1 := apiv1.TaintEffectNoExecute
 	taintKey1 := "key 1"
 	taintValue1 := "value 1"
 	taint1 := eks.Taint{
@@ -577,7 +580,8 @@ func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
 		Value:  &taintValue1,
 	}
 
-	taintEffect2 := "effect 2"
+	taintEffect2 := eks.TaintEffectPreferNoSchedule
+	taintEffectTranslated2 := apiv1.TaintEffectPreferNoSchedule
 	taintKey2 := "key 2"
 	taintValue2 := "value 2"
 	taint2 := eks.Taint{
@@ -608,10 +612,10 @@ func TestGetManagedNodegroupTaintsNoCachedNodegroup(t *testing.T) {
 	taintsList, err := c.getManagedNodegroupTaints(nodegroupName, clusterName)
 	require.NoError(t, err)
 	assert.Equal(t, len(taintsList), 2)
-	assert.Equal(t, taintsList[0].Effect, apiv1.TaintEffect(taintEffect1))
+	assert.Equal(t, taintsList[0].Effect, taintEffectTranslated1)
 	assert.Equal(t, taintsList[0].Key, taintKey1)
 	assert.Equal(t, taintsList[0].Value, taintValue1)
-	assert.Equal(t, taintsList[1].Effect, apiv1.TaintEffect(taintEffect2))
+	assert.Equal(t, taintsList[1].Effect, taintEffectTranslated2)
 	assert.Equal(t, taintsList[1].Key, taintKey2)
 	assert.Equal(t, taintsList[1].Value, taintValue2)
 	k.AssertCalled(t, "DescribeNodegroup", &eks.DescribeNodegroupInput{
@@ -627,11 +631,11 @@ func TestGetManagedNodegroupTagsWithCachedNodegroup(t *testing.T) {
 	clusterName := "clusterName"
 	labelKey := "label key 1"
 	labelValue := "label value 1"
-	taintEffect := "effect 1"
+	taintEffect := apiv1.TaintEffectNoSchedule
 	taintKey := "key 1"
 	taintValue := "value 1"
 	taint := apiv1.Taint{
-		Effect: apiv1.TaintEffect(taintEffect),
+		Effect: taintEffect,
 		Key:    taintKey,
 		Value:  taintValue,
 	}
@@ -667,7 +671,7 @@ func TestGetManagedNodegroupTagsNoCachedNodegroup(t *testing.T) {
 	k8sVersion := "1.19"
 	diskSize := int64(100)
 
-	taintEffect1 := "effect 1"
+	taintEffect1 := eks.TaintEffectNoSchedule
 	taintKey1 := "key 1"
 	taintValue1 := "value 1"
 	taint1 := eks.Taint{
@@ -676,7 +680,7 @@ func TestGetManagedNodegroupTagsNoCachedNodegroup(t *testing.T) {
 		Value:  &taintValue1,
 	}
 
-	taintEffect2 := "effect 2"
+	taintEffect2 := eks.TaintEffectPreferNoSchedule
 	taintKey2 := "key 2"
 	taintValue2 := "value 2"
 	taint2 := eks.Taint{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug between AWS EKS API understanding of Kubernetes taints and normal Kubernetes understanding of taints by introducing a translation method. Since the AWS API response when calling DescribeNodegroup have taints in the format of NO_SCHEDULE instead of NoSchedule as an example.

#### Which issue(s) this PR fixes:

Fixes #6481

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
