### PR TITLE
vpa-admission-controller: Improve finding the matching VPA for Pod

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -52,30 +52,46 @@ func NewMatcher(vpaLister vpa_lister.VerticalPodAutoscalerLister,
 }
 
 func (m *matcher) GetMatchingVPA(ctx context.Context, pod *core.Pod) *vpa_types.VerticalPodAutoscaler {
+	parentController, err := vpa_api_util.FindParentControllerForPod(ctx, pod, m.controllerFetcher)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get parent controller for pod", "pod", klog.KObj(pod))
+		return nil
+	}
+	if parentController == nil {
+		return nil
+	}
+
 	configs, err := m.vpaLister.VerticalPodAutoscalers(pod.Namespace).List(labels.Everything())
 	if err != nil {
 		klog.ErrorS(err, "Failed to get vpa configs")
 		return nil
 	}
-	onConfigs := make([]*vpa_api_util.VpaWithSelector, 0)
+
+	var controllingVpa *vpa_types.VerticalPodAutoscaler
 	for _, vpaConfig := range configs {
 		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff {
 			continue
 		}
+		if vpaConfig.Spec.TargetRef == nil {
+			continue
+		}
+		if vpaConfig.Spec.TargetRef.Kind != parentController.Kind ||
+			vpaConfig.Namespace != parentController.Namespace ||
+			vpaConfig.Spec.TargetRef.Name != parentController.Name {
+			continue // This pod is not associated to the right controller
+		}
+
 		selector, err := m.selectorFetcher.Fetch(ctx, vpaConfig)
 		if err != nil {
 			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpaConfig), "error", err)
 			continue
 		}
-		onConfigs = append(onConfigs, &vpa_api_util.VpaWithSelector{
-			Vpa:      vpaConfig,
-			Selector: selector,
-		})
+
+		vpaWithSelector := &vpa_api_util.VpaWithSelector{Vpa: vpaConfig, Selector: selector}
+		if vpa_api_util.PodMatchesVPA(pod, vpaWithSelector) && vpa_api_util.Stronger(vpaConfig, controllingVpa) {
+			controllingVpa = vpaConfig
+		}
 	}
-	klog.V(2).InfoS("Let's choose from", "configs", len(onConfigs), "pod", klog.KObj(pod))
-	result := vpa_api_util.GetControllingVPAForPod(ctx, pod, onConfigs, m.controllerFetcher)
-	if result != nil {
-		return result.Vpa
-	}
-	return nil
+
+	return controllingVpa
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -73,6 +73,7 @@ func (m *matcher) GetMatchingVPA(ctx context.Context, pod *core.Pod) *vpa_types.
 			continue
 		}
 		if vpaConfig.Spec.TargetRef == nil {
+			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object switch to v1", "vpa", klog.KObj(vpaConfig))
 			continue
 		}
 		if vpaConfig.Spec.TargetRef.Kind != parentController.Kind ||

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -73,7 +73,7 @@ func (m *matcher) GetMatchingVPA(ctx context.Context, pod *core.Pod) *vpa_types.
 			continue
 		}
 		if vpaConfig.Spec.TargetRef == nil {
-			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object switch to v1", "vpa", klog.KObj(vpaConfig))
+			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object, switch to v1", "vpa", klog.KObj(vpaConfig))
 			continue
 		}
 		if vpaConfig.Spec.TargetRef.Kind != parentController.Kind ||

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -57,10 +57,16 @@ func TestGetMatchingVpa(t *testing.T) {
 		Name:       sts.Name,
 		APIVersion: sts.APIVersion,
 	}
+	targetRefWithNoMatches := &v1.CrossVersionObjectReference{
+		Kind:       "ReplicaSet",
+		Name:       "rs",
+		APIVersion: "apps/v1",
+	}
 	podBuilderWithoutCreator := test.Pod().WithName("test-pod").WithLabels(map[string]string{"app": "test"}).
 		AddContainer(test.Container().WithName("i-am-container").Get())
 	podBuilder := podBuilderWithoutCreator.WithCreator(&sts.ObjectMeta, &sts.TypeMeta)
 	vpaBuilder := test.VerticalPodAutoscaler().WithContainer("i-am-container")
+
 	testCases := []struct {
 		name            string
 		pod             *core.Pod
@@ -79,12 +85,25 @@ func TestGetMatchingVpa(t *testing.T) {
 			expectedFound:   true,
 			expectedVpaName: "auto-vpa",
 		}, {
-			name: "matching selector but not match ownerRef (orphan pod)",
+			name: "no matching ownerRef (orphan pod)",
 			pod:  podBuilderWithoutCreator.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
 				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRef).Get(),
 			},
-			labelSelector: "app = test",
+			expectedFound: false,
+		}, {
+			name: "vpa without targetRef",
+			pod:  podBuilder.Get(),
+			vpas: []*vpa_types.VerticalPodAutoscaler{
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").Get(),
+			},
+			expectedFound: false,
+		}, {
+			name: "no vpa with matching targetRef",
+			pod:  podBuilder.Get(),
+			vpas: []*vpa_types.VerticalPodAutoscaler{
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRefWithNoMatches).Get(),
+			},
 			expectedFound: false,
 		}, {
 			name: "not matching selector",
@@ -100,10 +119,9 @@ func TestGetMatchingVpa(t *testing.T) {
 			vpas: []*vpa_types.VerticalPodAutoscaler{
 				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).WithName("off-vpa").WithTargetRef(targetRef).Get(),
 			},
-			labelSelector: "app = test",
 			expectedFound: false,
 		}, {
-			name: "two vpas one in off mode",
+			name: "two vpas, one in off mode",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
 				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).WithName("off-vpa").WithTargetRef(targetRef).Get(),
