### PR TITLE
Add --enable-provisioning-requests flag

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -258,9 +258,8 @@ var (
 			"--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default."+
 			"Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature)."+
 			"Eg. flag usage:  '10000:20,1000:100,0:60'")
-	// Intentionally disabled for the 1.30 Cluster Autoscaler release, since the ProvisioningRequest API is not stable yet.
-	// provisioningRequestsEnabled = flag.Bool("enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
-	frequentLoopsEnabled = flag.Bool("frequent-loops-enabled", false, "Whether clusterautoscaler triggers new iterations more frequently when it's needed")
+	provisioningRequestsEnabled = flag.Bool("enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
+	frequentLoopsEnabled        = flag.Bool("frequent-loops-enabled", false, "Whether clusterautoscaler triggers new iterations more frequently when it's needed")
 )
 
 func isFlagPassed(name string) bool {
@@ -433,8 +432,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		},
 		DynamicNodeDeleteDelayAfterTaintEnabled: *dynamicNodeDeleteDelayAfterTaintEnabled,
 		BypassedSchedulers:                      scheduler_util.GetBypassedSchedulersMap(*bypassedSchedulers),
-		// Intentionally disabled for the 1.30 Cluster Autoscaler release, since the ProvisioningRequest API is not stable yet.
-		ProvisioningRequestEnabled: false,
+		ProvisioningRequestEnabled:              *provisioningRequestsEnabled,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

Fixes #6814

Check-capacity was tested manually. The following scenarious were tested: 
- 1 ProvReq, cluster doesn’t have capacity, verify Provisioned=False
- 1 ProvReq, cluster has capacity which is used by real pods, verify Provisioned=False
- 1 ProvReq, cluster has capacity, verify Provisioned=True
- 1 ProvReq, multiple pod templates, only 1 pod template could fit, verify Provisioned=False
- 2 ProvReqs, each ProvReq could fit, but not both of them. Verify only 1 ProvReq has Provisioned=True, when BookingExpired=True, second ProvReq has Provisioned=True.

/assign @MaciekPytel  
