### PR TITLE
vpa-recommender: Prevent `nil pointer dereference`

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -233,13 +233,13 @@ func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.Vertica
 	vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
 	vpa, exists := feeder.clusterState.Vpas[vpaID]
 	if !exists {
-		return fmt.Errorf("cannot load checkpoint to missing VPA object %s/%s", vpa.ID.Namespace, vpa.ID.VpaName)
+		return fmt.Errorf("cannot load checkpoint to missing VPA object %s/%s", vpaID.Namespace, vpaID.VpaName)
 	}
 
 	cs := model.NewAggregateContainerState()
 	err := cs.LoadFromCheckpoint(&checkpoint.Status)
 	if err != nil {
-		return fmt.Errorf("cannot load checkpoint for VPA %s/%s. Reason: %v", vpa.ID.Namespace, vpa.ID.VpaName, err)
+		return fmt.Errorf("cannot load checkpoint for VPA %s/%s. Reason: %v", vpaID.Namespace, vpaID.VpaName, err)
 	}
 	vpa.ContainersInitialAggregateState[checkpoint.Spec.ContainerName] = cs
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
With https://github.com/kubernetes/autoscaler/commit/628fc39443098c7e6683da739c62accf39100c51 I introduced the following nil pointer dereference to VPA 1.2.0:
```
I0814 11:04:28.216725       1 cluster_feeder.go:265] Loading VPA kube-system/kube-proxy-cpu-8-64-v1.29 checkpoint for conntrack-fix
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x161e6d5]

goroutine 102 [running]:
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input.(*clusterStateFeeder).setVpaCheckpoint(0xc00bc06450?, 0xc010efa1e0)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go:236 +0x1d5
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input.(*clusterStateFeeder).InitFromCheckpoints(0xc001fc8160)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go:266 +0x6bc
main.run(0xc0004ff890)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/main.go:269 +0xf38
main.main.func1({0xc000003c80?, 0x0?})
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/main.go:169 +0x17
created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run in goroutine 1
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:213 +0xe6
```

In https://github.com/kubernetes/autoscaler/blob/3b8fdfef983e84dc15ed3ab490f7ea320705a9e3/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go#L233-L237

for returning the err we have to use the `vpaID` var as the `vpa` var will be always nil when entry with the given key does not exist in the map.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
but see the panic above

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A `nil pointer dereference` regression introduced in vpa-recommender v1.2.0 is now fixed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
