### PR TITLE
Format BlockingPodReason in human readbale way with %v

### DIFF
--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package drain
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -67,6 +68,31 @@ const (
 	// UnexpectedError - pod is blocking scale down because of an unexpected error.
 	UnexpectedError
 )
+
+func (e BlockingPodReason) String() string {
+	switch e {
+	case NoReason:
+		return "NoReason"
+	case ControllerNotFound:
+		return "ControllerNotFound"
+	case MinReplicasReached:
+		return "MinReplicasReached"
+	case NotReplicated:
+		return "NotReplicated"
+	case LocalStorageRequested:
+		return "LocalStorageRequested"
+	case NotSafeToEvictAnnotation:
+		return "NotSafeToEvictAnnotation"
+	case UnmovableKubeSystemPod:
+		return "UnmovableKubeSystemPod"
+	case NotEnoughPdb:
+		return "NotEnoughPdb"
+	case UnexpectedError:
+		return "UnexpectedError"
+	default:
+		return fmt.Sprintf("unrecognized reason: %d", int(e))
+	}
+}
 
 // ControllerRef returns the OwnerReference to pod's controller.
 func ControllerRef(pod *apiv1.Pod) *metav1.OwnerReference {

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package drain
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -124,6 +125,60 @@ func TestIsPodLongTerminating(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsPodLongTerminating(&tc.pod, testTime); got != tc.want {
 				t.Errorf("IsPodLongTerminating() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBlockingPodReasonFormatting(t *testing.T) {
+	for _, tc := range []struct {
+		bpr  BlockingPodReason
+		want string
+	}{
+		{
+			bpr:  NoReason,
+			want: "0",
+		},
+		{
+			bpr:  ControllerNotFound,
+			want: "1",
+		},
+		{
+			bpr:  MinReplicasReached,
+			want: "2",
+		},
+		{
+			bpr:  NotReplicated,
+			want: "3",
+		},
+		{
+			bpr:  LocalStorageRequested,
+			want: "4",
+		},
+		{
+			bpr:  NotSafeToEvictAnnotation,
+			want: "5",
+		},
+		{
+			bpr:  UnmovableKubeSystemPod,
+			want: "6",
+		},
+		{
+			bpr:  NotEnoughPdb,
+			want: "7",
+		},
+		{
+			bpr:  UnexpectedError,
+			want: "8",
+		},
+		{
+			bpr:  BlockingPodReason(9),
+			want: "9",
+		},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := fmt.Sprintf("%v", tc.bpr); got != tc.want {
+				t.Errorf("got: %s, want %s", got, tc.want)
 			}
 		})
 	}

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -137,43 +137,43 @@ func TestBlockingPodReasonFormatting(t *testing.T) {
 	}{
 		{
 			bpr:  NoReason,
-			want: "0",
+			want: "NoReason",
 		},
 		{
 			bpr:  ControllerNotFound,
-			want: "1",
+			want: "ControllerNotFound",
 		},
 		{
-			bpr:  MinReplicasReached,
-			want: "2",
+			bpr:  ControllerNotFound,
+			want: "ControllerNotFound",
 		},
 		{
 			bpr:  NotReplicated,
-			want: "3",
+			want: "NotReplicated",
 		},
 		{
 			bpr:  LocalStorageRequested,
-			want: "4",
+			want: "LocalStorageRequested",
 		},
 		{
 			bpr:  NotSafeToEvictAnnotation,
-			want: "5",
+			want: "NotSafeToEvictAnnotation",
 		},
 		{
 			bpr:  UnmovableKubeSystemPod,
-			want: "6",
+			want: "UnmovableKubeSystemPod",
 		},
 		{
 			bpr:  NotEnoughPdb,
-			want: "7",
+			want: "NotEnoughPdb",
 		},
 		{
 			bpr:  UnexpectedError,
-			want: "8",
+			want: "UnexpectedError",
 		},
 		{
 			bpr:  BlockingPodReason(9),
-			want: "9",
+			want: "unrecognized reason: 9",
 		},
 	} {
 		t.Run(tc.want, func(t *testing.T) {


### PR DESCRIPTION
Without this the enum is output as its int value, which is not readable

/kind cleanup