### PR TITLE
Bump VPA version to 1.1.0

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.0.0"
+const VerticalPodAutoscalerVersion = "1.1.0"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates the version of VPA to 1.1.0

Precursor to cutting the next release of VPA.

#### Which issue(s) this PR fixes:

Part of release process #6388
