### PR TITLE
Increase booking time for ProvisioningRequest to 20 minutes

### DIFF
--- a/cluster-autoscaler/processors/provreq/provisioning_request_processor.go
+++ b/cluster-autoscaler/processors/provreq/provisioning_request_processor.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultReservationTime = 10 * time.Minute
+	defaultReservationTime = 20 * time.Minute
 	defaultExpirationTime  = 7 * 24 * time.Hour // 7 days
 	// defaultMaxUpdated is a limit for ProvisioningRequest to update conditions in one ClusterAutoscaler loop.
 	defaultMaxUpdated = 20


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
As discussed with @towca : the default timeout for a VM coming up after a scale-up request is 15min, so it makes sense to have booking time greater than 15 minutes.

#### Does this PR introduce a user-facing change?
```release-note
Increase booking time for ProvisioningRequest to 20 minutes.
```
cc: @kisieland 