### PR TITLE
Track auto-provisioned queued provisioning node groups.

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -390,20 +390,22 @@ var (
 		},
 	)
 
-	nodeGroupCreationCount = k8smetrics.NewCounter(
+	nodeGroupCreationCount = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
 			Namespace: caNamespace,
 			Name:      "created_node_groups_total",
 			Help:      "Number of node groups created by Node Autoprovisioning.",
 		},
+		[]string{"group_type"},
 	)
 
-	nodeGroupDeletionCount = k8smetrics.NewCounter(
+	nodeGroupDeletionCount = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
 			Namespace: caNamespace,
 			Name:      "deleted_node_groups_total",
 			Help:      "Number of node groups deleted by Node Autoprovisioning.",
 		},
+		[]string{"group_type"},
 	)
 
 	nodeTaintsCount = k8smetrics.NewGaugeVec(
@@ -643,12 +645,22 @@ func UpdateNapEnabled(enabled bool) {
 
 // RegisterNodeGroupCreation registers node group creation
 func RegisterNodeGroupCreation() {
-	nodeGroupCreationCount.Add(1.0)
+	RegisterNodeGroupCreationWithLabelValues("")
+}
+
+// RegisterQueuedProvisioningNodeGroupCreation registers node group creation with the provided labels
+func RegisterNodeGroupCreationWithLabelValues(groupType string) {
+	nodeGroupCreationCount.WithLabelValues(groupType).Add(1.0)
 }
 
 // RegisterNodeGroupDeletion registers node group deletion
 func RegisterNodeGroupDeletion() {
-	nodeGroupDeletionCount.Add(1.0)
+	RegisterNodeGroupDeletionWithLabelValues("")
+}
+
+// RegisterNodeGroupDeletion registers node group deletion with the provided labels
+func RegisterNodeGroupDeletionWithLabelValues(groupType string) {
+	nodeGroupDeletionCount.WithLabelValues(groupType).Add(1.0)
 }
 
 // UpdateScaleDownInCooldown registers if the cluster autoscaler

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -648,7 +648,7 @@ func RegisterNodeGroupCreation() {
 	RegisterNodeGroupCreationWithLabelValues("")
 }
 
-// RegisterQueuedProvisioningNodeGroupCreation registers node group creation with the provided labels
+// RegisterNodeGroupCreationWithLabelValues registers node group creation with the provided labels
 func RegisterNodeGroupCreationWithLabelValues(groupType string) {
 	nodeGroupCreationCount.WithLabelValues(groupType).Add(1.0)
 }
@@ -658,7 +658,7 @@ func RegisterNodeGroupDeletion() {
 	RegisterNodeGroupDeletionWithLabelValues("")
 }
 
-// RegisterNodeGroupDeletion registers node group deletion with the provided labels
+// RegisterNodeGroupDeletionWithLabelValues registers node group deletion with the provided labels
 func RegisterNodeGroupDeletionWithLabelValues(groupType string) {
 	nodeGroupDeletionCount.WithLabelValues(groupType).Add(1.0)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
It allows us to differentiate between standard and queued-provisioning node groups that are getting auto-provisioned.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
