### PR TITLE
Show requests/responses made towards Hetzner cloud for high log levels

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_debug_writer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_debug_writer.go
@@ -1,0 +1,13 @@
+package hetzner
+
+import (
+	"k8s.io/klog/v2"
+)
+
+// DebugWriter is a writer that logs to klog at level 5.
+type DebugWriter struct{}
+
+func (d DebugWriter) Write(p []byte) (n int, err error) {
+	klog.V(5).Info(string(p))
+	return len(p), nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -95,6 +95,7 @@ func newManager() (*hetznerManager, error) {
 		hcloud.WithHTTPClient(httpClient),
 		hcloud.WithApplication("cluster-autoscaler", version.ClusterAutoscalerVersion),
 		hcloud.WithPollBackoffFunc(hcloud.ExponentialBackoff(2, 500*time.Millisecond)),
+		hcloud.WithDebugWriter(&DebugWriter{}),
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
It shows api calls toward Hetzner from log level 5 onward. 

#### Which issue(s) this PR fixes:
Fixes #6860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), ```docs

```
