### PR TITLE
Parallelly fetch mig instances in differet zones when  is enabled

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -199,9 +199,9 @@ func (c *cachingMigInfoProvider) listInstancesInAllZonesWithMigs() ([]GceInstanc
 	zoneInstances := make([][]GceInstance, len(zones))
 	defer metrics.UpdateDurationFromStart(metrics.BulkListAllGceInstances, time.Now())
 
-	workqueue.ParallelizeUntil(context.Background(), c.concurrentGceRefreshes, len(zones), func(piece int) {
+	workqueue.ParallelizeUntil(context.Background(), len(zones), len(zones), func(piece int) {
 		zoneInstances[piece], errors[piece] = c.gceClient.FetchAllInstances(c.projectId, zones[piece], "")
-	}, workqueue.WithChunkSize(c.concurrentGceRefreshes))
+	})
 
 	for _, instances := range zoneInstances {
 		allInstances = append(allInstances, instances...)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR increase the parallelism of bulk mig instance fetcing to number of zones when `bulk-mig-instances-listing-enabled` is enabled.




#### Does this PR introduce a user-facing change?
NONE

