### PR TITLE
Decouple test and install script

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          args: ["--v=4", "--stderrthreshold=info"]
+          args: ["--v=4", "--stderrthreshold=info", "--reload-cert"]
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -19,5 +19,11 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+DEFAULT_TAG="1.1.2"
+TAG_TO_APPLY=${TAG-$DEFAULT_TAG}
+
+if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then
+  git switch --detach vertical-pod-autoscaler-${DEFAULT_TAG}
+fi
 
 $SCRIPT_ROOT/hack/vpa-process-yamls.sh create $*


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR decouples the way that we provide for installing VPA directly from this repository (via `./hack/vpa-up.sh`) from the e2e tests. Currently, both take their payload directly from `master`: this makes sense for e2e tests, as they should continuously make sure that the master is still nice and green, but leads to problems, when we introduce change like new parameters for the components (e.g. #6665) or modify the CRD (e.g. #5911).

In those cases, `./hack/vpa-up.sh` _also_ gets the new CRDs or Deployment yaml files, which don't work well with the last released versions – because they don't contain the necessary code changes. This leads to problems like #6977 and https://github.com/kubernetes/autoscaler/issues/5982#issuecomment-1651663433 

With this PR, we switch to the latest release TAG, so we don't get in new, unreleased changes in the CRDs, yamls, etc. The `./hack/vpa-up.sh` script is also [used during release validation](https://github.com/kubernetes/autoscaler/blob/c8e47217692c1fe70f53f4841a3b83b70cc0e878/vertical-pod-autoscaler/RELEASE.md#L82), therefore we assume that the user knows what they are doing if they have set a custom TAG and just leave the current state of the repo.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7011

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
