### PR TITLE
chore: cherry-pick scale-down-delay-* per nodegroup to 1.29

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -189,13 +189,8 @@ func (csr *ClusterStateRegistry) Stop() {
 	close(csr.interrupt)
 }
 
-// RegisterOrUpdateScaleUp registers scale-up for give node group or changes requested node increase
-// count.
-// If delta is positive then number of new nodes requested is increased; Time and expectedAddTime
-// are reset.
-// If delta is negative the number of new nodes requested is decreased; Time and expectedAddTime are
-// left intact.
-func (csr *ClusterStateRegistry) RegisterOrUpdateScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
+// RegisterScaleUp registers scale-up for give node group
+func (csr *ClusterStateRegistry) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
 	csr.Lock()
 	defer csr.Unlock()
 	csr.registerOrUpdateScaleUpNoLock(nodeGroup, delta, currentTime)
@@ -247,7 +242,14 @@ func (csr *ClusterStateRegistry) registerOrUpdateScaleUpNoLock(nodeGroup cloudpr
 }
 
 // RegisterScaleDown registers node scale down.
-func (csr *ClusterStateRegistry) RegisterScaleDown(request *ScaleDownRequest) {
+func (csr *ClusterStateRegistry) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
+	nodeName string, currentTime time.Time, expectedDeleteTime time.Time) {
+	request := &ScaleDownRequest{
+		NodeGroup:          nodeGroup,
+		NodeName:           nodeName,
+		Time:               currentTime,
+		ExpectedDeleteTime: expectedDeleteTime,
+	}
 	csr.Lock()
 	defer csr.Unlock()
 	csr.scaleDownRequests = append(csr.scaleDownRequests, request)
@@ -311,14 +313,19 @@ func (csr *ClusterStateRegistry) backoffNodeGroup(nodeGroup cloudprovider.NodeGr
 // RegisterFailedScaleUp should be called after getting error from cloudprovider
 // when trying to scale-up node group. It will mark this group as not safe to autoscale
 // for some time.
-func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, reason metrics.FailedScaleUpReason, errorMessage, gpuResourceName, gpuType string, currentTime time.Time) {
+func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, reason string, errorMessage, gpuResourceName, gpuType string, currentTime time.Time) {
 	csr.Lock()
 	defer csr.Unlock()
-	csr.registerFailedScaleUpNoLock(nodeGroup, reason, cloudprovider.InstanceErrorInfo{
+	csr.registerFailedScaleUpNoLock(nodeGroup, metrics.FailedScaleUpReason(reason), cloudprovider.InstanceErrorInfo{
 		ErrorClass:   cloudprovider.OtherErrorClass,
 		ErrorCode:    string(reason),
 		ErrorMessage: errorMessage,
 	}, gpuResourceName, gpuType, currentTime)
+}
+
+// RegisterFailedScaleDown records failed scale-down for a nodegroup.
+// We don't need to implement this function for cluster state registry
+func (csr *ClusterStateRegistry) RegisterFailedScaleDown(_ cloudprovider.NodeGroup, _ string, _ time.Time) {
 }
 
 func (csr *ClusterStateRegistry) registerFailedScaleUpNoLock(nodeGroup cloudprovider.NodeGroup, reason metrics.FailedScaleUpReason, errorInfo cloudprovider.InstanceErrorInfo, gpuResourceName, gpuType string, currentTime time.Time) {

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -158,6 +158,9 @@ type AutoscalingOptions struct {
 	ScaleDownDelayAfterDelete time.Duration
 	// ScaleDownDelayAfterFailure sets the duration before the next scale down attempt if scale down results in an error
 	ScaleDownDelayAfterFailure time.Duration
+	// ScaleDownDelayTypeLocal sets if the --scale-down-delay-after-* flags should be applied locally per nodegroup
+	// or globally across all nodegroups
+	ScaleDownDelayTypeLocal bool
 	// ScaleDownNonEmptyCandidatesCount is the maximum number of non empty nodes
 	// considered at once as candidates for scale down.
 	ScaleDownNonEmptyCandidatesCount int

--- a/cluster-autoscaler/config/const.go
+++ b/cluster-autoscaler/config/const.go
@@ -40,7 +40,8 @@ const (
 	DefaultMaxNodeProvisionTimeKey = "maxnodeprovisiontime"
 	// DefaultIgnoreDaemonSetsUtilizationKey identifies IgnoreDaemonSetsUtilization autoscaling option
 	DefaultIgnoreDaemonSetsUtilizationKey = "ignoredaemonsetsutilization"
-	// DefaultScaleDownUnneededTime identifies ScaleDownUnneededTime autoscaling option
+
+	// DefaultScaleDownUnneededTime is the default time duration for which CA waits before deleting an unneeded node
 	DefaultScaleDownUnneededTime = 10 * time.Minute
 	// DefaultScaleDownUnreadyTime identifies ScaleDownUnreadyTime autoscaling option
 	DefaultScaleDownUnreadyTime = 20 * time.Minute
@@ -48,4 +49,8 @@ const (
 	DefaultScaleDownUtilizationThreshold = 0.5
 	// DefaultScaleDownGpuUtilizationThreshold identifies ScaleDownGpuUtilizationThreshold autoscaling option
 	DefaultScaleDownGpuUtilizationThreshold = 0.5
+	// DefaultScaleDownDelayAfterFailure is the default value for ScaleDownDelayAfterFailure autoscaling option
+	DefaultScaleDownDelayAfterFailure = 3 * time.Minute
+	// DefaultScanInterval is the default scan interval for CA
+	DefaultScanInterval = 10 * time.Second
 )

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/observers/nodegroupchange"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -32,7 +33,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 
-	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 )
@@ -48,7 +48,7 @@ const (
 type NodeDeletionBatcher struct {
 	sync.Mutex
 	ctx                   *context.AutoscalingContext
-	clusterState          *clusterstate.ClusterStateRegistry
+	scaleStateNotifier    nodegroupchange.NodeGroupChangeObserver
 	nodeDeletionTracker   *deletiontracker.NodeDeletionTracker
 	deletionsPerNodeGroup map[string][]*apiv1.Node
 	deleteInterval        time.Duration
@@ -56,14 +56,14 @@ type NodeDeletionBatcher struct {
 }
 
 // NewNodeDeletionBatcher return new NodeBatchDeleter
-func NewNodeDeletionBatcher(ctx *context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, deleteInterval time.Duration) *NodeDeletionBatcher {
+func NewNodeDeletionBatcher(ctx *context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, deleteInterval time.Duration) *NodeDeletionBatcher {
 	return &NodeDeletionBatcher{
 		ctx:                   ctx,
-		clusterState:          csr,
 		nodeDeletionTracker:   nodeDeletionTracker,
 		deletionsPerNodeGroup: make(map[string][]*apiv1.Node),
 		deleteInterval:        deleteInterval,
 		drainedNodeDeletions:  make(map[string]bool),
+		scaleStateNotifier:    scaleStateNotifier,
 	}
 }
 
@@ -85,13 +85,13 @@ func (d *NodeDeletionBatcher) AddNodes(nodes []*apiv1.Node, nodeGroup cloudprovi
 }
 
 func (d *NodeDeletionBatcher) deleteNodesAndRegisterStatus(nodes []*apiv1.Node, drain bool) {
-	nodeGroup, err := deleteNodesFromCloudProvider(d.ctx, nodes)
+	nodeGroup, err := deleteNodesFromCloudProvider(d.ctx, d.scaleStateNotifier, nodes)
 	for _, node := range nodes {
 		if err != nil {
 			result := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
 			CleanUpAndRecordFailedScaleDownEvent(d.ctx, node, nodeGroup.Id(), drain, d.nodeDeletionTracker, "", result)
 		} else {
-			RegisterAndRecordSuccessfulScaleDownEvent(d.ctx, d.clusterState, node, nodeGroup, drain, d.nodeDeletionTracker)
+			RegisterAndRecordSuccessfulScaleDownEvent(d.ctx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
 		}
 	}
 }
@@ -129,14 +129,14 @@ func (d *NodeDeletionBatcher) remove(nodeGroupId string) error {
 
 	go func(nodes []*apiv1.Node, drainedNodeDeletions map[string]bool) {
 		var result status.NodeDeleteResult
-		nodeGroup, err := deleteNodesFromCloudProvider(d.ctx, nodes)
+		nodeGroup, err := deleteNodesFromCloudProvider(d.ctx, d.scaleStateNotifier, nodes)
 		for _, node := range nodes {
 			drain := drainedNodeDeletions[node.Name]
 			if err != nil {
 				result = status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
 				CleanUpAndRecordFailedScaleDownEvent(d.ctx, node, nodeGroupId, drain, d.nodeDeletionTracker, "", result)
 			} else {
-				RegisterAndRecordSuccessfulScaleDownEvent(d.ctx, d.clusterState, node, nodeGroup, drain, d.nodeDeletionTracker)
+				RegisterAndRecordSuccessfulScaleDownEvent(d.ctx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
 			}
 		}
 	}(nodes, drainedNodeDeletions)
@@ -145,12 +145,15 @@ func (d *NodeDeletionBatcher) remove(nodeGroupId string) error {
 
 // deleteNodeFromCloudProvider removes the given nodes from cloud provider. No extra pre-deletion actions are executed on
 // the Kubernetes side.
-func deleteNodesFromCloudProvider(ctx *context.AutoscalingContext, nodes []*apiv1.Node) (cloudprovider.NodeGroup, error) {
+func deleteNodesFromCloudProvider(ctx *context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, nodes []*apiv1.Node) (cloudprovider.NodeGroup, error) {
 	nodeGroup, err := ctx.CloudProvider.NodeGroupForNode(nodes[0])
 	if err != nil {
 		return nodeGroup, errors.NewAutoscalerError(errors.CloudProviderError, "failed to find node group for %s: %v", nodes[0].Name, err)
 	}
 	if err := nodeGroup.DeleteNodes(nodes); err != nil {
+		scaleStateNotifier.RegisterFailedScaleDown(nodeGroup,
+			string(errors.CloudProviderError),
+			time.Now())
 		return nodeGroup, errors.NewAutoscalerError(errors.CloudProviderError, "failed to delete nodes from group %s: %v", nodeGroup.Id(), err)
 	}
 	return nodeGroup, nil
@@ -193,14 +196,11 @@ func CleanUpAndRecordFailedScaleDownEvent(ctx *context.AutoscalingContext, node 
 }
 
 // RegisterAndRecordSuccessfulScaleDownEvent register scale down and record successful scale down event.
-func RegisterAndRecordSuccessfulScaleDownEvent(ctx *context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker) {
+func RegisterAndRecordSuccessfulScaleDownEvent(ctx *context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker) {
 	ctx.Recorder.Eventf(node, apiv1.EventTypeNormal, "ScaleDown", "nodes removed by cluster autoscaler")
-	csr.RegisterScaleDown(&clusterstate.ScaleDownRequest{
-		NodeGroup:          nodeGroup,
-		NodeName:           node.Name,
-		Time:               time.Now(),
-		ExpectedDeleteTime: time.Now().Add(MaxCloudProviderNodeDeletionTime),
-	})
+	currentTime := time.Now()
+	expectedDeleteTime := time.Now().Add(MaxCloudProviderNodeDeletionTime)
+	scaleStateNotifier.RegisterScaleDown(nodeGroup, node.Name, currentTime, expectedDeleteTime)
 	gpuConfig := ctx.CloudProvider.GetNodeGpuConfig(node)
 	metricResourceName, metricGpuType := gpu.GetGpuInfoForMetrics(gpuConfig, ctx.CloudProvider.GetAvailableGPUTypes(), node, nodeGroup)
 	metrics.RegisterScaleDown(1, metricResourceName, metricGpuType, nodeScaleDownReason(node, drain))

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -74,7 +74,7 @@ func (o *ScaleUpOrchestrator) Initialize(
 	o.clusterStateRegistry = clusterStateRegistry
 	o.taintConfig = taintConfig
 	o.resourceManager = resource.NewManager(processors.CustomResourcesProcessor)
-	o.scaleUpExecutor = newScaleUpExecutor(autoscalingContext, clusterStateRegistry)
+	o.scaleUpExecutor = newScaleUpExecutor(autoscalingContext, processors.ScaleStateNotifier)
 	o.initialized = true
 }
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -973,6 +973,7 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults))
 	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
 	processors := NewTestProcessors(&context)
+	processors.ScaleStateNotifier.Register(clusterState)
 	orchestrator := New()
 	orchestrator.Initialize(&context, processors, clusterState, taints.TaintConfig{})
 	expander := NewMockRepotingStrategy(t, config.ExpansionOptionToChoose)

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/random"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/observers/nodegroupchange"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/binpacking"
@@ -193,6 +194,7 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 		CustomResourcesProcessor:    customresources.NewDefaultCustomResourcesProcessor(),
 		ActionableClusterProcessor:  actionablecluster.NewDefaultActionableClusterProcessor(),
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
+		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),
 	}
 }
 

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupchange
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+)
+
+// NodeGroupChangeObserver is an observer of:
+// * scale-up(s) for a nodegroup
+// * scale-down(s) for a nodegroup
+// * scale-up failure(s) for a nodegroup
+// * scale-down failure(s) for a nodegroup
+type NodeGroupChangeObserver interface {
+	// RegisterScaleUp records scale up for a nodegroup.
+	RegisterScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time)
+	// RegisterScaleDowns records scale down for a nodegroup.
+	RegisterScaleDown(nodeGroup cloudprovider.NodeGroup, nodeName string, currentTime time.Time, expectedDeleteTime time.Time)
+	// RegisterFailedScaleUp records failed scale-up for a nodegroup.
+	// reason denotes optional reason for failed scale-up
+	// errMsg denotes the actual error message
+	RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, reason string, errMsg string, gpuResourceName, gpuType string, currentTime time.Time)
+	// RegisterFailedScaleDown records failed scale-down for a nodegroup.
+	RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup, reason string, currentTime time.Time)
+}
+
+// NodeGroupChangeObserversList is a slice of observers
+// of state of scale up/down in the cluster
+type NodeGroupChangeObserversList struct {
+	observers []NodeGroupChangeObserver
+	// TODO(vadasambar): consider using separate mutexes for functions not related to each other
+	mutex sync.Mutex
+}
+
+// Register adds new observer to the list.
+func (l *NodeGroupChangeObserversList) Register(o NodeGroupChangeObserver) {
+	l.observers = append(l.observers, o)
+}
+
+// RegisterScaleUp calls RegisterScaleUp for each observer.
+func (l *NodeGroupChangeObserversList) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
+	delta int, currentTime time.Time) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, observer := range l.observers {
+		observer.RegisterScaleUp(nodeGroup, delta, currentTime)
+	}
+}
+
+// RegisterScaleDown calls RegisterScaleDown for each observer.
+func (l *NodeGroupChangeObserversList) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
+	nodeName string, currentTime time.Time, expectedDeleteTime time.Time) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, observer := range l.observers {
+		observer.RegisterScaleDown(nodeGroup, nodeName, currentTime, expectedDeleteTime)
+	}
+}
+
+// RegisterFailedScaleUp calls RegisterFailedScaleUp for each observer.
+func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup,
+	reason string, errMsg, gpuResourceName, gpuType string, currentTime time.Time) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, observer := range l.observers {
+		observer.RegisterFailedScaleUp(nodeGroup, reason, errMsg, gpuResourceName, gpuType, currentTime)
+	}
+}
+
+// RegisterFailedScaleDown records failed scale-down for a nodegroup.
+func (l *NodeGroupChangeObserversList) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
+	reason string, currentTime time.Time) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, observer := range l.observers {
+		observer.RegisterFailedScaleDown(nodeGroup, reason, currentTime)
+	}
+}
+
+// NewNodeGroupChangeObserversList return empty list of scale state observers.
+func NewNodeGroupChangeObserversList() *NodeGroupChangeObserversList {
+	return &NodeGroupChangeObserversList{}
+}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -18,6 +18,7 @@ package processors
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/observers/nodegroupchange"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/binpacking"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
@@ -67,6 +68,12 @@ type AutoscalingProcessors struct {
 	ActionableClusterProcessor actionablecluster.ActionableClusterProcessor
 	// ScaleDownCandidatesNotifier  is used to Update and Register new scale down candidates observer.
 	ScaleDownCandidatesNotifier *scaledowncandidates.ObserversList
+	// ScaleStateNotifier is used to notify
+	// * scale-ups per nodegroup
+	// * scale-downs per nodegroup
+	// * scale-up failures per nodegroup
+	// * scale-down failures per nodegroup
+	ScaleStateNotifier *nodegroupchange.NodeGroupChangeObserversList
 }
 
 // DefaultProcessors returns default set of processors.
