### PR TITLE
Support custom HCLOUD_ENDPOINT in cluster-autoscaler Hetzner manager

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -90,13 +90,20 @@ func newManager() (*hetznerManager, error) {
 		return nil, errors.New("`HCLOUD_TOKEN` is not specified")
 	}
 
-	client := hcloud.NewClient(
+	opts := []hcloud.ClientOption{
 		hcloud.WithToken(token),
 		hcloud.WithHTTPClient(httpClient),
 		hcloud.WithApplication("cluster-autoscaler", version.ClusterAutoscalerVersion),
 		hcloud.WithPollBackoffFunc(hcloud.ExponentialBackoff(2, 500*time.Millisecond)),
 		hcloud.WithDebugWriter(&debugWriter{}),
-	)
+	}
+
+	endpoint := os.Getenv("HCLOUD_ENDPOINT")
+	if endpoint != "" {
+		opts = append(opts, hcloud.WithEndpoint(endpoint))
+	}
+
+	client := hcloud.NewClient(opts...)
 
 	ctx := context.Background()
 	var err error


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support to the HCLOUD_ENDPOINT environment variable, following what's used by other projects like https://github.com/hetznercloud/hcloud-cloud-controller-manager and https://github.com/hetznercloud/csi-driver.

#### Which issue(s) this PR fixes:

Fixes #7284

#### Special notes for your reviewer:

[We](https://github.com/altinity) have developed a soon-to-be-open-source proxy that forces specific labels in order to provide scoped API access. This support is required to make full use of it inside a Kubernetes cluster.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The HCLOUD_ENDPOINT environment variable is now supported to set a custom endpoint for Hetzner usage is cluster-autoscaler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
