### PR TITLE
Backport #5901 [CA] Remove unneeded node groups regardless of scale down being in cooldown into CA1.27

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -626,22 +626,26 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 			a.processorCallbacks.disableScaleDownForLoop, scaleDownInCooldown)
 		metrics.UpdateScaleDownInCooldown(scaleDownInCooldown)
 
+		// We want to delete unneeded Node Groups only if here is no current delete
+		// in progress.
+		_, drained := scaleDownActuationStatus.DeletionsInProgress()
+		var removedNodeGroups []cloudprovider.NodeGroup
+		if len(drained) == 0 {
+			var err error
+			removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(autoscalingContext)
+			if err != nil {
+				klog.Errorf("Error while removing unneeded node groups: %v", err)
+			}
+			scaleDownStatus.RemovedNodeGroups = removedNodeGroups
+		}
+
 		if scaleDownInCooldown {
 			scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
+			if len(removedNodeGroups) > 0 {
+				a.processors.ScaleDownStatusProcessor.Process(autoscalingContext, scaleDownStatus)
+			}
 		} else {
 			klog.V(4).Infof("Starting scale down")
-
-			// We want to delete unneeded Node Groups only if there was no recent scale up,
-			// and there is no current delete in progress and there was no recent errors.
-			_, drained := actuationStatus.DeletionsInProgress()
-			var removedNodeGroups []cloudprovider.NodeGroup
-			if len(drained) == 0 {
-				var err error
-				removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(autoscalingContext)
-				if err != nil {
-					klog.Errorf("Error while removing unneeded node groups: %v", err)
-				}
-			}
 
 			scaleDownStart := time.Now()
 			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is cherry-picked, which backports #5901 into CA 1.27

#### Which issue(s) this PR fixes:

Part of #6467

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
