### PR TITLE
Added Ignore option in depandabot.yaml to ignore golang rc versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
   directory: "/vertical-pod-autoscaler/pkg/recommender"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "golang"
+      versions: ["*.*rc*"]
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"
@@ -18,6 +21,9 @@ updates:
   directory: "/vertical-pod-autoscaler/pkg/updater"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "golang"
+      versions: ["*.*rc*"]
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"
@@ -25,6 +31,9 @@ updates:
   directory: "/vertical-pod-autoscaler/pkg/admission-controller"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "golang"
+      versions: ["*.*rc*"]
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR configures the `ignore` option in depandabot.yaml so that Depandadabot ignores Golang rc versions.
#### Which issue(s) this PR fixes:

Fixes #7029

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
