### PR TITLE
Bump openstackmagnum/cluster-autoscaler image version.

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment-control-plane.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: cluster-autoscaler-account
       containers:
         - name: cluster-autoscaler
-          image: openstackmagnum/cluster-autoscaler:v1.23.0
+          image: openstackmagnum/cluster-autoscaler:v1.28.0
           imagePullPolicy: Always
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/cluster-autoscaler-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: cluster-autoscaler-account
       containers:
         - name: cluster-autoscaler
-          image: openstackmagnum/cluster-autoscaler:v1.23.0
+          image: openstackmagnum/cluster-autoscaler:v1.28.0
           imagePullPolicy: Always
           command:
             - ./cluster-autoscaler

--- a/cluster-autoscaler/cloudprovider/magnum/examples/values-autodiscovery.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/values-autodiscovery.yaml
@@ -8,7 +8,7 @@ autoDiscovery:
 
 image:
   repository: docker.io/openstackmagnum/cluster-autoscaler
-  tag: v1.23.0
+  tag: v1.28.0
 
 nodeSelector:
   node-role.kubernetes.io/control-plane: ""

--- a/cluster-autoscaler/cloudprovider/magnum/examples/values-example.yaml
+++ b/cluster-autoscaler/cloudprovider/magnum/examples/values-example.yaml
@@ -9,7 +9,7 @@ autoscalingGroups:
 
 image:
   repository: docker.io/openstackmagnum/cluster-autoscaler
-  tag: v1.23.0
+  tag: v1.28.0
 
 nodeSelector:
   node-role.kubernetes.io/control-plane: ""


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR upgraded `openstackmagnum/cluster-autoscaler` image version to v1.28.0.
#### Which issue(s) this PR fixes:

Fixes #6878

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
