### PR TITLE
Implemented batch processing for check capacity provisioning class

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -301,6 +301,12 @@ type AutoscalingOptions struct {
 	ProvisioningRequestMaxBackoffTime time.Duration
 	// ProvisioningRequestMaxCacheSize is the max size for ProvisioningRequest cache that is stored for retry backoff.
 	ProvisioningRequestMaxBackoffCacheSize int
+	// CheckCapacityBatchProcessing is used to enable/disable batch processing of check capacity provisioning class
+	CheckCapacityBatchProcessing bool
+	// CheckCapacityProvisioningRequestMaxBatchSize is the maximum number of provisioning requests to process in a single batch
+	CheckCapacityProvisioningRequestMaxBatchSize int
+	// CheckCapacityProvisioningRequestBatchTimebox is the maximum time to spend processing a batch of provisioning requests
+	CheckCapacityProvisioningRequestBatchTimebox time.Duration
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/processors/provreq/testutils.go
+++ b/cluster-autoscaler/processors/provreq/testutils.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provreq
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
+	"k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+)
+
+// NewFakePodsInjector creates a new instance of ProvisioningRequestPodsInjector with the given client and clock for testing.
+func NewFakePodsInjector(client *provreqclient.ProvisioningRequestClient, clock *testing.FakePassiveClock) *ProvisioningRequestPodsInjector {
+	return &ProvisioningRequestPodsInjector{initialRetryTime: 1 * time.Minute, maxBackoffTime: 10 * time.Minute, backoffDuration: lru.New(1000), client: client, clock: clock}
+}

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -18,6 +18,9 @@ package checkcapacity
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -26,29 +29,36 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/provreq"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/klog/v2"
 
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 type checkCapacityProvClass struct {
-	context  *context.AutoscalingContext
-	client   *provreqclient.ProvisioningRequestClient
-	injector *scheduling.HintingSimulator
+	context                                      *context.AutoscalingContext
+	client                                       *provreqclient.ProvisioningRequestClient
+	schedulingSimulator                          *scheduling.HintingSimulator
+	checkCapacityProvisioningRequestMaxBatchSize int
+	checkCapacityProvisioningRequestBatchTimebox time.Duration
+	provreqInjector                              *provreq.ProvisioningRequestPodsInjector
 }
 
 // New create check-capacity scale-up mode.
 func New(
 	client *provreqclient.ProvisioningRequestClient,
+	provreqInjector *provreq.ProvisioningRequestPodsInjector,
 ) *checkCapacityProvClass {
-	return &checkCapacityProvClass{client: client}
+	return &checkCapacityProvClass{client: client, provreqInjector: provreqInjector}
 }
 
 func (o *checkCapacityProvClass) Initialize(
@@ -57,10 +67,16 @@ func (o *checkCapacityProvClass) Initialize(
 	clusterStateRegistry *clusterstate.ClusterStateRegistry,
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
-	injector *scheduling.HintingSimulator,
+	schedulingSimulator *scheduling.HintingSimulator,
 ) {
 	o.context = autoscalingContext
-	o.injector = injector
+	o.schedulingSimulator = schedulingSimulator
+	if autoscalingContext.CheckCapacityBatchProcessing {
+		o.checkCapacityProvisioningRequestBatchTimebox = autoscalingContext.CheckCapacityProvisioningRequestBatchTimebox
+		o.checkCapacityProvisioningRequestMaxBatchSize = autoscalingContext.CheckCapacityProvisioningRequestMaxBatchSize
+	} else {
+		o.checkCapacityProvisioningRequestMaxBatchSize = 1
+	}
 }
 
 // Provision return if there is capacity in the cluster for pods from ProvisioningRequest.
@@ -70,43 +86,230 @@ func (o *checkCapacityProvClass) Provision(
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*schedulerframework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
-	if len(unschedulablePods) == 0 {
-		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
-	}
+	combinedStatus := NewCombinedStatusSet()
+	provisioningRequestsProcessed := make(map[string]bool)
+	startTime := time.Now()
 
-	prs := provreqclient.ProvisioningRequestsForPods(o.client, unschedulablePods)
-	prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassCheckCapacity)
-	if len(prs) == 0 {
-		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
-	}
-	// Pick 1 ProvisioningRequest.
-	pr := prs[0]
 	o.context.ClusterSnapshot.Fork()
 	defer o.context.ClusterSnapshot.Revert()
 
-	scaleUpIsSuccessful, err := o.checkcapacity(unschedulablePods, pr)
-	if err != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+	prPods := unschedulablePods
+
+	for len(prPods) > 0 {
+		prs := provreqclient.ProvisioningRequestsForPods(o.client, prPods)
+		prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassCheckCapacity)
+		if len(prs) == 0 {
+			break
+		}
+
+		// Pick 1 ProvisioningRequest.
+		pr := prs[0]
+
+		scaleUpIsSuccessful, err := o.checkcapacity(prPods, pr)
+		if err != nil {
+			scaleUpStatus, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+			combinedStatus.Add(scaleUpStatus)
+		} else if scaleUpIsSuccessful {
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
+		} else {
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
+		}
+
+		provisioningRequestsProcessed[pr.Name] = true
+		if stopBatch := o.shouldStopBatchProcessing(len(provisioningRequestsProcessed), startTime); stopBatch {
+			break
+		}
+
+		// For batch processing, the next ProvisioningRequest's pods are fetched using the provisioningRequest pods injector.
+		// TODO: Refactor such that injector injects pods for multiple ProvisioningRequests at once. Pods should be segregated by ProvisioningRequest before being processed.
+		prPods, err = o.getNextPrPods(provisioningRequestsProcessed)
+		// Error might be returned here if the pod-template for current ProvisioningRequest is not found in cluster. We continue with the next ProvisioningRequest as it might have a valid pod-template and may be processed successfully.
+		if err != nil {
+			st, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+			combinedStatus.Add(st)
+		}
 	}
-	if scaleUpIsSuccessful {
-		return &status.ScaleUpStatus{Result: status.ScaleUpSuccessful}, nil
-	}
-	return &status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable}, nil
+
+	return combinedStatus.Export()
 }
 
