### PR TITLE
Remove not yet supported parameter from admission-controller deployment

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          args: ["--v=4", "--stderrthreshold=info", "--reload-cert"]
+          args: ["--v=4", "--stderrthreshold=info"]
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


#### What this PR does / why we need it:
Remove `--reload-cert` from the admission-controller deployment, as this references image version 1.1.2, which doesn't support this parameter yet. It will be available from version 1.2.0 onwards.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6977
