### PR TITLE
Script for finding Cluster Autoscaler OWNERS

### DIFF
--- a/cluster-autoscaler/hack/list-owners.py
+++ b/cluster-autoscaler/hack/list-owners.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Python script to list all OWNERS of various parts of Cluster Autoscaler.
+
+Traverse all subdirectories and find OWNERS. This is useful for tagging people
+on broad announcements, for instance before a new patch release.
+"""
+
+import glob
+import yaml
+import sys
+
+files = glob.glob('**/OWNERS', recursive=True)
+owners = set()
+
+for fname in files:
+  with open(fname) as f:
+    parsed = yaml.safe_load(f)
+    if 'approvers' in parsed and parsed['approvers'] is not None:
+      for approver in parsed['approvers']:
+        owners.add(approver)
+    else:
+      print("No approvers found in {}: {}".format(fname, parsed), file=sys.stderr)
+
+for owner in sorted(owners):
+  print('@', owner, sep='')


### PR DESCRIPTION
#### What this PR does / why we need it:

Simplify finding people to notify about project wide announcements.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