-// Assuming that all unschedulable pods comes from one ProvisioningRequest.
-func (o *checkCapacityProvClass) checkcapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) (capacityAvailable bool, err error) {
-	capacityAvailable = true
-	st, _, err := o.injector.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
-	if len(st) < len(unschedulablePods) || err != nil {
-		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-		capacityAvailable = false
-	} else {
-		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+// checkcapacity checks if there is capacity in the cluster for pods from a ProvisioningRequest. It persists the scheduling in cluster snapshot whenever all pods can be scheduled, and doesn't change the snapshot otherwise.
+func (o *checkCapacityProvClass) checkcapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) (bool, error) {
+	var capacityAvailable bool
+	err, cleanupErr := clustersnapshot.WithForkedSnapshot(o.context.ClusterSnapshot, func() (bool, error) {
+		st, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
+		if len(st) < len(unschedulablePods) || err != nil {
+			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+			capacityAvailable = false
+		} else {
+			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+			capacityAvailable = true
+		}
+
+		_, updErr := o.client.UpdateProvisioningRequest(provReq.ProvisioningRequest)
+		if updErr != nil {
+			return false, fmt.Errorf("failed to update Provisioned condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
+		}
+
+		return capacityAvailable, nil
+	})
+
+	if cleanupErr != nil {
+		return false, cleanupErr
 	}
-	_, updErr := o.client.UpdateProvisioningRequest(provReq.ProvisioningRequest)
-	if updErr != nil {
-		return false, fmt.Errorf("failed to update Provisioned condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
+
+	if err != nil {
+		return false, err
 	}
-	return capacityAvailable, err
+
+	return capacityAvailable, nil
+}
+
+// shouldStopBatchProcessing returns true if the batch processing should be stopped when:
+// - Batch processing is misconfigured
+// - Upper limits of batch processing parameters are reached
+func (o *checkCapacityProvClass) shouldStopBatchProcessing(prsProcessed int, startTime time.Time) bool {
+	if prsProcessed >= o.checkCapacityProvisioningRequestMaxBatchSize {
+		return true
+	}
+
+	if o.provreqInjector == nil {
+		klog.Errorf("ProvisioningRequestPodsInjector is not set, falling back to non-batch processing")
+		return true
+	}
+
+	if o.checkCapacityProvisioningRequestMaxBatchSize <= 1 {
+		klog.Errorf("MaxBatchSize is set to %d, falling back to non-batch processing", o.checkCapacityProvisioningRequestMaxBatchSize)
+		return true
+	}
+
+	if time.Since(startTime) > o.checkCapacityProvisioningRequestBatchTimebox {
+		klog.Infof("Batch timebox exceeded, processed %d check capacity provisioning requests this iteration", prsProcessed)
+		return true
+	}
+
+	return false
+}
+
+// getNextPrPods retreives pods from the next CheckCapacity ProvisioningRequest.
+func (o *checkCapacityProvClass) getNextPrPods(provisioningRequestsProcessed map[string]bool) ([]*apiv1.Pod, error) {
+	return o.provreqInjector.GetPodsFromNextRequest(func(pr *provreqwrapper.ProvisioningRequest) bool {
+		if pr.Spec.ProvisioningClassName != v1.ProvisioningClassCheckCapacity {
+			return false
+		}
+		if _, found := provisioningRequestsProcessed[pr.Name]; found {
+			return false
+		}
+		return true
+	})
+}
+
+// combinedStatusSet is a helper struct to combine multiple ScaleUpStatuses into one. It keeps track of the best result and all errors that occurred during the ScaleUp process.
+type combinedStatusSet struct {
+	Result        status.ScaleUpResult
+	ScaleupErrors map[*errors.AutoscalerError]bool
+}
+
+// Add adds a ScaleUpStatus to the combinedStatusSet.
+func (c *combinedStatusSet) Add(newStatus *status.ScaleUpStatus) {
+	// This represents the priority of the ScaleUpResult. The final result is the one with the highest priority in the set.
+	resultPriority := map[status.ScaleUpResult]int{
+		status.ScaleUpNotTried:           0,
+		status.ScaleUpNoOptionsAvailable: 1,
+		status.ScaleUpError:              2,
+		status.ScaleUpSuccessful:         3,
+	}
+
+	// If even one scaleUpSuccessful is present, the final result is ScaleUpSuccessful.
+	// If no ScaleUpSuccessful is present, and even one ScaleUpError is present, the final result is ScaleUpError.
+	// If no ScaleUpSuccessful or ScaleUpError is present, and even one ScaleUpNoOptionsAvailable is present, the final result is ScaleUpNoOptionsAvailable.
+	// If no ScaleUpSuccessful, ScaleUpError or ScaleUpNoOptionsAvailable is present, the final result is ScaleUpNotTried.
+	if resultPriority[c.Result] < resultPriority[newStatus.Result] {
+		c.Result = newStatus.Result
+	}
+	if newStatus.ScaleUpError != nil {
+		if _, found := c.ScaleupErrors[newStatus.ScaleUpError]; !found {
+			c.ScaleupErrors[newStatus.ScaleUpError] = true
+		}
+	}
+}
+
+// formatMessageFromBatchErrors formats a message from a list of errors.
+func (c *combinedStatusSet) formatMessageFromBatchErrors(errs []errors.AutoscalerError) string {
+	firstErr := errs[0]
+	var builder strings.Builder
+	builder.WriteString(firstErr.Error())
+	builder.WriteString(" ...and other concurrent errors: [")
+	formattedErrs := map[errors.AutoscalerError]bool{
+		firstErr: true,
+	}
+	for _, err := range errs {
+		if _, has := formattedErrs[err]; has {
+			continue
+		}
+		formattedErrs[err] = true
+		message := err.Error()
+		if len(formattedErrs) > 2 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(fmt.Sprintf("%q", message))
+	}
+	builder.WriteString("]")
+	return builder.String()
+}
+
+// combineBatchScaleUpErrors combines multiple errors into one. If there is only one error, it returns that error. If there are multiple errors, it combines them into one error with a message that contains all the errors.
+func (c *combinedStatusSet) combineBatchScaleUpErrors() *errors.AutoscalerError {
+	if len(c.ScaleupErrors) == 0 {
+		return nil
+	}
+	if len(c.ScaleupErrors) == 1 {
+		for err := range c.ScaleupErrors {
+			return err
+		}
+	}
+	uniqueMessages := make(map[string]bool)
+	for err := range c.ScaleupErrors {
+		uniqueMessages[(*err).Error()] = true
+	}
+	if len(uniqueMessages) == 1 {
+		for err := range c.ScaleupErrors {
+			return err
+		}
+	}
+	// sort to stabilize the results and easier log aggregation
+	errs := make([]errors.AutoscalerError, 0, len(c.ScaleupErrors))
+	for err := range c.ScaleupErrors {
+		errs = append(errs, *err)
+	}
+	sort.Slice(errs, func(i, j int) bool {
+		return errs[i].Error() < errs[j].Error()
+	})
+	message := c.formatMessageFromBatchErrors(errs)
+	combinedErr := errors.NewAutoscalerError(errors.InternalError, message)
+	return &combinedErr
+}
+
+// Export converts the combinedStatusSet into a ScaleUpStatus.
+func (c *combinedStatusSet) Export() (*status.ScaleUpStatus, errors.AutoscalerError) {
+	result := &status.ScaleUpStatus{Result: c.Result}
+	if len(c.ScaleupErrors) > 0 {
+		result.ScaleUpError = c.combineBatchScaleUpErrors()
+	}
+
+	var resErr errors.AutoscalerError
+
+	if result.Result == status.ScaleUpError {
+		resErr = *result.ScaleUpError
+	}
+
+	return result, resErr
+}
+
+// NewCombinedStatusSet creates a new combinedStatusSet.
+func NewCombinedStatusSet() combinedStatusSet {
+	return combinedStatusSet{
+		Result:        status.ScaleUpNotTried,
+		ScaleupErrors: make(map[*errors.AutoscalerError]bool),
+	}
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checkcapacity
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+func TestCombinedStatusSet(t *testing.T) {
+	// TestCombinedStatusSet tests the CombinedStatusSet function.
+	testCases := []struct {
+		name          string
+		statuses      []*status.ScaleUpStatus
+		exportedResut status.ScaleUpResult
+		exportedError errors.AutoscalerError
+		returnedError errors.AutoscalerError
+	}{
+		{
+			name:          "empty",
+			statuses:      []*status.ScaleUpStatus{},
+			exportedResut: status.ScaleUpNotTried,
+		},
+		{
+			name:          "all successful",
+			statuses:      generateStatuses(2, status.ScaleUpSuccessful),
+			exportedResut: status.ScaleUpSuccessful,
+		},
+		{
+			name:          "all errors",
+			statuses:      generateStatuses(2, status.ScaleUpError),
+			exportedResut: status.ScaleUpError,
+			exportedError: errors.NewAutoscalerError(errors.InternalError, "error 0 ...and other concurrent errors: [\"error 1\"]"),
+			returnedError: errors.NewAutoscalerError(errors.InternalError, "error 0 ...and other concurrent errors: [\"error 1\"]"),
+		},
+		{
+			name:          "all no options available",
+			statuses:      generateStatuses(2, status.ScaleUpNoOptionsAvailable),
+			exportedResut: status.ScaleUpNoOptionsAvailable,
+		},
+		{
+			name:          "error and successful",
+			statuses:      append(generateStatuses(1, status.ScaleUpError), generateStatuses(1, status.ScaleUpSuccessful)...),
+			exportedResut: status.ScaleUpSuccessful,
+			exportedError: errors.NewAutoscalerError(errors.InternalError, "error 0"),
+		},
+		{
+			name:          "error and no options available",
+			statuses:      append(generateStatuses(1, status.ScaleUpError), generateStatuses(1, status.ScaleUpNoOptionsAvailable)...),
+			exportedResut: status.ScaleUpError,
+			exportedError: errors.NewAutoscalerError(errors.InternalError, "error 0"),
+			returnedError: errors.NewAutoscalerError(errors.InternalError, "error 0"),
+		},
+		{
+			name:          "successful and no options available",
+			statuses:      append(generateStatuses(1, status.ScaleUpSuccessful), generateStatuses(1, status.ScaleUpNoOptionsAvailable)...),
+			exportedResut: status.ScaleUpSuccessful,
+		},
+		{
+			name:          "error, successful and no options available",
+			statuses:      append(generateStatuses(1, status.ScaleUpNoOptionsAvailable), append(generateStatuses(1, status.ScaleUpError), generateStatuses(1, status.ScaleUpSuccessful)...)...),
+			exportedResut: status.ScaleUpSuccessful,
+			exportedError: errors.NewAutoscalerError(errors.InternalError, "error 0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			combinedStatus := NewCombinedStatusSet()
+
+			for _, s := range tc.statuses {
+				combinedStatus.Add(s)
+			}
+
+			export, retErr := combinedStatus.Export()
+
+			assert.Equal(t, export.Result, tc.exportedResut)
+
+			if tc.exportedError == nil {
+				assert.Nil(t, export.ScaleUpError)
+			} else {
+				assert.Equal(t, tc.exportedError.Error(), (*export.ScaleUpError).Error())
+			}
+
+			if tc.returnedError == nil {
+				assert.Nil(t, retErr)
+			} else {
+				assert.Equal(t, tc.returnedError.Error(), retErr.Error())
+			}
+		})
+	}
+}
+
+func generateStatuses(n int, result status.ScaleUpResult) []*status.ScaleUpStatus {
+	// generateStatuses generates n statuses with the given result.
+	statuses := make([]*status.ScaleUpStatus, n)
+	for i := 0; i < n; i++ {
+		var scaleUpErr *errors.AutoscalerError
+
+		if result == status.ScaleUpError {
+			newErr := errors.NewAutoscalerError(errors.InternalError, fmt.Sprintf("error %d", i))
+			scaleUpErr = &newErr
+		}
+
+		statuses[i] = &status.ScaleUpStatus{Result: result, ScaleUpError: scaleUpErr}
+	}
+	return statuses
+}

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -331,7 +331,7 @@ func setupTest(t *testing.T, nodes []*apiv1.Node, prs []*provreqwrapper.Provisio
 
 	orchestrator := &provReqOrchestrator{
 		client:              client,
-		provisioningClasses: []ProvisioningClass{checkcapacity.New(client), besteffortatomic.New(client)},
+		provisioningClasses: []ProvisioningClass{checkcapacity.New(client, nil), besteffortatomic.New(client)},
 	}
 	orchestrator.Initialize(&autoscalingContext, processors, clusterState, estimatorBuilder, taints.TaintConfig{})
 	return orchestrator, nodeInfos

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/provreq"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/besteffortatomic"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/checkcapacity"
@@ -44,8 +45,9 @@ import (
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/client-go/kubernetes/fake"
+	clocktesting "k8s.io/utils/clock/testing"
+
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
 )
@@ -81,12 +83,38 @@ func TestScaleUp(t *testing.T) {
 			Class:    v1.ProvisioningClassCheckCapacity,
 		})
 
+	anotherCheckCapacityCpuProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "anotherCheckCapacityCpuProvReq",
+			CPU:      "5m",
+			Memory:   "5",
+			PodCount: int32(100),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
 	newCheckCapacityMemProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
 			Name:     "newCheckCapacityMemProvReq",
 			CPU:      "1m",
 			Memory:   "100",
 			PodCount: int32(100),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+	impossibleCheckCapacityReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "impossibleCheckCapacityRequest",
+			CPU:      "1m",
+			Memory:   "1",
+			PodCount: int32(5001),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
+	anotherImpossibleCheckCapacityReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "anotherImpossibleCheckCapacityRequest",
+			CPU:      "1m",
+			Memory:   "1",
+			PodCount: int32(5001),
 			Class:    v1.ProvisioningClassCheckCapacity,
 		})
 
@@ -166,12 +194,17 @@ func TestScaleUp(t *testing.T) {
 		})
 
 	testCases := []struct {
-		name             string
-		provReqs         []*provreqwrapper.ProvisioningRequest
-		provReqToScaleUp *provreqwrapper.ProvisioningRequest
-		scaleUpResult    status.ScaleUpResult
-		autoprovisioning bool
-		err              bool
+		name                string
+		provReqs            []*provreqwrapper.ProvisioningRequest
+		provReqToScaleUp    *provreqwrapper.ProvisioningRequest
+		scaleUpResult       status.ScaleUpResult
+		autoprovisioning    bool
+		err                 bool
+		batchProcessing     bool
+		maxBatchSize        int
+		batchTimebox        time.Duration
+		numProvisionedTrue  int
+		numProvisionedFalse int
 	}{
 		{
 			name:          "no ProvisioningRequests",
@@ -239,10 +272,137 @@ func TestScaleUp(t *testing.T) {
 			autoprovisioning: true,
 			scaleUpResult:    status.ScaleUpSuccessful,
 		},
+		// Batch processing tests
+		{
+			name:               "batch processing of check capacity requests with one request",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       3,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 1,
+		},
+		{
+			name:               "batch processing of check capacity requests with less requests than max batch size",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, newCheckCapacityMemProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       3,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 2,
+		},
+		{
+			name:               "batch processing of check capacity requests with requests equal to max batch size",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, newCheckCapacityMemProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       2,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 2,
+		},
+		{
+			name:               "batch processing of check capacity requests with more requests than max batch size",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, newCheckCapacityMemProvReq, anotherCheckCapacityCpuProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       2,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 2,
+		},
+		{
+			name:               "batch processing of check capacity requests where cluster contains already provisioned requests",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, bookedCapacityProvReq, anotherCheckCapacityCpuProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       2,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 3,
+		},
+		{
+			name:               "batch processing of check capacity requests where timebox is exceeded",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, newCheckCapacityMemProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       5,
+			batchTimebox:       0 * time.Nanosecond,
+			numProvisionedTrue: 1,
+		},
+		{
+			name:               "batch processing of check capacity requests where max batch size is invalid",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, newCheckCapacityMemProvReq},
+			provReqToScaleUp:   newCheckCapacityCpuProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       0,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 1,
+		},
+		{
+			name:               "batch processing of check capacity requests where best effort atomic scale-up request is also present in cluster",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityMemProvReq, newCheckCapacityCpuProvReq, atomicScaleUpProvReq},
+			provReqToScaleUp:   newCheckCapacityMemProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       2,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 2,
+		},
+		{
+			name:               "process atomic scale-up requests where batch processing of check capacity requests is enabled",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{possibleAtomicScaleUpReq},
+			provReqToScaleUp:   possibleAtomicScaleUpReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			batchProcessing:    true,
+			maxBatchSize:       3,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 1,
+		},
+		{
+			name:               "process atomic scale-up requests where batch processing of check capacity requests is enabled and check capacity requests are present in cluster",
+			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityMemProvReq, newCheckCapacityCpuProvReq, atomicScaleUpProvReq},
+			provReqToScaleUp:   atomicScaleUpProvReq,
+			scaleUpResult:      status.ScaleUpNotNeeded,
+			batchProcessing:    true,
+			maxBatchSize:       3,
+			batchTimebox:       5 * time.Minute,
+			numProvisionedTrue: 1,
+		},
+		{
+			name:                "batch processing of check capacity requests where some requests' capacity is not available",
+			provReqs:            []*provreqwrapper.ProvisioningRequest{newCheckCapacityMemProvReq, impossibleCheckCapacityReq, newCheckCapacityCpuProvReq},
+			provReqToScaleUp:    newCheckCapacityMemProvReq,
+			scaleUpResult:       status.ScaleUpSuccessful,
+			batchProcessing:     true,
+			maxBatchSize:        3,
+			batchTimebox:        5 * time.Minute,
+			numProvisionedTrue:  2,
+			numProvisionedFalse: 1,
+		},
+		{
+			name:                "batch processing of check capacity requests where all requests' capacity is not available",
+			provReqs:            []*provreqwrapper.ProvisioningRequest{impossibleCheckCapacityReq, anotherImpossibleCheckCapacityReq},
+			provReqToScaleUp:    impossibleCheckCapacityReq,
+			scaleUpResult:       status.ScaleUpNoOptionsAvailable,
+			batchProcessing:     true,
+			maxBatchSize:        3,
+			batchTimebox:        5 * time.Minute,
+			numProvisionedFalse: 2,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
-		allNodes := allNodes
+
+		nodes := []*apiv1.Node{}
+		for _, n := range allNodes {
+			nodes = append(nodes, n.DeepCopy())
+		}
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -255,7 +415,14 @@ func TestScaleUp(t *testing.T) {
 				}
 				return fmt.Errorf("unexpected scale-up of %s by %d", name, n)
 			}
-			orchestrator, nodeInfos := setupTest(t, allNodes, tc.provReqs, onScaleUpFunc, tc.autoprovisioning)
+
+			testProvReqs := []*provreqwrapper.ProvisioningRequest{}
+			for _, pr := range tc.provReqs {
+				testProvReqs = append(testProvReqs, &provreqwrapper.ProvisioningRequest{ProvisioningRequest: pr.DeepCopy(), PodTemplates: pr.PodTemplates})
+			}
+
+			client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, testProvReqs...)
+			orchestrator, nodeInfos := setupTest(t, client, nodes, onScaleUpFunc, tc.autoprovisioning, tc.batchProcessing, tc.maxBatchSize, tc.batchTimebox)
 
 			st, err := orchestrator.ScaleUp(prPods, []*apiv1.Node{}, []*appsv1.DaemonSet{}, nodeInfos, false)
 			if !tc.err {
@@ -266,6 +433,16 @@ func TestScaleUp(t *testing.T) {
 					t.Errorf("noScaleUpInfo: %#v", st.PodsRemainUnschedulable[0].RejectedNodeGroups)
 				}
 				assert.Equal(t, tc.scaleUpResult, st.Result)
+
+				provReqsAfterScaleUp, err := client.ProvisioningRequestsNoCache()
+				assert.NoError(t, err)
+				assert.Equal(t, len(tc.provReqs), len(provReqsAfterScaleUp))
+
+				if tc.batchProcessing {
+					// Since batch processing returns aggregated result, we need to check the number of provisioned requests which have the provisioned condition.
+					assert.Equal(t, tc.numProvisionedTrue, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionTrue))
+					assert.Equal(t, tc.numProvisionedFalse, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionFalse))
+				}
 			} else {
 				assert.Error(t, err)
 			}
