### PR TITLE
Update Azure cluster-autoscaler e2e cluster template

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
@@ -19,6 +19,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
+  version: ${KUBERNETES_VERSION}
   resources:
   - apiVersion: containerservice.azure.com/v1api20231001
     kind: ManagedCluster
@@ -52,7 +53,54 @@ spec:
         buildProvenance: ${BUILD_PROVENANCE}
         creationTimestamp: ${TIMESTAMP}
         jobName: ${JOB_NAME}
-  version: ${KUBERNETES_VERSION}
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      annotations:
+        serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
+      name: ${CLUSTER_NAME}
+      namespace: default
+    spec:
+      location: ${AZURE_LOCATION}
+      operatorSpec:
+        configMaps:
+          principalId:
+            key: principal-id
+            name: ${CLUSTER_NAME}-identity
+      owner:
+        name: ${CLUSTER_NAME}
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: FederatedIdentityCredential
+    metadata:
+      annotations:
+        serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
+      name: ${CLUSTER_NAME}
+      namespace: default
+    spec:
+      audiences:
+      - api://AzureADTokenExchange
+      issuerFromConfig:
+        key: issuer
+        name: ${CLUSTER_NAME}-oidc
+      owner:
+        name: ${CLUSTER_NAME}
+      subject: system:serviceaccount:${CLUSTER_AUTOSCALER_NAMESPACE:=default}:${CLUSTER_AUTOSCALER_SERVICEACCOUNT_NAME:=cluster-autoscaler}
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      annotations:
+        serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
+      name: ${CLUSTER_NAME}
+      namespace: default
+    spec:
+      owner:
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/MC_${CLUSTER_NAME}_${CLUSTER_NAME}_${AZURE_LOCATION}
+      principalIdFromConfig:
+        key: principal-id
+        name: ${CLUSTER_NAME}-identity
+      roleDefinitionReference:
+        # Contributor
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedCluster
@@ -219,53 +267,62 @@ spec:
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
 ---
-apiVersion: managedidentity.azure.com/v1api20230131
-kind: UserAssignedIdentity
+apiVersion: v1
+kind: Secret
 metadata:
-  annotations:
-    serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
-  name: ${CLUSTER_NAME}
-  namespace: default
-spec:
-  location: ${AZURE_LOCATION}
-  operatorSpec:
-    configMaps:
-      principalId:
-        key: principal-id
-        name: ${CLUSTER_NAME}-identity
-  owner:
-    name: ${CLUSTER_NAME}
+  name: ${ASO_CREDENTIAL_SECRET_NAME}
+stringData:
+  AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID}
+  AZURE_TENANT_ID:       ${AZURE_TENANT_ID}
+  AZURE_CLIENT_ID:       ${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}
+  AUTH_MODE:             ${ASO_CREDENTIAL_SECRET_MODE:-workloadidentity}
 ---
-apiVersion: managedidentity.azure.com/v1api20230131
-kind: FederatedIdentityCredential
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  annotations:
-    serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
-  name: ${CLUSTER_NAME}
-  namespace: default
-spec:
-  audiences:
-  - api://AzureADTokenExchange
-  issuerFromConfig:
-    key: issuer
-    name: ${CLUSTER_NAME}-oidc
-  owner:
-    name: ${CLUSTER_NAME}
-  subject: system:serviceaccount:${CLUSTER_AUTOSCALER_NAMESPACE:=default}:${CLUSTER_AUTOSCALER_SERVICEACCOUNT_NAME:=cluster-autoscaler}
----
-apiVersion: authorization.azure.com/v1api20220401
-kind: RoleAssignment
-metadata:
-  annotations:
-    serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
-  name: ${CLUSTER_NAME}
-  namespace: default
-spec:
-  owner:
-    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/MC_${CLUSTER_NAME}_${CLUSTER_NAME}_${AZURE_LOCATION}
-  principalIdFromConfig:
-    key: principal-id
-    name: ${CLUSTER_NAME}-identity
-  roleDefinitionReference:
-    # Contributor
-    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c
+  name: capz-${CLUSTER_NAME}
+  labels:
+    cluster.x-k8s.io/aggregate-to-capz-manager: "true"
+rules:
+- apiGroups:
+  - authorization.azure.com
+  resources:
+  - roleassignments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorization.azure.com
+  resources:
+  - roleassignments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - managedidentity.azure.com
+  resources:
+  - userassignedidentities
+  - federatedidentitycredentials
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managedidentity.azure.com
+  resources:
+  - userassignedidentities/status
+  - federatedidentitycredentials/status
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This change adds a Secret stub to the CAPZ cluster template for cluster-autoscaler e2e tests on Azure to play nice with the changes made in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4946

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
