### PR TITLE
VPA: Add option to set the webhook failurePolicy to Fail

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -392,7 +392,7 @@ These options cannot be used together and are mutually exclusive.
 
  It is possible to set the failurePolicy of the webhook to `Fail` by passing `--webhook-failure-policy-fail=true` to the VPA admission controller.
  Please use this option with caution as it may be possible to break Pod creation if there is a failure with the VPA.
-Using it in conjunction with `--ignored-vpa-object-namespaces` or `--vpa-object-namespace` to reduce risk.
+Using it in conjunction with `--ignored-vpa-object-namespaces=kube-system` or `--vpa-object-namespace` to reduce risk.
 
 # Known limitations
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -25,7 +25,6 @@
   - [Controlling eviction behavior based on scaling direction and resource](#controlling-eviction-behavior-based-on-scaling-direction-and-resource)
   - [Limiting which namespaces are used](#limiting-which-namespaces-are-used)
   - [Setting the webhook failurePolicy](#setting-the-webhook-failurepolicy)
-
 - [Known limitations](#known-limitations)
 - [Related links](#related-links)
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -24,6 +24,8 @@
   - [Using CPU management with static policy](#using-cpu-management-with-static-policy)
   - [Controlling eviction behavior based on scaling direction and resource](#controlling-eviction-behavior-based-on-scaling-direction-and-resource)
   - [Limiting which namespaces are used](#limiting-which-namespaces-are-used)
+  - [Setting the webhook failurePolicy](#setting-the-webhook-failurepolicy)
+
 - [Known limitations](#known-limitations)
 - [Related links](#related-links)
 
@@ -387,6 +389,11 @@ vpa-post-processor.kubernetes.io/{containerName}_integerCPU=true
 
 These options cannot be used together and are mutually exclusive. 
 
+ ### Setting the webhook failurePolicy
+
+ It is possible to set the failurePolicy of the webhook to `Fail` by passing `--webhook-failure-policy-fail=true` to the VPA admission controller.
+ Please use this option with caution as it may be possible to break Pod creation if there is a failure with the VPA.
+Using it in conjunction with `--ignored-vpa-object-namespaces` or `--vpa-object-namespace` to reduce risk.
 
 # Known limitations
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -75,6 +75,7 @@ var (
 	webhookAddress             = flag.String("webhook-address", "", "Address under which webhook is registered. Used when registerByURL is set to true.")
 	webhookPort                = flag.String("webhook-port", "", "Server Port for Webhook")
 	webhookTimeout             = flag.Int("webhook-timeout-seconds", 30, "Timeout in seconds that the API server should wait for this webhook to respond before failing.")
+	webHookFailurePolicy       = flag.Bool("webhook-failure-policy-fail", false, "If set to true, will configure the admission webhook failurePolicy to \"Fail\". Use with caution.")
 	registerWebhook            = flag.Bool("register-webhook", true, "If set to true, admission webhook object will be created on start up to register with the API server.")
 	registerByURL              = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 	vpaObjectNamespace         = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects. Empty means all namespaces will be used. Must not be used if ignored-vpa-object-namespaces is set.")
@@ -146,7 +147,7 @@ func main() {
 	ignoredNamespaces := strings.Split(*ignoredVpaObjectNamespaces, ",")
 	go func() {
 		if *registerWebhook {
-			selfRegistration(kubeClient, readFile(*certsConfiguration.clientCaFile), webHookDelay, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout), *vpaObjectNamespace, ignoredNamespaces)
+			selfRegistration(kubeClient, readFile(*certsConfiguration.clientCaFile), webHookDelay, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout), *vpaObjectNamespace, ignoredNamespaces, *webHookFailurePolicy)
 		}
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allows a user to set the failurePolicy of the VPA webhook

#### Which issue(s) this PR fixes:

Fixes #7180

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add --webhook-failure-policy-fail flag to admission-controller to allow web hook failurePolicy to be set to Fail
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
