### PR TITLE
Update FAQ.md to add steps for self-hosted provreq

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -589,6 +589,19 @@ rules:
   - apiGroups: [""]
     resources: ["podtemplates"]
     verbs: ["watch", "list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-provisioning-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-provisioning
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
 ```
 
 #### Supported ProvisioningClasses

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -569,7 +569,7 @@ Provisioning Request (abbr. ProvReq) is a new namespaced Custom Resource that ai
 1. **Cluster Autoscaler Version**: Ensure you are using Cluster Autoscaler version 1.30.1 or later.
 
 2. **Feature Flag**: Enable ProvisioningRequest support by setting the following flag in your Cluster Autoscaler configuration:
-`--enable-provisioning-reques=true`.
+`--enable-provisioning-requests=true`.
 
 3. **Content Type**: This feature requires that the [API content type flag](https://github.com/kubernetes/autoscaler/blob/522c6fcc06c8cf663175ba03549773cc66a02837/cluster-autoscaler/main.go#L114) is set to application/json: `--kube-api-content-type application/json`.
 

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -569,7 +569,27 @@ Provisioning Request (abbr. ProvReq) is a new namespaced Custom Resource that ai
 1. **Cluster Autoscaler Version**: Ensure you are using Cluster Autoscaler version 1.30.1 or later.
 
 2. **Feature Flag**: Enable ProvisioningRequest support by setting the following flag in your Cluster Autoscaler configuration:
---enable-provisioning-reques=true.
+`--enable-provisioning-reques=true`.
+
+3. **Content Type**: This feature requires that the [API content type flag](https://github.com/kubernetes/autoscaler/blob/522c6fcc06c8cf663175ba03549773cc66a02837/cluster-autoscaler/main.go#L114) is set to application/json: `--kube-api-content-type application/json`.
+
+4. **RBAC permissions**: Ensure your cluster-autoscaler pod has the necessary permissions to interact with ProvisioningRequests and PodTemplates:
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-provisioning
+rules:
+  - apiGroups:
+    - "autoscaling.x-k8s.io"
+    resources:
+    - provisioningrequests
+    - provisioningrequests/status
+    verbs: ["watch", "list", "get", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["podtemplates"]
+    verbs: ["watch", "list", "get"]
+```
 
 #### Supported ProvisioningClasses
 


### PR DESCRIPTION
Adding more observed requirements to use the `ProvisioningRequest` feature.

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Updating docs so that others can use `ProvisioningRequests`

#### Special notes for your reviewer:
Chatted with @yaroslava-serdiuk about these changes in [Slack](https://kubernetes.slack.com/archives/C09R1LV8S/p1720805795604139?thread_ts=1720506646.971539&cid=C09R1LV8S).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
