### PR TITLE
Lower errors verbosity for kube-env label missing

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -144,13 +144,13 @@ func (t *GceTemplateBuilder) MigOsInfo(migId string, kubeEnv KubeEnv) (MigOsInfo
 	osDistribution := extractOperatingSystemDistributionFromKubeEnv(kubeEnv)
 	if osDistribution == OperatingSystemDistributionUnknown {
 		osDistribution = OperatingSystemDistributionDefault
-		klog.Errorf("could not obtain os-distribution from kube-env from template metadata, falling back to %q", osDistribution)
+		klog.V(5).Infof("could not obtain os-distribution from kube-env from template metadata, falling back to %q", osDistribution)
 	}
 
 	arch, err := extractSystemArchitectureFromKubeEnv(kubeEnv)
 	if err != nil {
 		arch = DefaultArch
-		klog.Errorf("Couldn't extract architecture from kube-env for MIG %q, falling back to %q. Error: %v", migId, arch, err)
+		klog.V(5).Infof("Couldn't extract architecture from kube-env for MIG %q, falling back to %q. Error: %v", migId, arch, err)
 	}
 	return NewMigOsInfo(os, osDistribution, arch), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When `kube-env` doesn't have osDistro or arch labels set, the CA spam errors (on every loop).
The system works perfectly fine with defaults, so it's not as critical.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```