### PR TITLE
Fix nil pointer panic in eviction admission

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -108,6 +108,10 @@ func (s *scalingDirectionPodEvictionAdmission) LoopInit(_ []*apiv1.Pod, vpaContr
 	s.EvictionRequirements = make(map[*apiv1.Pod][]*vpa_types.EvictionRequirement)
 	for vpa, pods := range vpaControlledPods {
 		for _, pod := range pods {
+			// When UpdatePolicy is not specified, the default policy will be followed, and the EvictionRequirements field will be nil
+			if vpa.Spec.UpdatePolicy == nil {
+				continue
+			}
 			s.EvictionRequirements[pod] = vpa.Spec.UpdatePolicy.EvictionRequirements
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
@@ -55,6 +55,21 @@ func TestLoopInit(t *testing.T) {
 		Get()
 	vpaToPodMap := map[*v1.VerticalPodAutoscaler][]*corev1.Pod{testVPA: {pod, pod2}}
 
+	t.Run("it should not require UpdateMode and EvictionRequirements.", func(t *testing.T) {
+		sdpea := NewScalingDirectionPodEvictionAdmission()
+		sdpea.LoopInit(nil, vpaToPodMap)
+
+		newTestVPA := test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithContainer(container1Name).
+			Get()
+
+		newVpaToPodMap := map[*v1.VerticalPodAutoscaler][]*corev1.Pod{newTestVPA: {pod, pod2}}
+
+		sdpea.LoopInit(nil, newVpaToPodMap)
+		assert.Len(t, sdpea.(*scalingDirectionPodEvictionAdmission).EvictionRequirements, 0)
+	})
+
 	t.Run("it should store EvictionRequirements from VPA in a map per Pod", func(t *testing.T) {
 		sdpea := NewScalingDirectionPodEvictionAdmission()
 		sdpea.LoopInit(nil, vpaToPodMap)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
See https://github.com/kubernetes/autoscaler/issues/6808

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
6808
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
