### PR TITLE
Fix: GCE FetchAvailableDiskTypes zones parsing

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -695,7 +695,13 @@ func (client *autoscalingGceClientV1) FetchAvailableDiskTypes() (map[string][]st
 	if err := req.Pages(context.TODO(), func(page *gce.DiskTypeAggregatedList) error {
 		for _, diskTypesScopedList := range page.Items {
 			for _, diskType := range diskTypesScopedList.DiskTypes {
-				availableDiskTypes[diskType.Zone] = append(availableDiskTypes[diskType.Zone], diskType.Name)
+				// skip data for regions
+				if diskType.Zone == "" {
+					continue
+				}
+				// convert URL of the zone, into the short name, e.g. us-central1-a
+				zone := path.Base(diskType.Zone)
+				availableDiskTypes[zone] = append(availableDiskTypes[zone], diskType.Name)
 			}
 		}
 		return nil

--- a/cluster-autoscaler/cloudprovider/gce/fixtures/diskTypes_aggregatedList.json
+++ b/cluster-autoscaler/cloudprovider/gce/fixtures/diskTypes_aggregatedList.json
@@ -1,0 +1,162 @@
+{
+    "kind": "compute#diskTypeAggregatedList",
+    "id": "projects/project-id/aggregated/diskTypes",
+    "items": {
+        "regions/us-central1": {
+            "diskTypes": [
+                {
+                    "kind": "compute#diskType",
+                    "id": "30007",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-balanced",
+                    "description": "Balanced Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/regions/us-central1/diskTypes/pd-balanced",
+                    "defaultDiskSizeGb": "100",
+                    "region": "https://www.googleapis.com/compute/v1/projects/project-id/regions/us-central1"
+                }
+            ]
+        },
+        "zones/us-central1-a": {
+            "diskTypes": [
+                {
+                    "kind": "compute#diskType",
+                    "id": "30003",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "local-ssd",
+                    "description": "Local SSD",
+                    "validDiskSize": "375GB-375GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/diskTypes/local-ssd",
+                    "defaultDiskSizeGb": "375"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30007",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-balanced",
+                    "description": "Balanced Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/diskTypes/pd-balanced",
+                    "defaultDiskSizeGb": "100"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30002",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-ssd",
+                    "description": "SSD Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/diskTypes/pd-ssd",
+                    "defaultDiskSizeGb": "100"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30001",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-standard",
+                    "description": "Standard Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/diskTypes/pd-standard",
+                    "defaultDiskSizeGb": "500"
+                }
+            ]
+        },
+        "zones/us-central1-b": {
+            "diskTypes": [
+                {
+                    "kind": "compute#diskType",
+                    "id": "30014",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "hyperdisk-balanced",
+                    "description": "Hyperdisk Balanced Persistent Disk",
+                    "validDiskSize": "4GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/hyperdisk-balanced",
+                    "defaultDiskSizeGb": "100"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30012",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "hyperdisk-extreme",
+                    "description": "Hyperdisk Extreme Persistent Disk",
+                    "validDiskSize": "64GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/hyperdisk-extreme",
+                    "defaultDiskSizeGb": "1000"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30013",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "hyperdisk-throughput",
+                    "description": "Hyperdisk Throughput Persistent Disk",
+                    "validDiskSize": "2048GB-32768GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/hyperdisk-throughput",
+                    "defaultDiskSizeGb": "2048"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30003",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "local-ssd",
+                    "description": "Local SSD",
+                    "validDiskSize": "375GB-375GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/local-ssd",
+                    "defaultDiskSizeGb": "375"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30007",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-balanced",
+                    "description": "Balanced Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/pd-balanced",
+                    "defaultDiskSizeGb": "100"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30008",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-extreme",
+                    "description": "Extreme Persistent Disk",
+                    "validDiskSize": "500GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/pd-extreme",
+                    "defaultDiskSizeGb": "1000"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30002",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-ssd",
+                    "description": "SSD Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/pd-ssd",
+                    "defaultDiskSizeGb": "100"
+                },
+                {
+                    "kind": "compute#diskType",
+                    "id": "30001",
+                    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+                    "name": "pd-standard",
+                    "description": "Standard Persistent Disk",
+                    "validDiskSize": "10GB-65536GB",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-b/diskTypes/pd-standard",
+                    "defaultDiskSizeGb": "500"
+                }
+            ]
+        }
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-id/aggregated/diskTypes"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `FetchAvailableDiskTypes` method has wrong assumptions about `gce.DiskTypeAggregatedList` response format.
 1. The `resp.Items[].Zone` field is a URL, not a zone name.
 2. It would include regional (aggregated) data into output, whereas only zone level is needed

#### Which issue(s) this PR fixes:

There were no issues, as this method was recently added and was not used, yet.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```