### PR TITLE
Refactor to format VPA Updater log more efficiently

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -171,26 +171,26 @@ func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvictionAdmissi
 func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_types.RecommendedPodResources) string {
 	sb := &strings.Builder{}
 	for _, cr := range r.ContainerRecommendations {
-		sb.WriteString(fmt.Sprintf("%s: ", cr.ContainerName))
+		fmt.Fprintf(sb, "%s: ", cr.ContainerName)
 		if cr.Target != nil {
-			sb.WriteString("target: ")
+			fmt.Fprint(sb, "target: ")
 			if !cr.Target.Memory().IsZero() {
-				sb.WriteString(fmt.Sprintf("%dk ", cr.Target.Memory().ScaledValue(resource.Kilo)))
+				fmt.Fprintf(sb, "%dk ", cr.Target.Memory().ScaledValue(resource.Kilo))
 			}
 			if !cr.Target.Cpu().IsZero() {
-				sb.WriteString(fmt.Sprintf("%vm; ", cr.Target.Cpu().MilliValue()))
+				fmt.Fprintf(sb, "%vm; ", cr.Target.Cpu().MilliValue())
 			}
 		}
 		if cr.UncappedTarget != nil {
-			sb.WriteString("uncappedTarget: ")
+			fmt.Fprintf(sb, "uncappedTarget: ")
 			if !cr.UncappedTarget.Memory().IsZero() {
-				sb.WriteString(fmt.Sprintf("%dk ", cr.UncappedTarget.Memory().ScaledValue(resource.Kilo)))
+				fmt.Fprintf(sb, "%dk ", cr.UncappedTarget.Memory().ScaledValue(resource.Kilo))
 			}
 			if !cr.UncappedTarget.Cpu().IsZero() {
-				sb.WriteString(fmt.Sprintf("%vm;", cr.UncappedTarget.Cpu().MilliValue()))
+				fmt.Fprintf(sb, "%vm;", cr.UncappedTarget.Cpu().MilliValue())
 			}
 		}
-		sb.WriteString("\n")
+		fmt.Fprintf(sb, "\n")
 	}
 	return sb.String()
 }


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:

- Small refactor to improve the efficiency of formatting one of the logs for VPA Updater.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up to https://github.com/kubernetes/autoscaler/pull/6723

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
