### PR TITLE
fix alicloud target size

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess/describe_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess/describe_scaling_groups.go
@@ -167,6 +167,7 @@ type ScalingGroup struct {
 	RemovingCapacity             int             `json:"RemovingCapacity" xml:"RemovingCapacity"`
 	ScalingGroupName             string          `json:"ScalingGroupName" xml:"ScalingGroupName"`
 	ActiveCapacity               int             `json:"ActiveCapacity" xml:"ActiveCapacity"`
+	DesiredCapacity              int             `json:"DesiredCapacity" xml:"DesiredCapacity"`
 	StandbyCapacity              int             `json:"StandbyCapacity" xml:"StandbyCapacity"`
 	ProtectedCapacity            int             `json:"ProtectedCapacity" xml:"ProtectedCapacity"`
 	ActiveScalingConfigurationId string          `json:"ActiveScalingConfigurationId" xml:"ActiveScalingConfigurationId"`

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
@@ -107,7 +107,7 @@ func (m *AliCloudManager) GetAsgSize(asgConfig *Asg) (int64, error) {
 	if err != nil {
 		return -1, fmt.Errorf("failed to describe ASG %s,Because of %s", asgConfig.id, err.Error())
 	}
-	return int64(sg.ActiveCapacity + sg.PendingCapacity), nil
+	return int64(sg.DesiredCapacity), nil
 }
 
 // SetAsgSize sets ASG size.

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
@@ -107,7 +107,7 @@ func (m *AliCloudManager) GetAsgSize(asgConfig *Asg) (int64, error) {
 	if err != nil {
 		return -1, fmt.Errorf("failed to describe ASG %s,Because of %s", asgConfig.id, err.Error())
 	}
-	return int64(sg.DesiredCapacity), nil
+	return int64(max(sg.DesiredCapacity, sg.ActiveCapacity + sg.PendingCapacity)), nil
 }
 
 // SetAsgSize sets ASG size.

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_manager.go
@@ -107,7 +107,7 @@ func (m *AliCloudManager) GetAsgSize(asgConfig *Asg) (int64, error) {
 	if err != nil {
 		return -1, fmt.Errorf("failed to describe ASG %s,Because of %s", asgConfig.id, err.Error())
 	}
-	return int64(max(sg.DesiredCapacity, sg.ActiveCapacity + sg.PendingCapacity)), nil
+	return int64(sg.DesiredCapacity), nil
 }
 
 // SetAsgSize sets ASG size.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
The targetSize function in alicloud is implemented by calling the Alibaba Cloud ESS API DescribeScalingGroups. In the function func (m *AliCloudManager) GetAsgSize(asgConfig *Asg) (int64, error), targetSize is calculated as sg.ActiveCapacity + sg.PendingCapacity. However, this approach poses certain risks and issues during actual execution.
﻿
ActiveCapacity represents the number of ECS instances that have successfully joined the scaling group and are running normally. PendingCapacity represents the number of ECS instances that are in the process of joining the scaling group but have not completed the relevant configurations. However, since ESS operates asynchronously, there is a risk of the sum of these two values not changing even after modifying the expected value, especially when desired is large.
﻿
The official documentation mentions that DesiredCapacity represents the desired number of ECS instances within the scaling group, which seems more reasonable.
﻿
During execution, I encountered this issue where despite modifying desired, the targetSize remained 0 at the start of the second onceOnce. However, a new value was retrieved during increase, resulting in an incorrect number of instances being scaled up, exceeding the expected value.

![image](https://github.com/kubernetes/autoscaler/assets/100843245/b71fed15-a490-4f95-ace6-dc433fdc05d7)
Added logs at key locations for easier localization.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://help.aliyun.com/zh/auto-scaling/developer-reference/api-describescalinggroups?spm=a2c4g.11186623.0.i3#doc-api-Ess-DescribeScalingGroups