@@ -273,12 +450,14 @@ func TestScaleUp(t *testing.T) {
 	}
 }
 
-func setupTest(t *testing.T, nodes []*apiv1.Node, prs []*provreqwrapper.ProvisioningRequest, onScaleUpFunc func(string, int) error, autoprovisioning bool) (*provReqOrchestrator, map[string]*schedulerframework.NodeInfo) {
+func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, nodes []*apiv1.Node, onScaleUpFunc func(string, int) error, autoprovisioning bool, batchProcessing bool, maxBatchSize int, batchTimebox time.Duration) (*provReqOrchestrator, map[string]*schedulerframework.NodeInfo) {
 	provider := testprovider.NewTestCloudProvider(onScaleUpFunc, nil)
+	clock := clocktesting.NewFakePassiveClock(time.Now())
+	now := clock.Now()
 	if autoprovisioning {
 		machineTypes := []string{"large-machine"}
 		template := BuildTestNode("large-node-template", 100, 100)
-		SetNodeReadyState(template, true, time.Now())
+		SetNodeReadyState(template, true, now)
 		nodeInfoTemplate := schedulerframework.NewNodeInfo()
 		nodeInfoTemplate.SetNode(template)
 		machineTemplates := map[string]*schedulerframework.NodeInfo{
@@ -295,30 +474,26 @@ func setupTest(t *testing.T, nodes []*apiv1.Node, prs []*provreqwrapper.Provisio
 
 	podLister := kube_util.NewTestPodLister(nil)
 	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
-	autoscalingContext, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, &fake.Clientset{}, listers, provider, nil, nil)
+
+	options := config.AutoscalingOptions{}
+	if batchProcessing {
+		options.CheckCapacityBatchProcessing = true
+		options.CheckCapacityProvisioningRequestMaxBatchSize = maxBatchSize
+		options.CheckCapacityProvisioningRequestBatchTimebox = batchTimebox
+	}
+
+	autoscalingContext, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingContext.ClusterSnapshot, nodes, nil)
-	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, prs...)
 	processors := NewTestProcessors(&autoscalingContext)
 	if autoprovisioning {
 		processors.NodeGroupListProcessor = &MockAutoprovisioningNodeGroupListProcessor{T: t}
 		processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{T: t, ExtraGroups: 2}
 	}
-
-	now := time.Now()
 	nodeInfos, err := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&autoscalingContext, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	assert.NoError(t, err)
 
-	options := config.AutoscalingOptions{
-		EstimatorName:                    estimator.BinpackingEstimatorName,
-		MaxCoresTotal:                    config.DefaultMaxClusterCores,
-		MaxMemoryTotal:                   config.DefaultMaxClusterMemory * units.GiB,
-		MinCoresTotal:                    0,
-		MinMemoryTotal:                   0,
-		NodeAutoprovisioningEnabled:      autoprovisioning,
-		MaxAutoprovisionedNodeGroupCount: 10,
-	}
 	estimatorBuilder, _ := estimator.NewEstimatorBuilder(
 		estimator.BinpackingEstimatorName,
 		estimator.NewThresholdBasedEstimationLimiter(nil),
@@ -326,13 +501,34 @@ func setupTest(t *testing.T, nodes []*apiv1.Node, prs []*provreqwrapper.Provisio
 		nil,
 	)
 
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, autoscalingContext.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), processors.AsyncNodeGroupStateChecker)
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, autoscalingContext.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(autoscalingContext.NodeGroupDefaults), processors.AsyncNodeGroupStateChecker)
 	clusterState.UpdateNodes(nodes, nodeInfos, now)
