### PR TITLE
Fix NPE in vpa-updater when Pod owner isn't scalable

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
@@ -389,6 +389,16 @@ func TestControllerFetcher(t *testing.T) {
 			expectedKey:   nil,
 			expectedError: fmt.Errorf("Unhandled targetRef v1 / Node / node, last error node is not a valid owner"),
 		},
+		{
+			name: "custom resource with no scale subresource",
+			key: &ControllerKeyWithAPIVersion{
+				ApiVersion: "Foo/Foo", ControllerKey: ControllerKey{
+					Name: "bah", Kind: "Foo", Namespace: testNamespace},
+			},
+			objects:       []runtime.Object{},
+			expectedKey:   nil, // Pod owner does not support scale subresource so should return nil"
+			expectedError: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := simpleControllerFetcher()

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -153,6 +153,9 @@ func GetControllingVPAForPod(pod *core.Pod, vpas []*VpaWithSelector, ctrlFetcher
 		klog.Errorf("fail to get pod controller: pod=%s err=%s", pod.Name, err.Error())
 		return nil
 	}
+	if parentController == nil {
+		return nil
+	}
 
 	var controlling *VpaWithSelector
 	var controllingVpa *vpa_types.VerticalPodAutoscaler

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -139,6 +139,15 @@ func TestPodMatchesVPA(t *testing.T) {
 	}
 }
 
+type NilControllerFetcher struct{}
+
+// FindTopMostWellKnownOrScalable returns the same key for that fake implementation
+func (f NilControllerFetcher) FindTopMostWellKnownOrScalable(_ *controllerfetcher.ControllerKeyWithAPIVersion) (*controllerfetcher.ControllerKeyWithAPIVersion, error) {
+	return nil, nil
+}
+
+var _ controllerfetcher.ControllerFetcher = &NilControllerFetcher{}
+
 func TestGetControllingVPAForPod(t *testing.T) {
 	isController := true
 	pod := test.Pod().WithName("test-pod").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).Get()
@@ -171,6 +180,12 @@ func TestGetControllingVPAForPod(t *testing.T) {
 		{nonMatchingVPA, parseLabelSelector("app = other")},
 	}, &controllerfetcher.FakeControllerFetcher{})
 	assert.Equal(t, vpaA, chosen.Vpa)
+
+	// For some Pods (which are *not* under VPA), controllerFetcher.FindTopMostWellKnownOrScalable will return `nil`, e.g. when the Pod owner is a custom resource, which doesn't implement the /scale subresource
+	// See pkg/target/controller_fetcher/controller_fetcher_test.go:393 for testing this behavior
+	// This test case makes sure that GetControllingVPAForPod will just return `nil` in that case as well
+	chosen = GetControllingVPAForPod(pod, []*VpaWithSelector{{vpaA, parseLabelSelector("app = testingApp")}}, &NilControllerFetcher{})
+	assert.Nil(t, chosen)
 }
 
 func TestGetContainerResourcePolicy(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The method `ctrlFetcher.FindTopMostWellKnownOrScalable` returns `nil` without an additional `error`, when there is no owner that is either scalable (implementing the `/scale` subresource) or is well-known. In this case, just skip the current Pod, as it cannot be controlled by a VPA.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6709 

#### Special notes for your reviewer:
This PR adds two tests to make sure this cannot regress:
* `vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go` gets the new testcase `custom resource with no scale subresource` which ensures that for a Pod, which is not under VPA control and has an `ownerRef` to a custom resource that doesn't implement `/scale`, the method `FindTopMostWellKnownOrScalable` returns `nil`, `nil`
* `vertical-pod-autoscaler/pkg/utils/vpa/api_test.go` gets an additional test assertion which uses a fake `controllerFetcher`, which _always_ returns `nil` to make sure that `GetControllingVPAForPod` can deal with a `nil`, `nil` response from `ctrlFetcher.FindTopMostWellKnownOrScalable`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: NPE in vpa-updater when Pods have an `ownerReference` to a Custom Resource which doesn't implement the `/scale` subresource
```

