### PR TITLE
fix(hetzner): deprecated server type will break on 2024-09-06

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -41,7 +41,6 @@ const (
 	providerIDPrefix           = "hcloud://"
 	nodeGroupLabel             = hcloudLabelNamespace + "/node-group"
 	hcloudLabelNamespace       = "hcloud"
-	drainingNodePoolId         = "draining-node-pool"
 	serverCreateTimeoutDefault = 5 * time.Minute
 	serverRegisterTimeout      = 10 * time.Minute
 	defaultPodAmountsLimit     = 110

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -206,16 +206,6 @@ func newManager() (*hetznerManager, error) {
 		cachedServers:    newServersCache(ctx, client),
 	}
 
-	m.nodeGroups[drainingNodePoolId] = &hetznerNodeGroup{
-		manager:      m,
-		instanceType: "cx11",
-		region:       "fsn1",
-		targetSize:   0,
-		maxSize:      0,
-		minSize:      0,
-		id:           drainingNodePoolId,
-	}
-
 	return m, nil
 }
 
@@ -250,11 +240,6 @@ func (m *hetznerManager) deleteByNode(node *apiv1.Node) error {
 func (m *hetznerManager) deleteServer(server *hcloud.Server) error {
 	_, err := m.client.Server.Delete(m.apiCallContext, server)
 	return err
-}
-
-func (m *hetznerManager) addNodeToDrainingPool(node *apiv1.Node) (*hetznerNodeGroup, error) {
-	m.nodeGroups[drainingNodePoolId].targetSize += 1
-	return m.nodeGroups[drainingNodePoolId], nil
 }
 
 func (m *hetznerManager) validProviderID(providerID string) bool {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -287,7 +287,7 @@ func (n *hetznerNodeGroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, err
 	}
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, nodeGroupLabels)
 
-	if n.manager.clusterConfig.IsUsingNewFormat && n.id != drainingNodePoolId {
+	if n.manager.clusterConfig.IsUsingNewFormat {
 		for _, taint := range n.manager.clusterConfig.NodeConfigs[n.id].Taints {
 			node.Spec.Taints = append(node.Spec.Taints, apiv1.Taint{
 				Key:    taint.Key,
@@ -391,7 +391,7 @@ func buildNodeGroupLabels(n *hetznerNodeGroup) (map[string]string, error) {
 		nodeGroupLabel:               n.id,
 	}
 
-	if n.manager.clusterConfig.IsUsingNewFormat && n.id != drainingNodePoolId {
+	if n.manager.clusterConfig.IsUsingNewFormat {
 		maps.Copy(labels, n.manager.clusterConfig.NodeConfigs[n.id].Labels)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The `cx11` server type was deprecated on 2024-06-06 and will be removed from the API on 2024-09-06. Once it is removed, the cluster-autoscaler provider hetzner will fail every main loop with with the following error messages:

    mixed_nodeinfos_processor.go:160] Unable to build proper template node for draining-node-pool: failed to create resource list for node group draining-node-pool error: failed to get machine type cx11 info error: server type not found
    static_autoscaler.go:387] Failed to get node infos for groups: failed to create resource list for node group draining-node-pool error: failed to get machine type cx11 info error: server type not found

The server type is hardcoded in the `draining-node-pool`, which was used in the OG PR #3640 but unused in the second PR #3838 that was actually merged.

As the `draining-node-pool` is unused since the first release of this provider, I have opted to remove it altogether. In theory this is a user visible change, as this node pool is visible through the status config map

#### Which issue(s) this PR fixes:

Fixes #7210

#### Special notes for your reviewer:

We would like to back port this change to all actives releases ASAP. If you think this change does not qualify for a back port, I am happy to submit a different PR that only changes the  hardcoded server type to one that will be available for longer.

This one is one me. I should have noticed this reference when checking our projects for hardcoded `cx11` references when the deprecation was announced.

#### Does this PR introduce a user-facing change?

```release-note
Fix Hetzner Provider not starting after 2024-09-07
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Hetzner Cloud Changelog](https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated)
```
