### PR TITLE
Add support for node pool placement group config

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -187,9 +187,9 @@ func getLargePlacementGroups(nodeGroups map[string]*hetznerNodeGroup, threshold 
 
 	// Calculate totals for each placement group
 	for _, nodeGroup := range nodeGroups {
-		if nodeGroup.placementGroup == nil || nodeGroup.placementGroup.Name == "" {  
-            continue  
-        }
+		if nodeGroup.placementGroup == nil || nodeGroup.placementGroup.Name == "" {
+			continue
+		}
 
 		placementGroup := nodeGroup.placementGroup
 		placementGroupTotals[placementGroup] += nodeGroup.maxSize

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -182,19 +182,21 @@ func (d *HetznerCloudProvider) Refresh() error {
 }
 
 // Check if any defined placement groups could potentially have more than the maximum allowed number of nodes
-func getLargePlacementGroups(nodeGroups map[string]*hetznerNodeGroup, threshold int) []hcloud.PlacementGroup {
+func getLargePlacementGroups(nodeGroups map[string]*hetznerNodeGroup, threshold int) []*hcloud.PlacementGroup {
 	placementGroupTotals := make(map[hcloud.PlacementGroup]int)
 
 	// Calculate totals for each placement group
 	for _, nodeGroup := range nodeGroups {
-		if nodeGroup.placementGroup.Name != "" { // Check if placementGroup is defined
-			placementGroup := nodeGroup.placementGroup
-			placementGroupTotals[placementGroup] += nodeGroup.maxSize
-		}
+		if nodeGroup.placementGroup == nil || nodeGroup.placementGroup.Name == "" {  
+            continue  
+        }
+
+		placementGroup := nodeGroup.placementGroup
+		placementGroupTotals[placementGroup] += nodeGroup.maxSize
 	}
 
 	// Collect placement groups with total maxSize > threshold
-	var largePlacementGroups []hcloud.PlacementGroup
+	var largePlacementGroups []*hcloud.PlacementGroup
 	for placementGroup, totalMaxSize := range placementGroupTotals {
 		if totalMaxSize > threshold {
 			largePlacementGroups = append(largePlacementGroups, placementGroup)
@@ -253,7 +255,13 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 		}
 
 		// If a placement group was specified, check with the API to see if it exists
-		if manager.clusterConfig.IsUsingNewFormat && placementGroupRef := manager.clusterConfig.NodeConfigs[spec.name].PlacementGroup; placementGroupRef != nil {
+		if manager.clusterConfig.IsUsingNewFormat {
+
+			placementGroupRef := manager.clusterConfig.NodeConfigs[spec.name].PlacementGroup
+
+			if placementGroupRef == "" {
+				continue
+			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -284,7 +292,7 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 	largePlacementGroups := getLargePlacementGroups(manager.nodeGroups, maxPlacementGroupSize)
 
 	// Fail if we have placement groups over the max size
-	if (len(largePlacementGroups) > 0) {
+	if len(largePlacementGroups) > 0 {
 
 		// Gather placement group names
 		var placementGroupNames string

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -28,7 +28,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -300,7 +299,7 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 			if i > 0 {
 				placementGroupIDs += ", "
 			}
-			placementGroupIDs += strconv.Itoa(placementGroupID)
+			placementGroupIDs += strconv.FormatInt(placementGroupID, 10)
 		}
 
 		klog.Fatalf("The following placement groups have a potential size over the allowed maximum of %d: %s.", maxPlacementGroupSize, placementGroupIDs)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hetzner
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -179,6 +181,29 @@ func (d *HetznerCloudProvider) Refresh() error {
 	return nil
 }
 
+// Check if any defined placement groups could potentially have more than the maximum allowed number of nodes
+func getLargePlacementGroups(nodeGroups map[string]*hetznerNodeGroup, threshold int) []hcloud.PlacementGroup {
+	placementGroupTotals := make(map[hcloud.PlacementGroup]int)
+
+	// Calculate totals for each placement group
+	for _, nodeGroup := range nodeGroups {
+		if nodeGroup.placementGroup.Name != "" { // Check if placementGroup is defined
+			placementGroup := nodeGroup.placementGroup
+			placementGroupTotals[placementGroup] += nodeGroup.maxSize
+		}
+	}
+
+	// Collect placement groups with total maxSize > threshold
+	var largePlacementGroups []hcloud.PlacementGroup
+	for placementGroup, totalMaxSize := range placementGroupTotals {
+		if totalMaxSize > threshold {
+			largePlacementGroups = append(largePlacementGroups, placementGroup)
+		}
+	}
+
+	return largePlacementGroups
+}
+
 // BuildHetzner builds the Hetzner cloud provider.
 func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	manager, err := newManager()
@@ -226,6 +251,51 @@ func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscove
 			targetSize:         len(servers),
 			clusterUpdateMutex: &clusterUpdateLock,
 		}
+
+		// If a placement group was specified, check with the API to see if it exists
+		if manager.clusterConfig.IsUsingNewFormat && placementGroupRef := manager.clusterConfig.NodeConfigs[spec.name].PlacementGroup; placementGroupRef != nil {
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			placementGroup, _, err := manager.client.PlacementGroup.Get(ctx, placementGroupRef)
+
+			// Check if an error occurred
+			if err != nil {
+				if err == context.DeadlineExceeded {
+					klog.Fatalf("Timed out checking if placement group `%s` exists.", placementGroupRef)
+				} else {
+					klog.Fatalf("Failed to verify if placement group `%s` exists error: %v", placementGroupRef, err)
+				}
+			}
+
+			// If the placement group exists, add it to the node group config
+			if placementGroup != nil {
+				manager.nodeGroups[spec.name].placementGroup = placementGroup
+			} else {
+				klog.Fatalf("The requested placement group `%s` does not appear to exist.", placementGroupRef)
+			}
+		}
+	}
+
+	// Get placement groups with total maxSize over the maximum allowed
+	maxPlacementGroupSize := 10
+
+	largePlacementGroups := getLargePlacementGroups(manager.nodeGroups, maxPlacementGroupSize)
+
+	// Fail if we have placement groups over the max size
+	if (len(largePlacementGroups) > 0) {
+
+		// Gather placement group names
+		var placementGroupNames string
+		for i, pg := range largePlacementGroups {
+			if i > 0 {
+				placementGroupNames += ", "
+			}
+			placementGroupNames += pg.Name
+		}
+
+		klog.Fatalf("The following placement groups have a potential size over the allowed maximum of %d: %s.", maxPlacementGroupSize, placementGroupNames)
 	}
 
 	return provider

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -73,9 +73,10 @@ type ImageList struct {
 
 // NodeConfig holds the configuration for a single nodepool
 type NodeConfig struct {
-	CloudInit string
-	Taints    []apiv1.Taint
-	Labels    map[string]string
+	CloudInit      string
+	PlacementGroup string
+	Taints         []apiv1.Taint
+	Labels         map[string]string
 }
 
 // LegacyConfig holds the configuration in the legacy format

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -445,6 +445,7 @@ func createServer(n *hetznerNodeGroup) error {
 			EnableIPv4: n.manager.publicIPv4,
 			EnableIPv6: n.manager.publicIPv6,
 		},
+		PlacementGroup: n.placementGroup,
 	}
 	if n.manager.sshKey != nil {
 		opts.SSHKeys = []*hcloud.SSHKey{n.manager.sshKey}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -47,6 +47,7 @@ type hetznerNodeGroup struct {
 	instanceType string
 
 	clusterUpdateMutex *sync.Mutex
+	placementGroup     *hcloud.PlacementGroup
 }
 
 type hetznerNodeGroupSpec struct {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds support for specifying a placement group for a node pool using the `HCLOUD_CLUSTER_CONFIG` JSON. This is a nice feature to have because it allows you to spread a node pool's VMs over different physical hardware, increasing the overall resilience of the pool.

#### Which issue(s) this PR fixes:
Fixes #5919 

#### Special notes for your reviewer:
This is the first go code that I have written, so I apologize if it's a total mess. Also, I'm not sure how to setup a dev/testing environment for this project, so I was not able to actually run this code to test it.

#### Does this PR introduce a user-facing change?
```release-note
Add support for specifying node pool placement groups when using HCLOUD_CLUSTER_CONFIG
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
To specify a placement group, use JSON like this:

{
  "nodeConfigs": {
    "pool-1": {
      "placementGroup": "name or ID here"
    }
}
```
