### PR TITLE
vpa-recommender: Use the MaintainCheckpoints context only for that step

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -149,8 +149,6 @@ func (r *recommender) RunOnce() {
 	defer timer.ObserveTotal()
 
 	ctx := context.Background()
-	ctx, cancelFunc := context.WithDeadline(ctx, time.Now().Add(*checkpointsWriteTimeout))
-	defer cancelFunc()
 
 	klog.V(3).Infof("Recommender Run")
 
@@ -167,7 +165,9 @@ func (r *recommender) RunOnce() {
 	r.UpdateVPAs()
 	timer.ObserveStep("UpdateVPAs")
 
-	r.MaintainCheckpoints(ctx, *minCheckpointsPerRun)
+	stepCtx, cancelFunc := context.WithDeadline(ctx, time.Now().Add(*checkpointsWriteTimeout))
+	defer cancelFunc()
+	r.MaintainCheckpoints(stepCtx, *minCheckpointsPerRun)
 	timer.ObserveStep("MaintainCheckpoints")
 
 	r.clusterState.RateLimitedGarbageCollectAggregateCollectionStates(ctx, time.Now(), r.controllerFetcher)


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
In https://github.com/kubernetes/autoscaler/pull/6899/files#diff-5c44f22eb0f35931ab799838d2584dd10037916c74f114124e6904af48fcd608R157, I wrongly passed a context that is specific only to the `MaintainCheckpoints` step to 2 other steps: `LoadVPAs` and `GarbageCollect `.
This PR reverts to the old behaviour where the context with timeout of 1min by default was used only for the `MaintainCheckpoints` step.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
