### PR TITLE
Add CP node deletion param configurable

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -289,6 +289,8 @@ type AutoscalingOptions struct {
 	BypassedSchedulers map[string]bool
 	// ProvisioningRequestEnabled tells if CA processes ProvisioningRequest.
 	ProvisioningRequestEnabled bool
+	// MaxCloudProviderNodeDeletionTime is the maximum time needed by cloud provider to delete a node
+	MaxCloudProviderNodeDeletionTime time.Duration
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -109,7 +109,7 @@ func (c *Checker) FilterOutUnremovable(context *context.AutoscalingContext, scal
 func (c *Checker) unremovableReasonAndNodeUtilization(context *context.AutoscalingContext, timestamp time.Time, nodeInfo *schedulerframework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {
 	node := nodeInfo.Node()
 
-	if actuation.IsNodeBeingDeleted(node, timestamp) {
+	if actuation.IsNodeBeingDeleted(context, node, timestamp) {
 		klog.V(1).Infof("Skipping %s from delete consideration - the node is currently being deleted", node.Name)
 		return simulator.CurrentlyBeingDeleted, nil
 	}

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -164,6 +164,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 					ScaleDownUnreadyTime:             config.DefaultScaleDownUnreadyTime,
 					IgnoreDaemonSetsUtilization:      tc.ignoreDaemonSetsUtilization,
 				},
+				MaxCloudProviderNodeDeletionTime: 5 * time.Minute,
 			}
 			s := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
 			c := NewChecker(s)

--- a/cluster-autoscaler/core/scaledown/resource/limits.go
+++ b/cluster-autoscaler/core/scaledown/resource/limits.go
@@ -62,7 +62,7 @@ func NoLimits() Limits {
 // LimitsLeft returns the amount of each resource that can be deleted from the
 // cluster without violating any constraints.
 func (lf *LimitsFinder) LimitsLeft(context *context.AutoscalingContext, nodes []*apiv1.Node, resourceLimiter *cloudprovider.ResourceLimiter, timestamp time.Time) Limits {
-	totalCores, totalMem := coresMemoryTotal(nodes, timestamp)
+	totalCores, totalMem := coresMemoryTotal(context, nodes, timestamp)
 
 	var totalResources map[string]int64
 	var totalResourcesErr error
@@ -102,10 +102,10 @@ func computeAboveMin(total int64, min int64) int64 {
 	return 0
 }
 
-func coresMemoryTotal(nodes []*apiv1.Node, timestamp time.Time) (int64, int64) {
+func coresMemoryTotal(ctx *context.AutoscalingContext, nodes []*apiv1.Node, timestamp time.Time) (int64, int64) {
 	var coresTotal, memoryTotal int64
 	for _, node := range nodes {
-		if actuation.IsNodeBeingDeleted(node, timestamp) {
+		if actuation.IsNodeBeingDeleted(ctx, node, timestamp) {
 			// Nodes being deleted do not count towards total cluster resources
 			continue
 		}
@@ -122,7 +122,7 @@ func (lf *LimitsFinder) customResourcesTotal(context *context.AutoscalingContext
 	result := make(map[string]int64)
 	ngCache := make(map[string][]customresources.CustomResourceTarget)
 	for _, node := range nodes {
-		if actuation.IsNodeBeingDeleted(node, timestamp) {
+		if actuation.IsNodeBeingDeleted(context, node, timestamp) {
 			// Nodes being deleted do not count towards total cluster resources
 			continue
 		}

--- a/cluster-autoscaler/core/scaledown/resource/limits_test.go
+++ b/cluster-autoscaler/core/scaledown/resource/limits_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -55,7 +56,12 @@ func TestCalculateCoresAndMemoryTotal(t *testing.T) {
 		},
 	}
 
-	coresTotal, memoryTotal := coresMemoryTotal(nodes, time.Now())
+	options := config.AutoscalingOptions{
+		MaxCloudProviderNodeDeletionTime: 5 * time.Minute,
+	}
+	context, err := NewScaleTestAutoscalingContext(options, nil, nil, nil, nil, nil)
+	assert.NoError(t, err)
+	coresTotal, memoryTotal := coresMemoryTotal(&context, nodes, time.Now())
 
 	assert.Equal(t, int64(42), coresTotal)
 	assert.Equal(t, int64(44000*utils.MiB), memoryTotal)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -322,7 +322,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	// Update cluster resource usage metrics
-	coresTotal, memoryTotal := calculateCoresMemoryTotal(allNodes, currentTime)
+	coresTotal, memoryTotal := calculateCoresMemoryTotal(a.AutoscalingContext, allNodes, currentTime)
 	metrics.UpdateClusterCPUCurrentCores(coresTotal)
 	metrics.UpdateClusterMemoryCurrentBytes(memoryTotal)
 
@@ -1048,12 +1048,12 @@ func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*s
 	return upcomingNodes
 }
 
-func calculateCoresMemoryTotal(nodes []*apiv1.Node, timestamp time.Time) (int64, int64) {
+func calculateCoresMemoryTotal(context *context.AutoscalingContext, nodes []*apiv1.Node, timestamp time.Time) (int64, int64) {
 	// this function is essentially similar to the calculateScaleDownCoresMemoryTotal
 	// we want to check all nodes, aside from those deleting, to sum the cluster resource usage.
 	var coresTotal, memoryTotal int64
 	for _, node := range nodes {
-		if actuation.IsNodeBeingDeleted(node, timestamp) {
+		if actuation.IsNodeBeingDeleted(context, node, timestamp) {
 			// Nodes being deleted do not count towards total cluster resources
 			continue
 		}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -257,7 +257,8 @@ var (
 			"--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default."+
 			"Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature)."+
 			"Eg. flag usage:  '10000:20,1000:100,0:60'")
-	provisioningRequestsEnabled = flag.Bool("enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
+	provisioningRequestsEnabled      = flag.Bool("enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
+	maxCloudProviderNodeDeletionTime = flag.Duration("max-cloud-provider-node-deletion-time", 5*time.Minute, "Maximum time needed by cloud provider to delete a node")
 )
 
 func isFlagPassed(name string) bool {


### PR DESCRIPTION
#### What type of PR is this?
feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Making cloud-provider node deletion param configurable so all cloud-providers can set this as per their need if needed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE. Defaults are present.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
