### PR TITLE
add least-nodes expander to cluster-autoscaler

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -737,6 +737,8 @@ smaller nodes at once.
 * `least-waste` - selects the node group that will have the least idle CPU (if tied, unused memory)
 after scale-up. This is useful when you have different classes of nodes, for example, high CPU or high memory nodes, and only want to expand those when there are pending pods that need a lot of those resources.
 
+* `least-nodes` - selects the node group that will use the least number of nodes after scale-up. This is useful when you want to minimize the number of nodes in the cluster and instead opt for fewer larger nodes. Useful when chained with the `most-pods` expander before it to ensure that the node group selected can fit the most pods on the fewest nodes.
+
 * `price` - select the node group that will cost the least and, at the same time, whose machines
 would match the cluster size. This expander is described in more details
 [HERE](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/pricing.md). Currently it works only for GCE, GKE and Equinix Metal (patches welcome.)

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -31,6 +31,8 @@ var (
 	MostPodsExpanderName = "most-pods"
 	// LeastWasteExpanderName selects a node group that leaves the least fraction of CPU and Memory
 	LeastWasteExpanderName = "least-waste"
+	// LeastNodesExpanderName selects a node group that uses the least number of nodes
+	LeastNodesExpanderName = "least-nodes"
 	// PriceBasedExpanderName selects a node group that is the most cost-effective and consistent with
 	// the preferred node size for the cluster
 	PriceBasedExpanderName = "price"

--- a/cluster-autoscaler/expander/factory/expander_factory.go
+++ b/cluster-autoscaler/expander/factory/expander_factory.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/grpcplugin"
+	"k8s.io/autoscaler/cluster-autoscaler/expander/leastnodes"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/mostpods"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/price"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/priority"
@@ -82,6 +83,7 @@ func (f *Factory) RegisterDefaultExpanders(cloudProvider cloudprovider.CloudProv
 	f.RegisterFilter(expander.RandomExpanderName, random.NewFilter)
 	f.RegisterFilter(expander.MostPodsExpanderName, mostpods.NewFilter)
 	f.RegisterFilter(expander.LeastWasteExpanderName, waste.NewFilter)
+	f.RegisterFilter(expander.LeastNodesExpanderName, leastnodes.NewFilter)
 	f.RegisterFilter(expander.PriceBasedExpanderName, func() expander.Filter {
 		if _, err := cloudProvider.Pricing(); err != nil {
 			klog.Fatalf("Couldn't access cloud provider pricing for %s expander: %v", expander.PriceBasedExpanderName, err)

--- a/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
+++ b/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
@@ -25,18 +25,89 @@ import (
 )
 
 func TestLeastNodes(t *testing.T) {
-	e := NewFilter()
-
-	eo0 := expander.Option{Debug: "EO0", NodeCount: 2}
-	ret := e.BestOptions([]expander.Option{eo0}, nil)
-	assert.Equal(t, ret, []expander.Option{eo0})
-
-	eo1 := expander.Option{Debug: "EO1", NodeCount: 1}
-	ret = e.BestOptions([]expander.Option{eo0, eo1}, nil)
-	assert.Equal(t, ret, []expander.Option{eo1})
-
-	eo1b := expander.Option{Debug: "EO1b", NodeCount: 1}
-	ret = e.BestOptions([]expander.Option{eo0, eo1, eo1b}, nil)
-	assert.NotEqual(t, ret, []expander.Option{eo1})
-	assert.ObjectsAreEqual(ret, []expander.Option{eo1, eo1b})
+	for _, tc := range []struct {
+		name                     string
+		expansionOptions         []expander.Option
+		expectedExpansionOptions []expander.Option
+	}{
+		{
+			name:                     "no options",
+			expansionOptions:         nil,
+			expectedExpansionOptions: nil,
+		},
+		{
+			name: "no valid options",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 0},
+			},
+			expectedExpansionOptions: nil,
+		},
+		{
+			name: "1 valid option",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 2},
+			},
+			expectedExpansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 2},
+			},
+		},
+		{
+			name: "2 valid options, not equal",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 2},
+				{Debug: "EO1", NodeCount: 1},
+			},
+			expectedExpansionOptions: []expander.Option{
+				{Debug: "EO1", NodeCount: 1},
+			},
+		},
+		{
+			name: "3 valid options, 2 equal",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 6},
+				{Debug: "EO1", NodeCount: 2},
+				{Debug: "EO2", NodeCount: 2},
+			},
+			expectedExpansionOptions: []expander.Option{
+				{Debug: "EO1", NodeCount: 2},
+				{Debug: "EO2", NodeCount: 2},
+			},
+		},
+		{
+			name: "3 valid options, all equal",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 8},
+				{Debug: "EO1", NodeCount: 8},
+				{Debug: "EO2", NodeCount: 8},
+			},
+			expectedExpansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 8},
+				{Debug: "EO1", NodeCount: 8},
+				{Debug: "EO2", NodeCount: 8},
+			},
+		},
+		{
+			name: "6 valid options, 1 invalid option, 3 equal",
+			expansionOptions: []expander.Option{
+				{Debug: "EO0", NodeCount: 23},
+				{Debug: "EO1", NodeCount: 0},
+				{Debug: "EO2", NodeCount: 5},
+				{Debug: "EO3", NodeCount: 8},
+				{Debug: "EO4", NodeCount: 5},
+				{Debug: "EO5", NodeCount: 5},
+				{Debug: "EO6", NodeCount: 22},
+			},
+			expectedExpansionOptions: []expander.Option{
+				{Debug: "EO2", NodeCount: 5},
+				{Debug: "EO4", NodeCount: 5},
+				{Debug: "EO5", NodeCount: 5},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewFilter()
+			ret := e.BestOptions(tc.expansionOptions, nil)
+			assert.Equal(t, ret, tc.expectedExpansionOptions)
+		})
+	}
 }

--- a/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
+++ b/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leastnodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+)
+
+func TestLeastNodes(t *testing.T) {
+	e := NewFilter()
+
+	eo0 := expander.Option{Debug: "EO0", NodeCount: 2}
+	ret := e.BestOptions([]expander.Option{eo0}, nil)
+	assert.Equal(t, ret, []expander.Option{eo0})
+
+	eo1 := expander.Option{Debug: "EO1", NodeCount: 1}
+	ret = e.BestOptions([]expander.Option{eo0, eo1}, nil)
+	assert.Equal(t, ret, []expander.Option{eo1})
+
+	eo1b := expander.Option{Debug: "EO1b", NodeCount: 1}
+	ret = e.BestOptions([]expander.Option{eo0, eo1, eo1b}, nil)
+	assert.NotEqual(t, ret, []expander.Option{eo1})
+	assert.ObjectsAreEqual(ret, []expander.Option{eo1, eo1b})
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a new `least-nodes` expander 🎉 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No related issues

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new `least-nodes` expander
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
