### PR TITLE
Implement TemplateNodeInfo for magnum cloudprovider

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/doc.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/doc.go
@@ -1,0 +1,137 @@
+/*
+Package flavors provides information and interaction with the flavor API
+in the OpenStack Compute service.
+
+A flavor is an available hardware configuration for a server. Each flavor
+has a unique combination of disk space, memory capacity and priority for CPU
+time.
+
+Example to List Flavors
+
+	listOpts := flavors.ListOpts{
+		AccessType: flavors.PublicAccess,
+	}
+
+	allPages, err := flavors.ListDetail(computeClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, flavor := range allFlavors {
+		fmt.Printf("%+v\n", flavor)
+	}
+
+Example to Create a Flavor
+
+	createOpts := flavors.CreateOpts{
+		ID:         "1",
+		Name:       "m1.tiny",
+		Disk:       gophercloud.IntToPointer(1),
+		RAM:        512,
+		VCPUs:      1,
+		RxTxFactor: 1.0,
+	}
+
+	flavor, err := flavors.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Flavor Access
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	allPages, err := flavors.ListAccesses(computeClient, flavorID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAccesses, err := flavors.ExtractAccesses(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, access := range allAccesses {
+		fmt.Printf("%+v", access)
+	}
+
+Example to Grant Access to a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := flavors.AddAccessOpts{
+		Tenant: "15153a0979884b59b0592248ef947921",
+	}
+
+	accessList, err := flavors.AddAccess(computeClient, flavor.ID, accessOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove/Revoke Access to a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := flavors.RemoveAccessOpts{
+		Tenant: "15153a0979884b59b0592248ef947921",
+	}
+
+	accessList, err := flavors.RemoveAccess(computeClient, flavor.ID, accessOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create Extra Specs for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	createOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy":        "CPU-POLICY",
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+	}
+	createdExtraSpecs, err := flavors.CreateExtraSpecs(computeClient, flavorID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", createdExtraSpecs)
+
+Example to Get Extra Specs for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	extraSpecs, err := flavors.ListExtraSpecs(computeClient, flavorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpecs)
+
+Example to Update Extra Specs for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	updateOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY-UPDATED",
+	}
+	updatedExtraSpec, err := flavors.UpdateExtraSpec(computeClient, flavorID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", updatedExtraSpec)
+
+Example to Delete an Extra Spec for a Flavor
+
+	flavorID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+	err := flavors.DeleteExtraSpec(computeClient, flavorID, "hw:cpu_thread_policy").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package flavors

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -1,0 +1,357 @@
+package flavors
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFlavorListQuery() (string, error)
+}
+
+/*
+AccessType maps to OpenStack's Flavor.is_public field. Although the is_public
+field is boolean, the request options are ternary, which is why AccessType is
+a string. The following values are allowed:
+
+The AccessType arguement is optional, and if it is not supplied, OpenStack
+returns the PublicAccess flavors.
+*/
+type AccessType string
+
+const (
+	// PublicAccess returns public flavors and private flavors associated with
+	// that project.
+	PublicAccess AccessType = "true"
+
+	// PrivateAccess (admin only) returns private flavors, across all projects.
+	PrivateAccess AccessType = "false"
+
+	// AllAccess (admin only) returns public and private flavors across all
+	// projects.
+	AllAccess AccessType = "None"
+)
+
+/*
+ListOpts filters the results returned by the List() function.
+For example, a flavor with a minDisk field of 10 will not be returned if you
+specify MinDisk set to 20.
+
+Typically, software will use the last ID of the previous call to List to set
+the Marker for the current call.
+*/
+type ListOpts struct {
+	// ChangesSince, if provided, instructs List to return only those things which
+	// have changed since the timestamp provided.
+	ChangesSince string `q:"changes-since"`
+
+	// MinDisk and MinRAM, if provided, elides flavors which do not meet your
+	// criteria.
+	MinDisk int `q:"minDisk"`
+	MinRAM  int `q:"minRam"`
+
+	// SortDir allows to select sort direction.
+	// It can be "asc" or "desc" (default).
+	SortDir string `q:"sort_dir"`
+
+	// SortKey allows to sort by one of the flavors attributes.
+	// Default is flavorid.
+	SortKey string `q:"sort_key"`
+
+	// Marker and Limit control paging.
+	// Marker instructs List where to start listing from.
+	Marker string `q:"marker"`
+
+	// Limit instructs List to refrain from sending excessively large lists of
+	// flavors.
+	Limit int `q:"limit"`
+
+	// AccessType, if provided, instructs List which set of flavors to return.
+	// If IsPublic not provided, flavors for the current project are returned.
+	AccessType AccessType `q:"is_public"`
+}
+
+// ToFlavorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToFlavorListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListDetail instructs OpenStack to provide a list of flavors.
+// You may provide criteria by which List curtails its results for easier
+// processing.
+func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToFlavorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return FlavorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateOptsBuilder interface {
+	ToFlavorCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters used for creating a flavor.
+type CreateOpts struct {
+	// Name is the name of the flavor.
+	Name string `json:"name" required:"true"`
+
+	// RAM is the memory of the flavor, measured in MB.
+	RAM int `json:"ram" required:"true"`
+
+	// VCPUs is the number of vcpus for the flavor.
+	VCPUs int `json:"vcpus" required:"true"`
+
+	// Disk the amount of root disk space, measured in GB.
+	Disk *int `json:"disk" required:"true"`
+
+	// ID is a unique ID for the flavor.
+	ID string `json:"id,omitempty"`
+
+	// Swap is the amount of swap space for the flavor, measured in MB.
+	Swap *int `json:"swap,omitempty"`
+
+	// RxTxFactor alters the network bandwidth of a flavor.
+	RxTxFactor float64 `json:"rxtx_factor,omitempty"`
+
+	// IsPublic flags a flavor as being available to all projects or not.
+	IsPublic *bool `json:"os-flavor-access:is_public,omitempty"`
+
+	// Ephemeral is the amount of ephemeral disk space, measured in GB.
+	Ephemeral *int `json:"OS-FLV-EXT-DATA:ephemeral,omitempty"`
+}
+
+// ToFlavorCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToFlavorCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "flavor")
+}
+
+// Create requests the creation of a new flavor.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToFlavorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Get retrieves details of a single flavor. Use Extract to convert its
+// result into a Flavor.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// Delete deletes the specified flavor ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// ListAccesses retrieves the tenants which have access to a flavor.
+func ListAccesses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	url := accessURL(client, id)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AccessPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// AddAccessOptsBuilder allows extensions to add additional parameters to the
+// AddAccess requests.
+type AddAccessOptsBuilder interface {
+	ToFlavorAddAccessMap() (map[string]interface{}, error)
+}
+
+// AddAccessOpts represents options for adding access to a flavor.
+type AddAccessOpts struct {
+	// Tenant is the project/tenant ID to grant access.
+	Tenant string `json:"tenant"`
+}
+
+// ToFlavorAddAccessMap constructs a request body from AddAccessOpts.
+func (opts AddAccessOpts) ToFlavorAddAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "addTenantAccess")
+}
+
+// AddAccess grants a tenant/project access to a flavor.
+func AddAccess(client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+	b, err := opts.ToFlavorAddAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(accessActionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// RemoveAccessOptsBuilder allows extensions to add additional parameters to the
+// RemoveAccess requests.
+type RemoveAccessOptsBuilder interface {
+	ToFlavorRemoveAccessMap() (map[string]interface{}, error)
+}
+
+// RemoveAccessOpts represents options for removing access to a flavor.
+type RemoveAccessOpts struct {
+	// Tenant is the project/tenant ID to grant access.
+	Tenant string `json:"tenant"`
+}
+
+// ToFlavorRemoveAccessMap constructs a request body from RemoveAccessOpts.
+func (opts RemoveAccessOpts) ToFlavorRemoveAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "removeTenantAccess")
+}
+
+// RemoveAccess removes/revokes a tenant/project access to a flavor.
+func RemoveAccess(client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+	b, err := opts.ToFlavorRemoveAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(accessActionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// ExtraSpecs requests all the extra-specs for the given flavor ID.
+func ListExtraSpecs(client *gophercloud.ServiceClient, flavorID string) (r ListExtraSpecsResult) {
+	_, r.Err = client.Get(extraSpecsListURL(client, flavorID), &r.Body, nil)
+	return
+}
+
+func GetExtraSpec(client *gophercloud.ServiceClient, flavorID string, key string) (r GetExtraSpecResult) {
+	_, r.Err = client.Get(extraSpecsGetURL(client, flavorID, key), &r.Body, nil)
+	return
+}
+
+// CreateExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// CreateExtraSpecs requests.
+type CreateExtraSpecsOptsBuilder interface {
+	ToFlavorExtraSpecsCreateMap() (map[string]interface{}, error)
+}
+
+// ExtraSpecsOpts is a map that contains key-value pairs.
+type ExtraSpecsOpts map[string]string
+
+// ToFlavorExtraSpecsCreateMap assembles a body for a Create request based on
+// the contents of ExtraSpecsOpts.
+func (opts ExtraSpecsOpts) ToFlavorExtraSpecsCreateMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"extra_specs": opts}, nil
+}
+
+// CreateExtraSpecs will create or update the extra-specs key-value pairs for
+// the specified Flavor.
+func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+	b, err := opts.ToFlavorExtraSpecsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(extraSpecsCreateURL(client, flavorID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateExtraSpecOptsBuilder interface {
+	ToFlavorExtraSpecUpdateMap() (map[string]string, string, error)
+}
+
+// ToFlavorExtraSpecUpdateMap assembles a body for an Update request based on
+// the contents of a ExtraSpecOpts.
+func (opts ExtraSpecsOpts) ToFlavorExtraSpecUpdateMap() (map[string]string, string, error) {
+	if len(opts) != 1 {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "flavors.ExtraSpecOpts"
+		err.Info = "Must have 1 and only one key-value pair"
+		return nil, "", err
+	}
+
+	var key string
+	for k := range opts {
+		key = k
+	}
+
+	return opts, key, nil
+}
+
+// UpdateExtraSpec will updates the value of the specified flavor's extra spec
+// for the key in opts.
+func UpdateExtraSpec(client *gophercloud.ServiceClient, flavorID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+	b, key, err := opts.ToFlavorExtraSpecUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(extraSpecUpdateURL(client, flavorID, key), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DeleteExtraSpec will delete the key-value pair with the given key for the given
+// flavor ID.
+func DeleteExtraSpec(client *gophercloud.ServiceClient, flavorID, key string) (r DeleteExtraSpecResult) {
+	_, r.Err = client.Delete(extraSpecDeleteURL(client, flavorID, key), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a flavor's ID given its
+// name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	allPages, err := ListDetail(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractFlavors(allPages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range all {
+		if f.Name == name {
+			count++
+			id = f.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		err := &gophercloud.ErrResourceNotFound{}
+		err.ResourceType = "flavor"
+		err.Name = name
+		return "", err
+	case 1:
+		return id, nil
+	default:
+		err := &gophercloud.ErrMultipleResourcesFound{}
+		err.ResourceType = "flavor"
+		err.Name = name
+		err.Count = count
+		return "", err
+	}
+}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/results.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/results.go
@@ -1,0 +1,252 @@
+package flavors
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response of a Get operations. Call its Extract method to
+// interpret it as a Flavor.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the response of a Get operations. Call its Extract method to
+// interpret it as a Flavor.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult is the result from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract provides access to the individual Flavor returned by the Get and
+// Create functions.
+func (r commonResult) Extract() (*Flavor, error) {
+	var s struct {
+		Flavor *Flavor `json:"flavor"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Flavor, err
+}
+
+// Flavor represent (virtual) hardware configurations for server resources
+// in a region.
+type Flavor struct {
+	// ID is the flavor's unique ID.
+	ID string `json:"id"`
+
+	// Disk is the amount of root disk, measured in GB.
+	Disk int `json:"disk"`
+
+	// RAM is the amount of memory, measured in MB.
+	RAM int `json:"ram"`
+
+	// Name is the name of the flavor.
+	Name string `json:"name"`
+
+	// RxTxFactor describes bandwidth alterations of the flavor.
+	RxTxFactor float64 `json:"rxtx_factor"`
+
+	// Swap is the amount of swap space, measured in MB.
+	Swap int `json:"-"`
+
+	// VCPUs indicates how many (virtual) CPUs are available for this flavor.
+	VCPUs int `json:"vcpus"`
+
+	// IsPublic indicates whether the flavor is public.
+	IsPublic bool `json:"os-flavor-access:is_public"`
+
+	// Ephemeral is the amount of ephemeral disk space, measured in GB.
+	Ephemeral int `json:"OS-FLV-EXT-DATA:ephemeral"`
+}
+
+func (r *Flavor) UnmarshalJSON(b []byte) error {
+	type tmp Flavor
+	var s struct {
+		tmp
+		Swap interface{} `json:"swap"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Flavor(s.tmp)
+
+	switch t := s.Swap.(type) {
+	case float64:
+		r.Swap = int(t)
+	case string:
+		switch t {
+		case "":
+			r.Swap = 0
+		default:
+			swap, err := strconv.ParseFloat(t, 64)
+			if err != nil {
+				return err
+			}
+			r.Swap = int(swap)
+		}
+	}
+
+	return nil
+}
+
+// FlavorPage contains a single page of all flavors from a ListDetails call.
+type FlavorPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines if a FlavorPage contains any results.
+func (page FlavorPage) IsEmpty() (bool, error) {
+	flavors, err := ExtractFlavors(page)
+	return len(flavors) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (page FlavorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"flavors_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractFlavors provides access to the list of flavors in a page acquired
+// from the ListDetail operation.
+func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
+	var s struct {
+		Flavors []Flavor `json:"flavors"`
+	}
+	err := (r.(FlavorPage)).ExtractInto(&s)
+	return s.Flavors, err
+}
+
+// AccessPage contains a single page of all FlavorAccess entries for a flavor.
+type AccessPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether an AccessPage is empty.
+func (page AccessPage) IsEmpty() (bool, error) {
+	v, err := ExtractAccesses(page)
+	return len(v) == 0, err
+}
+
+// ExtractAccesses interprets a page of results as a slice of FlavorAccess.
+func ExtractAccesses(r pagination.Page) ([]FlavorAccess, error) {
+	var s struct {
+		FlavorAccesses []FlavorAccess `json:"flavor_access"`
+	}
+	err := (r.(AccessPage)).ExtractInto(&s)
+	return s.FlavorAccesses, err
+}
+
+type accessResult struct {
+	gophercloud.Result
+}
+
+// AddAccessResult is the response of an AddAccess operation. Call its
+// Extract method to interpret it as a slice of FlavorAccess.
+type AddAccessResult struct {
+	accessResult
+}
+
+// RemoveAccessResult is the response of a RemoveAccess operation. Call its
+// Extract method to interpret it as a slice of FlavorAccess.
+type RemoveAccessResult struct {
+	accessResult
+}
+
+// Extract provides access to the result of an access create or delete.
+// The result will be all accesses that the flavor has.
+func (r accessResult) Extract() ([]FlavorAccess, error) {
+	var s struct {
+		FlavorAccesses []FlavorAccess `json:"flavor_access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.FlavorAccesses, err
+}
+
+// FlavorAccess represents an ACL of tenant access to a specific Flavor.
+type FlavorAccess struct {
+	// FlavorID is the unique ID of the flavor.
+	FlavorID string `json:"flavor_id"`
+
+	// TenantID is the unique ID of the tenant.
+	TenantID string `json:"tenant_id"`
+}
+
+// Extract interprets any extraSpecsResult as ExtraSpecs, if possible.
+func (r extraSpecsResult) Extract() (map[string]string, error) {
+	var s struct {
+		ExtraSpecs map[string]string `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExtraSpecs, err
+}
+
+// extraSpecsResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// ListExtraSpecsResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type ListExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// CreateExtraSpecResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type CreateExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// extraSpecResult contains the result of a call for individual a single
+// key-value pair.
+type extraSpecResult struct {
+	gophercloud.Result
+}
+
+// GetExtraSpecResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type GetExtraSpecResult struct {
+	extraSpecResult
+}
+
+// UpdateExtraSpecResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type UpdateExtraSpecResult struct {
+	extraSpecResult
+}
+
+// DeleteExtraSpecResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
+type DeleteExtraSpecResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r extraSpecResult) Extract() (map[string]string, error) {
+	var s map[string]string
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/doc.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/doc.go
@@ -1,0 +1,2 @@
+// flavors unit tests
+package testing

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/fixtures.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/fixtures.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper"
+	fake "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/client"
+)
+
+// ExtraSpecsGetBody provides a GET result of the extra_specs for a flavor
+const ExtraSpecsGetBody = `
+{
+    "extra_specs" : {
+        "hw:cpu_policy": "CPU-POLICY",
+        "hw:cpu_thread_policy": "CPU-THREAD-POLICY"
+    }
+}
+`
+
+// GetExtraSpecBody provides a GET result of a particular extra_spec for a flavor
+const GetExtraSpecBody = `
+{
+    "hw:cpu_policy": "CPU-POLICY"
+}
+`
+
+// UpdatedExtraSpecBody provides an PUT result of a particular updated extra_spec for a flavor
+const UpdatedExtraSpecBody = `
+{
+    "hw:cpu_policy": "CPU-POLICY-2"
+}
+`
+
+// ExtraSpecs is the expected extra_specs returned from GET on a flavor's extra_specs
+var ExtraSpecs = map[string]string{
+	"hw:cpu_policy":        "CPU-POLICY",
+	"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+}
+
+// ExtraSpec is the expected extra_spec returned from GET on a flavor's extra_specs
+var ExtraSpec = map[string]string{
+	"hw:cpu_policy": "CPU-POLICY",
+}
+
+// UpdatedExtraSpec is the expected extra_spec returned from PUT on a flavor's extra_specs
+var UpdatedExtraSpec = map[string]string{
+	"hw:cpu_policy": "CPU-POLICY-2",
+}
+
+func HandleExtraSpecsListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, GetExtraSpecBody)
+	})
+}
+
+func HandleExtraSpecsCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"extra_specs": {
+					"hw:cpu_policy":        "CPU-POLICY",
+					"hw:cpu_thread_policy": "CPU-THREAD-POLICY"
+				}
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ExtraSpecsGetBody)
+	})
+}
+
+func HandleExtraSpecUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+				"hw:cpu_policy":        "CPU-POLICY-2"
+			}`)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdatedExtraSpecBody)
+	})
+}
+
+func HandleExtraSpecDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/flavors/1/os-extra_specs/hw:cpu_policy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/requests_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/testing/requests_test.go
@@ -1,0 +1,403 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination"
+
+	th "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper"
+	fake "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/client"
+)
+
+const tokenID = "blerb"
+
+func TestListFlavors(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		r.ParseForm()
+		marker := r.Form.Get("marker")
+		switch marker {
+		case "":
+			fmt.Fprintf(w, `
+					{
+						"flavors": [
+							{
+								"id": "1",
+								"name": "m1.tiny",
+								"vcpus": 1,
+								"disk": 1,
+								"ram": 9216000,
+								"swap":"",
+								"os-flavor-access:is_public": true,
+								"OS-FLV-EXT-DATA:ephemeral": 10
+							},
+							{
+								"id": "2",
+								"name": "m1.small",
+								"vcpus": 1,
+								"disk": 20,
+								"ram": 2048,
+								"swap": 1000,
+								"os-flavor-access:is_public": true,
+								"OS-FLV-EXT-DATA:ephemeral": 0
+							},
+							{
+								"id": "3",
+								"name": "m1.medium",
+								"vcpus": 2,
+								"disk": 40,
+								"ram": 4096,
+								"swap": 1000,
+								"os-flavor-access:is_public": false,
+								"OS-FLV-EXT-DATA:ephemeral": 0
+							}
+						],
+						"flavors_links": [
+							{
+								"href": "%s/flavors/detail?marker=2",
+								"rel": "next"
+							}
+						]
+					}
+				`, th.Server.URL)
+		case "2":
+			fmt.Fprintf(w, `{ "flavors": [] }`)
+		default:
+			t.Fatalf("Unexpected marker: [%s]", marker)
+		}
+	})
+
+	pages := 0
+	// Get public and private flavors
+	err := flavors.ListDetail(fake.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := flavors.ExtractFlavors(page)
+		if err != nil {
+			return false, err
+		}
+
+		expected := []flavors.Flavor{
+			{ID: "1", Name: "m1.tiny", VCPUs: 1, Disk: 1, RAM: 9216000, Swap: 0, IsPublic: true, Ephemeral: 10},
+			{ID: "2", Name: "m1.small", VCPUs: 1, Disk: 20, RAM: 2048, Swap: 1000, IsPublic: true, Ephemeral: 0},
+			{ID: "3", Name: "m1.medium", VCPUs: 2, Disk: 40, RAM: 4096, Swap: 1000, IsPublic: false, Ephemeral: 0},
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %#v, but was %#v", expected, actual)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pages != 1 {
+		t.Errorf("Expected one page, got %d", pages)
+	}
+}
+
+func TestGetFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/12345", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+				"flavor": {
+					"id": "1",
+					"name": "m1.tiny",
+					"disk": 1,
+					"ram": 512,
+					"vcpus": 1,
+					"rxtx_factor": 1,
+					"swap": ""
+				}
+			}
+		`)
+	})
+
+	actual, err := flavors.Get(fake.ServiceClient(), "12345").Extract()
+	if err != nil {
+		t.Fatalf("Unable to get flavor: %v", err)
+	}
+
+	expected := &flavors.Flavor{
+		ID:         "1",
+		Name:       "m1.tiny",
+		Disk:       1,
+		RAM:        512,
+		VCPUs:      1,
+		RxTxFactor: 1,
+		Swap:       0,
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestCreateFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+				"flavor": {
+					"id": "1",
+					"name": "m1.tiny",
+					"disk": 1,
+					"ram": 512,
+					"vcpus": 1,
+					"rxtx_factor": 1,
+					"swap": ""
+				}
+			}
+		`)
+	})
+
+	disk := 1
+	opts := &flavors.CreateOpts{
+		ID:         "1",
+		Name:       "m1.tiny",
+		Disk:       &disk,
+		RAM:        512,
+		VCPUs:      1,
+		RxTxFactor: 1.0,
+	}
+	actual, err := flavors.Create(fake.ServiceClient(), opts).Extract()
+	if err != nil {
+		t.Fatalf("Unable to create flavor: %v", err)
+	}
+
+	expected := &flavors.Flavor{
+		ID:         "1",
+		Name:       "m1.tiny",
+		Disk:       1,
+		RAM:        512,
+		VCPUs:      1,
+		RxTxFactor: 1,
+		Swap:       0,
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestDeleteFlavor(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/12345678", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	res := flavors.Delete(fake.ServiceClient(), "12345678")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestFlavorAccessesList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/12345678/os-flavor-access", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+			  "flavor_access": [
+			    {
+			      "flavor_id": "12345678",
+			      "tenant_id": "2f954bcf047c4ee9b09a37d49ae6db54"
+			    }
+			  ]
+			}
+		`)
+	})
+
+	expected := []flavors.FlavorAccess{
+		{
+			FlavorID: "12345678",
+			TenantID: "2f954bcf047c4ee9b09a37d49ae6db54",
+		},
+	}
+
+	allPages, err := flavors.ListAccesses(fake.ServiceClient(), "12345678").AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := flavors.ExtractAccesses(allPages)
+	th.AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestFlavorAccessAdd(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/12345678/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "accept", "application/json")
+		th.TestJSONRequest(t, r, `
+			{
+			  "addTenantAccess": {
+			    "tenant": "2f954bcf047c4ee9b09a37d49ae6db54"
+			  }
+			}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+			{
+			  "flavor_access": [
+			    {
+			      "flavor_id": "12345678",
+			      "tenant_id": "2f954bcf047c4ee9b09a37d49ae6db54"
+			    }
+			  ]
+			}
+			`)
+	})
+
+	expected := []flavors.FlavorAccess{
+		{
+			FlavorID: "12345678",
+			TenantID: "2f954bcf047c4ee9b09a37d49ae6db54",
+		},
+	}
+
+	addAccessOpts := flavors.AddAccessOpts{
+		Tenant: "2f954bcf047c4ee9b09a37d49ae6db54",
+	}
+
+	actual, err := flavors.AddAccess(fake.ServiceClient(), "12345678", addAccessOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestFlavorAccessRemove(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/flavors/12345678/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "accept", "application/json")
+		th.TestJSONRequest(t, r, `
+			{
+			  "removeTenantAccess": {
+			    "tenant": "2f954bcf047c4ee9b09a37d49ae6db54"
+			  }
+			}
+		`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+			{
+			  "flavor_access": []
+			}
+			`)
+	})
+
+	expected := []flavors.FlavorAccess{}
+	removeAccessOpts := flavors.RemoveAccessOpts{
+		Tenant: "2f954bcf047c4ee9b09a37d49ae6db54",
+	}
+
+	actual, err := flavors.RemoveAccess(fake.ServiceClient(), "12345678", removeAccessOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, but was %#v", expected, actual)
+	}
+}
+
+func TestFlavorExtraSpecsList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsListSuccessfully(t)
+
+	expected := ExtraSpecs
+	actual, err := flavors.ListExtraSpecs(fake.ServiceClient(), "1").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestFlavorExtraSpecGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecGetSuccessfully(t)
+
+	expected := ExtraSpec
+	actual, err := flavors.GetExtraSpec(fake.ServiceClient(), "1", "hw:cpu_policy").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestFlavorExtraSpecsCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecsCreateSuccessfully(t)
+
+	createOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy":        "CPU-POLICY",
+		"hw:cpu_thread_policy": "CPU-THREAD-POLICY",
+	}
+	expected := ExtraSpecs
+	actual, err := flavors.CreateExtraSpecs(fake.ServiceClient(), "1", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestFlavorExtraSpecUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecUpdateSuccessfully(t)
+
+	updateOpts := flavors.ExtraSpecsOpts{
+		"hw:cpu_policy": "CPU-POLICY-2",
+	}
+	expected := UpdatedExtraSpec
+	actual, err := flavors.UpdateExtraSpec(fake.ServiceClient(), "1", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestFlavorExtraSpecDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleExtraSpecDeleteSuccessfully(t)
+
+	res := flavors.DeleteExtraSpec(fake.ServiceClient(), "1", "hw:cpu_policy")
+	th.AssertNoErr(t, res.Err)
+}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/urls.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors/urls.go
@@ -1,0 +1,49 @@
+package flavors
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
+)
+
+func getURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("flavors", "detail")
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("flavors")
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id)
+}
+
+func accessURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "os-flavor-access")
+}
+
+func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "action")
+}
+
+func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs")
+}
+
+func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}
+
+func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs")
+}
+
+func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}
+
+func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("flavors", id, "os-extra_specs", key)
+}

--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/client/fake.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper/client/fake.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper"
+)
+
+// Fake token to use.
+const TokenID = "cbc36478b0bd8e67e89469c7749d4127"
+
+// ServiceClient returns a generic service client for use in tests.
+func ServiceClient() *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: TokenID},
+		Endpoint:       testhelper.Endpoint(),
+	}
+}

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
@@ -30,8 +30,21 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/nodegroups"
 )
+
+func (m *magnumManagerMock) getFlavorById(flavorId string) (*flavors.Flavor, error) {
+	flavor := flavors.Flavor{}
+	flavor.VCPUs = 2
+	flavor.RAM = 2048
+	flavor.Disk = 25
+	flavor.Name = "s1.small"
+	flavor.ID = "s1.small"
+	flavor.IsPublic = true
+
+	return &flavor, nil
+}
 
 // magnumManagerDiscoveryMock overrides magnumManagerMock's autoDiscoverNodeGroups
 // to return a random set of node groups each time, so that refreshNodeGroups
@@ -190,6 +203,83 @@ func TestRefreshNodeGroupsAdd(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(provider.nodeGroups), "wrong number of node groups after refresh")
 	assert.ElementsMatch(t, []string{"test-ng-1-ece653dd", "test-ng-2-946ffca0"}, []string{provider.nodeGroups[0].Id(), provider.nodeGroups[1].Id()}, "didn't find both node groups")
+}
+func TestNodeInf(t *testing.T) {
+	manager := &magnumManagerMock{}
+	provider := magnumCloudProvider{
+		magnumManager:        manager,
+		usingAutoDiscovery:   true,
+		autoDiscoveryConfigs: nil,
+		nodeGroupsLock:       &sync.Mutex{},
+		clusterUpdateLock:    &sync.Mutex{},
+	}
+
+	autoDiscoverySpec, err := parseMagnumAutoDiscoverySpec("magnum:role=autoscaling")
+	require.NoError(t, err, "error parsing auto discovery spec")
+	provider.autoDiscoveryConfigs = []magnumAutoDiscoveryConfig{autoDiscoverySpec}
+
+	three := 3
+	labels := make(map[string]string)
+	labels["Label1"] = "Label1"
+	labels["Label2"] = "Label2"
+
+	nodeGroupWithLabels := []*nodegroups.NodeGroup{
+		{
+			UUID:         "1ce653dd-2544-4f2e-b553-3c136af0ffa6",
+			Name:         "ng-with-labels",
+			Role:         "autoscaling",
+			NodeCount:    0,
+			MinNodeCount: 1,
+			MaxNodeCount: &three,
+			FlavorID:     "s1.small",
+			Labels:       labels,
+		},
+	}
+
+	nodeGroupWithoutLabels := []*nodegroups.NodeGroup{
+		{
+			UUID:         "2ce653dd-2544-4f2e-b553-3c136af0ffa6",
+			Name:         "ng-without-labels",
+			Role:         "autoscaling",
+			NodeCount:    0,
+			MinNodeCount: 1,
+			MaxNodeCount: &three,
+			FlavorID:     "s1.small",
+		},
+	}
+
+	manager.On("autoDiscoverNodeGroups", []magnumAutoDiscoveryConfig{autoDiscoverySpec}).Return(nodeGroupWithLabels, nil).Once()
+	manager.On("autoDiscoverNodeGroups", []magnumAutoDiscoveryConfig{autoDiscoverySpec}).Return(nodeGroupWithoutLabels, nil).Once()
+
+	manager.On("", mock.AnythingOfType("string")).Return(manager.getFlavorById("s1.small"))
+	manager.On("getFlavorById", mock.AnythingOfType("string")).Return(manager.getFlavorById("s1.small"))
+	manager.On("fetchNodeGroupStackIDs", mock.AnythingOfType("string")).Return(nodeGroupStacks{}, nil)
+
+	err = provider.refreshNodeGroups()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(provider.nodeGroups), "wrong number of initial node groups")
+
+	nodeInfo, err := provider.nodeGroups[0].TemplateNodeInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, len(nodeInfo.Pods()), 1, "should have one template pod")
+	assert.Equal(t, nodeInfo.Node().Status.Capacity.Cpu().ToDec().Value(), int64(2000), "should match cpu capacity ")
+	assert.Equal(t, nodeInfo.Node().Status.Capacity.Memory().ToDec().Value(), int64(2048*1024*1024), "should match memory capacity")
+	assert.Equal(t, 3, len(nodeInfo.Node().Labels), "We should have 3 labels")
+	assert.Equal(t, nodeInfo.Node().Labels["magnum.openstack.org/nodegroup"], "ng-with-labels", "Magnum nodegroup label should be")
+	assert.Equal(t, nodeInfo.Node().Labels["Label1"], "Label1")
+	assert.Equal(t, nodeInfo.Node().Labels["Label2"], "Label2")
+
+	err = provider.refreshNodeGroups()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(provider.nodeGroups), "wrong number of initial node groups")
+
+	nodeInfo, err = provider.nodeGroups[0].TemplateNodeInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(nodeInfo.Pods()), "should have one template pod")
+	assert.Equal(t, int64(2000), nodeInfo.Node().Status.Capacity.Cpu().ToDec().Value(), "should match cpu capacity ")
+	assert.Equal(t, int64(2048*1024*1024), nodeInfo.Node().Status.Capacity.Memory().ToDec().Value(), "should match memory capacity")
+	assert.Equal(t, 1, len(nodeInfo.Node().Labels), "We should have 1 labels")
+	assert.Equal(t, "ng-without-labels", nodeInfo.Node().Labels["magnum.openstack.org/nodegroup"], "Magnum nodegroup label should be")
 }
 
 // TestRefreshNodeGroupsRemove checks that refreshNodeGroups correctly

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_manager.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
@@ -45,6 +46,7 @@ type magnumManager interface {
 	fetchNodeGroupStackIDs(nodegroup string) (nodeGroupStacks, error)
 	uniqueNameAndIDForNodeGroup(nodegroup string) (string, string, error)
 	nodeGroupForNode(node *apiv1.Node) (string, error)
+	getFlavorById(flavor string) (*flavors.Flavor, error)
 }
 
 // createMagnumManager creates the necessary OpenStack clients and returns
@@ -78,5 +80,10 @@ func createMagnumManager(configReader io.Reader, discoverOpts cloudprovider.Node
 		return nil, fmt.Errorf("could not create heat client: %v", err)
 	}
 
-	return createMagnumManagerImpl(clusterClient, heatClient, opts)
+	novaClient, err := createNovaClient(cfg, provider, opts)
+	if err != nil {
+		return nil, fmt.Errorf("could not create nova client: %v", err)
+	}
+
+	return createMagnumManagerImpl(clusterClient, heatClient, novaClient, opts)
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -18,10 +18,13 @@ package magnum
 
 import (
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -59,6 +62,16 @@ type magnumNodeGroup struct {
 	// to try to repeatedly delete it.
 	// Maps provider ID -> time of deletion request.
 	deletedNodes map[string]time.Time
+	nodeTemplate *MagnumNodeTemplate
+	// getOptions   *autoscaler.NodeGroupAutoscalingOptions
+}
+
+// MagnumNodeTemplate reference to implements TemplateNodeInfo
+type MagnumNodeTemplate struct {
+	CPUCores      int               `json:"cpu_cores,omitempty"`
+	RAMMegabytes  int               `json:"ram_mb,omitempty"`
+	DiskGigabytes int               `json:"disk_gb,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
 }
 
 // IncreaseSize increases the number of nodes by replacing the cluster's node_count.
@@ -207,7 +220,14 @@ func (ng *magnumNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 
 // TemplateNodeInfo returns a node template for this node group.
 func (ng *magnumNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	node, err := ng.buildNodeFromTemplate(ng.Id(), ng.nodeTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build node from template")
+	}
+	klog.V(5).Infof("TemplateNodeInfo: built template for nodegroup: %s", ng.Id())
+	nodeInfo := framework.NewNodeInfo(node, nil, &framework.PodInfo{Pod: cloudprovider.BuildKubeProxy(ng.Id())})
+
+	return nodeInfo, nil
 }
 
 // Exist returns if this node group exists.
@@ -250,4 +270,44 @@ func (ng *magnumNodeGroup) MinSize() int {
 // TargetSize returns the target size of the node group.
 func (ng *magnumNodeGroup) TargetSize() (int, error) {
 	return ng.targetSize, nil
+}
+
+// buildNodeFromTemplate returns a Node object from the given template
+func (ng *magnumNodeGroup) buildNodeFromTemplate(name string, template *MagnumNodeTemplate) (*apiv1.Node, error) {
+	node := &apiv1.Node{}
+	nodeName := fmt.Sprintf("%s-nodegroup-%d", name, rand.Int63())
+
+	node.ObjectMeta = metav1.ObjectMeta{
+		Name:     nodeName,
+		SelfLink: fmt.Sprintf("/api/v1/nodes/%s", nodeName),
+		Labels:   map[string]string{},
+	}
+
+	node.Status = apiv1.NodeStatus{
+		Capacity: apiv1.ResourceList{},
+	}
+	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(int64(template.CPUCores*1000), resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(int64(template.RAMMegabytes*1024*1024), resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(template.DiskGigabytes*1024*1024*1024), resource.DecimalSI)
+
+	node.Status.Allocatable = node.Status.Capacity
+
+	// GenericLabels and NodeLabels
+	node.Labels = cloudprovider.JoinStringMaps(node.Labels, buildLabels(template, nodeName))
+
+	node.Status.Conditions = cloudprovider.BuildReadyConditions()
+
+	return node, nil
+}
+
+func buildLabels(template *MagnumNodeTemplate, nodeName string) map[string]string {
+	result := make(map[string]string)
+
+	// NodeLabels
+	for key, value := range template.Labels {
+		result[key] = value
+	}
+
+	return result
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
@@ -93,6 +93,7 @@ func createTestNodeGroup(manager magnumManager) *magnumNodeGroup {
 		maxSize:           10,
 		targetSize:        1,
 		deletedNodes:      make(map[string]time.Time),
+		nodeTemplate:      &MagnumNodeTemplate{},
 	}
 	return &ng
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_openstack_clients.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_openstack_clients.go
@@ -231,3 +231,12 @@ func createHeatClient(cfg *Config, provider *gophercloud.ProviderClient, opts co
 
 	return heatClient, nil
 }
+
+func createNovaClient(cfg *Config, provider *gophercloud.ProviderClient, opts config.AutoscalingOptions) (*gophercloud.ServiceClient, error) {
+	novaClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{Type: "compute", Name: "nova", Region: cfg.Global.Region})
+	if err != nil {
+		return nil, fmt.Errorf("could not create compute client: %v", err)
+	}
+
+	return novaClient, nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implement TempalteNodeInfo() for the cluster-autoscaler magnum cloud provider 

#### Which issue(s) this PR fixes:

Haven't found any. 

#### Special notes for your reviewer:

Scaling up a nodegroup from zero didn't work because TemplateNodeInfo was not implemented.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

