### PR TITLE
[v1.27][Hetzner] Fix Autoscaling for worker nodes with invalid ProviderID

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -204,9 +204,19 @@ func (m *hetznerManager) addNodeToDrainingPool(node *apiv1.Node) (*hetznerNodeGr
 	return m.nodeGroups[drainingNodePoolId], nil
 }
 
+func (m *hetznerManager) validProviderID(providerID string) bool {
+	return strings.HasPrefix(providerID, providerIDPrefix)
+}
+
 func (m *hetznerManager) serverForNode(node *apiv1.Node) (*hcloud.Server, error) {
 	var nodeIdOrName string
 	if node.Spec.ProviderID != "" {
+		if !m.validProviderID(node.Spec.ProviderID) {
+			// This cluster-autoscaler provider only handles Hetzner Cloud servers.
+			// Any other provider ID prefix is invalid, and we return no server. Returning an error here breaks hybrid
+			// clusters with nodes from Hetzner Cloud & Robot (or other providers).
+			return nil, nil
+		}
 		nodeIdOrName = strings.TrimPrefix(node.Spec.ProviderID, providerIDPrefix)
 	} else {
 		nodeIdOrName = node.Name

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache.go
@@ -18,7 +18,6 @@ package hetzner
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"sync"
 	"time"
@@ -136,7 +135,8 @@ func (m *serversCache) getServer(nodeIdOrName string) (*hcloud.Server, error) {
 		}
 	}
 
-	return nil, errors.New("server not found")
+	// return nil if server not found
+	return nil, nil
 }
 
 func (m *serversCache) getServersByNodeGroupName(nodeGroup string) ([]*hcloud.Server, error) {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_servers_cache_test.go
@@ -70,6 +70,7 @@ func TestServersCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test2", foundservers.Name)
 
-	_, err = c.getServer("test3")
-	require.Error(t, err)
+	server, err := c.getServer("test3")
+	require.Nil(t, server)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area provider/hetzner

#### What this PR does / why we need it:

This change fixes a bug that arises when the user's cluster includes worker nodes not from Hetzner Cloud, such as a Hetzner Dedicated server or any server resource other than Hetzner. It also corrects the behavior when a server has been physically deleted from Hetzner Cloud.

Backport of #6717 to `v1.27` branch.

#### Which issue(s) this PR fixes:

Fixes #6716

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where the Hetzner provider breaks when nodes from other providers are present
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
