### PR TITLE
Update Azure cluster-autoscaler e2e test

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/test/.gitignore
+++ b/cluster-autoscaler/cloudprovider/azure/test/.gitignore
@@ -1,0 +1,1 @@
+_artifacts

--- a/cluster-autoscaler/cloudprovider/azure/test/Makefile
+++ b/cluster-autoscaler/cloudprovider/azure/test/Makefile
@@ -54,7 +54,9 @@ install-e2e: $(HELM)
 		--set extraArgs.skip-nodes-with-local-storage=false \
 		--wait
 
+ARTIFACTS?=_artifacts
+
 .PHONY: test-e2e
 test-e2e: install-e2e
-	go run github.com/onsi/ginkgo/v2/ginkgo e2e -v -- \
+	go run github.com/onsi/ginkgo/v2/ginkgo -v --trace --output-dir "$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" e2e -- \
 		-resource-group="$$(KUBECONFIG= kubectl get managedclusters -o jsonpath='{.items[0].status.nodeResourceGroup}')"

--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Azure Provider", func() {
 		Expect(k8s.Delete(ctx, namespace)).To(Succeed())
 		Eventually(func() bool {
 			err := k8s.Get(ctx, client.ObjectKeyFromObject(namespace), &corev1.Namespace{})
-			GinkgoLogr.Info("got err", "error", err)
 			return apierrors.IsNotFound(err)
 		}, "1m", "5s").Should(BeTrue(), "Namespace "+namespace.Name+" still exists")
 	})
@@ -123,21 +122,20 @@ var _ = Describe("Azure Provider", func() {
 		Expect(k8s.Delete(ctx, deploy)).To(Succeed())
 
 		By("Waiting for the original number of Nodes to be Ready")
-		Eventually(func() (int, error) {
-			readyCount := 0
+		Eventually(func(g Gomega) {
 			nodes := &corev1.NodeList{}
-			if err := k8s.List(ctx, nodes); err != nil {
-				return 0, err
-			}
-			for _, node := range nodes.Items {
-				for _, cond := range node.Status.Conditions {
-					if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-						readyCount++
-						break
+			g.Expect(k8s.List(ctx, nodes)).To(Succeed())
+			g.Expect(nodes.Items).To(SatisfyAll(
+				HaveLen(nodeCountBefore),
+				ContainElements(Satisfy(func(node corev1.Node) bool {
+					for _, cond := range node.Status.Conditions {
+						if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+							return true
+						}
 					}
-				}
-			}
-			return readyCount, nil
-		}, "10m", "10s").Should(Equal(nodeCountBefore))
+					return false
+				})),
+			))
+		}, "20m", "10s").Should(Succeed())
 	})
 })

--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
@@ -77,14 +77,12 @@ func allVMSSStable(g Gomega) {
 	g.Expect(nodes.Items).To(SatisfyAll(
 		HaveLen(int(expectedNodes)),
 		ContainElements(Satisfy(func(node corev1.Node) bool {
-			ready := false
 			for _, cond := range node.Status.Conditions {
 				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					ready = true
-					break
+					return true
 				}
 			}
-			return ready
+			return false
 		})),
 	))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR makes some changes to spruce up the output of the cluster-autoscaler Azure test.
- Generate junit report
- Remove debug log statement
- Wait for NotReady Nodes not to exist at the end of the test

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
