### PR TITLE
[Azure VMs Pool] Support mixed agentpool types in Azure Cache

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -51,6 +51,7 @@ type azureCache struct {
 	// Cache content.
 	resourceGroup        string
 	vmType               string
+	vmsPoolSet           map[string]struct{} // track the nodepools that're vms pool
 	scaleSets            map[string]compute.VirtualMachineScaleSet
 	virtualMachines      map[string][]compute.VirtualMachine
 	registeredNodeGroups []cloudprovider.NodeGroup
@@ -67,6 +68,7 @@ func newAzureCache(client *azClient, cacheTTL time.Duration, resourceGroup, vmTy
 		refreshInterval:      cacheTTL,
 		resourceGroup:        resourceGroup,
 		vmType:               vmType,
+		vmsPoolSet:           make(map[string]struct{}),
 		scaleSets:            make(map[string]compute.VirtualMachineScaleSet),
 		virtualMachines:      make(map[string][]compute.VirtualMachine),
 		registeredNodeGroups: make([]cloudprovider.NodeGroup, 0),
@@ -85,6 +87,13 @@ func newAzureCache(client *azClient, cacheTTL time.Duration, resourceGroup, vmTy
 	}
 
 	return cache, nil
+}
+
+func (m *azureCache) getVMsPoolSet() map[string]struct{} {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.vmsPoolSet
 }
 
 func (m *azureCache) getVirtualMachines() map[string][]compute.VirtualMachine {
@@ -165,54 +174,77 @@ func (m *azureCache) fetchAzureResources() error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	switch m.vmType {
-	case vmTypeVMSS:
-		// List all VMSS in the RG.
-		vmssResult, err := m.fetchScaleSets()
-		if err == nil {
-			m.scaleSets = vmssResult
-		} else {
-			return err
-		}
-	case vmTypeStandard:
-		// List all VMs in the RG.
-		vmResult, err := m.fetchVirtualMachines()
-		if err == nil {
-			m.virtualMachines = vmResult
-		} else {
-			return err
-		}
+	// fetch all the resources since CAS may be operating on mixed nodepools
+	// including both VMSS and VMs pools
+	vmssResult, err := m.fetchScaleSets()
+	if err == nil {
+		m.scaleSets = vmssResult
+	} else {
+		return err
+	}
+
+	vmResult, vmsPoolSet, err := m.fetchVirtualMachines()
+	if err == nil {
+		m.virtualMachines = vmResult
+		m.vmsPoolSet = vmsPoolSet
+	} else {
+		return err
 	}
 
 	return nil
 }
 
+const (
+	legacyAgentpoolNameTag = "poolName"
+	agentpoolNameTag       = "aks-managed-poolName"
+	agentpoolTypeTag       = "aks-managed-agentpool-type"
+	vmsPoolType            = "VirtualMachines"
+)
+
 // fetchVirtualMachines returns the updated list of virtual machines in the config resource group using the Azure API.
-func (m *azureCache) fetchVirtualMachines() (map[string][]compute.VirtualMachine, error) {
+func (m *azureCache) fetchVirtualMachines() (map[string][]compute.VirtualMachine, map[string]struct{}, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
 	result, err := m.azClient.virtualMachinesClient.List(ctx, m.resourceGroup)
 	if err != nil {
 		klog.Errorf("VirtualMachinesClient.List in resource group %q failed: %v", m.resourceGroup, err)
-		return nil, err.Error()
+		return nil, nil, err.Error()
 	}
 
 	instances := make(map[string][]compute.VirtualMachine)
+	// track the nodepools that're vms pools
+	vmsPoolSet := make(map[string]struct{})
 	for _, instance := range result {
 		if instance.Tags == nil {
 			continue
 		}
 
 		tags := instance.Tags
-		vmPoolName := tags["poolName"]
+		vmPoolName := tags[agentpoolNameTag]
+		// fall back to legacy tag name if not found
+		if vmPoolName == nil {
+			vmPoolName = tags[legacyAgentpoolNameTag]
+		}
 		if vmPoolName == nil {
 			continue
 		}
 
 		instances[to.String(vmPoolName)] = append(instances[to.String(vmPoolName)], instance)
+
+		// if the nodepool is already in the map, skip it
+		if _, ok := vmsPoolSet[to.String(vmPoolName)]; ok {
+			continue
+		}
+
+		// nodes from vms pool will have tag "aks-managed-agentpool-type" set to "VirtualMachines"
+		if agnetpoolType := tags[agentpoolTypeTag]; agnetpoolType != nil {
+			if strings.EqualFold(to.String(agnetpoolType), vmsPoolType) {
+				vmsPoolSet[to.String(vmPoolName)] = struct{}{}
+			}
+		}
 	}
-	return instances, nil
+	return instances, vmsPoolSet, nil
 }
 
 // fetchScaleSets returns the updated list of scale sets in the config resource group using the Azure API.
@@ -323,6 +355,7 @@ func (m *azureCache) getAutoscalingOptions(ref azureRef) map[string]string {
 
 // FindForInstance returns node group of the given Instance
 func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudprovider.NodeGroup, error) {
+	vmsPoolSet := m.getVMsPoolSet()
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -340,7 +373,8 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 		return nil, nil
 	}
 
-	if vmType == vmTypeVMSS {
+	// cluster with vmss pool only
+	if vmType == vmTypeVMSS && len(vmsPoolSet) == 0 {
 		if m.areAllScaleSetsUniform() {
 			// Omit virtual machines not managed by vmss only in case of uniform scale set.
 			if ok := virtualMachineRE.Match([]byte(inst.Name)); ok {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -161,6 +161,11 @@ func (m *AzureManager) buildNodeGroupFromSpec(spec string) (cloudprovider.NodeGr
 		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
 	}
 
+	vmsPoolSet := m.azureCache.getVMsPoolSet()
+	if _, ok := vmsPoolSet[s.Name]; ok {
+		return NewVMsPool(s, m), nil
+	}
+
 	switch m.config.VMType {
 	case vmTypeStandard:
 		return NewAgentPool(s, m)

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -144,6 +144,7 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachineScaleSet{}, nil).Times(2)
+	mockVMClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachine{}, nil).Times(2)
 	mockAzClient := &azClient{
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
@@ -226,6 +227,7 @@ func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
 	mockVMClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachine{}, nil).Times(2)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachineScaleSet{}, nil).Times(2)
 	mockAzClient := &azClient{
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
@@ -338,6 +340,7 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), "resourceGroup").Return([]compute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	mockVMClient.EXPECT().List(gomock.Any(), "resourceGroup").Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	mockAzClient := &azClient{
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
@@ -737,6 +740,9 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	manager.azClient.virtualMachinesClient = mockVMClient
+	mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	err := manager.forceRefresh()
 	assert.NoError(t, err)
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// VMsPool is single instance VM pool
+// this is a placeholder for now, no real implementation
+type VMsPool struct {
+	azureRef
+	manager       *AzureManager
+	resourceGroup string
+
+	minSize int
+	maxSize int
+
+	curSize int64
+	// sizeMutex       sync.Mutex
+	// lastSizeRefresh time.Time
+}
+
+// NewVMsPool creates a new VMsPool
+func NewVMsPool(spec *dynamic.NodeGroupSpec, am *AzureManager) *VMsPool {
+	nodepool := &VMsPool{
+		azureRef: azureRef{
+			Name: spec.Name,
+		},
+
+		manager:       am,
+		resourceGroup: am.config.ResourceGroup,
+
+		curSize: -1,
+		minSize: spec.MinSize,
+		maxSize: spec.MaxSize,
+	}
+
+	return nodepool
+}
+
+// MinSize returns the minimum size the cluster is allowed to scaled down
+// to as provided by the node spec in --node parameter.
+func (agentPool *VMsPool) MinSize() int {
+	return agentPool.minSize
+}
+
+// Exist is always true since we are initialized with an existing agentpool
+func (agentPool *VMsPool) Exist() bool {
+	return true
+}
+
+// Create creates the node group on the cloud provider side.
+func (agentPool *VMsPool) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrAlreadyExist
+}
+
+// Delete deletes the node group on the cloud provider side.
+func (agentPool *VMsPool) Delete() error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// Autoprovisioned is always false since we are initialized with an existing agentpool
+func (agentPool *VMsPool) Autoprovisioned() bool {
+	return false
+}
+
+// GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
+// NodeGroup. Returning a nil will result in using default options.
+func (agentPool *VMsPool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	// TODO(wenxuan): Implement this method
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// MaxSize returns the maximum size scale limit provided by --node
+// parameter to the autoscaler main
+func (agentPool *VMsPool) MaxSize() int {
+	return agentPool.maxSize
+}
+
+// TargetSize returns the current TARGET size of the node group. It is possible that the
+// number is different from the number of nodes registered in Kubernetes.
+func (agentPool *VMsPool) TargetSize() (int, error) {
+	// TODO(wenxuan): Implement this method
+	return -1, cloudprovider.ErrNotImplemented
+}
+
+// IncreaseSize increase the size through a PUT AP call. It calculates the expected size
+// based on a delta provided as parameter
+func (agentPool *VMsPool) IncreaseSize(delta int) error {
+	// TODO(wenxuan): Implement this method
+	return cloudprovider.ErrNotImplemented
+}
+
+// DeleteNodes extracts the providerIDs from the node spec and
+// delete or deallocate the nodes from the agent pool based on the scale down policy.
+func (agentPool *VMsPool) DeleteNodes(nodes []*apiv1.Node) error {
+	// TODO(wenxuan): Implement this method
+	return cloudprovider.ErrNotImplemented
+}
+
+// DecreaseTargetSize decreases the target size of the node group.
+func (agentPool *VMsPool) DecreaseTargetSize(delta int) error {
+	// TODO(wenxuan): Implement this method
+	return cloudprovider.ErrNotImplemented
+}
+
+// Id returns the name of the agentPool
+func (agentPool *VMsPool) Id() string {
+	return agentPool.azureRef.Name
+}
+
+// Debug returns a string with basic details of the agentPool
+func (agentPool *VMsPool) Debug() string {
+	return fmt.Sprintf("%s (%d:%d)", agentPool.Id(), agentPool.MinSize(), agentPool.MaxSize())
+}
+
+func (agentPool *VMsPool) getVMsFromCache() ([]compute.VirtualMachine, error) {
+	// vmsPoolMap is a map of agent pool name to the list of virtual machines
+	vmsPoolMap := agentPool.manager.azureCache.getVirtualMachines()
+	if _, ok := vmsPoolMap[agentPool.Name]; !ok {
+		return []compute.VirtualMachine{}, fmt.Errorf("vms pool %s not found in the cache", agentPool.Name)
+	}
+
+	return vmsPoolMap[agentPool.Name], nil
+}
+
+// Nodes returns the list of nodes in the vms agentPool.
+func (agentPool *VMsPool) Nodes() ([]cloudprovider.Instance, error) {
+	vms, err := agentPool.getVMsFromCache()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]cloudprovider.Instance, 0, len(vms))
+	for _, vm := range vms {
+		if len(*vm.ID) == 0 {
+			continue
+		}
+		resourceID, err := convertResourceGroupNameToLower("azure://" + *vm.ID)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, cloudprovider.Instance{Id: resourceID})
+	}
+
+	return nodes, nil
+}
+
+// TemplateNodeInfo is not implemented.
+func (agentPool *VMsPool) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// AtomicIncreaseSize is not implemented.
+func (agentPool *VMsPool) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func newTestVMsPool(manager *AzureManager, name string) *VMsPool {
+	return &VMsPool{
+		azureRef: azureRef{
+			Name: name,
+		},
+		manager: manager,
+		minSize: 3,
+		maxSize: 10,
+	}
+}
+
+const (
+	fakeVMsPoolVMID = "/subscriptions/test-subscription-id/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/%d"
+)
+
+func newTestVMsPoolVMList(count int) []compute.VirtualMachine {
+	var vmList []compute.VirtualMachine
+	for i := 0; i < count; i++ {
+		vm := compute.VirtualMachine{
+			ID: to.StringPtr(fmt.Sprintf(fakeVMsPoolVMID, i)),
+			VirtualMachineProperties: &compute.VirtualMachineProperties{
+				VMID: to.StringPtr(fmt.Sprintf("123E4567-E89B-12D3-A456-426655440000-%d", i)),
+			},
+			Tags: map[string]*string{
+				agentpoolTypeTag: to.StringPtr("VirtualMachines"),
+				agentpoolNameTag: to.StringPtr("test-vms-pool"),
+			},
+		}
+		vmList = append(vmList, vm)
+	}
+	return vmList
+}
+
+func newVMsNode(vmID int64) *apiv1.Node {
+	node := &apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: "azure://" + fmt.Sprintf(fakeVMsPoolVMID, vmID),
+		},
+	}
+	return node
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use Azure cache to track VMs pools. As of today, CAS can only be used for single type of agentpool - either vmss or standard. We need to support vms pool and mixed agentpool types (vmss + vms). During the cache generation, we will fetch all resources regardless of the vmType, and also track the vms pools using a set (implemented with golang map) so we can distinguish between vmss vm instances and vms instances.

More details in the PR targeting 1.29 release:
https://github.com/kubernetes/autoscaler/pull/6689

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
