### PR TITLE
Update VPA dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,28 +6,28 @@ updates:
     interval: daily
   open-pull-requests-limit: 0 # setting this to 0 means only allowing security updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
   labels:
-    - "vertical-pod-autoscaler"
+    - "area/vertical-pod-autoscaler"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/recommender"
   schedule:
     interval: daily
   open-pull-requests-limit: 3
   labels:
-    - "vertical-pod-autoscaler"
+    - "area/vertical-pod-autoscaler"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/updater"
   schedule:
     interval: daily
   open-pull-requests-limit: 3
   labels:
-    - "vertical-pod-autoscaler"
+    - "area/vertical-pod-autoscaler"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/admission-controller"
   schedule:
     interval: daily
   open-pull-requests-limit: 3
   labels:
-    - "vertical-pod-autoscaler"
+    - "area/vertical-pod-autoscaler"
 - package-ecosystem: gomod
   directory: "/addon-resizer"
   schedule:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
Some time back we changed the labels to be correctly prefixed with `area/`. Dependabot still had the old labels configured, which resulted in errors like this: https://github.com/kubernetes/autoscaler/pull/6799#issuecomment-2099022655

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
