### PR TITLE
feat: Add relabelings config to ServiceMonitor resource

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.40.0
+version: 9.41.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -483,6 +483,7 @@ vpa:
 | serviceMonitor.metricRelabelings | object | `{}` | MetricRelabelConfigs to apply to samples before ingestion. |
 | serviceMonitor.namespace | string | `"monitoring"` | Namespace which Prometheus is running in. |
 | serviceMonitor.path | string | `"/metrics"` | The path to scrape for metrics; autoscaler exposes `/metrics` (this is standard) |
+| serviceMonitor.relabelings | object | `{}` | RelabelConfigs to apply to metrics before scraping. |
 | serviceMonitor.selector | object | `{"release":"prometheus-operator"}` | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install. |
 | tolerations | list | `[]` | List of node taints to tolerate (requires Kubernetes >= 1.6). |
 | topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |

--- a/charts/cluster-autoscaler/templates/servicemonitor.yaml
+++ b/charts/cluster-autoscaler/templates/servicemonitor.yaml
@@ -20,6 +20,10 @@ spec:
   - port: {{ .Values.service.portName }}
     interval: {{ .Values.serviceMonitor.interval }}
     path: {{ .Values.serviceMonitor.path }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.serviceMonitor.relabelings | indent 6) . }}
+    {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 6) . }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -398,6 +398,9 @@ serviceMonitor:
   # serviceMonitor.annotations -- Annotations to add to service monitor
   annotations: {}
   ## [RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig)
+  # serviceMonitor.relabelings -- RelabelConfigs to apply to metrics before scraping.
+  relabelings: {}
+  ## [RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig)
   # serviceMonitor.metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion.
   metricRelabelings: {}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Prometheus service discovery meta-labels `__meta_kubernetes_*` labels are not necessarily still attached to a metric when the metric_relabel_configs step is reached. Consequently, it is not possible to configure a label on pod as a metric tag using the chart solely. Adding the `relabelings` value to the ServiceMonitor will allow this use case. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added relabelings config for the ServiceMonitor to the Helm chart
```