### PR TITLE
Set "pd-balanced" as DefaultBootDiskType

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_price_info.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_info.go
@@ -546,8 +546,9 @@ var (
 		"pd-balanced": 0.100 / hoursInMonth,
 		"pd-ssd":      0.170 / hoursInMonth,
 	}
-	// DefaultBootDiskType is pd-standard disk type.
-	DefaultBootDiskType = "pd-standard"
+	// DefaultBootDiskType is pd-balanced disk type.
+	// ref: https://cloud.google.com/kubernetes-engine/docs/how-to/custom-boot-disks#specify
+	DefaultBootDiskType = "pd-balanced"
 )
 
 // GcePriceInfo is the GCE specific implementation of the PricingInfo.

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
@@ -110,7 +110,7 @@ func TestGetNodePrice(t *testing.T) {
 		"custom node price scales linearly": {
 			cheaperNode:                testNode(t, "small_custom", "custom-1", 1000, 3.75*units.GiB, "", 0, false, false),
 			expensiveNode:              testNode(t, "large_custom", "custom-8", 8000, 30*units.GiB, "", 0, false, false),
-			priceComparisonCoefficient: 0.14,
+			priceComparisonCoefficient: 0.16,
 		},
 		"custom node price scales linearly 2": {
 			cheaperNode:                testNode(t, "large_custom", "custom-8", 8000, 30*units.GiB, "", 0, false, false),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix/Update the default disk type.
Change in k/k: https://github.com/kubernetes/kubernetes/pull/123863

#### Does this PR introduce a user-facing change?

```release-note
Change the default disk type for the legacy GCE storage provider; the default type is now `pd-balanced`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Other doc]: https://cloud.google.com/kubernetes-engine/docs/how-to/custom-boot-disks#specify
```
