### PR TITLE
Refactor scale-up to apply resource limits before creating a node group

### DIFF
--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -122,9 +122,11 @@ type ScaleUpTestConfig struct {
 	Pods                    []PodConfig
 	ExtraPods               []PodConfig
 	OnScaleUp               testcloudprovider.OnScaleUpFunc
+	OnCreateGroup           testcloudprovider.OnNodeGroupCreateFunc
 	ExpansionOptionToChoose *GroupSizeChange
 	Options                 *config.AutoscalingOptions
 	NodeTemplateConfigs     map[string]*NodeTemplateConfig
+	EnableAutoprovisioning  bool
 }
 
 // ScaleUpTestResult represents a node groups scale up result


### PR DESCRIPTION
Small refactor prior to the implementation of atomic scale-up support for Provisioning Requests: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/provisioning-request.md 

#### What this PR does / why we need it:

Apply resource limits to scale-up plan before creating a new node group. Note that this is independent of the steps that happen immediately before and after - `newNodes` aren't used until we balance similar node groups, and non-existent node groups already have to expose node resources (otherwise scale-up simulations wouldn't be possible). 

There's already a check in place for skipping a node group if adding even one node would exceed resource limits, so it's not technically a bug right now, and so this PR doesn't change current behavior. However, for the atomic scale up support for Provisioning Requests, we'll want to apply resource limits before taking any action, including creating a new node group.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```