### PR TITLE
[CA 1.28 #6596 cherry-pick] Remove shadow err variable in deleteCreatedNodesWithErros func

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -848,7 +848,8 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
 		} else {
-			opts, err := nodeGroup.GetOptions(a.NodeGroupDefaults)
+			var opts *config.NodeGroupAutoscalingOptions
+			opts, err = nodeGroup.GetOptions(a.NodeGroupDefaults)
 			if err != nil {
 				klog.Warningf("Failed to get node group options for %s: %s", nodeGroupId, err)
 				continue


### PR DESCRIPTION
Cherry-pick of #6596 to Cluster Autoscaler 1.28 branch