### PR TITLE
fix: support ErrNotImplemented for ZeroOrMaxNodeScaling nodeGroup option

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -793,14 +793,14 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clu
 		}
 		nodesToDelete := toNodes(unregisteredNodesToDelete)
 
-		opts, err := nodeGroup.GetOptions(a.NodeGroupDefaults)
+		zeroOrMaxNodeScaling, err := a.processors.NodeGroupConfigProcessor.GetZeroOrMaxNodeScaling(nodeGroup)
 		if err != nil {
 			klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
 			continue
 		}
 		// If a scale-up of "ZeroOrMaxNodeScaling" node group failed, the cleanup
 		// should stick to the all-or-nothing principle. Deleting all nodes.
-		if opts != nil && opts.ZeroOrMaxNodeScaling {
+		if zeroOrMaxNodeScaling {
 			instances, err := nodeGroup.Nodes()
 			if err != nil {
 				klog.Warningf("Failed to fill in unregistered nodes from group %s based on ZeroOrMaxNodeScaling option: %s", nodeGroupId, err)
@@ -872,15 +872,14 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
 		} else {
-			var opts *config.NodeGroupAutoscalingOptions
-			opts, err = nodeGroup.GetOptions(a.NodeGroupDefaults)
+			zeroOrMaxNodeScaling, err := a.processors.NodeGroupConfigProcessor.GetZeroOrMaxNodeScaling(nodeGroup)
 			if err != nil {
 				klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
 				continue
 			}
 			// If a scale-up of "ZeroOrMaxNodeScaling" node group failed, the cleanup
 			// should stick to the all-or-nothing principle. Deleting all nodes.
-			if opts != nil && opts.ZeroOrMaxNodeScaling {
+			if zeroOrMaxNodeScaling {
 				instances, err := nodeGroup.Nodes()
 				if err != nil {
 					klog.Warningf("Failed to fill in failed nodes from group %s based on ZeroOrMaxNodeScaling option: %s", nodeGroupId, err)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1603,7 +1603,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 		clusterStateRegistry:  clusterState,
 		lastScaleUpTime:       time.Now(),
 		lastScaleDownFailTime: time.Now(),
-		processorCallbacks:    processorCallbacks,
+		processors: &ca_processors.AutoscalingProcessors{
+			NodeGroupConfigProcessor: nodeGroupConfigProcessor,
+		},
+		processorCallbacks: processorCallbacks,
 	}
 
 	nodeGroupA := &mockprovider.NodeGroup{}
@@ -2178,10 +2181,13 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 		},
 		CloudProvider: provider,
 	}
+
+	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(context.AutoscalingOptions.NodeGroupDefaults)
+
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}, fakeLogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(context.AutoscalingOptions.NodeGroupDefaults))
+	}, fakeLogRecorder, NewBackoff(), nodeGroupConfigProcessor)
 	err := clusterState.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
@@ -2191,6 +2197,9 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	autoscaler := &StaticAutoscaler{
 		AutoscalingContext:   context,
 		clusterStateRegistry: clusterState,
+		processors: &ca_processors.AutoscalingProcessors{
+			NodeGroupConfigProcessor: nodeGroupConfigProcessor,
+		},
 	}
 
 	// Nothing should be removed. The unregistered node is not old enough.
@@ -2238,10 +2247,11 @@ func TestRemoveOldUnregisteredNodesAtomic(t *testing.T) {
 		},
 		CloudProvider: provider,
 	}
+	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(context.AutoscalingOptions.NodeGroupDefaults)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}, fakeLogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(context.AutoscalingOptions.NodeGroupDefaults))
+	}, fakeLogRecorder, NewBackoff(), nodeGroupConfigProcessor)
 	err := clusterState.UpdateNodes([]*apiv1.Node{regNode}, nil, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
@@ -2251,6 +2261,9 @@ func TestRemoveOldUnregisteredNodesAtomic(t *testing.T) {
 	autoscaler := &StaticAutoscaler{
 		AutoscalingContext:   context,
 		clusterStateRegistry: clusterState,
+		processors: &ca_processors.AutoscalingProcessors{
+			NodeGroupConfigProcessor: nodeGroupConfigProcessor,
+		},
 	}
 
 	// Nothing should be removed. The unregistered node is not old enough.

--- a/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor.go
+++ b/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor.go
@@ -37,6 +37,8 @@ type NodeGroupConfigProcessor interface {
 	GetMaxNodeProvisionTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error)
 	// GetIgnoreDaemonSetsUtilization returns IgnoreDaemonSetsUtilization value that should be used for a given NodeGroup.
 	GetIgnoreDaemonSetsUtilization(nodeGroup cloudprovider.NodeGroup) (bool, error)
+	// GetZeroOrMaxNodeScaling returns ZeroOrMaxNodeScaling value that should be used for a given NodeGroup.
+	GetZeroOrMaxNodeScaling(nodeGroup cloudprovider.NodeGroup) (bool, error)
 	// CleanUp cleans up processor's internal structures.
 	CleanUp()
 }
@@ -118,6 +120,18 @@ func (p *DelegatingNodeGroupConfigProcessor) GetIgnoreDaemonSetsUtilization(node
 		return p.nodeGroupDefaults.IgnoreDaemonSetsUtilization, nil
 	}
 	return ngConfig.IgnoreDaemonSetsUtilization, nil
+}
+
+// GetZeroOrMaxNodeScaling returns ZeroOrMaxNodeScaling value that should be used for a given NodeGroup.
+func (p *DelegatingNodeGroupConfigProcessor) GetZeroOrMaxNodeScaling(nodeGroup cloudprovider.NodeGroup) (bool, error) {
+	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
+	if err != nil && err != cloudprovider.ErrNotImplemented {
+		return false, err
+	}
+	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+		return p.nodeGroupDefaults.ZeroOrMaxNodeScaling, nil
+	}
+	return ngConfig.ZeroOrMaxNodeScaling, nil
 }
 
 // CleanUp cleans up processor's internal structures.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Previously the code would fail with a log if `NodeGroup.GetOptions(options)`  returns a `ErrNotImplemented` (which is currently the case in e.g. the `clusterapi` provider). 

#### Which issue(s) this PR fixes:
related to #6676 and #6599 but I didn't check all instances where it calls GetOptions() yet so it might not fully fix those issues.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

