### PR TITLE
Minor clarification in rancher provider example config.yaml

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
+++ b/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
@@ -1,4 +1,4 @@
-# Rancher URL (Not API endpoint)
+# Rancher Base URL (Not API endpoint)
 url: https://rancher.example.org
 # When you create a token in the Rancher UI
 # it gives you the API endpoint, that is the Rancher URL with the /v3 appended at the end.

--- a/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
+++ b/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
@@ -1,5 +1,9 @@
-# rancher server credentials
+# Rancher URL (Not API endpoint)
 url: https://rancher.example.org
+# When you create a token in the Rancher UI
+# it gives you the API endpoint, that is the Rancher URL with the /v3 appended at the end.
+# make sure the url does not contains the /v3 appended
+# rancher server credentials
 token: <rancher token>
 # name and namespace of the clusters.provisioning.cattle.io resource on the
 # rancher server

--- a/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
+++ b/cluster-autoscaler/cloudprovider/rancher/examples/config.yaml
@@ -1,8 +1,8 @@
+# When you create a token in the Rancher UI, 
+# it shows you the API endpoint, that is the Rancher URL with the /v3 appended at the end.
+# Make sure the URL does not contains this /v3 appended.
 # Rancher Base URL (Not API endpoint)
 url: https://rancher.example.org
-# When you create a token in the Rancher UI
-# it gives you the API endpoint, that is the Rancher URL with the /v3 appended at the end.
-# make sure the url does not contains the /v3 appended
 # rancher server credentials
 token: <rancher token>
 # name and namespace of the clusters.provisioning.cattle.io resource on the


### PR DESCRIPTION
Added clarification on the URL. I made the mistake of copying the API endpoint provided in the Rancher UI when you create a token. Of course, this wrong URL generated confusing errors that took me hours to understand.  Wishing no one in the community loses this much time as me :)

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

Minor clarification on the example config.yaml to avoid confusion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
