### PR TITLE
vpa-admission-controller: Contextify status updates. Add timeout of 10s

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -116,7 +116,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 	defer timer.ObserveTotal()
 
 	if u.useAdmissionControllerStatus {
-		isValid, err := u.statusValidator.IsStatusValid(status.AdmissionControllerStatusTimeout)
+		isValid, err := u.statusValidator.IsStatusValid(ctx, status.AdmissionControllerStatusTimeout)
 		if err != nil {
 			klog.Errorf("Error getting Admission Controller status: %v. Skipping eviction loop", err)
 			return

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -257,6 +257,6 @@ func newFakeValidator(isValid bool) status.Validator {
 	return &fakeValidator{isValid}
 }
 
-func (f *fakeValidator) IsStatusValid(statusTimeout time.Duration) (bool, error) {
+func (f *fakeValidator) IsStatusValid(ctx context.Context, statusTimeout time.Duration) (bool, error) {
 	return f.isValid, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/status/status_object.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_object.go
@@ -60,7 +60,7 @@ type Client struct {
 
 // Validator for the status object.
 type Validator interface {
-	IsStatusValid(statusTimeout time.Duration) (bool, error)
+	IsStatusValid(ctx context.Context, statusTimeout time.Duration) (bool, error)
 }
 
 // NewClient returns a client for the status object.
@@ -87,18 +87,18 @@ func NewValidator(c clientset.Interface, leaseName, leaseNamespace string) Valid
 
 // UpdateStatus renews status object lease.
 // Status object will be created if it doesn't exist.
-func (c *Client) UpdateStatus() error {
-	updateFn := func() error {
-		lease, err := c.client.Get(context.TODO(), c.leaseName, metav1.GetOptions{})
+func (c *Client) UpdateStatus(ctx context.Context) error {
+	updateFn := func(ctx context.Context) error {
+		lease, err := c.client.Get(ctx, c.leaseName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// Create lease if it doesn't exist.
-			return c.create()
+			return c.create(ctx)
 		} else if err != nil {
 			return err
 		}
 		lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 		lease.Spec.HolderIdentity = pointer.String(c.holderIdentity)
-		_, err = c.client.Update(context.TODO(), lease, metav1.UpdateOptions{})
+		_, err = c.client.Update(ctx, lease, metav1.UpdateOptions{})
 		if apierrors.IsConflict(err) {
 			// Lease was updated by an another replica of the component.
 			// No error should be returned.
@@ -106,11 +106,11 @@ func (c *Client) UpdateStatus() error {
 		}
 		return err
 	}
-	return retryWithExponentialBackOff(updateFn)
+	return retryWithExponentialBackOff(ctx, updateFn)
 }
 
-func (c *Client) create() error {
-	_, err := c.client.Create(context.TODO(), c.newLease(), metav1.CreateOptions{})
+func (c *Client) create(ctx context.Context) error {
+	_, err := c.client.Create(ctx, c.newLease(), metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		// Lease was created by an another replica of the component.
 		// No error should be returned.
@@ -134,22 +134,22 @@ func (c *Client) newLease() *apicoordinationv1.Lease {
 
 // IsStatusValid verifies if the current status object
 // was updated before lease timing out.
-func (c *Client) IsStatusValid(statusTimeout time.Duration) (bool, error) {
-	status, err := c.getStatus()
+func (c *Client) IsStatusValid(ctx context.Context, statusTimeout time.Duration) (bool, error) {
+	status, err := c.getStatus(ctx)
 	if err != nil {
 		return false, err
 	}
 	return isStatusValid(status, statusTimeout, time.Now()), nil
 }
 
-func (c *Client) getStatus() (*apicoordinationv1.Lease, error) {
+func (c *Client) getStatus(ctx context.Context) (*apicoordinationv1.Lease, error) {
 	var lease *apicoordinationv1.Lease
-	getFn := func() error {
+	getFn := func(ctx context.Context) error {
 		var err error
-		lease, err = c.client.Get(context.TODO(), c.leaseName, metav1.GetOptions{})
+		lease, err = c.client.Get(ctx, c.leaseName, metav1.GetOptions{})
 		return err
 	}
-	err := retryWithExponentialBackOff(getFn)
+	err := retryWithExponentialBackOff(ctx, getFn)
 	return lease, err
 }
 
@@ -179,16 +179,16 @@ func isRetryableNetError(err error) bool {
 	return false
 }
 
-func retryWithExponentialBackOff(fn func() error) error {
+func retryWithExponentialBackOff(ctx context.Context, fn func(context.Context) error) error {
 	backoff := wait.Backoff{
 		Duration: retryBackoffInitialDuration,
 		Factor:   retryBackoffFactor,
 		Jitter:   retryBackoffJitter,
 		Steps:    retryBackoffSteps,
 	}
-	retryFn := func(fn func() error) func() (bool, error) {
-		return func() (bool, error) {
-			err := fn()
+	retryFn := func(fn func(context.Context) error) func(context.Context) (bool, error) {
+		return func(ctx context.Context) (bool, error) {
+			err := fn(ctx)
 			if err == nil {
 				return true, nil
 			}
@@ -198,5 +198,5 @@ func retryWithExponentialBackOff(fn func() error) error {
 			return false, err
 		}
 	}
-	return wait.ExponentialBackoff(backoff, retryFn(fn))
+	return wait.ExponentialBackoffWithContext(ctx, backoff, retryFn(fn))
 }

--- a/vertical-pod-autoscaler/pkg/utils/status/status_object_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_object_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"testing"
@@ -133,7 +134,7 @@ func TestUpdateStatus(t *testing.T) {
 			fc.PrependReactor("create", "leases", tc.updateReactor)
 			fc.PrependReactor("update", "leases", tc.updateReactor)
 			client := NewClient(fc, leaseName, leaseNamespace, 10*time.Second, leaseName)
-			err := client.UpdateStatus()
+			err := client.UpdateStatus(context.Background())
 			assert.True(t, (err != nil) == tc.wantErr, fmt.Sprintf("gotErr: %v, wantErr: %v", (err != nil), tc.wantErr))
 		})
 	}
@@ -206,7 +207,7 @@ func TestGetStatus(t *testing.T) {
 			fc := fake.NewSimpleClientset()
 			fc.PrependReactor("get", "leases", tc.getReactor)
 			client := NewClient(fc, leaseName, leaseNamespace, 10*time.Second, leaseName)
-			_, err := client.getStatus()
+			_, err := client.getStatus(context.Background())
 			assert.True(t, (err != nil) == tc.wantErr)
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
@@ -48,18 +48,28 @@ func NewUpdater(c clientset.Interface, statusName, statusNamespace string,
 // Run starts status updates.
 func (su *Updater) Run(stopCh <-chan struct{}) {
 	go func() {
+		ticker := time.NewTicker(su.updateInterval)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-stopCh:
 				return
-			case <-time.After(su.updateInterval):
-				ctx, cancel := context.WithTimeout(context.Background(), su.updateInterval)
-				defer cancel()
-
-				if err := su.client.UpdateStatus(ctx); err != nil {
-					klog.Errorf("Status update by %s failed: %v", su.client.holderIdentity, err)
-				}
+			case <-ticker.C:
+				su.updateStatus()
 			}
 		}
 	}()
+}
+
+func (su *Updater) updateStatus() {
+	// The lease renewal has timeout of the given update interval (10s).
+	// If the lease cannot be renewed in the allotted time (for example due to client-side throttling),
+	// the vpa-updater will consider that vpa-admission-controller as unhealthy and won't evict Pods in endless loop.
+	ctx, cancel := context.WithTimeout(context.Background(), su.updateInterval)
+	defer cancel()
+
+	if err := su.client.UpdateStatus(ctx); err != nil {
+		klog.Errorf("Status update by %s failed: %v", su.client.holderIdentity, err)
+	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"time"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -52,7 +53,10 @@ func (su *Updater) Run(stopCh <-chan struct{}) {
 			case <-stopCh:
 				return
 			case <-time.After(su.updateInterval):
-				if err := su.client.UpdateStatus(); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), su.updateInterval)
+				defer cancel()
+
+				if err := su.client.UpdateStatus(ctx); err != nil {
 					klog.Errorf("Status update by %s failed: %v", su.client.holderIdentity, err)
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For details, see #6884.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6884

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-admission-controller: The lease updates that the vpa-admission-controller performs (that are later on checked by the vpa-updater for healthiness of the vpa-admission-controller) are now executed with a timeout of 10s. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
