### PR TITLE
filter out pods that have deletion timestamp set in currentlyDrainedPods

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -53,7 +53,7 @@ func currentlyDrainedPods(context *context.AutoscalingContext) []*apiv1.Pod {
 		for _, podInfo := range nodeInfo.Pods {
 			// Filter out pods that has deletion timestamp set
 			if podInfo.Pod.DeletionTimestamp != nil {
-				klog.Infof("Pod %v has deletion timestamp set, skipping", podInfo.Pod.Name)
+				klog.Infof("Pod %v has deletion timestamp set, skipping injection to unschedulable pods list", podInfo.Pod.Name)
 				continue
 			}
 			pods = append(pods, podInfo.Pod)

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -51,6 +51,11 @@ func currentlyDrainedPods(context *context.AutoscalingContext) []*apiv1.Pod {
 			continue
 		}
 		for _, podInfo := range nodeInfo.Pods {
+			// Filter out pods that has deletion timestamp set
+			if podInfo.Pod.DeletionTimestamp != nil {
+				klog.Infof("Pod %v has deletion timestamp set, skipping", podInfo.Pod.Name)
+				continue
+			}
 			pods = append(pods, podInfo.Pod)
 		}
 	}

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -77,7 +77,7 @@ func TestCurrentlyDrainedNodesPodListProcessor(t *testing.T) {
 			},
 			pods: []*apiv1.Pod{
 				BuildScheduledTestPod("p1", 100, 1, "n"),
-				BuildTestPodWithDeletionTimestamp("p2", 200, 1, "n", time.Now()),
+				BuildTestPod("p2", 200, 1, WithNodeName("n"), WithDeletionTimestamp(time.Now())),
 			},
 			wantPods: []*apiv1.Pod{
 				BuildTestPod("p1", 100, 1),

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -70,6 +70,20 @@ func TestCurrentlyDrainedNodesPodListProcessor(t *testing.T) {
 			},
 		},
 		{
+			name:         "single node undergoing deletion, pods with deletion timestamp set",
+			drainedNodes: []string{"n"},
+			nodes: []*apiv1.Node{
+				BuildTestNode("n", 1000, 10),
+			},
+			pods: []*apiv1.Pod{
+				BuildScheduledTestPod("p1", 100, 1, "n"),
+				BuildTestPodWithDeletionTimestamp("p2", 200, 1, "n", time.Now()),
+			},
+			wantPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 1),
+			},
+		},
+		{
 			name:         "single empty node undergoing deletion",
 			drainedNodes: []string{"n"},
 			nodes: []*apiv1.Node{

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -195,6 +195,13 @@ func BuildScheduledTestPod(name string, cpu, memory int64, nodeName string) *api
 	return p
 }
 
+// BuildTestPodWithDeletionTimestamp builds a test pod with deletion timestamp set
+func BuildTestPodWithDeletionTimestamp(name string, cpu, memory int64, nodeName string, deletionTimestamp time.Time) *apiv1.Pod {
+	p := BuildScheduledTestPod(name, cpu, memory, nodeName)
+	p.DeletionTimestamp = &metav1.Time{Time: deletionTimestamp}
+	return p
+}
+
 // SetStaticPodSpec sets pod spec to make it a static pod
 func SetStaticPodSpec(pod *apiv1.Pod) *apiv1.Pod {
 	pod.Annotations[kube_types.ConfigSourceAnnotationKey] = kube_types.FileSource

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -150,6 +150,13 @@ func WithMaxSkew(maxSkew int32, topologySpreadingKey string) func(*apiv1.Pod) {
 	}
 }
 
+// WithDeletionTimestamp sets deletion timestamp to the pod.
+func WithDeletionTimestamp(deletionTimestamp time.Time) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.DeletionTimestamp = &metav1.Time{Time: deletionTimestamp}
+	}
+}
+
 // BuildTestPodWithEphemeralStorage creates a pod with cpu, memory and ephemeral storage resources.
 func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage int64) *apiv1.Pod {
 	startTime := metav1.Unix(0, 0)
@@ -192,13 +199,6 @@ func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage in
 func BuildScheduledTestPod(name string, cpu, memory int64, nodeName string) *apiv1.Pod {
 	p := BuildTestPod(name, cpu, memory)
 	p.Spec.NodeName = nodeName
-	return p
-}
-
-// BuildTestPodWithDeletionTimestamp builds a test pod with deletion timestamp set
-func BuildTestPodWithDeletionTimestamp(name string, cpu, memory int64, nodeName string, deletionTimestamp time.Time) *apiv1.Pod {
-	p := BuildScheduledTestPod(name, cpu, memory, nodeName)
-	p.DeletionTimestamp = &metav1.Time{Time: deletionTimestamp}
 	return p
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
Shouldn't put pods that have deletionTimestamp set on the draining node to the unshedulable pods list.
The issue has more detailed analysis. Thanks!!!

#### Which issue(s) this PR fixes:
Fixes #6718
