### PR TITLE
Sanitize ENV from podSpec to improve scheduling simulation performance.

### DIFF
--- a/cluster-autoscaler/utils/utils.go
+++ b/cluster-autoscaler/utils/utils.go
@@ -70,7 +70,17 @@ func PodSpecSemanticallyEqual(p1 apiv1.PodSpec, p2 apiv1.PodSpec) bool {
 func sanitizePodSpec(podSpec apiv1.PodSpec) apiv1.PodSpec {
 	dropProjectedVolumesAndMounts(&podSpec)
 	dropHostname(&podSpec)
+	dropEnv(&podSpec)
 	return podSpec
+}
+
+func dropEnv(podSpec *apiv1.PodSpec) {
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].Env = nil
+	}
+	for i := range podSpec.InitContainers {
+		podSpec.InitContainers[i].Env = nil
+	}
 }
 
 func dropProjectedVolumesAndMounts(podSpec *apiv1.PodSpec) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Sanitize ENV from podSpec to improve scheduling simulation performance.

##### Background
Cluster Autoscaler groups pods by their scheduling requirements for performance reasons. Group equality is determined by comparing pod specs, after sanitizing parts of the spec that are unique to specific pods, and that have no bearing on scheduling.

Currently ENV in containers of podSpec is not sanitized which in some cases make each pod in its own group affecting performance of scheduling simulation performance in Cluster Autoscaler.

It has triggered alert from 'overflowing_controllers_count' metric.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
