### PR TITLE
PR#7186 Backport for 1.30: Move response variable inside for loop

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -42,9 +42,9 @@ func (c *nodePoolCache) nodePools() map[string]*oke.NodePool {
 
 func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodepoolRetries int) (httpStatusCode int, err error) {
 	klog.Infof("rebuilding cache")
-	var resp oke.GetNodePoolResponse
 	var statusCode int
 	for id := range staticNodePools {
+		var resp oke.GetNodePoolResponse
 		for i := 1; i <= maxGetNodepoolRetries; i++ {
 			// prevent us from getting a node pool at the same time that we're performing delete actions on the node pool.
 			c.mu.Lock()


### PR DESCRIPTION
…ted.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

Backport of PR [7186](https://github.com/kubernetes/autoscaler/pull/7186)

This PR fixes an issue with the [Oracle Cloud provider](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/oci) where node-group details stored in the internal cache-map can be unintentionally overwritten with the details of a different node group. 

This can occur because the node-group variable `resp` is declared _outside_ the loop that adds the next node-group value to the cache-map. The end result is the cache-map contains only the the _last_ NodePool in the list, which is referenced by different node-pool-ids / keys.


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
