### PR TITLE
Update ProvisioningRequest API with the new name of scale-up provisioning class

### DIFF
--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -197,7 +197,7 @@ const (
 	// ProvisioningClassCheckCapacity denotes that CA will check if current cluster state can fulfill this request,
 	// and reserve the capacity for a specified time.
 	ProvisioningClassCheckCapacity string = "check-capacity.autoscaling.x-k8s.io"
-	// ProvisioningClassAtomicScaleUp denotes that CA try to provision the capacity
+	// ProvisioningClassBestEffortAtomicScaleUp denotes that CA try to provision the capacity
 	// in an atomic manner.
-	ProvisioningClassAtomicScaleUp string = "atomic-scale-up.autoscaling.x-k8s.io"
+	ProvisioningClassBestEffortAtomicScaleUp string = "best-effort-atomic-scale-up.autoscaling.x-k8s.io"
 )

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -83,7 +83,7 @@ func TestScaleUp(t *testing.T) {
 			CPU:      "1",
 			Memory:   "1",
 			PodCount: int32(5),
-			Class:    v1beta1.ProvisioningClassAtomicScaleUp,
+			Class:    v1beta1.ProvisioningClassBestEffortAtomicScaleUp,
 		})
 
 	// Already provisioned provisioning request - capacity should be booked before processing a new request.

--- a/cluster-autoscaler/vendor/k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/vendor/k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -197,7 +197,7 @@ const (
 	// ProvisioningClassCheckCapacity denotes that CA will check if current cluster state can fulfill this request,
 	// and reserve the capacity for a specified time.
 	ProvisioningClassCheckCapacity string = "check-capacity.autoscaling.x-k8s.io"
-	// ProvisioningClassAtomicScaleUp denotes that CA try to provision the capacity
+	// ProvisioningClassBestEffortAtomicScaleUp denotes that CA try to provision the capacity
 	// in an atomic manner.
-	ProvisioningClassAtomicScaleUp string = "atomic-scale-up.autoscaling.x-k8s.io"
+	ProvisioningClassBestEffortAtomicScaleUp string = "best-effort-atomic-scale-up.autoscaling.x-k8s.io"
 )


### PR DESCRIPTION
#### What type of PR is this?
cherry-pick of #6854 
this is needed to cherry-pick https://github.com/kubernetes/autoscaler/pull/7030

/kind bug

#### Does this PR introduce a user-facing change?

```release-note
Changed the name of provisioning class from `atomic-scale-up.autoscaling.x-k8s.io` to `best-effort-atomic-scale-up.autoscaling.x-k8s.io` in v1beta1. Note that this API is in draft stage and not yet supported in any release.
```
