### PR TITLE
azure labels to skip in nodegroupset

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
@@ -30,6 +30,16 @@ const AzureNodepoolLabel = "kubernetes.azure.com/agentpool"
 // AzureDiskTopologyKey is the topology key of Azure Disk CSI driver
 const AzureDiskTopologyKey = "topology.disk.csi.azure.com/zone"
 
+// Those labels are added on the VMSS and shouldn't affect nodepool similarity
+const aksEngineVersionLabel = "aksEngineVersion"
+const creationSource = "creationSource"
+const poolName = "poolName"
+const resourceNameSuffix = "resourceNameSuffix"
+const aksConsolidatedAdditionalProperties = "kubernetes.azure.com/consolidated-additional-properties"
+
+// AKS node image version
+const aksNodeImageVersion = "kubernetes.azure.com/node-image-version"
+
 func nodesFromSameAzureNodePool(n1, n2 *schedulerframework.NodeInfo) bool {
 	n1AzureNodePool := n1.Node().Labels[AzureNodepoolLabel]
 	n2AzureNodePool := n2.Node().Labels[AzureNodepoolLabel]
@@ -53,6 +63,13 @@ func CreateAzureNodeInfoComparator(extraIgnoredLabels []string, ratioOpts config
 	azureIgnoredLabels[AzureNodepoolLegacyLabel] = true
 	azureIgnoredLabels[AzureNodepoolLabel] = true
 	azureIgnoredLabels[AzureDiskTopologyKey] = true
+	azureIgnoredLabels[aksEngineVersionLabel] = true
+	azureIgnoredLabels[creationSource] = true
+	azureIgnoredLabels[poolName] = true
+	azureIgnoredLabels[resourceNameSuffix] = true
+	azureIgnoredLabels[aksNodeImageVersion] = true
+	azureIgnoredLabels[aksConsolidatedAdditionalProperties] = true
+	
 	for _, k := range extraIgnoredLabels {
 		azureIgnoredLabels[k] = true
 	}

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups.go
@@ -69,7 +69,7 @@ func CreateAzureNodeInfoComparator(extraIgnoredLabels []string, ratioOpts config
 	azureIgnoredLabels[resourceNameSuffix] = true
 	azureIgnoredLabels[aksNodeImageVersion] = true
 	azureIgnoredLabels[aksConsolidatedAdditionalProperties] = true
-	
+
 	for _, k := range extraIgnoredLabels {
 		azureIgnoredLabels[k] = true
 	}

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
@@ -67,9 +67,26 @@ func TestIsAzureNodeInfoSimilar(t *testing.T) {
 	n1.ObjectMeta.Labels["agentpool"] = "foo"
 	n2.ObjectMeta.Labels["agentpool"] = "bar"
 	checkNodesSimilar(t, n1, n2, comparator, true)
+	// Different creationSource
+	n1.ObjectMeta.Labels["creationSource"] = "aks-aks-nodepool2-vmss"
+	n2.ObjectMeta.Labels["creationSource"] = "aks-aks-nodepool3-vmss"
+	checkNodesSimilar(t, n1, n2, comparator, true)
+	// Different node image version
+	n1.ObjectMeta.Labels["kubernetes.azure.com/node-image-version"] = "AKSUbuntu-1804gen2-2021.01.28"
+	n2.ObjectMeta.Labels["kubernetes.azure.com/node-image-version"] = "AKSUbuntu-1804gen2-2022.01.30"
+	checkNodesSimilar(t, n1, n2, comparator, true)
 	// Custom label
 	n1.ObjectMeta.Labels["example.com/ready"] = "true"
 	n2.ObjectMeta.Labels["example.com/ready"] = "false"
+	checkNodesSimilar(t, n1, n2, comparator, true)
+	// One node with aksConsolidatedAdditionalProperties label
+	n1.ObjectMeta.Labels[aksConsolidatedAdditionalProperties] = "foo"
+	checkNodesSimilar(t, n1, n2, comparator, true)
+	// Same aksConsolidatedAdditionalProperties
+	n2.ObjectMeta.Labels[aksConsolidatedAdditionalProperties] = "foo"
+	checkNodesSimilar(t, n1, n2, comparator, true)
+	// Different aksConsolidatedAdditionalProperties label
+	n2.ObjectMeta.Labels[aksConsolidatedAdditionalProperties] = "bar"
 	checkNodesSimilar(t, n1, n2, comparator, true)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
feature - skip a few azure specific labels in nodegroupset

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR add a few azure specific labels that needs to be skipped when checking for nodegroup similarity.
This change doesn't include moving azure specific lables under /azure directory - that chore will be covered in another change

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Skips Azure-specific node labels that might mistakenly categorize nodegroups as different when, in reality, they are similar.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
