### PR TITLE
Show requests/responses made towards Hetzner cloud for high log levels

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -96,3 +96,8 @@ cd cluster-autoscaler/cloudprovider/hetzner
 UPSTREAM_REF=v2.0.0 hack/update-vendor.sh
 git add hcloud-go/
 ```
+
+## Debugging
+
+To enable debug logging, set the log level of the autoscaler to at least level 5 via cli flag: `--v=5`  
+The logs will include all requests and responses made towards the Hetzner API including headers and body.

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_debug_writer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_debug_writer.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hetzner
+
+import (
+	"k8s.io/klog/v2"
+)
+
+// debugWriter is a writer that logs to klog at level 5.
+type debugWriter struct{}
+
+func (d debugWriter) Write(p []byte) (n int, err error) {
+	klog.V(5).Info(string(p))
+	return len(p), nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -95,6 +95,7 @@ func newManager() (*hetznerManager, error) {
 		hcloud.WithHTTPClient(httpClient),
 		hcloud.WithApplication("cluster-autoscaler", version.ClusterAutoscalerVersion),
 		hcloud.WithPollBackoffFunc(hcloud.ExponentialBackoff(2, 500*time.Millisecond)),
+		hcloud.WithDebugWriter(&debugWriter{}),
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
It shows api calls toward Hetzner from log level 5 onward. 

#### Which issue(s) this PR fixes:
Fixes #6860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), ```docs

```
