### PR TITLE
Allow removing some volumes so that bounded PV check can pass when scaling down

### DIFF
--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -52,6 +52,7 @@ func GetPodsToMove(nodeInfo *schedulerframework.NodeInfo, deleteOptions options.
 	}
 	for _, podInfo := range nodeInfo.Pods {
 		pod := podInfo.Pod
+		drain.RemoveIgnoredVolumes(pod)
 		status := drainabilityRules.Drainable(drainCtx, pod, nodeInfo)
 		switch status.Outcome {
 		case drainability.UndefinedOutcome, drainability.DrainOk:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6417

#### Special notes for your reviewer:

Previous PR: #6418
Specifying `--skip-nodes-with-local-storage=false` won't help, because this flag only affects drainable check
After drainable check, the pod will enter bounded PV check where it will fail
(because local pv is bounded to the specified node)


#### Does this PR introduce a user-facing change?

```release-note
Allow removing some volumes so that bounded PV check can pass when scaling down
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
