### PR TITLE
Reduce log spam in AtomicResizeFilteringProcessor

### DIFF
--- a/cluster-autoscaler/utils/klogx/defaults.go
+++ b/cluster-autoscaler/utils/klogx/defaults.go
@@ -25,6 +25,12 @@ const (
 	// MaxPodsLoggedV5 is the maximum number of pods for which we will
 	// log detailed information every loop at verbosity >= 5.
 	MaxPodsLoggedV5 = 1000
+	// MaxNodesLogged is the maximum number of nodes for which we will
+	// log detailed information every loop at verbosity < 5.
+	MaxNodesLogged = 20
+	// MaxNodesLoggedV5 is the maximum number of nodes for which we will
+	// log detailed information every loop at verbosity >= 5.
+	MaxNodesLoggedV5 = 1000
 )
 
 // PodsLoggingQuota returns a new quota with default limit for pods at current verbosity.
@@ -33,4 +39,12 @@ func PodsLoggingQuota() *Quota {
 		return NewLoggingQuota(MaxPodsLoggedV5)
 	}
 	return NewLoggingQuota(MaxPodsLogged)
+}
+
+// NodesLoggingQuota returns a new quota with default limit for nodes at current verbosity.
+func NodesLoggingQuota() *Quota {
+	if klog.V(5).Enabled() {
+		return NewLoggingQuota(MaxNodesLoggedV5)
+	}
+	return NewLoggingQuota(MaxNodesLogged)
 }


### PR DESCRIPTION
Also, introduce default per-node logging quotas. For now, identical to the per-pod ones.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reduces log spam.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
