### PR TITLE
Migrate GCE client to server-side wait

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -37,9 +37,8 @@ import (
 )
 
 const (
-	defaultOperationWaitTimeout          = 20 * time.Second
-	defaultOperationPollInterval         = 100 * time.Millisecond
-	defaultOperationDeletionPollInterval = 1 * time.Second
+	defaultOperationWaitTimeout  = 20 * time.Second
+	defaultOperationPollInterval = 100 * time.Millisecond
 	// ErrorCodeQuotaExceeded is an error code used in InstanceErrorInfo if quota exceeded error occurs.
 	ErrorCodeQuotaExceeded = "QUOTA_EXCEEDED"
 
@@ -115,6 +114,11 @@ type AutoscalingGceClient interface {
 	ResizeMig(GceRef, int64) error
 	DeleteInstances(migRef GceRef, instances []GceRef) error
 	CreateInstances(GceRef, string, int64, []string) error
+
+	// WaitForOperation can be used to poll GCE operations until completion/timeout using WAIT calls.
+	// Calling this is normally not needed when interacting with the client, other methods should call it internally.
+	// Can be used to extend the interface with more methods outside of this package.
+	WaitForOperation(operationName, operationType, project, zone string) error
 }
 
 type autoscalingGceClientV1 struct {
@@ -123,39 +127,36 @@ type autoscalingGceClientV1 struct {
 	projectId string
 	domainUrl string
 
-	// These can be overridden, e.g. for testing.
-	operationWaitTimeout          time.Duration
-	operationPollInterval         time.Duration
-	operationDeletionPollInterval time.Duration
+	// Can be overridden, e.g. for testing.
+	operationWaitTimeout  time.Duration
+	operationPollInterval time.Duration
 }
 
 // NewAutoscalingGceClientV1WithTimeout creates a new client with custom timeouts
 // for communicating with GCE v1 API
-func NewAutoscalingGceClientV1WithTimeout(client *http.Client, projectId string, userAgent string,
-	waitTimeout, pollInterval, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
+func NewAutoscalingGceClientV1WithTimeout(client *http.Client, projectId string, userAgent string, waitTimeout time.Duration, pollInterval time.Duration) (*autoscalingGceClientV1, error) {
 	gceService, err := gce.New(client)
 	if err != nil {
 		return nil, err
 	}
 	gceService.UserAgent = userAgent
+
 	return &autoscalingGceClientV1{
-		projectId:                     projectId,
-		gceService:                    gceService,
-		operationWaitTimeout:          waitTimeout,
-		operationPollInterval:         pollInterval,
-		operationDeletionPollInterval: deletionPollInterval,
+		projectId:             projectId,
+		gceService:            gceService,
+		operationWaitTimeout:  waitTimeout,
+		operationPollInterval: pollInterval,
 	}, nil
 }
 
 // NewAutoscalingGceClientV1 creates a new client for communicating with GCE v1 API.
 func NewAutoscalingGceClientV1(client *http.Client, projectId string, userAgent string) (*autoscalingGceClientV1, error) {
-	return NewAutoscalingGceClientV1WithTimeout(client, projectId, userAgent, defaultOperationWaitTimeout, defaultOperationPollInterval, defaultOperationDeletionPollInterval)
+	return NewAutoscalingGceClientV1WithTimeout(client, projectId, userAgent, defaultOperationWaitTimeout, defaultOperationPollInterval)
 }
 
 // NewCustomAutoscalingGceClientV1 creates a new client using custom server url and timeouts
 // for communicating with GCE v1 API.
-func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, userAgent, domainUrl string,
-	waitTimeout, pollInterval time.Duration, deletionPollInterval time.Duration) (*autoscalingGceClientV1, error) {
+func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, userAgent, domainUrl string, waitTimeout time.Duration, pollInterval time.Duration) (*autoscalingGceClientV1, error) {
 	gceService, err := gce.New(client)
 	if err != nil {
 		return nil, err
@@ -164,12 +165,11 @@ func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, 
 	gceService.UserAgent = userAgent
 
 	return &autoscalingGceClientV1{
-		projectId:                     projectId,
-		gceService:                    gceService,
-		domainUrl:                     domainUrl,
-		operationWaitTimeout:          waitTimeout,
-		operationPollInterval:         pollInterval,
-		operationDeletionPollInterval: deletionPollInterval,
+		projectId:             projectId,
+		gceService:            gceService,
+		domainUrl:             domainUrl,
+		operationWaitTimeout:  waitTimeout,
+		operationPollInterval: pollInterval,
 	}, nil
 }
 
@@ -240,7 +240,7 @@ func (client *autoscalingGceClientV1) ResizeMig(migRef GceRef, size int64) error
 	if err != nil {
 		return err
 	}
-	return client.waitForOp(op, migRef.Project, migRef.Zone, false)
+	return client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
 func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName string, delta int64, existingInstanceProviderIds []string) error {
@@ -257,7 +257,7 @@ func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName st
 	if err != nil {
 		return err
 	}
-	return client.waitForOp(op, migRef.Project, migRef.Zone, false)
+	return client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
 func instanceIdsToNamesMap(instanceProviderIds []string) map[string]bool {
@@ -274,32 +274,37 @@ func instanceIdsToNamesMap(instanceProviderIds []string) map[string]bool {
 	return instanceNames
 }
 
-func (client *autoscalingGceClientV1) waitForOp(operation *gce.Operation, project, zone string, isDeletion bool) error {
-	pollInterval := client.operationPollInterval
-	if isDeletion {
-		pollInterval = client.operationDeletionPollInterval
-	}
-	for start := time.Now(); time.Since(start) < client.operationWaitTimeout; time.Sleep(pollInterval) {
-		klog.V(4).Infof("Waiting for operation %s %s %s", project, zone, operation.Name)
-		registerRequest("zone_operations", "get")
-		if op, err := client.gceService.ZoneOperations.Get(project, zone, operation.Name).Do(); err == nil {
-			klog.V(4).Infof("Operation %s %s %s status: %s", project, zone, operation.Name, op.Status)
-			if op.Status == "DONE" {
-				if op.Error != nil {
-					errBytes, err := op.Error.MarshalJSON()
-					if err != nil {
-						errBytes = []byte(fmt.Sprintf("operation failed, but error couldn't be recovered: %v", err))
-					}
-					return fmt.Errorf("error while getting operation %s on %s: %s", operation.Name, operation.TargetLink, errBytes)
-				}
+// WaitForOperation can be used to poll GCE operations until completion/timeout using WAIT calls.
+// Calling this is normally not needed when interacting with the client, other methods should call it internally.
+// Can be used to extend the interface with more methods outside of this package.
+func (client *autoscalingGceClientV1) WaitForOperation(operationName, operationType, project, zone string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), client.operationWaitTimeout)
+	defer cancel()
 
-				return nil
-			}
-		} else {
-			klog.Warningf("Error while getting operation %s on %s: %v", operation.Name, operation.TargetLink, err)
+	for {
+		klog.V(4).Infof("Waiting for operation %s/%s (%s/%s)", operationType, operationName, project, zone)
+		registerRequest("zone_operations", "wait")
+		op, err := client.gceService.ZoneOperations.Wait(project, zone, operationName).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("error while waiting for operation %s/%s: %w", operationType, operationName, err)
 		}
+
+		klog.V(4).Infof("Operation %s/%s (%s/%s) status: %s", operationType, operationName, project, zone, op.Status)
+		if op.Status == "DONE" {
+			if op.Error != nil {
+				errBytes, err := op.Error.MarshalJSON()
+				if err != nil {
+					errBytes = []byte(fmt.Sprintf("operation failed, but error couldn't be recovered: %v", err))
+				}
+				return fmt.Errorf("error while waiting for operation %s/%s: %s", operationType, operationName, errBytes)
+			}
+
+			return nil
+		}
+
+		// NOTE: sleep in order not to overload server, as potentially response may be returned immediately
+		time.Sleep(client.operationPollInterval)
 	}
-	return fmt.Errorf("timeout while waiting for operation %s on %s to complete.", operation.Name, operation.TargetLink)
 }
 
 func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances []GceRef) error {
@@ -315,7 +320,7 @@ func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances [
 	if err != nil {
 		return err
 	}
-	return client.waitForOp(op, migRef.Project, migRef.Zone, true)
+	return client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
 func (client *autoscalingGceClientV1) FetchMigInstances(migRef GceRef) ([]GceInstance, error) {

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -329,7 +329,6 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 
 	// Override wait for op timeouts.
 	gceService.operationWaitTimeout = 50 * time.Millisecond
-	gceService.operationPollInterval = 1 * time.Millisecond
 
 	cache := &GceCache{
 		migs:                    make(map[GceRef]Mig),
@@ -473,7 +472,7 @@ func TestDeleteInstances(t *testing.T) {
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/listManagedInstances").Return(buildFourRunningInstancesOnDefaultMigManagedInstancesResponse(zoneB)).Once()
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/deleteInstances").Return(deleteInstancesResponse).Once()
-	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505802641136-55984ff86d980-a99e8c2b-0c8aaaaa").Return(deleteInstancesOperationResponse).Once()
+	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505802641136-55984ff86d980-a99e8c2b-0c8aaaaa/wait").Return(deleteInstancesOperationResponse).Once()
 
 	instances := []GceRef{
 		{
@@ -583,7 +582,7 @@ func TestGetAndSetMigSize(t *testing.T) {
 
 	// set target size for extraPoolMig; will require resize API call and API call for polling for resize operation
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%s/resize", extraPoolMigName)).Return(setMigSizeResponse).Once()
-	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505739408819-5597646964339-eb839c88-28805931").Return(setMigSizeOperationResponse).Once()
+	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505739408819-5597646964339-eb839c88-28805931/wait").Return(setMigSizeOperationResponse).Once()
 	err = g.SetMigSize(extraPoolMig, 4)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
@@ -1509,7 +1508,7 @@ func TestAppendInstances(t *testing.T) {
 	defaultPoolMig := setupTestDefaultPool(g, true)
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/listManagedInstances").Return(buildFourRunningInstancesOnDefaultMigManagedInstancesResponse(zoneB)).Once()
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%v/createInstances", defaultPoolMig.gceRef.Name)).Return(createInstancesResponse).Once()
-	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1624366531120-5c55a4e128c15-fc5daa90-e1ef6c32").Return(createInstancesOperationResponse).Once()
+	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1624366531120-5c55a4e128c15-fc5daa90-e1ef6c32/wait").Return(createInstancesOperationResponse).Once()
 	err := g.CreateInstances(defaultPoolMig, 2)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -121,6 +121,10 @@ func (client *mockAutoscalingGceClient) CreateInstances(_ GceRef, _ string, _ in
 	return nil
 }
 
+func (client *mockAutoscalingGceClient) WaitForOperation(_, _, _, _ string) error {
+	return nil
+}
+
 func TestFillMigInstances(t *testing.T) {
 	migRef := GceRef{Project: "test", Zone: "zone-A", Name: "some-mig"}
 	oldInstances := []GceInstance{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

[GCE CloudProvider](cluster-autoscaler/cloudprovider/gce) is currently using polling as a primary method for awaiting async operations. GCE now provides [method for server side wait](https://cloud.google.com/compute/docs/reference/rest/v1/zoneOperations/wait), which will decrease RPS compared to polling approach. 

#### Special notes for your reviewer:

1. WaitForOperation method becomes part of public interface to allow further extension of interface without reimplementing await logic once again;
2. In case we are sure that timeouts more than 2 minutes are required we may combine wait method with polling as the last resort.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
