### PR TITLE
Change GCE AnnotationNodeInfoProvider nested provider to interface instead of concrete type

### DIFF
--- a/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
@@ -29,19 +29,26 @@ import (
 
 // AnnotationNodeInfoProvider is a wrapper for MixedTemplateNodeInfoProvider.
 type AnnotationNodeInfoProvider struct {
-	mixedTemplateNodeInfoProvider *MixedTemplateNodeInfoProvider
+	templateNodeInfoProvider TemplateNodeInfoProvider
 }
 
-// NewAnnotationNodeInfoProvider returns AnnotationNodeInfoProvider.
+// NewAnnotationNodeInfoProvider returns AnnotationNodeInfoProvider wrapping MixedTemplateNodeInfoProvider.
 func NewAnnotationNodeInfoProvider(t *time.Duration, forceDaemonSets bool) *AnnotationNodeInfoProvider {
 	return &AnnotationNodeInfoProvider{
-		mixedTemplateNodeInfoProvider: NewMixedTemplateNodeInfoProvider(t, forceDaemonSets),
+		templateNodeInfoProvider: NewMixedTemplateNodeInfoProvider(t, forceDaemonSets),
+	}
+}
+
+// NewCustomAnnotationNodeInfoProvider returns AnnotationNodeInfoProvider wrapping TemplateNodeInfoProvider.
+func NewCustomAnnotationNodeInfoProvider(templateNodeInfoProvider TemplateNodeInfoProvider) *AnnotationNodeInfoProvider {
+	return &AnnotationNodeInfoProvider{
+		templateNodeInfoProvider: templateNodeInfoProvider,
 	}
 }
 
 // Process returns the nodeInfos set for this cluster.
 func (p *AnnotationNodeInfoProvider) Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
-	nodeInfos, err := p.mixedTemplateNodeInfoProvider.Process(ctx, nodes, daemonsets, taintConfig, currentTime)
+	nodeInfos, err := p.templateNodeInfoProvider.Process(ctx, nodes, daemonsets, taintConfig, currentTime)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
GCE AnnotationNodeInfoProvider used concrete `MixedTemplateNodeInfoProvider` type instead of generic `TemplateNodeInfoProvider` interface.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