+
+	var injector *provreq.ProvisioningRequestPodsInjector
+	if batchProcessing {
+		injector = provreq.NewFakePodsInjector(client, clocktesting.NewFakePassiveClock(now))
+	}
 
 	orchestrator := &provReqOrchestrator{
 		client:              client,
-		provisioningClasses: []ProvisioningClass{checkcapacity.New(client, nil), besteffortatomic.New(client)},
+		provisioningClasses: []ProvisioningClass{checkcapacity.New(client, injector), besteffortatomic.New(client)},
 	}
+
 	orchestrator.Initialize(&autoscalingContext, processors, clusterState, estimatorBuilder, taints.TaintConfig{})
 	return orchestrator, nodeInfos
+}
+
+func NumProvisioningRequestsWithCondition(prList []*provreqwrapper.ProvisioningRequest, conditionType string, conditionStatus metav1.ConditionStatus) int {
+	count := 0
+
+	for _, pr := range prList {
+		for _, c := range pr.Status.Conditions {
+			if c.Type == conditionType && c.Status == conditionStatus {
+				count++
+				break
+			}
+		}
+	}
+
+	return count
 }

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -54,7 +54,7 @@ type ProvisioningRequestClient struct {
 func NewProvisioningRequestClient(kubeConfig *rest.Config) (*ProvisioningRequestClient, error) {
 	prClient, err := newPRClient(kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create Provisioning Request client: %v", err)
+		return nil, fmt.Errorf("failed to create Provisioning Request client: %v", err)
 	}
 
 	provReqLister, err := newPRsLister(prClient, make(chan struct{}))
@@ -64,7 +64,7 @@ func NewProvisioningRequestClient(kubeConfig *rest.Config) (*ProvisioningRequest
 
 	podTemplateClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create Pod Template client: %v", err)
+		return nil, fmt.Errorf("failed to create Pod Template client: %v", err)
 	}
 
 	podTemplLister, err := newPodTemplatesLister(podTemplateClient, make(chan struct{}))
@@ -181,7 +181,7 @@ func ProvisioningRequestsForPods(client *ProvisioningRequestClient, unschedulabl
 		return prList
 	}
 	for _, pod := range unschedulablePods {
-		if pod.OwnerReferences == nil || len(pod.OwnerReferences) == 0 {
+		if len(pod.OwnerReferences) == 0 {
 			klog.Errorf("pod %s has no OwnerReference", pod.Name)
 			continue
 		}

--- a/cluster-autoscaler/provisioningrequest/provreqclient/testutils.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/testutils.go
@@ -149,3 +149,22 @@ func (c *ProvisioningRequestClient) ProvisioningRequestNoCache(namespace, name s
 	}
 	return provreqwrapper.NewProvisioningRequest(v1, podTemplates), nil
 }
+
+// ProvisioningRequestsNoCache returns all ProvisioningRequests directly from client. For test purposes only.
+func (c *ProvisioningRequestClient) ProvisioningRequestsNoCache() ([]*provreqwrapper.ProvisioningRequest, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), provisioningRequestClientCallTimeout)
+	defer cancel()
+	v1s, err := c.client.AutoscalingV1().ProvisioningRequests("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	prs := make([]*provreqwrapper.ProvisioningRequest, 0, len(v1s.Items))
+	for _, v1 := range v1s.Items {
+		podTemplates, err := c.FetchPodTemplates(&v1)
+		if err != nil {
+			return nil, err
+		}
+		prs = append(prs, provreqwrapper.NewProvisioningRequest(&v1, podTemplates))
+	}
+	return prs, nil
+}

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
@@ -50,7 +50,6 @@ func NewProvisioningRequest(pr *v1.ProvisioningRequest, podTemplates []*apiv1.Po
 // SetConditions of the Provisioning Request.
 func (pr *ProvisioningRequest) SetConditions(conditions []metav1.Condition) {
 	pr.Status.Conditions = conditions
-	return
 }
 
 // PodSets of the Provisioning Request.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Implements batch processing such that user can configure CA to process multiple CheckCapacity ProvisioningRequests in a single autoscaling iteration.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allows CheckCapacity ProvisioningRequests to be processed in batch mode with configurable max batch size and batch timebox enabled by feature flags.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc: @yaroslava-serdiuk @aleksandra-malinowska @kawych 