### PR TITLE
Extend gce MachineType with MaxDiskSizeGb

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/machine_types.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types.go
@@ -35,6 +35,8 @@ type MachineType struct {
 	CPU int64
 	// Memory is the memory capacity of the machine in bytes.
 	Memory int64
+	// MaxDisk is the maximum total persistent disks size (GB) allowed.
+	MaxDiskSizeGb int64
 }
 
 // IsCustomMachine checks if a machine type is custom or predefined.
@@ -70,9 +72,10 @@ func NewMachineTypeFromAPI(name string, mt *gce_api.MachineType) (MachineType, e
 		return MachineType{}, fmt.Errorf("Failed to create MachineType %s from empty API object", name)
 	}
 	return MachineType{
-		Name:   name,
-		CPU:    mt.GuestCpus,
-		Memory: mt.MemoryMb * units.MiB,
+		Name:          name,
+		CPU:           mt.GuestCpus,
+		Memory:        mt.MemoryMb * units.MiB,
+		MaxDiskSizeGb: mt.MaximumPersistentDisksSizeGb,
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/machine_types_test.go
@@ -118,6 +118,7 @@ func TestNewCustomMachineType(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectCPU, m.CPU)
 				assert.Equal(t, tc.expectMemory, m.Memory)
+				assert.Equal(t, int64(0), m.MaxDiskSizeGb) // unset
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add MaximumPersistentDisksSizeGb info from GCE API into MachineType and gce cache.
This value is machie-type specific, e.g. "Shared-core machine types are limited to 16 Persistent Disk volumes and 3 TiB of total Persistent Disk space."

ref: https://cloud.google.com/compute/docs/disks#pdnumberlimits

#### Does this PR introduce a user-facing change?

```release-note
NONE
```