### PR TITLE
Regenerate ProvisioningRequest CRD for  v1

### DIFF
--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: provisioningrequests.autoscaling.x-k8s.io
 spec:
   group: autoscaling.x-k8s.io
@@ -17,6 +17,212 @@ spec:
     singular: provisioningrequest
   scope: Namespaced
   versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ProvisioningRequest is a way to express additional capacity
+          that we would like to provision in the cluster. Cluster Autoscaler
+          can use this information in its calculations and signal if the capacity
+          is available in the cluster or actively add capacity if needed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec contains specification of the ProvisioningRequest object.
+              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
+              The spec is immutable, to make changes to the request users are expected to delete an existing
+              and create a new object with the corrected fields.
+            properties:
+              parameters:
+                additionalProperties:
+                  description: Parameter is limited to 255 characters.
+                  maxLength: 255
+                  type: string
+                description: |-
+                  Parameters contains all other parameters classes may require.
+                  'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+                   a string denoting duration for which we should retry (measured since creation fo the CR).
+                maxProperties: 100
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              podSets:
+                description: |-
+                  PodSets lists groups of pods for which we would like to provision
+                  resources.
+                items:
+                  description: PodSet represents one group of pods for Provisioning
+                    Request to provision capacity.
+                  properties:
+                    count:
+                      description: |-
+                        Count contains the number of pods that will be created with a given
+                        template.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    podTemplateRef:
+                      description: |-
+                        PodTemplateRef is a reference to a PodTemplate object that is representing pods
+                        that will consume this reservation (must be within the same namespace).
+                        Users need to make sure that the  fields relevant to scheduler (e.g. node selector tolerations)
+                        are consistent between this template and actual pods consuming the Provisioning Request.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referenced object.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                          maxLength: 253
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - count
+                  - podTemplateRef
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              provisioningClassName:
+                description: |-
+                  ProvisioningClassName describes the different modes of provisioning the resources.
+                  Currently there is no support for 'ProvisioningClass' objects.
+                  Supported values:
+                  * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+                    do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
+                    CA will check if there is enough capacity in cluster to fulfill the request and put
+                    the answer in 'CapacityAvailable' condition.
+                  * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+                    Users should provide a reference to a valid PodTemplate object.
+                    CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
+                    and re-try the operation in a exponential back-off manner. Users can configure the timeout
+                    duration after which the request will fail by 'ValidUntilSeconds' key in 'Parameters'.
+                    CA will set 'Failed=true' or 'Provisioned=true' condition according to the outcome.
+                  * ... - potential other classes that are specific to the cloud providers.
+                  'kubernetes.io' suffix is reserved for the modes defined in Kubernetes projects.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            required:
+            - podSets
+            - provisioningClassName
+            type: object
+          status:
+            description: Status of the ProvisioningRequest. CA constantly reconciles
+              this field.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the observations of a Provisioning Request's
+                  current state. Those will contain information whether the capacity
+                  was found/created or if there were any issues. The condition types
+                  may differ between different provisioning classes.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              provisioningClassDetails:
+                additionalProperties:
+                  description: Detail is limited to 32768 characters.
+                  maxLength: 32768
+                  type: string
+                description: |-
+                  ProvisioningClassDetails contains all other values custom provisioning classes may
+                  want to pass to end users.
+                maxProperties: 64
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -97,6 +303,8 @@ spec:
                           maxLength: 253
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
+                      required:
+                      - name
                       type: object
                   required:
                   - count
@@ -146,16 +354,8 @@ spec:
                   was found/created or if there were any issues. The condition types
                   may differ between different provisioning classes.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -196,12 +396,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -231,6 +426,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
@@ -36,6 +36,7 @@ import (
 // is available in the cluster or actively add capacity if needed.
 //
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type ProvisioningRequest struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

In #7195 ProvisioningRequest API was bumped to v1, but CRD wasn't upgraded. CA 1.31 won't work without upgraded CRD.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds CRD for ProvisioningRequest v1
```

/cc @MaciekPytel @mwielgus 
