### PR TITLE
VPA: Fix regression where the case of Kind is inconsistant

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/spec"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	target_mock "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/mock"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )

--- a/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
@@ -117,7 +117,7 @@ func (pb *podBuilderImpl) Get() *apiv1.Pod {
 			{
 				UID:        pb.creatorObjectMeta.UID,
 				Name:       pb.creatorObjectMeta.Name,
-				APIVersion: pb.creatorObjectMeta.ResourceVersion,
+				APIVersion: pb.creatorTypeMeta.APIVersion,
 				Kind:       pb.creatorTypeMeta.Kind,
 				Controller: &isController,
 			},


### PR DESCRIPTION
Relates to https://github.com/kubernetes/autoscaler/issues/6924

Previously the case of the `Kind` in the `targetRef` didn't matter. Not it seems to matter for the admission-controller.

This change attempts to copy what the HPA does. https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/controller/podautoscaler/horizontal.go#L1321-L1325

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
This PR allows users to specify a kind in the targetRef and all 3 VPA components will still continue to work.
Prior to this change the admission-controller would ignore the new Pods if the case of the `Kind` was incorrect.

#### Which issue(s) this PR fixes:

Fixes # https://github.com/kubernetes/autoscaler/issues/6924

#### Special notes for your reviewer:

I'm not sure if this solution is the right way to go, but I copied the HPA as best I could, in order to maintain consistent behaviour between the VPA and HPA.
Another solution could be to change this line: https://github.com/kubernetes/autoscaler/blob/131d12bbf6ac1f5416f86692def0f227be7a5f64/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L167

It could do a strings.ToLower() before comparison.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix regression of how case was handled in the targetRef
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

