### PR TITLE
Add listManagedInstancesResults to GceCache.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -56,36 +56,38 @@ type GceCache struct {
 	cacheMutex sync.Mutex
 
 	// Cache content.
-	migs                      map[GceRef]Mig
-	instances                 map[GceRef][]GceInstance
-	instancesUpdateTime       map[GceRef]time.Time
-	instancesToMig            map[GceRef]GceRef
-	instancesFromUnknownMig   map[GceRef]bool
-	resourceLimiter           *cloudprovider.ResourceLimiter
-	autoscalingOptionsCache   map[GceRef]map[string]string
-	machinesCache             map[MachineTypeKey]MachineType
-	migTargetSizeCache        map[GceRef]int64
-	migBaseNameCache          map[GceRef]string
-	instanceTemplateNameCache map[GceRef]string
-	instanceTemplatesCache    map[GceRef]*gce.InstanceTemplate
-	kubeEnvCache              map[GceRef]KubeEnv
+	migs                             map[GceRef]Mig
+	instances                        map[GceRef][]GceInstance
+	instancesUpdateTime              map[GceRef]time.Time
+	instancesToMig                   map[GceRef]GceRef
+	instancesFromUnknownMig          map[GceRef]bool
+	resourceLimiter                  *cloudprovider.ResourceLimiter
+	autoscalingOptionsCache          map[GceRef]map[string]string
+	machinesCache                    map[MachineTypeKey]MachineType
+	migTargetSizeCache               map[GceRef]int64
+	migBaseNameCache                 map[GceRef]string
+	listManagedInstancesResultsCache map[GceRef]string
+	instanceTemplateNameCache        map[GceRef]string
+	instanceTemplatesCache           map[GceRef]*gce.InstanceTemplate
+	kubeEnvCache                     map[GceRef]KubeEnv
 }
 
 // NewGceCache creates empty GceCache.
 func NewGceCache() *GceCache {
 	return &GceCache{
-		migs:                      map[GceRef]Mig{},
-		instances:                 map[GceRef][]GceInstance{},
-		instancesUpdateTime:       map[GceRef]time.Time{},
-		instancesToMig:            map[GceRef]GceRef{},
-		instancesFromUnknownMig:   map[GceRef]bool{},
-		autoscalingOptionsCache:   map[GceRef]map[string]string{},
-		machinesCache:             map[MachineTypeKey]MachineType{},
-		migTargetSizeCache:        map[GceRef]int64{},
-		migBaseNameCache:          map[GceRef]string{},
-		instanceTemplateNameCache: map[GceRef]string{},
-		instanceTemplatesCache:    map[GceRef]*gce.InstanceTemplate{},
-		kubeEnvCache:              map[GceRef]KubeEnv{},
+		migs:                             map[GceRef]Mig{},
+		instances:                        map[GceRef][]GceInstance{},
+		instancesUpdateTime:              map[GceRef]time.Time{},
+		instancesToMig:                   map[GceRef]GceRef{},
+		instancesFromUnknownMig:          map[GceRef]bool{},
+		autoscalingOptionsCache:          map[GceRef]map[string]string{},
+		machinesCache:                    map[MachineTypeKey]MachineType{},
+		migTargetSizeCache:               map[GceRef]int64{},
+		migBaseNameCache:                 map[GceRef]string{},
+		listManagedInstancesResultsCache: map[GceRef]string{},
+		instanceTemplateNameCache:        map[GceRef]string{},
+		instanceTemplatesCache:           map[GceRef]*gce.InstanceTemplate{},
+		kubeEnvCache:                     map[GceRef]KubeEnv{},
 	}
 }
 
@@ -514,4 +516,26 @@ func (gc *GceCache) InvalidateAllMigBasenames() {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 	gc.migBaseNameCache = make(map[GceRef]string)
+}
+
+// SetListManagedInstancesResults sets listManagedInstancesResults for a given mig in cache
+func (gc *GceCache) SetListManagedInstancesResults(migRef GceRef, listManagedInstancesResults string) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+	gc.listManagedInstancesResultsCache[migRef] = listManagedInstancesResults
+}
+
+// GetListManagedInstancesResults gets listManagedInstancesResults for a given mig from cache.
+func (gc *GceCache) GetListManagedInstancesResults(migRef GceRef) (string, bool) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+	listManagedInstancesResults, found := gc.listManagedInstancesResultsCache[migRef]
+	return listManagedInstancesResults, found
+}
+
+// InvalidateAllListManagedInstancesResults invalidates all listManagedInstancesResults entries.
+func (gc *GceCache) InvalidateAllListManagedInstancesResults() {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+	gc.listManagedInstancesResultsCache = make(map[GceRef]string)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -300,6 +300,7 @@ func (m *gceManagerImpl) Refresh() error {
 	m.cache.InvalidateAllMigInstances()
 	m.cache.InvalidateAllMigTargetSizes()
 	m.cache.InvalidateAllMigBasenames()
+	m.cache.InvalidateAllListManagedInstancesResults()
 	m.cache.InvalidateAllMigInstanceTemplateNames()
 	if m.lastRefresh.Add(refreshInterval).After(time.Now()) {
 		return nil

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -343,11 +343,12 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 			{"us-central1-c", "n1-standard-1"}: {Name: "n1-standard-1", CPU: 1, Memory: 1},
 			{"us-central1-f", "n1-standard-1"}: {Name: "n1-standard-1", CPU: 1, Memory: 1},
 		},
-		migTargetSizeCache:        map[GceRef]int64{},
-		instanceTemplateNameCache: map[GceRef]string{},
-		instanceTemplatesCache:    map[GceRef]*gce.InstanceTemplate{},
-		kubeEnvCache:              map[GceRef]KubeEnv{},
-		migBaseNameCache:          map[GceRef]string{},
+		migTargetSizeCache:               map[GceRef]int64{},
+		instanceTemplateNameCache:        map[GceRef]string{},
+		instanceTemplatesCache:           map[GceRef]*gce.InstanceTemplate{},
+		kubeEnvCache:                     map[GceRef]KubeEnv{},
+		migBaseNameCache:                 map[GceRef]string{},
+		listManagedInstancesResultsCache: map[GceRef]string{},
 	}
 	migLister := NewMigLister(cache)
 	manager := &gceManagerImpl{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
It adds listManagedInstancesResults to GceCache. It allows to avoid extra calls to GCE when determining max node group size during scale up.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
