### PR TITLE
feat: add ipxe-script-url support for Equinix Metal

### DIFF
--- a/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// GPULabel is the label added to nodes with GPU resource.
-	GPULabel = "cloud.google.com/gke-accelerator"
+	GPULabel = "accelerator"
 	// DefaultControllerNodeLabelKey is the label added to Master/Controller to identify as
 	// master/controller node.
 	DefaultControllerNodeLabelKey = "node-role.kubernetes.io/master"
@@ -48,11 +48,9 @@ const (
 	ControllerNodeIdentifierMetalEnv = "METAL_CONTROLLER_NODE_IDENTIFIER_LABEL"
 )
 
-var (
-	availableGPUTypes = map[string]struct{}{
-		"nvidia-tesla-v100": {},
-	}
-)
+var availableGPUTypes = map[string]struct{}{
+	"nvidia-tesla-v100": {},
+}
 
 // equinixMetalCloudProvider implements CloudProvider interface from cluster-autoscaler/cloudprovider module.
 type equinixMetalCloudProvider struct {
@@ -152,7 +150,8 @@ func (pcp *equinixMetalCloudProvider) GetAvailableMachineTypes() ([]string, erro
 
 // NewNodeGroup is not implemented.
 func (pcp *equinixMetalCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
-	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+	taints []apiv1.Taint, extraResources map[string]resource.Quantity,
+) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5856

#### Special notes for your reviewer:

To simplify testing, I'd like to revisit the equinixmetal/examples in this PR to make it easier to run the example without hand tweaking the base64 encoded cloud-init and inserting the Equinix Metal project id and auth token.

There are conventional variable names, exported by the Metal CLI, which can be injected in this example through a combination of `kustomize` and/or `subst`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
adds ipxe-script-url and always-ipxe CloudConfig options for Equinix Metal
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
