### PR TITLE
Reduce memory usage by scoping informers

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -92,7 +92,7 @@ func main() {
 	vpaClient := vpa_clientset.NewForConfigOrDie(config)
 	vpaLister := vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), *vpaObjectNamespace)
 	kubeClient := kube_client.NewForConfigOrDie(config)
-	factory := informers.NewSharedInformerFactory(kubeClient, defaultResyncPeriod)
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(*vpaObjectNamespace))
 	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(config, kubeClient, factory)
 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 	podPreprocessor := pod.NewDefaultPreProcessor()

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -159,21 +159,21 @@ func (e *podsEvictionRestrictionImpl) Evict(podToEvict *apiv1.Pod, eventRecorder
 }
 
 // NewPodsEvictionRestrictionFactory creates PodsEvictionRestrictionFactory
-func NewPodsEvictionRestrictionFactory(client kube_client.Interface, minReplicas int,
+func NewPodsEvictionRestrictionFactory(client kube_client.Interface, namespace string, minReplicas int,
 	evictionToleranceFraction float64) (PodsEvictionRestrictionFactory, error) {
-	rcInformer, err := setUpInformer(client, replicationController)
+	rcInformer, err := setUpInformer(client, namespace, replicationController)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create rcInformer: %v", err)
 	}
-	ssInformer, err := setUpInformer(client, statefulSet)
+	ssInformer, err := setUpInformer(client, namespace, statefulSet)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create ssInformer: %v", err)
 	}
-	rsInformer, err := setUpInformer(client, replicaSet)
+	rsInformer, err := setUpInformer(client, namespace, replicaSet)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create rsInformer: %v", err)
 	}
-	dsInformer, err := setUpInformer(client, daemonSet)
+	dsInformer, err := setUpInformer(client, namespace, daemonSet)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create dsInformer: %v", err)
 	}
@@ -365,20 +365,20 @@ func managingControllerRef(pod *apiv1.Pod) *metav1.OwnerReference {
 	return &managingController
 }
 
-func setUpInformer(kubeClient kube_client.Interface, kind controllerKind) (cache.SharedIndexInformer, error) {
+func setUpInformer(kubeClient kube_client.Interface, namespace string, kind controllerKind) (cache.SharedIndexInformer, error) {
 	var informer cache.SharedIndexInformer
 	switch kind {
 	case replicationController:
-		informer = coreinformer.NewReplicationControllerInformer(kubeClient, apiv1.NamespaceAll,
+		informer = coreinformer.NewReplicationControllerInformer(kubeClient, namespace,
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	case replicaSet:
-		informer = appsinformer.NewReplicaSetInformer(kubeClient, apiv1.NamespaceAll,
+		informer = appsinformer.NewReplicaSetInformer(kubeClient, namespace,
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	case statefulSet:
-		informer = appsinformer.NewStatefulSetInformer(kubeClient, apiv1.NamespaceAll,
+		informer = appsinformer.NewStatefulSetInformer(kubeClient, namespace,
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	case daemonSet:
-		informer = appsinformer.NewDaemonSetInformer(kubeClient, apiv1.NamespaceAll,
+		informer = appsinformer.NewDaemonSetInformer(kubeClient, namespace,
 			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	default:
 		return nil, fmt.Errorf("Unknown controller kind: %v", kind)

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -86,7 +86,7 @@ func NewUpdater(
 	namespace string,
 ) (Updater, error) {
 	evictionRateLimiter := getRateLimiter(evictionRateLimit, evictionRateBurst)
-	factory, err := eviction.NewPodsEvictionRestrictionFactory(kubeClient, minReplicasForEvicition, evictionToleranceFraction)
+	factory, err := eviction.NewPodsEvictionRestrictionFactory(kubeClient, namespace, minReplicasForEvicition, evictionToleranceFraction)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create eviction restriction factory: %v", err)
 	}

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -88,7 +88,7 @@ func main() {
 	config := common.CreateKubeConfigOrDie(*kubeconfig, float32(*kubeApiQps), int(*kubeApiBurst))
 	kubeClient := kube_client.NewForConfigOrDie(config)
 	vpaClient := vpa_clientset.NewForConfigOrDie(config)
-	factory := informers.NewSharedInformerFactory(kubeClient, defaultResyncPeriod)
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(*vpaObjectNamespace))
 	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(config, kubeClient, factory)
 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 	var limitRangeCalculator limitrange.LimitRangeCalculator


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR reduces the memory usage of **vpa-updater** and **vpa-admission-controller** in large clusters by scoping informers to namespaces.

##### Test Results

**Cluster-Info**:
```shell
$ k get pod --all-namespaces | wc -l
    8915
$ k get ds --all-namespaces | wc -l
      17
$ k get deploy --all-namespaces | wc -l
    6316
$ k get sts --all-namespaces | wc -l
      20
$ k get rs --all-namespaces | wc -l
   63861
$ k get job --all-namespaces | wc -l
      87
```

**Running arguments**:
```yaml
      spec:
        containers:
        - args:
          - --vpa-object-namespace=my-namespace
          env:
          image: autoscaling/vpa-admission-controller:1.0.0 # or patched one
---
      spec:
        containers:
        - args:
          - --vpa-object-namespace=my-namespace
          image: autoscaling/vpa-updater:1.0.0 # or patched one
```


**Image:1.0.0**
```shell
NAME                                                             CPU(cores)   MEMORY(bytes)
vpa-admission-controller-youngbo-6595d7855c-tc2n8                6m           2348Mi
vpa-recommender-84d65bf78c-lr64k                                 3m           83Mi
vpa-updater-youngbo-74f7584cb6-z8dzm                             1m           3899Mi
```

**Image:1.0.0-patched**:
```shell
NAME                                                             CPU(cores)   MEMORY(bytes)
vpa-admission-controller-youngbo-8566bbd869-wqppr                2m           14Mi
vpa-recommender-84d65bf78c-lr64k                                 9m           82Mi
vpa-updater-youngbo-5f56bf954b-sgzx8                             1m           42Mi
```


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- vpa-updater: Reduce memory usage when --vpa-object-namespace option provided
- vpa-admission-controller: Reduce memory usage when --vpa-object-namespace option provided
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
