### PR TITLE
Allow overriding timeouts in GCE cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -129,21 +129,27 @@ type autoscalingGceClientV1 struct {
 	operationDeletionPollInterval time.Duration
 }
 
-// NewAutoscalingGceClientV1 creates a new client for communicating with GCE v1 API.
-func NewAutoscalingGceClientV1(client *http.Client, projectId string, userAgent string) (*autoscalingGceClientV1, error) {
+// NewAutoscalingGceClientV1WithTimeout creates a new client with custom timeouts
+// for communicating with GCE v1 API
+func NewAutoscalingGceClientV1WithTimeout(client *http.Client, projectId string, userAgent string,
+	waitTimeout, pollInterval, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
 	gceService, err := gce.New(client)
 	if err != nil {
 		return nil, err
 	}
 	gceService.UserAgent = userAgent
-
 	return &autoscalingGceClientV1{
 		projectId:                     projectId,
 		gceService:                    gceService,
-		operationWaitTimeout:          defaultOperationWaitTimeout,
-		operationPollInterval:         defaultOperationPollInterval,
-		operationDeletionPollInterval: defaultOperationDeletionPollInterval,
+		operationWaitTimeout:          waitTimeout,
+		operationPollInterval:         pollInterval,
+		operationDeletionPollInterval: deletionPollInterval,
 	}, nil
+}
+
+// NewAutoscalingGceClientV1 creates a new client for communicating with GCE v1 API.
+func NewAutoscalingGceClientV1(client *http.Client, projectId string, userAgent string) (*autoscalingGceClientV1, error) {
+	return NewAutoscalingGceClientV1WithTimeout(client, projectId, userAgent, defaultOperationWaitTimeout, defaultOperationPollInterval, defaultOperationDeletionPollInterval)
 }
 
 // NewCustomAutoscalingGceClientV1 creates a new client using custom server url and timeouts


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

This PR adds a wraper constructor to allow overriding just the timeout and poll intervals in calls made to GCE cloud provider.