### PR TITLE
ScaleDownFailed addition metric due to AccessDenied error

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -195,6 +195,9 @@ func CleanUpAndRecordFailedScaleDownEvent(ctx *context.AutoscalingContext, node 
 		klog.Errorf("Scale-down: couldn't delete empty node, %v, status error: %v", errMsg, status.Err)
 		ctx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to delete empty node: %v", status.Err)
 	}
+	gpuConfig := ctx.CloudProvider.GetNodeGpuConfig(node)
+	metricResourceName, metricGpuType := gpu.GetGpuInfoForMetrics(gpuConfig, ctx.CloudProvider.GetAvailableGPUTypes(), node, nil)
+	metrics.RegisterFailedScaleUp(metrics.CloudProviderError, metricResourceName, metricGpuType)
 	taints.CleanToBeDeleted(node, ctx.ClientSet, ctx.CordonNodeBeforeTerminate)
 	nodeDeletionTracker.EndDeletion(nodeGroupId, node.Name, status)
 }


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:

This PR introduces an additional metric for the ScaleDownFailed functionality. An error occurred, showing "ScaleDownFailed: failed to delete empty node: ip-.." (refer to the attached screenshot). This error was caused by an AccessDenied issue while attempting to delete an instance in the autoscaling group. Consequently, it disrupted the autoscaler, rendering the specific autoscaling group dysfunctional in production. To mitigate this issue, I implemented a new metric to notify us of such scenarios.

After my changes, I reviewed the metrics and confirmed that the new metric is now present:
```
cluster_autoscaler_failed_scale_ups_total{reason="cloudProviderError"} 1
```

Does this PR introduce a user-facing change?

No

Which component are you using?:

cluster-autoscaler

![autoscaler_issue](https://github.com/kubernetes/autoscaler/assets/14313467/ae637146-7eb0-4c78-ad58-bafb78ffd61d)
