### PR TITLE
Allow to override rancher provider settings

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/README.md
+++ b/cluster-autoscaler/cloudprovider/rancher/README.md
@@ -10,6 +10,12 @@ The `cluster-autoscaler` for Rancher needs a configuration file to work by
 using `--cloud-config` parameter. An up-to-date example can be found in
 [examples/config.yaml](./examples/config.yaml).
 
+### Configuration via environment variables
+In order to override URL, token or clustername use following environment variables:
+ - RANCHER_URL
+ - RANCHER_TOKEN
+ - RANCHER_CLUSTER_NAME
+
 ### Permissions
 
 The Rancher server account provided in the `cloud-config` requires the

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
@@ -23,12 +23,34 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	envUrl          = "RANCHER_URL"
+	envClusterName  = "RANCHER_CLUSTER_NAME"
+	envClusterToken = "RANCHER_TOKEN"
+)
+
 type cloudConfig struct {
 	URL               string `yaml:"url"`
 	Token             string `yaml:"token"`
 	ClusterName       string `yaml:"clusterName"`
 	ClusterNamespace  string `yaml:"clusterNamespace"`
 	ClusterAPIVersion string `yaml:"clusterAPIVersion"`
+}
+
+func overrideFromEnv(c *cloudConfig) *cloudConfig {
+	url := os.Getenv(envUrl)
+	cName := os.Getenv(envClusterName)
+	token := os.Getenv(envClusterToken)
+	if url != "" {
+		c.URL = url
+	}
+	if cName != "" {
+		c.ClusterName = cName
+	}
+	if token != "" {
+		c.Token = token
+	}
+	return c
 }
 
 func newConfig(file string) (*cloudConfig, error) {
@@ -41,6 +63,8 @@ func newConfig(file string) (*cloudConfig, error) {
 	if err := yaml.Unmarshal(b, config); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal config file: %w", err)
 	}
+
+	config = overrideFromEnv(config)
 
 	return config, nil
 }

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_config_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_config_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package rancher
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestNewConfig(t *testing.T) {
 	cfg, err := newConfig("./examples/config.yaml")
@@ -38,5 +41,27 @@ func TestNewConfig(t *testing.T) {
 
 	if len(cfg.ClusterNamespace) == 0 {
 		t.Fatal("expected cluster namespace to be set")
+	}
+}
+
+func TestEnvOverride(t *testing.T) {
+	expectedUrl := "http://rancher-site.com"
+	overrideToken := "token:changed"
+	overrideClusterName := "cluster-changed"
+	os.Setenv(envUrl, expectedUrl)
+	os.Setenv(envClusterToken, overrideToken)
+	os.Setenv(envClusterName, overrideClusterName)
+	cfg, err := newConfig("./examples/config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.URL != expectedUrl {
+		t.Fatal("expected url to be set")
+	}
+	if cfg.Token != overrideToken {
+		t.Fatal("expected token to be set")
+	}
+	if cfg.ClusterName != overrideClusterName {
+		t.Fatal("expected cluster name to be set")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently it is only possible to set provider settings over yaml file.

This commit introduces env variables to override URL, token and cluster name.

If particular environment variable is set it overrides value supplied in yaml file.
#### Which issue(s) this PR fixes
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Allow to override rancher provider setting via environment variables (`RANCHER_TOKEN`, `RANCHER_URL`, `RANCHER_CLUSTER_NAME`)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
