### PR TITLE
Deprecate the Linode Cluster Autoscaler provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/linode/README.md
+++ b/cluster-autoscaler/cloudprovider/linode/README.md
@@ -1,5 +1,9 @@
 # Cluster Autoscaler for Linode
 
+**⚠️ The Linode Cluster Autoscaler has been deprecated and will be removed some time in 2025. This implementation has only ever scaled the Linode Kubernetes Engine (LKE)
+deployments and [this product has had native autoscaling for years](https://www.linode.com/blog/kubernetes/horizontal-cluster-autoscaling-on-linode-kubernetes-engine/).
+This implementation is thus redundant.**
+
 The cluster autoscaler for Linode scales nodes in a LKE cluster.
 
 ## Linode Kubernetes Engine


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation


#### What this PR does / why we need it:

The Linode provider for CA has been redundant for years now and should be deprecated (and eventually removed).

#### Which issue(s) this PR fixes:

Fixes #6495

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The Linode Cluster Autoscaler provider is removed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None