### PR TITLE
Default Azure VMSS min size to 0 if not provided

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -315,7 +315,7 @@ func (m *AzureManager) getFilteredScaleSets(filter []labelAutoDiscoveryConfig) (
 		}
 		spec := &dynamic.NodeGroupSpec{
 			Name:               *scaleSet.Name,
-			MinSize:            1,
+			MinSize:            0,
 			MaxSize:            -1,
 			SupportScaleToZero: scaleToZeroSupportedVMSS,
 		}
@@ -327,9 +327,6 @@ func (m *AzureManager) getFilteredScaleSets(filter []labelAutoDiscoveryConfig) (
 				klog.Warningf("ignoring vmss %q because of invalid minimum size specified for vmss: %s", *scaleSet.Name, err)
 				continue
 			}
-		} else {
-			klog.Warningf("ignoring vmss %q because of no minimum size specified for vmss", *scaleSet.Name)
-			continue
 		}
 		if spec.MinSize < 0 {
 			klog.Warningf("ignoring vmss %q because of minimum size must be a non-negative number of nodes", *scaleSet.Name)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Currently the autoscaler will ignore a VMSS if no min size is provided. This PR changes the behaviour so it will instead default to 0. This is a safe minimum and will allow VMSS's without a `min` tag to be considered.

Azure has a limit of 50 tags per resource https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations. This change will allow people to save 1 tag space if they are ok with the default of 0.

#### Alternatives Considered

An alternative approach to this problem is having a `min` and `max` as part of the autodiscovery tags, similar to how GCP does it https://github.com/kubernetes/autoscaler/blob/cf606a1400d6e421d32349e25115b508382111ff/cluster-autoscaler/main.go#L182. The `min` and `max` could be optional for Azure and used as default values if a VMSS is missing its `min`/`max` tags

Here is the alternative PR https://github.com/kubernetes/autoscaler/pull/6863



#### Does this PR introduce a user-facing change?

```release-note
Default Azure VMSS min size to 0 if not provided
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```


