### PR TITLE
vpa-updater: Log the Pod namespace when evicting a Pod

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -139,12 +139,12 @@ func (u *updater) RunOnce(ctx context.Context) {
 	for _, vpa := range vpaList {
 		if vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeRecreate &&
 			vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeAuto {
-			klog.V(3).Infof("skipping VPA object %v because its mode is not \"Recreate\" or \"Auto\"", vpa.Name)
+			klog.V(3).Infof("skipping VPA object %s because its mode is not \"Recreate\" or \"Auto\"", klog.KObj(vpa))
 			continue
 		}
 		selector, err := u.selectorFetcher.Fetch(vpa)
 		if err != nil {
-			klog.V(3).Infof("skipping VPA object %v because we cannot fetch selector", vpa.Name)
+			klog.V(3).Infof("skipping VPA object %s because we cannot fetch selector", klog.KObj(vpa))
 			continue
 		}
 
@@ -214,13 +214,13 @@ func (u *updater) RunOnce(ctx context.Context) {
 			}
 			err := u.evictionRateLimiter.Wait(ctx)
 			if err != nil {
-				klog.Warningf("evicting pod %v failed: %v", pod.Name, err)
+				klog.Warningf("evicting pod %s failed: %v", klog.KObj(pod), err)
 				return
 			}
-			klog.V(2).Infof("evicting pod %v", pod.Name)
+			klog.V(2).Infof("evicting pod %s", klog.KObj(pod))
 			evictErr := evictionLimiter.Evict(pod, u.eventRecorder)
 			if evictErr != nil {
-				klog.Warningf("evicting pod %v failed: %v", pod.Name, evictErr)
+				klog.Warningf("evicting pod %s failed: %v", klog.KObj(pod), evictErr)
 			} else {
 				withEvicted = true
 				metrics_updater.AddEvictedPod(vpaSize)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently vpa logs for eviction look like:
```
I0607 09:56:37.171710       1 updater.go:220] evicting pod etcd-main-2
I0607 09:57:37.177733       1 updater.go:220] evicting pod etcd-main-0
I0607 09:58:37.059142       1 updater.go:220] evicting pod etcd-main-1
I0607 09:59:37.225718       1 updater.go:220] evicting pod etcd-events-2
I0607 10:00:37.083830       1 updater.go:220] evicting pod etcd-events-1
```

It is not possible to deduce which is the namespace of these Pods because it is simply not logged. We have hundreds of namespaces deploying StatefulSet Pods which at the end have the same name.

This PR logs the namespace as well so that log readers can locate the affected Pods unambiguously.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-updater logging is now improved. In many cases it now logs the objects' namespaces as well.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
