### PR TITLE
OCI: Fixing scale from zero if the nodeSelector of workload contains 'node.kubernetes.io/instance-type'

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -116,6 +116,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 	// Update the cache based on latest results
 	for _, s := range resp.Items {
 		osf.cache[*s.Shape] = &Shape{
+			Name:                    shapeName,
 			CPU:                     getFloat32(s.Ocpus) * 2, // convert ocpu to vcpu
 			GPU:                     getInt(s.Gpus),
 			MemoryInBytes:           getFloat32(s.MemoryInGBs) * 1024 * 1024 * 1024,

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -84,7 +84,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 	if np.NodeShapeConfig != nil {
 		return &Shape{
 			Name: shapeName,
-			CPU: *np.NodeShapeConfig.Ocpus * 2,
+			CPU:  *np.NodeShapeConfig.Ocpus * 2,
 			// num_bytes * kilo * mega * giga
 			MemoryInBytes:           *np.NodeShapeConfig.MemoryInGBs * 1024 * 1024 * 1024,
 			GPU:                     0,

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -83,6 +83,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 	shapeName := *np.NodeShape
 	if np.NodeShapeConfig != nil {
 		return &Shape{
+			Name: shapeName,
 			CPU: *np.NodeShapeConfig.Ocpus * 2,
 			// num_bytes * kilo * mega * giga
 			MemoryInBytes:           *np.NodeShapeConfig.MemoryInGBs * 1024 * 1024 * 1024,

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape_test.go
@@ -95,6 +95,7 @@ func TestNodePoolGetShape(t *testing.T) {
 		"basic shape": {
 			shape: "VM.Standard1.2",
 			expected: &Shape{
+				Name:                    "VM.Standard1.2",
 				CPU:                     4,
 				MemoryInBytes:           16 * 1024 * 1024 * 1024,
 				GPU:                     0,
@@ -108,6 +109,7 @@ func TestNodePoolGetShape(t *testing.T) {
 				MemoryInGBs: common.Float32(64),
 			},
 			expected: &Shape{
+				Name:                    "VM.Standard.E3.Flex",
 				CPU:                     8,
 				MemoryInBytes:           4 * 16 * 1024 * 1024 * 1024,
 				GPU:                     0,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently if workload contains a `nodeSelector` such as 

```
        "nodeSelector": {
          "node.kubernetes.io/instance-type": "VM.Standard.E4.Flex"
        },
```

then scale from zero does not work as `shape.Name` is not initialized during the templateNode creation.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This should be backported / cherry picked for all supported OKE versions such as 1.30 (upcoming), 1.29, 1.28

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
