### PR TITLE
cherry-pick: adding bryce soghigian to owners for azure (1.28)

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/OWNERS
+++ b/cluster-autoscaler/cloudprovider/azure/OWNERS
@@ -1,16 +1,18 @@
 approvers:
 - feiskyer
 - nilo19
-- gandhipr
 - tallaxes
+- bryce-soghigian
+- jackfrancis
 reviewers:
 - feiskyer
 - nilo19
-- gandhipr
 - tallaxes
+- bryce-soghigian 
+- jackfrancis
 emeritus_approvers:
 - marwanad
-
+- gandhipr
 
 labels:
 - area/provider/azure

--- a/cluster-autoscaler/cloudprovider/azure/OWNERS
+++ b/cluster-autoscaler/cloudprovider/azure/OWNERS
@@ -12,7 +12,6 @@ reviewers:
 - jackfrancis
 emeritus_approvers:
 - marwanad
-- gandhipr
 
 labels:
 - area/provider/azure


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cherry-pick
#### What this PR does / why we need it:
https://github.com/kubernetes/autoscaler/pull/7100/commits
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
