### PR TITLE
filter out pods that have deletion timestamp set in currentlyDrainedPods

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -51,6 +51,11 @@ func currentlyDrainedPods(context *context.AutoscalingContext) []*apiv1.Pod {
 			continue
 		}
 		for _, podInfo := range nodeInfo.Pods {
+			// Filter out pods that has deletion timestamp set
+			if podInfo.Pod.DeletionTimestamp != nil {
+				klog.Infof("Pod %v has deletion timestamp set, skipping", podInfo.Pod.Name)
+				continue
+			}
 			pods = append(pods, podInfo.Pod)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
Shouldn't put pods that have deletionTimestamp set on the draining node to the unshedulable pods list.
The issue has more detailed analysis. Thanks!!!

#### Which issue(s) this PR fixes:
Fixes #6718
