### PR TITLE
Add more precise logging for VPA resource recommendations

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -165,6 +165,8 @@ func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvictionAdmissi
 	return result
 }
 
+// GetProcessedRecommendationTargets takes a RecommendedPodResources object and returns a formatted string
+// with the recommended pod resources. Specifically, it formats the target and uncapped target CPU and memory.
 func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_types.RecommendedPodResources) string {
 	sb := &strings.Builder{}
 	for _, cr := range r.ContainerRecommendations {

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
@@ -174,7 +175,7 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 		if cr.Target != nil {
 			sb.WriteString("target: ")
 			if !cr.Target.Memory().IsZero() {
-				sb.WriteString(fmt.Sprintf("%sK ", cr.Target.Memory().AsDec()))
+				sb.WriteString(fmt.Sprintf("%dk ", cr.Target.Memory().ScaledValue(resource.Kilo)))
 			}
 			if !cr.Target.Cpu().IsZero() {
 				sb.WriteString(fmt.Sprintf("%vm; ", cr.Target.Cpu().MilliValue()))
@@ -183,7 +184,7 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 		if cr.UncappedTarget != nil {
 			sb.WriteString("uncappedTarget: ")
 			if !cr.UncappedTarget.Memory().IsZero() {
-				sb.WriteString(fmt.Sprintf("%sK ", cr.UncappedTarget.Memory().AsDec()))
+				sb.WriteString(fmt.Sprintf("%dk ", cr.UncappedTarget.Memory().ScaledValue(resource.Kilo)))
 			}
 			if !cr.UncappedTarget.Cpu().IsZero() {
 				sb.WriteString(fmt.Sprintf("%vm;", cr.UncappedTarget.Cpu().MilliValue()))

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -182,7 +182,14 @@ func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.String) {
 func getProcessedRecommendationTargets(r *vpa_types.RecommendedPodResources) string {
 	sb := &strings.Builder{}
 	for _, cr := range r.ContainerRecommendations {
-		sb.WriteString(fmt.Sprintf("%s: [ target: %sK, %vm; uncappedTarget: %sK, %vm ]\n", cr.ContainerName, cr.Target.Memory().AsDec(), cr.Target.Cpu().MilliValue(), cr.UncappedTarget.Memory().AsDec(), cr.UncappedTarget.Cpu().MilliValue()))
+		sb.WriteString(fmt.Sprintf("%s:", cr.ContainerName))
+		if cr.Target != nil {
+			sb.WriteString(fmt.Sprintf("target: %sK, %vm;", cr.Target.Memory().AsDec(), cr.Target.Cpu().MilliValue()))
+		}
+		if cr.UncappedTarget != nil {
+			sb.WriteString(fmt.Sprintf("uncappedTarget: %sK, %vm;", cr.UncappedTarget.Memory().AsDec(), cr.UncappedTarget.Cpu().MilliValue()))
+		}
+		sb.WriteString("\n")
 	}
 	return sb.String()
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -140,7 +140,7 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, now time.Time) {
 		klog.V(4).Infof("not updating pod %v/%v because resource would not change", pod.Namespace, pod.Name)
 		return
 	}
-	klog.V(2).Infof("pod accepted for update %v/%v with priority %v", pod.Namespace, pod.Name, updatePriority.ResourceDiff)
+	klog.V(2).Infof("pod accepted for update %v/%v with priority %v", pod.Namespace, pod.Name, updatePriority.ResourceDiff, processedRecommendation)
 	calc.pods = append(calc.pods, prioritizedPod{
 		pod:            pod,
 		priority:       updatePriority,

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -565,7 +565,7 @@ func TestAddPodLogs(t *testing.T) {
 		{
 			name:        "container with target and uncappedTarget",
 			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("4", "10M").Get(),
-			expectedLog: "container1: target: 10000000K 4000m; uncappedTarget: 10000000K 4000m;\n",
+			expectedLog: "container1: target: 10000k 4000m; uncappedTarget: 10000k 4000m;\n",
 		},
 		{
 			name:        "container with cpu only",
@@ -575,7 +575,7 @@ func TestAddPodLogs(t *testing.T) {
 		{
 			name:        "container with memory only",
 			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("", "10M").Get(),
-			expectedLog: "container1: target: 10000000K uncappedTarget: 10000000K \n",
+			expectedLog: "container1: target: 10000k uncappedTarget: 10000k \n",
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -555,3 +555,39 @@ func TestLessPodPriority(t *testing.T) {
 	}
 
 }
+
+func TestAddPodLogs(t *testing.T) {
+	testCases := []struct {
+		name        string
+		givenRec    *vpa_types.RecommendedPodResources
+		expectedLog string
+	}{
+		{
+			name:        "container with target and uncappedTarget",
+			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("4", "10M").Get(),
+			expectedLog: "container1: target: 10000000K 4000m; uncappedTarget: 10000000K 4000m;\n",
+		},
+		{
+			name:        "container with cpu only",
+			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("8", "").Get(),
+			expectedLog: "container1: target: 8000m; uncappedTarget: 8000m;\n",
+		},
+		{
+			name:        "container with memory only",
+			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("", "10M").Get(),
+			expectedLog: "container1: target: 10000000K uncappedTarget: 10000000K \n",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vpa := test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get()
+			priorityProcessor := NewFakeProcessor(map[string]PodPriority{
+				"POD1": {ScaleUp: true, ResourceDiff: 4.0}})
+			calculator := NewUpdatePriorityCalculator(vpa, nil,
+				&test.FakeRecommendationProcessor{}, priorityProcessor)
+
+			actualLog := calculator.GetProcessedRecommendationTargets(tc.givenRec)
+			assert.Equal(t, tc.expectedLog, actualLog)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -130,6 +130,7 @@ func getCappedRecommendationForContainer(
 				cappingAnnotations = append(cappingAnnotations, annotations...)
 			}
 		}
+		klog.V(3).Infof("processed capped recommendations for %s: %v", container.Name, cappingAnnotations)
 	}
 
 	process(cappedRecommendations.Target, true)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -130,7 +130,6 @@ func getCappedRecommendationForContainer(
 				cappingAnnotations = append(cappingAnnotations, annotations...)
 			}
 		}
-		klog.V(3).Infof("processed capped recommendations for %s: %v", container.Name, cappingAnnotations)
 	}
 
 	process(cappedRecommendations.Target, true)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it: 

This PR adds more precise logging for VPA recommendations.
* Logs the exact `processedRecommendation` from the VPA Updater, specifically, the capped and uncapped target resources (CPU/mem).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Helps to debug #6705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The VPA Updater logs the processed recommendations, specifically, the target and uncapped target CPU/memory.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
