### PR TITLE
NR-250703: cluster-autoscaler improvements for GCP

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -1,13 +1,13 @@
 ALL_ARCH = amd64 arm64 s390x
 all: $(addprefix build-arch-,$(ALL_ARCH))
 
-TAG?=dev
+TAG?=v1.25.3_NR
 FLAGS=
 LDFLAGS?=-s
 ENVVAR=CGO_ENABLED=0
 GOOS?=linux
 GOARCH?=$(shell go env GOARCH)
-REGISTRY?=staging-k8s.gcr.io
+REGISTRY?=cf-registry.nr-ops.net/container-fabric
 DOCKER_NETWORK?=default
 ifdef BUILD_TAGS
   TAGS_FLAG=--tags ${BUILD_TAGS}

--- a/cluster-autoscaler/cloudprovider/gce/README.md
+++ b/cluster-autoscaler/cloudprovider/gce/README.md
@@ -1,0 +1,36 @@
+# Cluster Autoscaler on GCP
+
+The cluster autoscaler on GCP dynamically scales Kubernetes worker nodes. It runs as a deployment in your cluster.
+
+## Auto-Discovery Setup
+
+To run a cluster-autoscaler which auto-discovers instance groups, use the `--node-group-auto-discovery` flag. There are 2 auto-discovery options to choose from.
+
+> NOTE - Only one of the 2 options can be used when configuring the `--node-group-auto-discovery` flag for cluster-autoscaler.    
+ 
+### Auto-Discovery by Labels 
+
+For example, `--node-group-auto-discovery=label:cluster-autoscaler-enabled=true,cluster-autoscaler-name=<YOUR CLUSTER NAME>` will find all the instance groups with instance templates that are tagged with those labels containing those values.
+
+---
+**NOTE**
+* It is recommended to use a second tag like `cluster-autoscaler-name=<YOUR CLUSTER NAME>` when `cluster-autoscaler-enabled=true` is used across many clusters to prevent Instance Groups from different clusters recognized as the node groups
+* There are no `--nodes` flags passed to cluster-autoscaler because the node groups are automatically discovered by tags
+* No `min/max` values are provided when using this option. cluster-autoscaler will detect the "min" and "max" labels on the Instane Group resource in GCP, adjusting the desired number of nodes within these limits.
+* If there are no `min/max` labels on the Instance Group resource, cluster-autoscaler will use the default min/max values of 0 and 1000 respectively.
+---
+
+### Auto-Discovery by NamePrefix
+
+For example, `--node-group-auto-discovery=mig:namePrefix=test-lemon-peel-mp,min=2,max=10` will internally use a Regular Expression to find all the instance groups whose name begins with `test-lemon-peel-mp` and set the minimum and maximum number of nodes to 2 and 10 respectively. 
+
+---
+**NOTE**
+* `Min` and `Max` key/value pairs where `max > min` must be specified when using this option and will not use any defaults. 
+* To add more than one instance groups that do not share the same name prefix, use the `--node-group-auto-discovery` flag multiple times. Ex:
+```
+--node-group-auto-discovery=mig:namePrefix=test-lemon-peel-mp,min=2,max=10
+--node-group-auto-discovery=mig:namePrefix=confab-nodes,min=2,max=10
+```
+* Clearly, the name-prefixes must be statically configured before the initialization of the cluster-autoscaler container which makes this option less flexible.
+---


### PR DESCRIPTION
Add support for label(similar to tags in Azure) based auto-discovery of GCP Managed Instance Groups. The discovery includes figuring out the min and max sizes for the mig pool via labels as well.

Add unit-tests for all the new code added.

Add GCP auto-discovery documentation.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
