### PR TITLE
Support azure vmss flex

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -201,6 +201,9 @@ func machineSetHasMachineDeploymentOwnerRef(machineSet *unstructured.Unstructure
 // normalizedProviderString splits s on '/' returning everything after
 // the last '/'.
 func normalizedProviderString(s string) normalizedProviderID {
+	if strings.HasPrefix(s, "azure://") && strings.Contains(s, "virtualMachineScaleSets") {
+		return normalizedProviderID(s)
+	}
 	split := strings.Split(s, "/")
 	return normalizedProviderID(split[len(split)-1])
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -201,7 +201,7 @@ func machineSetHasMachineDeploymentOwnerRef(machineSet *unstructured.Unstructure
 // normalizedProviderString splits s on '/' returning everything after
 // the last '/'.
 func normalizedProviderString(s string) normalizedProviderID {
-	if strings.HasPrefix(s, "azure://") && strings.Contains(s, "virtualMachineScaleSets") {
+	if strings.HasPrefix(s, "azure://") {
 		return normalizedProviderID(s)
 	}
 	split := strings.Split(s, "/")

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -422,6 +422,14 @@ func TestUtilNormalizedProviderID(t *testing.T) {
 		description: "id with / characters",
 		providerID:  "aws:////i-12345678",
 		expectedID:  "i-12345678",
+	}, {
+		description: "azure standard vm",
+		providerID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachines/control-plane-1cbe5-d4dx7",
+		expectedID:  "control-plane-1cbe5-d4dx7",
+	}, {
+		description: "azure vmss",
+		providerID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/vmssName/virtualMachines/0",
+		expectedID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/vmssName/virtualMachines/0",
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			actualID := normalizedProviderString(tc.providerID)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -425,7 +425,7 @@ func TestUtilNormalizedProviderID(t *testing.T) {
 	}, {
 		description: "azure standard vm",
 		providerID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachines/control-plane-1cbe5-d4dx7",
-		expectedID:  "control-plane-1cbe5-d4dx7",
+		expectedID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachines/control-plane-1cbe5-d4dx7",
 	}, {
 		description: "azure vmss",
 		providerID:  "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/vmssName/virtualMachines/0",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds support for Azure VMSS Flexible MachinePool deployments.

#### Which issue(s) this PR fixes:

Fixes #6454

#### Special notes for your reviewer:

Removes normalization of all azure resources, rather than just for Azure VMSS resources. The reason for this is that VMSS Flexible provisions VM's (`Microsoft.Compute/virtualMachines`) rather than instances as a sub-resource of the VMSS (`Microsoft.Compute/virtualMachineScaleSets`).

Should supersede #6632

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
