### PR TITLE
Bump Go version used for building to 1.22.2 to match k/k

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1
+FROM golang:1.22.2
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -2,7 +2,7 @@ module k8s.io/autoscaler/cluster-autoscaler
 
 go 1.22
 
-toolchain go1.22.1
+toolchain go1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/124196
