### PR TITLE
Add raywainman to reviewers in addon-resizer in addon-resizer-release-1.8 branch

### DIFF
--- a/addon-resizer/OWNERS
+++ b/addon-resizer/OWNERS
@@ -4,6 +4,7 @@ approvers:
 reviewers:
 - kwiesmueller
 - jbartosik
+- raywainman
 emeritus_approvers:
 - bskiba # 2022-09-30
 - wojtek-t # 2022-09-30


### PR DESCRIPTION
I have reviewed and contributed several PRs for this component:
https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+addon-resizer+raywainman

#7241 adds this to master branch.