### PR TITLE
Refactor Provisioning Request orchestrator unit tests

### DIFF
--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/apps/v1"
@@ -43,6 +42,9 @@ import (
 )
 
 func TestScaleUp(t *testing.T) {
+	// Set up a cluster with 200 nodes:
+	// - 100 nodes with high cpu, low memory
+	// - 100 nodes with high memory, low cpu
 	allNodes := []*apiv1.Node{}
 	for i := 0; i < 100; i++ {
 		name := fmt.Sprintf("test-cpu-node-%d", i)
@@ -54,13 +56,68 @@ func TestScaleUp(t *testing.T) {
 		node := BuildTestNode(name, 1, 1000)
 		allNodes = append(allNodes, node)
 	}
-	newCpuProvReq := provreqwrapper.BuildTestProvisioningRequest("ns", "newCpuProvReq", "5m", "5", "", int32(100), false, time.Now(), v1beta1.ProvisioningClassCheckCapacity)
-	newMemProvReq := provreqwrapper.BuildTestProvisioningRequest("ns", "newMemProvReq", "1m", "100", "", int32(100), false, time.Now(), v1beta1.ProvisioningClassCheckCapacity)
-	bookedCapacityProvReq := provreqwrapper.BuildTestProvisioningRequest("ns", "bookedCapacity", "1m", "200", "", int32(100), false, time.Now(), v1beta1.ProvisioningClassCheckCapacity)
+
+	// Active check capacity requests.
+	newCheckCapacityCpuProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "newCheckCapacityCpuProvReq",
+			CPU:      "5m",
+			Memory:   "5",
+			PodCount: int32(100),
+			Class:    v1beta1.ProvisioningClassCheckCapacity,
+		})
+
+	newCheckCapacityMemProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "newCheckCapacityMemProvReq",
+			CPU:      "1m",
+			Memory:   "100",
+			PodCount: int32(100),
+			Class:    v1beta1.ProvisioningClassCheckCapacity,
+		})
+
+	// Active atomic scale up request.
+	atomicScaleUpProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "atomicScaleUpProvReq",
+			CPU:      "1",
+			Memory:   "1",
+			PodCount: int32(5),
+			Class:    v1beta1.ProvisioningClassAtomicScaleUp,
+		})
+
+	// Already provisioned provisioning request - capacity should be booked before processing a new request.
+	bookedCapacityProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "bookedCapacityProvReq",
+			CPU:      "1m",
+			Memory:   "200",
+			PodCount: int32(100),
+			Class:    v1beta1.ProvisioningClassCheckCapacity,
+		})
 	bookedCapacityProvReq.SetConditions([]metav1.Condition{{Type: v1beta1.Provisioned, Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now()}})
-	expiredProvReq := provreqwrapper.BuildTestProvisioningRequest("ns", "bookedCapacity", "1m", "200", "", int32(100), false, time.Now(), v1beta1.ProvisioningClassCheckCapacity)
+
+	// Expired provisioning request - should be ignored.
+	expiredProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "expiredProvReq",
+			CPU:      "1m",
+			Memory:   "200",
+			PodCount: int32(100),
+			Class:    v1beta1.ProvisioningClassCheckCapacity,
+		})
 	expiredProvReq.SetConditions([]metav1.Condition{{Type: v1beta1.BookingExpired, Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now()}})
-	differentProvReqClass := provreqwrapper.BuildTestProvisioningRequest("ns", "differentProvReqClass", "1", "1", "", int32(5), false, time.Now(), v1beta1.ProvisioningClassAtomicScaleUp)
+
+	// Unsupported provisioning request - should be ignored.
+	unsupportedProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "unsupportedProvReq",
+			CPU:      "1",
+			Memory:   "1",
+			PodCount: int32(5),
+			Class:    "very much unsupported",
+		})
+
 	testCases := []struct {
 		name             string
 		provReqs         []*provreqwrapper.ProvisioningRequest
@@ -74,27 +131,27 @@ func TestScaleUp(t *testing.T) {
 			scaleUpResult: status.ScaleUpNotTried,
 		},
 		{
-			name:             "one ProvisioningRequest",
-			provReqs:         []*provreqwrapper.ProvisioningRequest{newCpuProvReq},
-			provReqToScaleUp: newCpuProvReq,
+			name:             "one ProvisioningRequest of check capacity class",
+			provReqs:         []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq},
+			provReqToScaleUp: newCheckCapacityCpuProvReq,
 			scaleUpResult:    status.ScaleUpSuccessful,
 		},
 		{
 			name:             "capacity in the cluster is booked",
-			provReqs:         []*provreqwrapper.ProvisioningRequest{newMemProvReq, bookedCapacityProvReq},
-			provReqToScaleUp: newMemProvReq,
+			provReqs:         []*provreqwrapper.ProvisioningRequest{newCheckCapacityMemProvReq, bookedCapacityProvReq},
+			provReqToScaleUp: newCheckCapacityMemProvReq,
 			scaleUpResult:    status.ScaleUpNoOptionsAvailable,
 		},
 		{
-			name:             "pods from different ProvisioningRequest class",
-			provReqs:         []*provreqwrapper.ProvisioningRequest{newCpuProvReq, bookedCapacityProvReq, differentProvReqClass},
-			provReqToScaleUp: differentProvReqClass,
+			name:             "unsupported ProvisioningRequest is ignored",
+			provReqs:         []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, bookedCapacityProvReq, atomicScaleUpProvReq, unsupportedProvReq},
+			provReqToScaleUp: unsupportedProvReq,
 			scaleUpResult:    status.ScaleUpNotTried,
 		},
 		{
-			name:             "some capacity is booked, succesfull ScaleUp",
-			provReqs:         []*provreqwrapper.ProvisioningRequest{newCpuProvReq, bookedCapacityProvReq, differentProvReqClass},
-			provReqToScaleUp: newCpuProvReq,
+			name:             "some capacity is pre-booked, successful capacity check",
+			provReqs:         []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, bookedCapacityProvReq, atomicScaleUpProvReq},
+			provReqToScaleUp: newCheckCapacityCpuProvReq,
 			scaleUpResult:    status.ScaleUpSuccessful,
 		},
 	}
@@ -106,9 +163,11 @@ func TestScaleUp(t *testing.T) {
 			provider := testprovider.NewTestCloudProvider(nil, nil)
 			autoscalingContext, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, &fake.Clientset{}, nil, provider, nil, nil)
 			assert.NoError(t, err)
+
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingContext.ClusterSnapshot, allNodes, nil)
 			prPods, err := pods.PodsForProvisioningRequest(tc.provReqToScaleUp)
 			assert.NoError(t, err)
+
 			client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, tc.provReqs...)
 			orchestrator := &provReqOrchestrator{
 				client:              client,


### PR DESCRIPTION
#### What this PR does / why we need it:

Cleanup unit tests a bit before implementing atomic scale-up support for Provisioning Requests: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/provisioning-request.md

/kind cleanup

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```