### PR TITLE
Add unit test to ensure un-schedulable pods slice is not overwritten by injector

### DIFF
--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
@@ -145,3 +145,17 @@ func BuildTestProvisioningRequest(namespace, name, cpu, memory, gpu string, podC
 			},
 		})
 }
+
+// BuildTestPods builds a list of pod objects for use as existing unschedulable pods in tests.
+func BuildTestPods(namespace, name string, podCount int) []*apiv1.Pod {
+	pods := make([]*apiv1.Pod, 0, podCount)
+	for i := 0; i < podCount; i++ {
+		pods = append(pods, &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", name, i),
+				Namespace: namespace,
+			},
+		})
+	}
+	return pods
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Added new unit test to ensure that un-schedulable pods list is not overwritten when the pod list injector's process method is called
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc: @aleksandra-malinowska @kawych 