@@ -97,6 +104,7 @@ func DefaultProcessors(options config.AutoscalingOptions) *AutoscalingProcessors
 		ActionableClusterProcessor:  actionablecluster.NewDefaultActionableClusterProcessor(),
 		TemplateNodeInfoProvider:    nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false),
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
+		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),
 	}
 }
 

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaledowncandidates
+
+import (
+	"reflect"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+// ScaleDownCandidatesDelayProcessor is a processor to filter out
+// nodes according to scale down delay per nodegroup
+type ScaleDownCandidatesDelayProcessor struct {
+	scaleUps          map[string]time.Time
+	scaleDowns        map[string]time.Time
+	scaleDownFailures map[string]time.Time
+}
+
+// GetPodDestinationCandidates returns nodes as is no processing is required here
+func (p *ScaleDownCandidatesDelayProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext,
+	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	return nodes, nil
+}
+
+// GetScaleDownCandidates returns filter nodes based on if scale down is enabled or disabled per nodegroup.
+func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext,
+	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	result := []*apiv1.Node{}
+
+	for _, node := range nodes {
+		nodeGroup, err := ctx.CloudProvider.NodeGroupForNode(node)
+		if err != nil {
+			klog.Warningf("Error while checking node group for %s: %v", node.Name, err)
+			continue
+		}
+		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
+			klog.V(4).Infof("Node %s should not be processed by cluster autoscaler (no node group config)", node.Name)
+			continue
+		}
+
+		currentTime := time.Now()
+
+		recent := func(m map[string]time.Time, d time.Duration, msg string) bool {
+			if !m[nodeGroup.Id()].IsZero() && m[nodeGroup.Id()].Add(d).After(currentTime) {
+				klog.V(4).Infof("Skipping scale down on node group %s because it %s recently at %v",
+					nodeGroup.Id(), msg, m[nodeGroup.Id()])
+				return true
+			}
+
+			return false
+		}
+
+		if recent(p.scaleUps, ctx.ScaleDownDelayAfterAdd, "scaled up") {
+			continue
+		}
+
+		if recent(p.scaleDowns, ctx.ScaleDownDelayAfterDelete, "scaled down") {
+			continue
+		}
+
+		if recent(p.scaleDownFailures, ctx.ScaleDownDelayAfterFailure, "failed to scale down") {
+			continue
+		}
+
+		result = append(result, node)
+	}
+	return result, nil
+}
+
+// CleanUp is called at CA termination.
+func (p *ScaleDownCandidatesDelayProcessor) CleanUp() {
+}
+
+// RegisterScaleUp records when the last scale up happened for a nodegroup.
+func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
+	_ int, currentTime time.Time) {
+	p.scaleUps[nodeGroup.Id()] = currentTime
+}
+
+// RegisterScaleDown records when the last scale down happened for a nodegroup.
+func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
+	nodeName string, currentTime time.Time, _ time.Time) {
+	p.scaleDowns[nodeGroup.Id()] = currentTime
+}
+
+// RegisterFailedScaleUp records when the last scale up failed for a nodegroup.
+func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(_ cloudprovider.NodeGroup,
+	_ string, _ string, _ string, _ string, _ time.Time) {
+}
+
+// RegisterFailedScaleDown records failed scale-down for a nodegroup.
+func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
+	reason string, currentTime time.Time) {
+	p.scaleDownFailures[nodeGroup.Id()] = currentTime
+}
+
+// NewScaleDownCandidatesDelayProcessor returns a new ScaleDownCandidatesDelayProcessor.
+func NewScaleDownCandidatesDelayProcessor() *ScaleDownCandidatesDelayProcessor {
+	return &ScaleDownCandidatesDelayProcessor{
+		scaleUps:          make(map[string]time.Time),
+		scaleDowns:        make(map[string]time.Time),
+		scaleDownFailures: make(map[string]time.Time),
+	}
+}

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaledowncandidates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+func TestGetScaleDownCandidates(t *testing.T) {
+	n1 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "n1",
+		},
+	}
+
+	n2 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "n2",
+		},
+	}
+
+	n3 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "n3",
+		},
+	}
+
+	ctx := context.AutoscalingContext{
+		AutoscalingOptions: config.AutoscalingOptions{
+			ScaleDownDelayAfterAdd:     time.Minute * 10,
+			ScaleDownDelayAfterDelete:  time.Minute * 10,
+			ScaleDownDelayAfterFailure: time.Minute * 10,
+			ScaleDownDelayTypeLocal:    true,
+		},
+	}
+
+	testCases := map[string]struct {
+		autoscalingContext context.AutoscalingContext
+		candidates         []*v1.Node
+		expected           []*v1.Node
+		setupProcessor     func(p *ScaleDownCandidatesDelayProcessor) *ScaleDownCandidatesDelayProcessor
+	}{
+		// Expectation: no nodegroups should be filtered out
+		"no scale ups - no scale downs - no scale down failures": {
+			autoscalingContext: ctx,
+			candidates:         []*v1.Node{n1, n2, n3},
+			expected:           []*v1.Node{n1, n2, n3},
+			setupProcessor:     nil,
+		},
+		// Expectation: only nodegroups in cool-down should be filtered out
+		"no scale ups - 2 scale downs - no scale down failures": {
+			autoscalingContext: ctx,
+			candidates:         []*v1.Node{n1, n2, n3},
+			expected:           []*v1.Node{n1, n3},
+			setupProcessor: func(p *ScaleDownCandidatesDelayProcessor) *ScaleDownCandidatesDelayProcessor {
+				// fake nodegroups for calling `RegisterScaleDown`
+				ng2 := test.NewTestNodeGroup("ng-2", 0, 0, 0, false, false, "", nil, nil)
+				ng3 := test.NewTestNodeGroup("ng-3", 0, 0, 0, false, false, "", nil, nil)
+				// in cool down
+				p.RegisterScaleDown(ng2, "n2", time.Now().Add(-time.Minute*5), time.Time{})
+				// not in cool down anymore
+				p.RegisterScaleDown(ng3, "n3", time.Now().Add(-time.Minute*11), time.Time{})
+
+				return p
+			},
+		},
+		// Expectation: only nodegroups in cool-down should be filtered out
+		"1 scale up - no scale down - no scale down failures": {
+			autoscalingContext: ctx,
+			candidates:         []*v1.Node{n1, n2, n3},
+			expected:           []*v1.Node{n1, n3},
+			setupProcessor: func(p *ScaleDownCandidatesDelayProcessor) *ScaleDownCandidatesDelayProcessor {
+				// fake nodegroups for calling `RegisterScaleUp`
+				ng2 := test.NewTestNodeGroup("ng-2", 0, 0, 0, false, false, "", nil, nil)
+				ng3 := test.NewTestNodeGroup("ng-3", 0, 0, 0, false, false, "", nil, nil)
+
+				// in cool down
+				p.RegisterScaleUp(ng2, 0, time.Now().Add(-time.Minute*5))
+				// not in cool down anymore
+				p.RegisterScaleUp(ng3, 0, time.Now().Add(-time.Minute*11))
+				return p
+			},
+		},
+		// Expectation: only nodegroups in cool-down should be filtered out
+		"no scale up - no scale down - 1 scale down failure": {
+			autoscalingContext: ctx,
+			candidates:         []*v1.Node{n1, n2, n3},
+			expected:           []*v1.Node{n1, n3},
+			setupProcessor: func(p *ScaleDownCandidatesDelayProcessor) *ScaleDownCandidatesDelayProcessor {
+				// fake nodegroups for calling `RegisterScaleUp`
+				ng2 := test.NewTestNodeGroup("ng-2", 0, 0, 0, false, false, "", nil, nil)
+				ng3 := test.NewTestNodeGroup("ng-3", 0, 0, 0, false, false, "", nil, nil)
+
+				// in cool down
+				p.RegisterFailedScaleDown(ng2, "", time.Now().Add(-time.Minute*5))
+				// not in cool down anymore
+				p.RegisterFailedScaleDown(ng3, "", time.Now().Add(-time.Minute*11))
+				return p
+			},
+		},
+	}
+
+	for description, testCase := range testCases {
+		t.Run(description, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProvider(nil, nil)
+
+			p := NewScaleDownCandidatesDelayProcessor()
+
+			if testCase.setupProcessor != nil {
+				p = testCase.setupProcessor(p)
+			}
+
+			provider.AddNodeGroup("ng-1", 1, 3, 2)
+			provider.AddNode("ng-1", n1)
+			provider.AddNodeGroup("ng-2", 1, 3, 2)
+			provider.AddNode("ng-2", n2)
+			provider.AddNodeGroup("ng-3", 1, 3, 2)
+			provider.AddNode("ng-3", n3)
+
+			testCase.autoscalingContext.CloudProvider = provider
+
+			no, err := p.GetScaleDownCandidates(&testCase.autoscalingContext, testCase.candidates)
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, no)
+		})
+	}
+}

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_processor.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaledowncandidates
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+type combinedScaleDownCandidatesProcessor struct {
+	processors []nodes.ScaleDownNodeProcessor
+}
+
+// NewCombinedScaleDownCandidatesProcessor returns a default implementation of the scale down candidates
+// processor, which wraps and sequentially runs other sub-processors.
+func NewCombinedScaleDownCandidatesProcessor() *combinedScaleDownCandidatesProcessor {
+	return &combinedScaleDownCandidatesProcessor{}
+
+}
+
+// Register registers a new ScaleDownNodeProcessor
+func (p *combinedScaleDownCandidatesProcessor) Register(np nodes.ScaleDownNodeProcessor) {
+	p.processors = append(p.processors, np)
+}
+
+// GetPodDestinationCandidates returns nodes that potentially could act as destinations for pods
+// that would become unscheduled after a scale down.
+func (p *combinedScaleDownCandidatesProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext, nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	var err errors.AutoscalerError
+	for _, processor := range p.processors {
+		nodes, err = processor.GetPodDestinationCandidates(ctx, nodes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nodes, nil
+}
+
+// GetScaleDownCandidates returns nodes that potentially could be scaled down.
+func (p *combinedScaleDownCandidatesProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext, nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	var err errors.AutoscalerError
+	for _, processor := range p.processors {
+		nodes, err = processor.GetScaleDownCandidates(ctx, nodes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nodes, nil
+}
+
+// CleanUp is called at CA termination
+func (p *combinedScaleDownCandidatesProcessor) CleanUp() {
+	for _, processor := range p.processors {
+		processor.CleanUp()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cherry-pick 

#### What this PR does / why we need it:
cherry-picks https://github.com/kubernetes/autoscaler/pull/5729 to 1.29

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added: `--scale-down-delay-type-local` flag. It specifies if `--scale-down-delay-after-*` flags should be applied locally per nodegroup or globally across all nodegroups)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
