### PR TITLE
Bump CA golang to 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.21.6'
+          go-version: '1.22.1'
 
       - uses: actions/checkout@v2
         with:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.8
+FROM golang:1.22.1
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/
@@ -21,6 +21,6 @@ ENV GO111MODULE auto
 
 RUN apt-get update && apt-get --yes install libseccomp-dev
 RUN go version
-RUN go get github.com/tools/godep
+RUN go install github.com/tools/godep@latest
 RUN godep version
 CMD ["/bin/bash"]

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -1,8 +1,8 @@
 module k8s.io/autoscaler/cluster-autoscaler
 
-go 1.21
+go 1.22
 
-toolchain go1.21.8
+toolchain go1.22.1
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bump `cluster-autoscaer` golang  version to match k/k:
https://github.com/kubernetes/kubernetes/commit/70221e8405e8d58273a06fc81554c3fceb717b43

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @olagacek 
/cc @damikag 
/cc @pmendelski 