### PR TITLE
capi: fix error when listing infra machines

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -81,6 +81,7 @@ type machineController struct {
 	machinePoolInformer         informers.GenericInformer
 	nodeInformer                cache.SharedIndexInformer
 	managementClient            dynamic.Interface
+	managementClientset         kubeclient.Interface
 	managementScaleClient       scale.ScalesGetter
 	machineSetResource          schema.GroupVersionResource
 	machineResource             schema.GroupVersionResource
@@ -441,6 +442,7 @@ func getCAPIVersion() string {
 // the cluster.
 func newMachineController(
 	managementClient dynamic.Interface,
+	managementClientset kubeclient.Interface,
 	workloadClient kubeclient.Interface,
 	managementDiscoveryClient discovery.DiscoveryInterface,
 	managementScaleClient scale.ScalesGetter,
@@ -560,6 +562,7 @@ func newMachineController(
 		machinePoolInformer:         machinePoolInformer,
 		nodeInformer:                nodeInformer,
 		managementClient:            managementClient,
+		managementClientset:         managementClientset,
 		managementScaleClient:       managementScaleClient,
 		machineSetResource:          gvrMachineSet,
 		machinePoolResource:         gvrMachinePool,

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -122,6 +122,7 @@ func mustCreateTestController(t testing.TB, testConfigs ...*testConfig) (*machin
 		},
 		machineObjects...,
 	)
+	mgmtclientSet := fakekube.NewSimpleClientset()
 	discoveryClient := &fakediscovery.FakeDiscovery{
 		Fake: &clientgotesting.Fake{
 			Resources: []*metav1.APIResourceList{
@@ -293,7 +294,7 @@ func mustCreateTestController(t testing.TB, testConfigs ...*testConfig) (*machin
 	scaleClient.AddReactor("*", "*", scaleReactor)
 
 	stopCh := make(chan struct{})
-	controller, err := newMachineController(dynamicClientset, kubeclientSet, discoveryClient, scaleClient, cloudprovider.NodeGroupDiscoveryOptions{}, stopCh)
+	controller, err := newMachineController(dynamicClientset, mgmtclientSet, kubeclientSet, discoveryClient, scaleClient, cloudprovider.NodeGroupDiscoveryOptions{}, stopCh)
 	if err != nil {
 		t.Fatal("failed to create test controller")
 	}
@@ -381,6 +382,7 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 								"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
 								"kind":       machineTemplateKind,
 								"name":       "TestMachineTemplate",
+								"namespace":  spec.namespace,
 							},
 						},
 					},
@@ -419,6 +421,7 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
 									"kind":       machineTemplateKind,
 									"name":       "TestMachineTemplate",
+									"namespace":  spec.namespace,
 								},
 							},
 						},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -180,6 +180,10 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	if err != nil {
 		klog.Fatalf("could not generate dynamic client for config")
 	}
+	managementClientSet, err := kubernetes.NewForConfig(managementConfig)
+	if err != nil {
+		klog.Fatalf("could not generate kube clientset from mgmt config")
+	}
 
 	workloadClient, err := kubernetes.NewForConfig(workloadConfig)
 	if err != nil {
@@ -205,7 +209,7 @@ func BuildClusterAPI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupD
 	// currently organised to do so.
 	stopCh := make(chan struct{})
 
-	controller, err := newMachineController(managementClient, workloadClient, managementDiscoveryClient, managementScaleClient, do, stopCh)
+	controller, err := newMachineController(managementClient, managementClientSet, workloadClient, managementDiscoveryClient, managementScaleClient, do, stopCh)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	authv1 "k8s.io/api/authorization/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -279,6 +280,8 @@ func (r unstructuredScalableResource) InstanceCapacity() (map[corev1.ResourceNam
 
 	infraObj, err := r.readInfrastructureReferenceResource()
 	if err != nil || infraObj == nil {
+		// err="machinetemplates.infrastructure.cluster.x-k8s.io \"TestMachineTemplate\" not found"
+		// infraObj=nil
 		// because it is possible that the infrastructure provider does not implement
 		// the capacity in the infrastructure reference, if there are annotations we
 		// should return them here.
@@ -396,6 +399,27 @@ func (r unstructuredScalableResource) readInfrastructureReferenceResource() (*un
 	kind = fmt.Sprintf("%ss", strings.ToLower(kind))
 	gvk := schema.FromAPIVersionAndKind(apiversion, kind)
 	res := schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: gvk.Kind}
+	for _, v := range []string{"list", "watch"} {
+		action := authv1.ResourceAttributes{
+			Namespace: r.Namespace(),
+			Verb:      v,
+			Resource:  gvk.Kind,
+			Version:   gvk.Version,
+			Group:     gvk.Group,
+		}
+		selfCheck := authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &action,
+			},
+		}
+		resp, err := r.controller.managementClientset.AuthorizationV1().
+			SelfSubjectAccessReviews().
+			Create(context.TODO(), &selfCheck, metav1.CreateOptions{})
+		if err != nil || !resp.Status.Allowed {
+			klog.V(4).Infof("Unable to validate infrastructure reference authorization, error: %v", err)
+			return nil, err
+		}
+	}
 
 	infra, err := r.controller.getInfrastructureResource(res, name, r.Namespace())
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR affects the CAPI provider of cluster-autoscaler only.

Here we check that we have the proper permissions to list an infra object before we bootstrap the informer factory. Doing the latter has error handling side-effects that we don't want:

- https://github.com/kubernetes/client-go/blob/v0.29.0-alpha.3/tools/cache/reflector.go#L146-L148

Specfically it results in the error short-circuiting the process and resulting in a pod restart, which has the ultimate side-effect of deadlocking the cluster-autoscaler reconciler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6490

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
capi cluster-autoscaler: fix error when listing infra machines
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
