### PR TITLE
Bump default VPA version to 1.1.0 in vpa-release-1.1 branch

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -50,12 +50,13 @@ procedure described below.
 
 # Installation
 
-The current default version is Vertical Pod Autoscaler 1.0.0
+The current default version is Vertical Pod Autoscaler 1.1.0
 
 ### Compatibility
 
 | VPA version     | Kubernetes version |
 |-----------------|--------------------|
+| 1.1             | 1.25+              |
 | 1.0             | 1.25+              |
 | 0.14            | 1.25+              |
 | 0.13            | 1.25+              |

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.0.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.1.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.0.0
+          image: registry.k8s.io/autoscaling/vpa-updater:1.1.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.0.0"
+DEFAULT_TAG="1.1.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}


### PR DESCRIPTION
Changes in the master branch are in #6655

What type of PR is this?
/kind feature

What this PR does / why we need it:
This is the last part of the 1.1.0 release: https://github.com/kubernetes/autoscaler/issues/6388

