### PR TITLE
fix VPA controller_fetcher node validation

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -257,14 +257,15 @@ func (f *controllerFetcher) isWellKnownOrScalable(key *ControllerKeyWithAPIVersi
 	if f.isWellKnown(key) {
 		return true
 	}
-	if gk, err := key.groupKind(); err != nil && wellKnownController(gk.Kind) == node {
-		return false
-	}
 
 	//if not well known check if it supports scaling
 	groupKind, err := key.groupKind()
 	if err != nil {
 		klog.Errorf("Could not find groupKind for %s/%s: %v", key.Namespace, key.Name, err)
+		return false
+	}
+
+	if wellKnownController(groupKind.Kind) == node {
 		return false
 	}
 
@@ -286,7 +287,7 @@ func (f *controllerFetcher) isWellKnownOrScalable(key *ControllerKeyWithAPIVersi
 
 func (f *controllerFetcher) getOwnerForScaleResource(groupKind schema.GroupKind, namespace, name string) (*ControllerKeyWithAPIVersion, error) {
 	if wellKnownController(groupKind.Kind) == node {
-		// Some pods specify nods as their owners. This causes performance problems
+		// Some pods specify nodes as their owners. This causes performance problems
 		// in big clusters when VPA tries to get all nodes. We know nodes aren't
 		// valid controllers so we can skip trying to fetch them.
 		return nil, fmt.Errorf("node is not a valid owner")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:

/kind regression

#### What this PR does / why we need it:

regression introduced by this [PR](https://github.com/kubernetes/autoscaler/commit/4b459a200989c6dff752ce346253e1f41e401c10)
if `gk, err := key.groupKind()` returns error, `gk` will be empty struct, the if condition will never become true  
