### PR TITLE
[GCE cloudprovider] Invalidate mig instances cache after node deletion

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -244,6 +244,16 @@ func (gc *GceCache) InvalidateAllMigInstances() {
 	gc.instancesUpdateTime = make(map[GceRef]time.Time)
 }
 
+// InvalidateMigInstances clears the mig instances cache for a given Mig
+func (gc *GceCache) InvalidateMigInstances(migRef GceRef) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	klog.V(5).Infof("Mig instances cache invalidated for %v", migRef.Name)
+	delete(gc.instances, migRef)
+	delete(gc.instancesUpdateTime, migRef)
+}
+
 // InvalidateInstancesToMig clears the instance to mig mapping for a GceRef
 func (gc *GceCache) InvalidateInstancesToMig(migRef GceRef) {
 	gc.cacheMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -277,6 +277,7 @@ func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
 		}
 	}
 	m.cache.InvalidateMigTargetSize(commonMig.GceRef())
+	m.cache.InvalidateMigInstances(commonMig.GceRef())
 	return m.GceService.DeleteInstances(commonMig.GceRef(), instances)
 }
 


### PR DESCRIPTION

#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

After deleting some instances from a mig, invalidate the mig instances cache so that the deleted instances are refreshed accordingly.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
