### PR TITLE
azure: document migration to new GPU Node label

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -54,7 +54,7 @@ k8s.io_cluster-autoscaler_node-template_resources_cpu: 3800m
 k8s.io_cluster-autoscaler_node-template_resources_memory: 11Gi
 ```
 
-> **_NOTE_**: GPU autoscaling consideration on VMSS : In case of scale set of GPU nodes, kubelet node label `accelerator` have to be added to node provisionned to make GPU scaling works.
+> **_NOTE_**: GPU autoscaling on VMSS is informed by the presence of BOTH the `accelerator` AND `kubernetes.azure.com/accelerator` Node labels. A VMSS with GPUs whose Nodes do not have BOTH labels may not be scaled correctly. In a future release of cluster-autoscaler, the `accelerator` label will no longer be used and only the `kubernetes.azure.com/accelerator` label will be required.
 
 #### Autoscaling options
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR documents the Azure provider's plan to migrate to a new label used to identify GPU Nodes in order to align with the labels used by AKS: https://learn.microsoft.com/en-us/azure/aks/use-labels#deprecated-labels

The rough plan is to:
- document that users need to set BOTH the current and new labels on GPU Nodes (this PR)
- wait for at least one minor version release cycle to allow users time to add the new label (until at least cluster-autoscaler 1.32)
- change the Azure provider from identifying GPU Nodes based on the old label to the new one

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: VMSS GPU Nodes must now also include the `kubernetes.azure.com/accelerator` label in addition to `accelerator`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
