### PR TITLE
Update version.go for VPA 1.2.0 release

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.1.0"
+const VerticalPodAutoscalerVersion = "1.2.0"


### PR DESCRIPTION
Version bump for VPA 1.2.0 release

#7098