@@ -125,10 +143,10 @@ func TestGetMatchingVpa(t *testing.T) {
 			name:          "no vpa objects",
 			pod:           podBuilder.Get(),
 			vpas:          []*vpa_types.VerticalPodAutoscaler{},
-			labelSelector: "app = test",
 			expectedFound: false,
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
@@ -142,7 +160,9 @@ func TestGetMatchingVpa(t *testing.T) {
 			vpaLister := &test.VerticalPodAutoscalerListerMock{}
 			vpaLister.On("VerticalPodAutoscalers", "default").Return(vpaNamespaceLister)
 
-			mockSelectorFetcher.EXPECT().Fetch(gomock.Any()).AnyTimes().Return(parseLabelSelector(tc.labelSelector), nil)
+			if tc.labelSelector != "" {
+				mockSelectorFetcher.EXPECT().Fetch(gomock.Any()).AnyTimes().Return(parseLabelSelector(tc.labelSelector), nil)
+			}
 			// This test is using a FakeControllerFetcher which returns the same ownerRef that is passed to it.
 			// In other words, it cannot go through the hierarchy of controllers like "ReplicaSet => Deployment"
 			// For this reason we are using "StatefulSet" as the ownerRef kind in the test, since it is a direct link.

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -118,7 +118,7 @@ type vpaTargetSelectorFetcher struct {
 
 func (f *vpaTargetSelectorFetcher) Fetch(ctx context.Context, vpa *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
 	if vpa.Spec.TargetRef == nil {
-		return nil, fmt.Errorf("targetRef not defined. If this is a v1beta1 object switch to v1beta2.")
+		return nil, fmt.Errorf("targetRef not defined. If this is a v1beta1 object switch to v1.")
 	}
 	kind := wellKnownController(vpa.Spec.TargetRef.Kind)
 	informer, exists := f.informersMap[kind]

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -118,7 +118,7 @@ type vpaTargetSelectorFetcher struct {
 
 func (f *vpaTargetSelectorFetcher) Fetch(ctx context.Context, vpa *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
 	if vpa.Spec.TargetRef == nil {
-		return nil, fmt.Errorf("targetRef not defined. If this is a v1beta1 object switch to v1.")
+		return nil, fmt.Errorf("targetRef not defined. If this is a v1beta1 object, switch to v1.")
 	}
 	kind := wellKnownController(vpa.Spec.TargetRef.Kind)
 	informer, exists := f.informersMap[kind]

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -143,7 +143,7 @@ func GetControllingVPAForPod(ctx context.Context, pod *core.Pod, vpas []*VpaWith
 	// Choose the strongest VPA from the ones that match this Pod.
 	for _, vpaWithSelector := range vpas {
 		if vpaWithSelector.Vpa.Spec.TargetRef == nil {
-			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object switch to v1", "vpa", klog.KObj(vpaWithSelector.Vpa))
+			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object, switch to v1", "vpa", klog.KObj(vpaWithSelector.Vpa))
 			continue
 		}
 		if vpaWithSelector.Vpa.Spec.TargetRef.Kind != parentController.Kind ||

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -143,6 +143,7 @@ func GetControllingVPAForPod(ctx context.Context, pod *core.Pod, vpas []*VpaWith
 	// Choose the strongest VPA from the ones that match this Pod.
 	for _, vpaWithSelector := range vpas {
 		if vpaWithSelector.Vpa.Spec.TargetRef == nil {
+			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object switch to v1", "vpa", klog.KObj(vpaWithSelector.Vpa))
 			continue
 		}
 		if vpaWithSelector.Vpa.Spec.TargetRef.Kind != parentController.Kind ||


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

As outlined in https://github.com/kubernetes/autoscaler/issues/6925, right now the logic in the vpa-admission-controller to find the matching VPA for a Pod is expensive/ineffective. In a summary, no matter the given Pod is scaled by VPA or not, the vpa-admission-controller gets all VPAs in the namespace and fetches the selector for every VPA. Fetching the selector for a VPA is an expensive operation when the VPA's targetRef is a custom resource. For such cases, the `/scale` subresource is being fetched. Note that the used `selectorFetcher` does not have a cache client-side and it always does a GET request for the `/scale` subresource: https://github.com/kubernetes/autoscaler/blob/c79bdaf76210eb9ed9952da579196b87afb5665c/vertical-pod-autoscaler/pkg/target/fetcher.go#L130

This PR improves the effectiveness of the operations by using the following steps.
1. Find to the "top most well-known scalable controller" (aka parent contrller) for the Pod
1. Find all VPAs that match the parent controller
1. Fetch the selector (fetch `/scale` subresource when the targetRef is a CR) only for VPAs  which targetRef is matching the parent controller
1. Find the strongest VPA that matches the Pod 


In this way the selector would be fetched only for VPAs that match the Pod's parent controller. Previously it was fetched always for all VPAs in the namespace.

In `GetControllingVPAForPod` func it was always fetching the parent controller for a Pod, hence we are not introducing a change by fetching always the Pod's parent controller at the beginning of the `GetMatchingVPA` func.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
but a result of the following issues https://github.com/kubernetes/autoscaler/issues/6925, https://github.com/kubernetes/autoscaler/issues/6884

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-admission-controller: The logic for finding the matching VPA for Pod is now more effective.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
