### PR TITLE
Bump VPA version to 1.1.1

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.1.0"
+const VerticalPodAutoscalerVersion = "1.1.1"


### PR DESCRIPTION
#### What type of PR is this?

Bump version for 1.1.1 release

#### What this PR does / why we need it:

Part of https://github.com/kubernetes/autoscaler/issues/6765