### PR TITLE
fix: Handle placeholder instance decommission safely in AWS ASGs

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -308,14 +308,37 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 		}
 	}
 
-	for _, instance := range instances {
-		// check if the instance is a placeholder - a requested instance that was never created by the node group
-		// if it is, just decrease the size of the node group, as there's no specific instance we can remove
-		if m.isPlaceholderInstance(instance) {
-			klog.V(4).Infof("instance %s is detected as a placeholder, decreasing ASG requested size instead "+
-				"of deleting instance", instance.Name)
-			m.decreaseAsgSizeByOneNoLock(commonAsg)
-		} else {
+    // Initialize the success flag for recent scaling activity.
+    var recentScalingActivitySuccess = false
+    var err error
+
+    // Check if there are any placeholder instances in the list.
+    if m.HasPlaceholder(instances) {
+        // Log the check for placeholders in the ASG.
+        klog.V(4).Infof("Detected a placeholder instance, checking recent scaling activity for ASG %s", commonAsg.Name)
+
+        // Retrieve the most recent scaling activity to determine its success state.
+        recentScalingActivitySuccess, err = m.getMostRecentScalingActivity(commonAsg)
+
+        // Handle errors from retrieving scaling activity.
+        if err != nil {
+            // Log the error if the scaling activity check fails and return the error.
+            klog.Errorf("Error retrieving scaling activity for ASG %s: %v", commonAsg.Name, err)
+            return err  // Return error to prevent further processing with uncertain state information.
+        }
+    }
+
+    for _, instance := range instances {
+        if m.isPlaceholderInstance(instance) {
+            if !recentScalingActivitySuccess {
+                // Log that scaling down due to unsuccessful recent activity
+                klog.V(4).Infof("Recent scaling activity unsuccessful; reducing ASG size for placeholder %s in ASG %s", instance.Name, commonAsg.Name)
+                m.decreaseAsgSizeByOneNoLock(commonAsg)
+                continue  // Continue to the next iteration after handling placeholder
+            }
+            klog.V(4).Infof("Skipping actions for placeholder %s in ASG %s due to successful recent scaling", instance.Name, commonAsg.Name)
+            continue
+        } else {
 			// check if the instance is already terminating - if it is, don't bother terminating again
 			// as doing so causes unnecessary API calls and can cause the curSize cached value to decrement
 			// unnecessarily.
@@ -350,6 +373,45 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 		}
 	}
 	return nil
+}
+
+func (m *asgCache) getMostRecentScalingActivity(asg *asg) (bool, error) {
+    input := &autoscaling.DescribeScalingActivitiesInput{
+        AutoScalingGroupName: aws.String(asg.Name),
+        MaxRecords:           aws.Int64(1),
+    }
+
+    var response *autoscaling.DescribeScalingActivitiesOutput
+    var err error
+    attempts := 3
+
+    for i := 0; i < attempts; i++ {
+        response, err = m.awsService.DescribeScalingActivities(input)
+        if err == nil {
+            break
+        }
+        klog.V(2).Infof("Failed to describe scaling activities, attempt %d/%d: %v", i+1, attempts, err)
+        time.Sleep(time.Second * 2)
+    }
+
+    if err != nil {
+        klog.Errorf("All attempts failed for DescribeScalingActivities: %v", err)
+        return false, err
+    }
+
+    if len(response.Activities) == 0 {
+        klog.Info("No scaling activities found for ASG:", asg.Name)
+        return false, nil
+    }
+
+    lastActivity := response.Activities[0]
+    if *lastActivity.StatusCode == "Successful" {
+        klog.Infof("Most recent scaling activity for ASG %s was successful", asg.Name)
+        return true, nil
+    } else {
+        klog.Infof("Most recent scaling activity for ASG %s was not successful: %s", asg.Name, *lastActivity.StatusMessage)
+        return false, fmt.Errorf("most recent scaling activity for ASG %s was not successful: %s", asg.Name, *lastActivity.StatusMessage)
+    }
 }
 
 // isPlaceholderInstance checks if the given instance is only a placeholder
@@ -618,6 +680,18 @@ func (m *asgCache) buildInstanceRefFromAWS(instance *autoscaling.Instance) AwsIn
 		ProviderID: providerID,
 		Name:       aws.StringValue(instance.InstanceId),
 	}
+}
+
+func (m *asgCache) HasPlaceholder(instances []*AwsInstanceRef) bool {
+	// check if there's a placeholder instance and verify most recent scaling activity before terminating it
+	var containsPlaceholder bool = false
+	for _, instance := range instances {
+		if strings.HasPrefix(instance.Name, placeholderInstanceNamePrefix) {
+			containsPlaceholder = true
+			break
+		}
+	}
+	return containsPlaceholder
 }
 
 // Cleanup closes the channel to signal the go routine to stop that is handling the cache


### PR DESCRIPTION
**Merge branch 'fix/aws-asg-placeholder-decommission'**

This merge resolves an issue in the Kubernetes Cluster Autoscaler where actual instances within AWS Auto Scaling Groups (ASGs) were incorrectly decommissioned instead of placeholders. The updates ensure that placeholders are exclusively targeted for scaling down under conditions where recent scaling activities have failed. This prevents the accidental termination of active nodes and enhances the reliability of the autoscaler in AWS environments.

Key improvements include:
- Refined logic to strictly identify unsuccessful scaling activities.
- Ensured that scaling operations affect placeholders only, preventing unintended impacts on real instances.
- Expanded unit tests and validations to bolster the resilience and correctness of the scaling process.

**Fixes #5829**

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
This PR prevents the Kubernetes Cluster Autoscaler from erroneously decommissioning actual nodes during scale-down operations in AWS environments, which could lead to unintended service disruptions.

### Which issue(s) this PR fixes:
Fixes #5829

### Special notes for your reviewer:

### Does this PR introduce a user-facing change?
```release-note
Fix an issue in the Kubernetes Cluster Autoscaler where actual AWS instances could be incorrectly scaled down instead of placeholders.
