### PR TITLE
Rename migInstancesState to migInstancesStateCount in gce cache

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -73,7 +73,7 @@ type GceCache struct {
 	machinesCache                    map[MachineTypeKey]MachineType
 	migTargetSizeCache               map[GceRef]int64
 	migBaseNameCache                 map[GceRef]string
-	migInstancesStateCache           map[GceRef]map[cloudprovider.InstanceState]int64
+	migInstancesStateCountCache      map[GceRef]map[cloudprovider.InstanceState]int64
 	listManagedInstancesResultsCache map[GceRef]string
 	instanceTemplateNameCache        map[GceRef]InstanceTemplateName
 	instanceTemplatesCache           map[GceRef]*gce.InstanceTemplate
@@ -92,7 +92,7 @@ func NewGceCache() *GceCache {
 		machinesCache:                    map[MachineTypeKey]MachineType{},
 		migTargetSizeCache:               map[GceRef]int64{},
 		migBaseNameCache:                 map[GceRef]string{},
-		migInstancesStateCache:           map[GceRef]map[cloudprovider.InstanceState]int64{},
+		migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 		listManagedInstancesResultsCache: map[GceRef]string{},
 		instanceTemplateNameCache:        map[GceRef]InstanceTemplateName{},
 		instanceTemplatesCache:           map[GceRef]*gce.InstanceTemplate{},
@@ -549,24 +549,24 @@ func (gc *GceCache) InvalidateAllListManagedInstancesResults() {
 	gc.listManagedInstancesResultsCache = make(map[GceRef]string)
 }
 
-// GetMigInstancesState returns instancesState for the given mig from cache.
-func (gc *GceCache) GetMigInstancesState(migRef GceRef) (instanceState map[cloudprovider.InstanceState]int64, found bool) {
+// GetMigInstancesStateCount returns counts of instances in different states for the given mig from cache.
+func (gc *GceCache) GetMigInstancesStateCount(migRef GceRef) (instanceState map[cloudprovider.InstanceState]int64, found bool) {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-	instanceState, found = gc.migInstancesStateCache[migRef]
+	instanceState, found = gc.migInstancesStateCountCache[migRef]
 	return
 }
 
-// SetMigInstancesState sets the InstancesState for a given mig in cache.
-func (gc *GceCache) SetMigInstancesState(migRef GceRef, instanceState map[cloudprovider.InstanceState]int64) {
+// SetMigInstancesStateCount sets the counts of instances in different states for a given mig in cache.
+func (gc *GceCache) SetMigInstancesStateCount(migRef GceRef, instanceState map[cloudprovider.InstanceState]int64) {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-	gc.migInstancesStateCache[migRef] = instanceState
+	gc.migInstancesStateCountCache[migRef] = instanceState
 }
 
-// InvalidateMigInstancesState invalidates all migInstancesStateCache entries.
-func (gc *GceCache) InvalidateMigInstancesState() {
+// InvalidateMigInstancesStateCount invalidates all migInstancesStateCountCache entries.
+func (gc *GceCache) InvalidateMigInstancesStateCount() {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-	gc.migInstancesStateCache = make(map[GceRef]map[cloudprovider.InstanceState]int64)
+	gc.migInstancesStateCountCache = make(map[GceRef]map[cloudprovider.InstanceState]int64)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -347,7 +347,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		instanceTemplatesCache:           map[GceRef]*gce.InstanceTemplate{},
 		kubeEnvCache:                     map[GceRef]KubeEnv{},
 		migBaseNameCache:                 map[GceRef]string{},
-		migInstancesStateCache:           map[GceRef]map[cloudprovider.InstanceState]int64{},
+		migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 		listManagedInstancesResultsCache: map[GceRef]string{},
 	}
 	migLister := NewMigLister(cache)

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -684,7 +684,7 @@ func TestRegenerateMigInstancesCache(t *testing.T) {
 				migBaseNameCache:                 map[GceRef]string{},
 				listManagedInstancesResultsCache: map[GceRef]string{},
 				instanceTemplateNameCache:        map[GceRef]InstanceTemplateName{},
-				migInstancesStateCache:           map[GceRef]map[cloudprovider.InstanceState]int64{},
+				migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 			},
 			fetchMigInstances:                 fetchMigInstancesConst(mig1Instances),
 			fetchMigs:                         fetchMigsConst([]*gce.InstanceGroupManager{mig1Igm}),
@@ -709,7 +709,7 @@ func TestRegenerateMigInstancesCache(t *testing.T) {
 				migBaseNameCache:                 map[GceRef]string{},
 				listManagedInstancesResultsCache: map[GceRef]string{},
 				instanceTemplateNameCache:        map[GceRef]InstanceTemplateName{},
-				migInstancesStateCache:           map[GceRef]map[cloudprovider.InstanceState]int64{},
+				migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 			},
 			fetchMigInstances: fetchMigInstancesConst(mig2Instances),
 			fetchMigs:         fetchMigsConst([]*gce.InstanceGroupManager{mig2Igm}),
@@ -735,7 +735,7 @@ func TestRegenerateMigInstancesCache(t *testing.T) {
 				migBaseNameCache:                 map[GceRef]string{},
 				listManagedInstancesResultsCache: map[GceRef]string{},
 				instanceTemplateNameCache:        map[GceRef]InstanceTemplateName{},
-				migInstancesStateCache:           map[GceRef]map[cloudprovider.InstanceState]int64{},
+				migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 			},
 			fetchMigs:                         fetchMigsConst([]*gce.InstanceGroupManager{mig2Igm}),
 			fetchAllInstances:                 fetchAllInstancesInZone(map[string][]GceInstance{"myzone2": {instance3, instance6}}),
@@ -1273,8 +1273,8 @@ func TestCreateInstancesState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			state := createInstancesState(tc.targetSize, tc.actionSummary)
-			assert.Equal(t, tc.want, state)
+			stateCount := createInstancesStateCount(tc.targetSize, tc.actionSummary)
+			assert.Equal(t, tc.want, stateCount)
 		})
 	}
 }
@@ -1742,7 +1742,7 @@ func TestIsMigInstancesConsistent(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := GceCache{
-				migInstancesStateCache: tc.migInstancesStateCache,
+				migInstancesStateCountCache: tc.migInstancesStateCache,
 			}
 			provider := &cachingMigInfoProvider{
 				cache: &cache,
@@ -1805,7 +1805,7 @@ func TestIsMigInCreatingOrDeletingInstanceState(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := GceCache{
-				migInstancesStateCache: tc.migInstancesStateCache,
+				migInstancesStateCountCache: tc.migInstancesStateCache,
 			}
 			provider := &cachingMigInfoProvider{
 				cache: &cache,
@@ -1878,12 +1878,12 @@ func TestUpdateMigInstancesCache(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := GceCache{
-				migs:                   tc.migs,
-				instances:              make(map[GceRef][]GceInstance),
-				instancesUpdateTime:    make(map[GceRef]time.Time),
-				migBaseNameCache:       make(map[GceRef]string),
-				migInstancesStateCache: tc.migInstancesStateCache,
-				instancesToMig:         make(map[GceRef]GceRef),
+				migs:                        tc.migs,
+				instances:                   make(map[GceRef][]GceInstance),
+				instancesUpdateTime:         make(map[GceRef]time.Time),
+				migBaseNameCache:            make(map[GceRef]string),
+				migInstancesStateCountCache: tc.migInstancesStateCache,
+				instancesToMig:              make(map[GceRef]GceRef),
 			}
 			migLister := NewMigLister(&cache)
 			client := &mockAutoscalingGceClient{
@@ -1921,7 +1921,7 @@ func emptyCache() *GceCache {
 		instancesUpdateTime:              make(map[GceRef]time.Time),
 		migTargetSizeCache:               make(map[GceRef]int64),
 		migBaseNameCache:                 make(map[GceRef]string),
-		migInstancesStateCache:           make(map[GceRef]map[cloudprovider.InstanceState]int64),
+		migInstancesStateCountCache:      make(map[GceRef]map[cloudprovider.InstanceState]int64),
 		listManagedInstancesResultsCache: make(map[GceRef]string),
 		instanceTemplateNameCache:        make(map[GceRef]InstanceTemplateName),
 		instanceTemplatesCache:           make(map[GceRef]*gce.InstanceTemplate),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR renames ```migInstancesState``` to ```migInstancesStateCount``` in gce cache
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
