### PR TITLE
fix memory leak in NodeDeleteTracker

### DIFF
--- a/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
+++ b/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
@@ -173,6 +173,9 @@ func (n *NodeDeletionTracker) ClearResultsNotNewerThan(t time.Time) {
 func (n *NodeDeletionTracker) Snapshot() *NodeDeletionTracker {
 	n.Lock()
 	defer n.Unlock()
+
+	n.evictions.DropNotNewerThan(n.clock.Now().Add(-n.evictionsTTL))
+
 	snapshot := NewNodeDeletionTracker(n.evictionsTTL)
 	for k, val := range n.emptyNodeDeletions {
 		snapshot.emptyNodeDeletions[k] = val


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix memory leak in `NodeDeleteTracker`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/autoscaler/issues/6543

#### Special notes for your reviewer:

`scaleDownActuator` has a NodeDeleteTracker, it add pods by `RegisterEviction`. But it never clear pods.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
