### PR TITLE
Only render ServiceMonitor annotations if not empty

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.42.0
+version: 9.43.0

--- a/charts/cluster-autoscaler/templates/servicemonitor.yaml
+++ b/charts/cluster-autoscaler/templates/servicemonitor.yaml
@@ -6,8 +6,10 @@ metadata:
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
   annotations:
 {{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
   labels:
   {{- range $key, $value := .Values.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR applies the same logic used in other `templates/` to the annotations of the ServiceMonitor.

While this is good general cleanup, this also has a side-effect of improving [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) integration. Without this, if you leave the annotations default (empty) and deploy with ArgoCD, it will *always* detect a noop diff
![Screenshot from 2024-07-19 08-10-17](https://github.com/user-attachments/assets/24b7dbf0-00eb-4f69-9548-8623659475a1)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```