### PR TITLE
VPA: Use kubectl apply to upsert VPA resource instead of create.

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -26,4 +26,4 @@ if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then
   git switch --detach vertical-pod-autoscaler-${DEFAULT_TAG}
 fi
 
-$SCRIPT_ROOT/hack/vpa-process-yamls.sh create $*
+$SCRIPT_ROOT/hack/vpa-process-yamls.sh apply $*


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:
This PR changes the recommended VPA install method to use `kubectl apply` instead of `kubectl create` under the hood to allow for rolling updates of VPA.

#### Does this PR introduce a user-facing change?
NONE

