### PR TITLE
Adding temporary multizone-nodepool support for CAS

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
-	cloudvolume "k8s.io/cloud-provider/volume"
 	"k8s.io/klog/v2"
 )
 
@@ -152,9 +151,14 @@ func buildGenericLabels(template compute.VirtualMachineScaleSet, nodeName string
 		for k, v := range *template.Zones {
 			failureDomains[k] = strings.ToLower(*template.Location) + "-" + v
 		}
-
-		result[apiv1.LabelTopologyZone] = strings.Join(failureDomains[:], cloudvolume.LabelMultiZoneDelimiter)
-		result[azureDiskTopologyKey] = strings.Join(failureDomains[:], cloudvolume.LabelMultiZoneDelimiter)
+		//Picks random zones for Multi-zone nodepool when scaling from zero.
+		//This random zone will not be the same as the zone of the VMSS that is being created, the purpose of creating
+		//the node template with random zone is to initiate scaling from zero on the multi-zone nodepool.
+		//Note that the if the customer is to have some pod affinity picking exact zone, this logic won't work.
+		//For now, discourage the customers from using podAffinity to pick the availability zones.
+		randomZone := failureDomains[rand.Intn(len(failureDomains))]
+		result[apiv1.LabelTopologyZone] = randomZone
+		result[azureDiskTopologyKey] = randomZone
 	} else {
 		result[apiv1.LabelTopologyZone] = "0"
 		result[azureDiskTopologyKey] = ""

--- a/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
@@ -20,8 +20,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -126,4 +129,51 @@ func makeTaintSet(taints []apiv1.Taint) map[apiv1.Taint]bool {
 		set[taint] = true
 	}
 	return set
+}
+
+func TestTopologyFromScaleSet(t *testing.T) {
+	testNodeName := "test-node"
+	testSkuName := "test-sku"
+	testVmss := compute.VirtualMachineScaleSet{
+		Response: autorest.Response{},
+		Sku:      &compute.Sku{Name: &testSkuName},
+		Plan:     nil,
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{OsProfile: nil}},
+		Zones:    &[]string{"1", "2", "3"},
+		Location: to.StringPtr("westus"),
+	}
+	expectedZoneValues := []string{"westus-1", "westus-2", "westus-3"}
+	labels := buildGenericLabels(testVmss, testNodeName)
+	topologyZone, ok := labels[apiv1.LabelTopologyZone]
+	assert.True(t, ok)
+	azureDiskTopology, ok := labels[azureDiskTopologyKey]
+	assert.True(t, ok)
+
+	assert.Contains(t, expectedZoneValues, topologyZone)
+	assert.Contains(t, expectedZoneValues, azureDiskTopology)
+}
+
+func TestEmptyTopologyFromScaleSet(t *testing.T) {
+	testNodeName := "test-node"
+	testSkuName := "test-sku"
+	testVmss := compute.VirtualMachineScaleSet{
+		Response: autorest.Response{},
+		Sku:      &compute.Sku{Name: &testSkuName},
+		Plan:     nil,
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{OsProfile: nil}},
+		Location: to.StringPtr("westus"),
+	}
+	expectedTopologyZone := "0"
+	expectedAzureDiskTopology := ""
+	labels := buildGenericLabels(testVmss, testNodeName)
+
+	topologyZone, ok := labels[apiv1.LabelTopologyZone]
+	assert.True(t, ok)
+	assert.Equal(t, expectedTopologyZone, topologyZone)
+
+	azureDiskTopology, ok := labels[azureDiskTopologyKey]
+	assert.True(t, ok)
+	assert.Equal(t, expectedAzureDiskTopology, azureDiskTopology)
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will prevent error once cluster-autoscaler is scaling the multi-zone nodepool from zero.
This is necessary because currently when we are trying to create a node template from the multi-zone nodepool, we create the zone-labels "[topology.kubernetes.io/zone](http://topology.kubernetes.io/zone)  " where the label is "eastus-1__eastus-2__eastus3".
However, this label is not recognized by some affinities.
With this PR, Cluster Autoscaler will create node templates using any random zone that the VMSS contains. However, this zone isn't the zone VMSS assigns VMs with. The VMSS will decide separately#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
None

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
