### PR TITLE
Set State to InstanceCreating for nodes that failed to join cluster

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -390,6 +390,7 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 			instances = append(instances, cloudprovider.Instance{
 				Id: *node.Id,
 				Status: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
 					ErrorInfo: &cloudprovider.InstanceErrorInfo{
 						ErrorClass:   errorClass,
 						ErrorCode:    *node.NodeError.Code,

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
@@ -154,6 +154,7 @@ func TestGetNodePoolNodes(t *testing.T) {
 		{
 			Id: "node6",
 			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OtherErrorClass,
 					ErrorCode:    "unknown",
@@ -164,6 +165,7 @@ func TestGetNodePoolNodes(t *testing.T) {
 		{
 			Id: "node7",
 			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
 					ErrorCode:    "LimitExceeded",
@@ -174,6 +176,7 @@ func TestGetNodePoolNodes(t *testing.T) {
 		{
 			Id: "node8",
 			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
 					ErrorCode:    "InternalServerError",


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does :
Cluster Autoscaler only handles deleting of cloud-provider instances that do not join the cluster within the max-node-provision-time only if the state of the cloud-provider instance is set to InstanceCreating. [[Code Link](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/clusterstate/clusterstate.go#L1180)]

This PR is set to the state of cloud-provider instance which have failed to InstanceCreating.