### PR TITLE
Modify logic to look for ocid type prefix in OCI cloud provider builder

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"strings"
 )
 
 // OciCloudProvider implements the CloudProvider interface for OCI. It contains an
@@ -134,7 +135,7 @@ func BuildOCI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if err != nil {
 		klog.Fatalf("Failed to get pool type: %v", err)
 	}
-	if ocidType == npconsts.OciNodePoolResourceIdent {
+	if strings.HasPrefix(ocidType, npconsts.OciNodePoolResourceIdent) {
 		manager, err := nodepools.CreateNodePoolManager(opts.CloudConfig, do, createKubeClient(opts))
 		if err != nil {
 			klog.Fatalf("Could not create OCI OKE cloud provider: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In OKE,  nodepools being created in a dev environment (integ) have the term nodepoolinteg instead of just nodepool . This is causing issues with CA. Our current logic in CA is to split the nodepool ocid by .  as the separator and move the control to OKE's implementation if the string in the 1st index of the array is nodepool , else we move the control to Instance Pool's implementation. Since it is now nodepoolinteg , it is moving to Instance Pool's implementation. This PRs fixes the logic.

#### Does this PR introduce a user-facing change?
No

