### PR TITLE
fix: implement HasInstance() for OCI providers

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
@@ -70,8 +70,25 @@ func (ocp *OciCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.G
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ocp *OciCloudProvider) HasInstance(n *apiv1.Node) (bool, error) {
-	return true, cloudprovider.ErrNotImplemented
+func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	instance, err := ocicommon.NodeToOciRef(node)
+	if err != nil {
+		return true, err
+	}
+	np, err := ocp.manager.GetNodePoolForInstance(instance)
+	if err != nil {
+		return true, err
+	}
+	nodes, err := ocp.manager.GetNodePoolNodes(np)
+	if err != nil {
+		return true, err
+	}
+	for _, n := range nodes {
+		if n.Id == instance.InstanceID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.


### PR DESCRIPTION
This implements HasInstance() for the OCI instance pool and node pool providers.

* this is a follow-up to #5054
* this should fix #4456 for OCI

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Citing [#5054 (comment)](https://github.com/kubernetes/autoscaler/pull/5054#issue-1319989728):
> ...original intent of determining the deleted nodes was incorrect, which led to the issues reported by other users. The nodes tainted with ToBeDeleted were misidentified as Deleted instead of Ready/Unready, which caused a miscalculation of the node being included as Upcoming. This caused problems described in #3949 and #4456.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4456

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: