### PR TITLE
Update ProvisioningRequest API with the new name of scale-up provisioning class

### DIFF
--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -197,7 +197,7 @@ const (
 	// ProvisioningClassCheckCapacity denotes that CA will check if current cluster state can fulfill this request,
 	// and reserve the capacity for a specified time.
 	ProvisioningClassCheckCapacity string = "check-capacity.autoscaling.x-k8s.io"
-	// ProvisioningClassAtomicScaleUp denotes that CA try to provision the capacity
+	// ProvisioningClassBestEffortAtomicScaleUp denotes that CA try to provision the capacity
 	// in an atomic manner.
-	ProvisioningClassAtomicScaleUp string = "atomic-scale-up.autoscaling.x-k8s.io"
+	ProvisioningClassBestEffortAtomicScaleUp string = "best-effort-atomic-scale-up.autoscaling.x-k8s.io"
 )

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -83,7 +83,7 @@ func TestScaleUp(t *testing.T) {
 			CPU:      "1",
 			Memory:   "1",
 			PodCount: int32(5),
-			Class:    v1beta1.ProvisioningClassAtomicScaleUp,
+			Class:    v1beta1.ProvisioningClassBestEffortAtomicScaleUp,
 		})
 
 	// Already provisioned provisioning request - capacity should be booked before processing a new request.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Changes the name of provisioning class from `atomic-scale-up.kubernetes.io` to `best-effort-atomic-scale-up.kubernetes.io` as agreed in #6849

#### Which issue(s) this PR fixes:

Fixes #6849

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed the name of provisioning class from `atomic-scale-up.kubernetes.io` to `best-effort-atomic-scale-up.kubernetes.io` in v1beta1. Note that this API is in draft stage and not yet supported in any release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP] https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/provisioning-request.md
```

/cc @yaroslava @kisieland 