### PR TITLE
azure: use new label to identity GPU Nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -54,7 +54,7 @@ k8s.io_cluster-autoscaler_node-template_resources_cpu: 3800m
 k8s.io_cluster-autoscaler_node-template_resources_memory: 11Gi
 ```
 
-> **_NOTE_**: GPU autoscaling on VMSS is informed by the presence of BOTH the `accelerator` AND `kubernetes.azure.com/accelerator` Node labels. A VMSS with GPUs whose Nodes do not have BOTH labels may not be scaled correctly. In a future release of cluster-autoscaler, the `accelerator` label will no longer be used and only the `kubernetes.azure.com/accelerator` label will be required.
+> **_NOTE_**: GPU autoscaling on VMSS is informed by the presence of the `kubernetes.azure.com/accelerator` Node label. A VMSS with GPUs whose Nodes do not have the label may not be scaled correctly. The `accelerator` label was used for this purpose in versions 1.31 and older.
 
 #### Autoscaling options
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -75,7 +75,7 @@ func (azure *AzureCloudProvider) Name() string {
 
 // GPULabel returns the label added to nodes with GPU resource.
 func (azure *AzureCloudProvider) GPULabel() string {
-	return legacyGPULabel // Use legacy to avoid breaking, for now
+	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR follows up from #7203 to migrate the Azure provider from using the `accelerator` label to identify GPU Nodes to the `kubernetes.azure.com/accelerator`. #7203 documented that users must set \*both\* labels in 1.31, so this change should not break users following that instruction.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: VMSS GPU Nodes are now identified by the `kubernetes.azure.com/accelerator` label instead of `accelerator`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
