### PR TITLE
Update README.md to include VPA 1.2.0 release

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -51,7 +51,7 @@ procedure described below.
 
 # Installation
 
-The current default version is Vertical Pod Autoscaler 1.1.2
+The current default version is Vertical Pod Autoscaler 1.2.0
 
 ### Compatibility
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -57,6 +57,7 @@ The current default version is Vertical Pod Autoscaler 1.1.2
 
 | VPA version     | Kubernetes version |
 |-----------------|--------------------|
+| 1.2.0           | 1.27+              |
 | 1.1.2           | 1.25+              |
 | 1.1.1           | 1.25+              |
 | 1.0             | 1.25+              |


### PR DESCRIPTION
#7098

/kind documentation

Tested in `1.27.14-gke.1059002` which is currently the lowest version available in GKE.