### PR TITLE
Remove shadow err variable in deleteCreatedNodesWithErros func

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -869,7 +869,8 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
 		} else {
-			opts, err := nodeGroup.GetOptions(a.NodeGroupDefaults)
+			var opts *config.NodeGroupAutoscalingOptions
+			opts, err = nodeGroup.GetOptions(a.NodeGroupDefaults)
 			if err != nil {
 				klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
 				continue


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes shadowed ```err``` variable in ```deleteCreatedNodesWithErrors()``` in ```static_autoscaler.go```. Previously the returned error from ```nodeGroup.DeleteNodes()``` was assigned to a shadowed ```err``` variable. Because of that the original variable remains ```nil``` even when node deletion failed and that original variable is used to determine whether there was a successful node deletion. If there was a successful node deletion the current CA loop will skip. Because of this shadowed variable, CA can get stuck in an infinite loop when there are created nodes with errors and node deletion fails for those nodes.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE



