### PR TITLE
Reduce time waited for pod evictions

### DIFF
--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -103,6 +103,13 @@ func WithNodeName(nodeName string) func(*apiv1.Pod) {
 	}
 }
 
+// WithTerminationGracePeriod sets a termination grace period on the pod.
+func WithTerminationGracePeriod(period int64) func(pod *apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.Spec.TerminationGracePeriodSeconds = &period
+	}
+}
+
 // BuildTestPodWithEphemeralStorage creates a pod with cpu, memory and ephemeral storage resources.
 func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage int64) *apiv1.Pod {
 	startTime := metav1.Unix(0, 0)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The time waited for all pods in a group to be drained from a node is guaranteed to be no more than the grace period configured for the PriorityClass group + the pod eviction headroom. However, if all the pod's termination grace periods are less than the PriorityClass-level grace period, we can reduce the time waited to the largest termination grace period of the pods in the group.  This prevents waiting an unnecessarily long time when a group is configured with a very high grace period but all the pods were safely evicted sooner.

Note: I originally opened https://github.com/kubernetes/autoscaler/pull/5711 for this a while ago, but the implementation of the `scaledown/actuation` package has changed drastically since then; I decided opening a new PR probably made more sense.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

RE: testing; I opted to add tests for the `curtailTerminationGracePeriod` function directly; I'm generally not a fan of unit tests for non-exported functions, but this felt cleaner/less invasive than trying to add timing/sleep logic into the tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
