### PR TITLE
docs: update outdated/deprecated taints in the examples

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -149,9 +149,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.2
           name: cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-autodiscover.yaml
@@ -154,9 +154,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-control-plane.yaml
@@ -156,9 +156,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-standard-msi.yaml
@@ -154,9 +154,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-control-plane.yaml
@@ -155,9 +155,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always

--- a/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml
@@ -153,9 +153,9 @@ spec:
         - effect: NoSchedule
           operator: "Equal"
           value: "true"
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/role: control-plane
       containers:
         - image: registry.k8s.io/autoscaling/cluster-autoscaler:{{ ca_version }}
           imagePullPolicy: Always

--- a/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/cherryservers/examples/cluster-autoscaler-deployment.yaml
@@ -18,16 +18,16 @@ spec:
     spec:
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       # Node affinity is used to force cluster-autoscaler to stick
-      # to the master node. This allows the cluster to reliably downscale
+      # to the macontrol-plane node. This allows the cluster to reliably downscale
       # to zero worker nodes when needed.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
       serviceAccountName: cluster-autoscaler
       containers:

--- a/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
@@ -140,16 +140,16 @@ spec:
       serviceAccountName: cluster-autoscaler
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       # Node affinity is used to force cluster-autoscaler to stick
-      # to the master node. This allows the cluster to reliably downscale
+      # to the control-plane node. This allows the cluster to reliably downscale
       # to zero worker nodes when needed.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node-role.kubernetes.io/master
+                  - key: node-role.kubernetes.io/control-plane
                     operator: Exists
       containers:
         - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest  # or your custom image

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-control-plane.yaml
@@ -18,7 +18,7 @@ spec:
         app: cluster-autoscaler
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       securityContext:
         runAsUser: 1001
       tolerations:
@@ -26,7 +26,7 @@ spec:
           value: "True"
           effect: NoSchedule
         - key: dedicated
-          value: "master"
+          value: "control-plane"
           effect: NoSchedule
       serviceAccountName: cluster-autoscaler-account
       containers:

--- a/cluster-autoscaler/cloudprovider/magnum/examples/values-autodiscovery.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/values-autodiscovery.yaml
@@ -11,16 +11,16 @@ image:
   tag: v1.23.0
 
 nodeSelector:
-  node-role.kubernetes.io/master: ""
+  node-role.kubernetes.io/control-plane: ""
 
 tolerations:
 - key: CriticalAddonsOnly
   value: "True"
   effect: NoSchedule
 - key: dedicated
-  value: "master"
+  value: "control-plane"
   effect: NoSchedule
-- key: node-role.kubernetes.io/master
+- key: node-role.kubernetes.io/control-plane
   effect: NoSchedule
 
 cloudConfigPath: /etc/kubernetes/cloud-config

--- a/cluster-autoscaler/cloudprovider/magnum/examples/values-example.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/values-example.yaml
@@ -12,16 +12,16 @@ image:
   tag: v1.23.0
 
 nodeSelector:
-  node-role.kubernetes.io/master: ""
+  node-role.kubernetes.io/control-plane: ""
 
 tolerations:
 - key: CriticalAddonsOnly
   value: "True"
   effect: NoSchedule
 - key: dedicated
-  value: "master"
+  value: "control-plane"
   effect: NoSchedule
-- key: node-role.kubernetes.io/master
+- key: node-role.kubernetes.io/control-plane
   effect: NoSchedule
 
 cloudConfigPath: "/etc/kubernetes/cloud-config"

--- a/cluster-autoscaler/cloudprovider/tencentcloud/README.md
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/README.md
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: kube-admin
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - hostPath:
           path: /etc/localtime


### PR DESCRIPTION
Refactor references to taints & tolerations, replacing `master` key with `control-plane` across all the example YAMLs.

#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes # https://github.com/kubernetes/autoscaler/issues/6561

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NO

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
