### PR TITLE
align Azure e2e tests with backports

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/test/Makefile
+++ b/cluster-autoscaler/cloudprovider/azure/test/Makefile
@@ -15,7 +15,7 @@ ARTIFACTS?=_artifacts
 
 .PHONY: test-e2e
 test-e2e: build-e2e
-	go run github.com/onsi/ginkgo/v2/ginkgo -v --trace --output-dir "$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" e2e -- \
+	go run github.com/onsi/ginkgo/v2/ginkgo --tags e2e -v --trace --output-dir "$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" e2e -- \
 		-resource-group="$$(KUBECONFIG= kubectl get managedclusters -n default -o jsonpath='{.items[0].status.nodeResourceGroup}')" \
 		-cluster-name="$$(KUBECONFIG= kubectl get cluster -n default -o jsonpath='{.items[0].metadata.name}')" \
 		-client-id="$$(KUBECONFIG= kubectl get userassignedidentities -n default -o jsonpath='{.items[0].status.clientId}')" \

--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2024 The Kubernetes Authors.
 

--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2024 The Kubernetes Authors.
 

--- a/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
@@ -19,7 +19,6 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
-  version: ${KUBERNETES_VERSION}
   resources:
   - apiVersion: containerservice.azure.com/v1api20231001
     kind: ManagedCluster
@@ -31,6 +30,7 @@ spec:
       dnsPrefix: ${CLUSTER_NAME}
       identity:
         type: SystemAssigned
+      kubernetesVersion: "${KUBERNETES_VERSION}"
       location: ${AZURE_LOCATION}
       networkProfile:
         networkPlugin: azure
@@ -142,7 +142,6 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedMachinePool
         name: ${CLUSTER_NAME}-pool0
-      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedMachinePool
@@ -164,6 +163,7 @@ spec:
         name: ${CLUSTER_NAME}
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
+      orchestratorVersion: "${KUBERNETES_VERSION}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -185,7 +185,6 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedMachinePool
         name: ${CLUSTER_NAME}-pool1
-      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedMachinePool
@@ -212,6 +211,7 @@ spec:
         min: "1"
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
+      orchestratorVersion: "${KUBERNETES_VERSION}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -233,7 +233,6 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedMachinePool
         name: ${CLUSTER_NAME}-pool2
-      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedMachinePool
@@ -261,6 +260,7 @@ spec:
         min: "1"
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}
+      orchestratorVersion: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR forward-ports(?) some small changes made on release branches to enable Azure e2e tests to the master branch.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
