### PR TITLE
Include kubernetes.io/os labels in managed nodegroup cache labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -57,6 +57,9 @@ type awsWrapper struct {
 	eksI
 }
 
+var linuxAmiTypeRegexp = regexp.MustCompile("^(AL2|AL2023|BOTTLEROCKET)_")
+var windowsAmiTypeRegexp = regexp.MustCompile("^WINDOWS_")
+
 func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName string) ([]apiv1.Taint, map[string]string, map[string]string, error) {
 	params := &eks.DescribeNodegroupInput{
 		ClusterName:   &clusterName,
@@ -82,6 +85,14 @@ func (m *awsWrapper) getManagedNodegroupInfo(nodegroupName string, clusterName s
 
 	if r.Nodegroup.AmiType != nil && len(*r.Nodegroup.AmiType) > 0 {
 		labels["amiType"] = *r.Nodegroup.AmiType
+
+		if linuxAmiTypeRegexp.MatchString(*r.Nodegroup.AmiType) {
+			labels["kubernetes.io/os"] = "linux"
+		}
+
+		if windowsAmiTypeRegexp.MatchString(*r.Nodegroup.AmiType) {
+			labels["kubernetes.io/os"] = "windows"
+		}
 	}
 
 	if r.Nodegroup.CapacityType != nil && len(*r.Nodegroup.CapacityType) > 0 {

--- a/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 

--- a/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/managed_nodegroup_cache_test.go
@@ -724,3 +724,175 @@ func TestGetManagedNodegroupTagsNoCachedNodegroup(t *testing.T) {
 		NodegroupName: &nodegroupName,
 	})
 }
+
+func TestGetManagedNodegroupWindowsOsLabel(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "WINDOWS_testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      nil,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+		Tags:          nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 0)
+	assert.Equal(t, len(cacheObj.labels), 5)
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, cacheObj.labels["kubernetes.io/os"], "windows")
+	assert.Equal(t, len(cacheObj.tags), 0)
+}
+
+func TestGetManagedNodegroupAmazonLinux2OsLabel(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "AL2_testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      nil,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+		Tags:          nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 0)
+	assert.Equal(t, len(cacheObj.labels), 5)
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, cacheObj.labels["kubernetes.io/os"], "linux")
+	assert.Equal(t, len(cacheObj.tags), 0)
+}
+
+func TestGetManagedNodegroupAmazonLinux2023OsLabel(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "AL2023_testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      nil,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+		Tags:          nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 0)
+	assert.Equal(t, len(cacheObj.labels), 5)
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, cacheObj.labels["kubernetes.io/os"], "linux")
+	assert.Equal(t, len(cacheObj.tags), 0)
+}
+
+func TestGetManagedNodegroupBottlerocketOsLabel(t *testing.T) {
+	k := &eksMock{}
+
+	nodegroupName := "testNodegroup"
+	clusterName := "testCluster"
+	amiType := "BOTTLEROCKET_testAmiType"
+	capacityType := "testCapacityType"
+	k8sVersion := "1.19"
+
+	// Create test nodegroup
+	testNodegroup := eks.Nodegroup{
+		AmiType:       &amiType,
+		ClusterName:   &clusterName,
+		DiskSize:      nil,
+		Labels:        nil,
+		NodegroupName: &nodegroupName,
+		CapacityType:  &capacityType,
+		Version:       &k8sVersion,
+		Taints:        nil,
+		Tags:          nil,
+	}
+
+	k.On("DescribeNodegroup", &eks.DescribeNodegroupInput{
+		ClusterName:   &clusterName,
+		NodegroupName: &nodegroupName,
+	}).Return(&eks.DescribeNodegroupOutput{Nodegroup: &testNodegroup}, nil)
+
+	c := newManagedNodeGroupCache(&awsWrapper{nil, nil, k})
+
+	cacheObj, err := c.getManagedNodegroup(nodegroupName, clusterName)
+	require.NoError(t, err)
+	assert.Equal(t, cacheObj.name, nodegroupName)
+	assert.Equal(t, cacheObj.clusterName, clusterName)
+	assert.Equal(t, len(cacheObj.taints), 0)
+	assert.Equal(t, len(cacheObj.labels), 5)
+	assert.Equal(t, cacheObj.labels["amiType"], amiType)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/capacityType"], capacityType)
+	assert.Equal(t, cacheObj.labels["k8sVersion"], k8sVersion)
+	assert.Equal(t, cacheObj.labels["eks.amazonaws.com/nodegroup"], nodegroupName)
+	assert.Equal(t, cacheObj.labels["kubernetes.io/os"], "linux")
+	assert.Equal(t, len(cacheObj.tags), 0)
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Nodes from EKS managed node groups start up with several automatically injected labels, one of them being `kubernetes.io/os` which is `windows` for windows based AMI types and `linux` for linux based AMI types.

Cluster autoscaler should be aware of this so it knows it can satisfy pods with a respective nodeselector on `kubernetes.io/os` when scaling up a managed node group from zero.

This is particularly useful for the case of pods running on EKS windows nodes using the AWS VPC CNI. The pods are required to have the nodeselector `kubernetes.io/os=windows` in order to get an IP assigned by the CNI plugin and start up. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7082

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

