### PR TITLE
Update Hetzner cluster-autoscaler-run-on-master.yaml to use valid image

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
@@ -152,7 +152,7 @@ spec:
                   - key: node-role.kubernetes.io/control-plane
                     operator: Exists
       containers:
-        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest  # or your custom image
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.20.0  # or your custom image
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
The current version of the example manifest does not function due to the latest version not being allowed.

Instead, pin the version to use a specific verison. I have setup to version registry.k8s.io/autoscaling/cluster-autoscaler:v1.20.0 instead of 1.30.0 as the latter does not function with the current manifest.

This update will allow the autoscaler to be deployed and function using 1.20.0.

Changes are needed to support 1.30.0 to the manifest which needs to be assessed.  Until then, i suggest allowing the valid configuration by setting the last known working version

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
