### PR TITLE
fix: implement function to identify if node is present in cluster-api

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
+	"fmt"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -84,7 +85,14 @@ func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup,
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
 func (p *provider) HasInstance(node *corev1.Node) (bool, error) {
-	return true, cloudprovider.ErrNotImplemented
+	machineID := node.Annotations[machineAnnotationKey]
+
+	machine, err := p.controller.findMachine(machineID)
+	if machine != nil {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("machine not found for node %s: %v", node.Name, err)
 }
 
 func (*provider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {


### PR DESCRIPTION
- this is a follow-up to https://github.com/kubernetes/autoscaler/pull/5054
- this might fix CA fails to scale-up or cancel in-progress scale down when there are un-schedulable pods  #4456
- this implements the same functionality, which was implemented it https://github.com/kubernetes/autoscaler/pull/5632 for aws provider

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
The same as in #5632, but for cluster-api provider
> I think description of https://github.com/kubernetes/autoscaler/pull/5054#issue-1319989728 explains it well:

>  ...original intent of determining the deleted nodes was incorrect, which led to the issues reported by other users. The nodes tainted with ToBeDeleted were misidentified as Deleted instead of Ready/Unready, which caused a miscalculation of the node being included as Upcoming. This caused problems described in https://github.com/kubernetes/autoscaler/issues/3949 and https://github.com/kubernetes/autoscaler/issues/4456.

> https://github.com/kubernetes/autoscaler/pull/5054 exposed interface function HasInstance for cloud providers to implement. This function is used to determine if a node is deleted by querying the cloud provider. It falls back to the ToBeDeleted taint if the function is not implemented.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4456 

#### Special notes for your reviewer:
The same changes were already implemented in #5632 for AWS provider

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
